### PR TITLE
Add failing indentation tests for lines starting with &nbsp;

### DIFF
--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -74,6 +74,8 @@ generateRuleTests({
       '{{/if}}',
     ].join('\n'),
     ['<div class="multi"', '     id="lines"></div>'].join('\n'),
+    ['{{#if foo}}', '  &nbsp;Hello', '{{/if}}'].join('\n'),
+    ['{{#if foo}}', '  &nbsp;<div></div>', '{{/if}}'].join('\n'),
     {
       config: 4,
 


### PR DESCRIPTION
For #120:

- `&nbsp;` followed by text (`&nbsp;Hello`) seems to interpret the `&nbsp;` as a space and fails: `Expected '   Hello\n' to be at an indentation of 2 but was found at 3."`
- `&nbsp;` followed by HTML (`&nbsp;<div></div>`) seems to interpret the `&nbsp;` as six separate whitespace characters and fails: `Expected '<div>' to be at an indentation of 2 but was found at 8.`
