### PR TITLE
add failing test for block-indentation: attributes

### DIFF
--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -276,5 +276,37 @@ generateRuleTests({
       'moduleId': 'layout.hbs',
       'source': '{{if (or logout.isRunning (not session.isAuthenticated)) "Logging Out..." "Log Out"}}'
     }]
+  },
+  {
+    template: [
+      '{{foo-bar',
+      'baz=true',
+      '}}'
+    ].join('\n'),
+
+    result: {
+      rule: 'attribute-indentation',
+      message: 'Incorrect indentation of attribute \'baz\' beginning at L2:C0. Expected \'baz\' to be at L2:C2.',
+      moduleId: 'layout.hbs',
+      source: '{{foo-bar\nbaz=true\n}}',
+      line: 2,
+      column: 0
+    }
+  }, {
+    template: [
+      '{{#foo-bar',
+      'baz=true',
+      '}}',
+      '{{/foo-bar}}'
+    ].join('\n'),
+
+    result: {
+      rule: 'attribute-indentation',
+      message: 'Incorrect indentation of attribute \'baz\' beginning at L2:C0. Expected \'baz\' to be at L2:C2.',
+      moduleId: 'layout.hbs',
+      source: '{{#foo-bar\nbaz=true\n}}\n{{/foo-bar}}',
+      line: 2,
+      column: 0
+    }
   }]
 });

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -640,38 +640,5 @@ generateRuleTests({
         }
       ]
     },
-    {
-      template: [
-        '{{foo-bar',
-        'baz=true',
-        '}}'
-      ].join('\n'),
-
-      result: {
-        rule: 'block-indentation',
-        message: 'Incorrect indentation for `{{! bad comment }}` beginning at L1:C6. Expected `{{! bad comment }}` to be at an indentation of 2 but was found at 6.',
-        moduleId: 'layout.hbs',
-        source: '<div> {{! bad comment }}\n  {{foo-bar}}\n</div>',
-        line: 1,
-        column: 6
-      }
-    },
-    {
-      template: [
-        '{{#foo-bar',
-        'baz=true',
-        '}}',
-        '{{/foo-bar}}'
-      ].join('\n'),
-
-      result: {
-        rule: 'block-indentation',
-        message: 'Incorrect indentation for `{{! bad comment }}` beginning at L1:C6. Expected `{{! bad comment }}` to be at an indentation of 2 but was found at 6.',
-        moduleId: 'layout.hbs',
-        source: '<div> {{! bad comment }}\n  {{foo-bar}}\n</div>',
-        line: 1,
-        column: 6
-      }
-    }
   ]
 });

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -639,6 +639,39 @@ generateRuleTests({
           column: 2
         }
       ]
+    },
+    {
+      template: [
+        '{{foo-bar',
+        'baz=true',
+        '}}'
+      ].join('\n'),
+
+      result: {
+        rule: 'block-indentation',
+        message: 'Incorrect indentation for `{{! bad comment }}` beginning at L1:C6. Expected `{{! bad comment }}` to be at an indentation of 2 but was found at 6.',
+        moduleId: 'layout.hbs',
+        source: '<div> {{! bad comment }}\n  {{foo-bar}}\n</div>',
+        line: 1,
+        column: 6
+      }
+    },
+    {
+      template: [
+        '{{#foo-bar',
+        'baz=true',
+        '}}',
+        '{{/foo-bar}}'
+      ].join('\n'),
+
+      result: {
+        rule: 'block-indentation',
+        message: 'Incorrect indentation for `{{! bad comment }}` beginning at L1:C6. Expected `{{! bad comment }}` to be at an indentation of 2 but was found at 6.',
+        moduleId: 'layout.hbs',
+        source: '<div> {{! bad comment }}\n  {{foo-bar}}\n</div>',
+        line: 1,
+        column: 6
+      }
     }
   ]
 });


### PR DESCRIPTION
Trying to enforce the attribute indentation. Trying to prevent:

```hbs
{{foo-bar
baz=true
}}
```

in favor of

```hbs
{{foo-bar
  baz=true
}}
```