### PR TITLE
Fix linter for mustaches containing only string literal

### DIFF
--- a/lib/plugins/transform-dot-component-invocation.js
+++ b/lib/plugins/transform-dot-component-invocation.js
@@ -43,7 +43,7 @@ module.exports = function transformDotComponentInvocation(env) {
 };
 
 function isMultipartPath(path)  {
-  return path.parts.length > 1;
+  return path.parts && path.parts.length > 1;
 }
 
 function isInlineInvocation(path, params, hash) {

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -195,7 +195,10 @@ generateRuleTests({
       '\uFEFF{{#if foo}}',
       '  <div></div>',
       '{{/if}}'
-    ].join('\n')
+    ].join('\n'),
+    [
+      '{{\'this works\'}}'
+    ].join('\n'),
   ],
 
   bad: [


### PR DESCRIPTION
Mustaches containing only string literal are legal. I found them useful when in, say, addon dummy app I want to render readable html, it's easy to do 

`{{"<div>example text</div>"}}`

When `isMultipartPath` finds template code like this, it receives something like

```
{ type: 'StringLiteral',
  value: '<div>example text</div>',
  original: '<div>example text</div>',
  loc:
   { source: null,
     start: { line: 1, column: 2 },
     end: { line: 1, column: 14 } } }
```

Which contains no `parts`, this generating error. I simply added a guard against this case.