### PR TITLE
Remove tabpanel from interactive elements array

### DIFF
--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -29,7 +29,6 @@ const ARIA_WIDGET_ROLES = [
   'slider',
   'spinbutton',
   'tab',
-  'tabpanel',
   'textbox',
   'tooltip',
   'treeitem'


### PR DESCRIPTION
We are having an issue with the template linter and elements with the `role="tabpanel"`. The tabpanel role is not an interactive element as defined on the W3C website, so the nested interactive error should not be fired (the superclass defined [here](https://www.w3.org/WAI/PF/aria/roles#tabpanel) is a region, not a widget). It would be great if this PR could get merged ASAP as the workaround we're using is to disable the linter which isn't ideal.