### PR TITLE
add aria-* properties to bare-strings rule

### DIFF
--- a/lib/rules/lint-bare-strings.js
+++ b/lib/rules/lint-bare-strings.js
@@ -26,7 +26,11 @@ const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
 
 const GLOBAL_ATTRIBUTES = [
-  'title'
+  'title',
+  'aria-label',
+  'aria-placeholder',
+  'aria-roledescription',
+  'aria-valuetext'
 ];
 
 const TAG_ATTRIBUTES = {

--- a/test/unit/rules/lint-bare-strings-test.js
+++ b/test/unit/rules/lint-bare-strings-test.js
@@ -137,6 +137,54 @@ generateRuleTests({
     },
 
     {
+      template: '<div role="contentinfo" aria-label="Contact, Policies and Legal"></div>',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message: 'Non-translated string used in `aria-label` attribute',
+        line: 1,
+        column: 24,
+        source: 'Contact, Policies and Legal'
+      }
+    },
+
+    {
+      template: '<div contenteditable role="searchbox" aria-placeholder="Search for things"></div>',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message: 'Non-translated string used in `aria-placeholder` attribute',
+        line: 1,
+        column: 38,
+        source: 'Search for things'
+      }
+    },
+
+    {
+      template: '<div role="region" aria-roledescription="slide"></div>',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message: 'Non-translated string used in `aria-roledescription` attribute',
+        line: 1,
+        column: 19,
+        source: 'slide'
+      }
+    },
+
+    {
+      template: '<div role="slider" aria-valuetext="Off" tabindex="0" aria-valuemin="0" aria-valuenow="0" aria-valuemax="3"></div>',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message: 'Non-translated string used in `aria-valuetext` attribute',
+        line: 1,
+        column: 19,
+        source: 'Off'
+      }
+    },
+
+    {
       config: { globalAttributes: ['data-foo'] },
       template: '<div data-foo="derpy"></div>',
 


### PR DESCRIPTION
This commit adds aria-label [1], aria-placeholder [2],
aria-roledescription [3], and aria-valuetext [4] to the
GLOBAL_ATTRIBUTES array in the bare-strings rule.

These are 4 of the 5 aria properties that take free-form strings
(aria-keyshortcuts is the other and it's not clear to me that would
be translated)

[1]: https://www.w3.org/TR/wai-aria-1.1/#aria-label
[2]: https://www.w3.org/TR/wai-aria-1.1/#aria-placeholder
[3]: https://www.w3.org/TR/wai-aria-1.1/#aria-roledescription
[3]: https://www.w3.org/TR/wai-aria-1.1/#aria-valuetext