### PR TITLE
Fix line/column reporting when either is 0.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -166,11 +166,10 @@ class Linter {
   static _formatError(error, options) {
     let message = '';
 
-    if (error.line && error.column) {
-      message += chalk.dim(`  ${error.line}:${error.column}`);
-    } else {
-      message += chalk.dim('  -:-');
-    }
+    let line = error.line === undefined ? '-' : error.line;
+    let column = error.column === undefined ? '-' : error.column;
+
+    message += chalk.dim(`  ${line}:${column}`);
 
     if (error.severity === WARNING_SEVERITY) {
       message += `  ${chalk.yellow('warning')}`;

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -535,6 +535,17 @@ describe('public api', function() {
       );
     });
 
+    it('formats error with rule, message, line and column numbers even when they are "falsey"', function() {
+      let result = Linter.errorsToMessages('file/path', [
+        { rule: 'some rule', message: 'some message', line: 1, column: 0 }
+      ]);
+
+      expect(result).to.equal(
+        'file/path\n'+
+        '  1:0  error  some message  some rule\n'
+      );
+    });
+
     it('formats error with rule, message, line and column numbers', function() {
       let result = Linter.errorsToMessages('file/path', [
         { rule: 'some rule', message: 'some message', line: 11, column: 12 }


### PR DESCRIPTION
Prior to this change, if either `line` or `column` were `0` the console message would reference location `-:-`.