### PR TITLE
Ensure deprecated rule names are properly migrated.

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -284,7 +284,7 @@ function validateRules(config, options) {
       const deprecation = DEPRECATED_RULES.get(key);
       if (deprecation) {
         deprecatedNamesFound.push({ oldName: key, newName: deprecation });
-        config.rules[deprecation.newName] = config.rules[key];
+        config.rules[deprecation] = config.rules[key];
         delete config.rules[key];
       } else {
         invalidKeysFound.push(key);

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -69,6 +69,18 @@ describe('public api', function() {
 
       expect(linter.config.rules).to.deep.equal(expected.rules);
     });
+
+    it('with deprecated rule config', function() {
+      let basePath = path.join(fixturePath, 'deprecated-rule-config');
+      let expected = require(path.join(basePath, '.template-lintrc'));
+
+      let linter = new Linter({
+        console: mockConsole,
+        config: expected
+      });
+
+      expect(linter.config.rules).to.deep.equal({ 'no-bare-strings': true });
+    });
   });
 
   describe('Linter.prototype.constructor', function() {

--- a/test/fixtures/deprecated-rule-config/.template-lintrc.js
+++ b/test/fixtures/deprecated-rule-config/.template-lintrc.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'bare-strings': true,
+  }
+}

--- a/test/unit/rules/lint-no-bare-strings-test.js
+++ b/test/unit/rules/lint-no-bare-strings-test.js
@@ -73,7 +73,14 @@ generateRuleTests({
       // combine bare string with a variable
       config: ['X'],
       template: '<input placeholder="{{foo}}X">'
-    }
+    },
+
+    '{{! template-lint-disable bare-strings}}LOL{{! template-lint-enable bare-strings}}',
+
+    `{{!-- template-lint-disable bare-strings --}}
+<i class="material-icons">folder_open</i>
+{{!-- template-lint-enable bare-strings --}}`,
+    '<div data-test-foo-bar></div>',
   ],
 
   bad: [


### PR DESCRIPTION
Prior to this change, deprecated rules specified in user specified config would not be included in the final config.

Fixes #417