### PR TITLE
Add and fix a test case for deprecated-inline-view-helper

### DIFF
--- a/lib/rules/deprecations/lint-deprecated-inline-view-helper.js
+++ b/lib/rules/deprecations/lint-deprecated-inline-view-helper.js
@@ -38,8 +38,9 @@ function manageMustacheViewInvocation(context, node, isBlockStatement) {
     for (let i = 0; i < pairs.length; i++) {
       let currentPair = pairs[i];
       let originalValue = currentPair.value.original;
+      let valueType = currentPair.value.type;
 
-      if (typeof originalValue === 'string' && originalValue.split('.')[0] == 'view') {
+      if (valueType !== 'StringLiteral' && typeof originalValue === 'string' && originalValue.split('.')[0] == 'view') {
         if (isBlockStatement) {
           context.processInBlockStatement(node, currentPair);
         } else {

--- a/test/unit/rules/deprecations/lint-deprecated-inline-view-helper-test.js
+++ b/test/unit/rules/deprecations/lint-deprecated-inline-view-helper-test.js
@@ -14,7 +14,8 @@ generateRuleTests({
   good: [
     '{{great-fishsticks}}',
     '{{input placeholder=(t "email") value=email}}',
-    '{{title "CrossCheck Web" prepend=true separator=" | "}}'
+    '{{title "CrossCheck Web" prepend=true separator=" | "}}',
+    '{{x-component foo="view"}}'
   ],
 
   bad: [


### PR DESCRIPTION
In the application I am working on, we have an icon component, that accepts an icon name as param. One of available icon names is "view", and those usages are flagged by `deprecated-inline-view-helper`.

This change makes sure that the rule does not flag string literals containing "view" string, and adds proper test case.

If the MR handles this update incorrectly in any sort, I am happy to update.

Fixes https://github.com/ember-template-lint/ember-template-lint/issues/191