### PR TITLE
Add scope tracking to block statements even when rule visitor isn't present.

### DIFF
--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -150,6 +150,7 @@ module.exports = class BaseRule {
 
     visitor.CommentStatement = visitor.CommentStatement || this._wrapVisitor(null, astHandlers.CommentStatement);
     visitor.MustacheCommentStatement = visitor.MustacheCommentStatement || this._wrapVisitor(null, astHandlers.MustacheCommentStatement);
+    visitor.BlockStatement = visitor.BlockStatement || this._wrapVisitor(null, astHandlers.BlockStatement);
     visitor.ElementNode = visitor.ElementNode || this._wrapVisitor(null, astHandlers.ElementNode);
 
     //


### PR DESCRIPTION
This was missed in https://github.com/ember-template-lint/ember-template-lint/pull/432.