### PR TITLE
Ignore Warnings / Only Report Errors with "--quiet" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ Example usage:
 
 # output errors as pretty-printed JSON string
 ./node_modules/.bin/ember-template-lint app/templates/application.hbs --json
+
+# ignore warnings / only report errors
+./node_modules/.bin/ember-template-lint app/templates/application.hbs --quiet
 ```
 
 ### ESLint

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -10,11 +10,27 @@ var linter = new Linter();
 const chalk = require('chalk');
 
 function printErrors(errors) {
+  const quiet = process.argv.indexOf('--quiet') !== -1;
+
   if (process.argv.indexOf('--json') + 1) {
+    let filteredErrors;
+
+    Object.keys(errors).forEach(filePath => {
+      let fileErrors = errors[filePath] || [];
+
+      filteredErrors = fileErrors.filter((error) => {
+        if (quiet && error.severity < Linter.ERROR_SEVERITY) {
+          return false;
+        }
+
+        return true;
+      });
+
+      errors[filePath] = filteredErrors;
+    });
+
     console.log(JSON.stringify(errors, null, 2));
   } else {
-    const quiet = process.argv.indexOf('--quiet') !== -1;
-
     let errorCount   = 0;
     let warningCount = 0;
 

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -13,21 +13,39 @@ function printErrors(errors) {
   if (process.argv.indexOf('--json') + 1) {
     console.log(JSON.stringify(errors, null, 2));
   } else {
-    let count = 0;
+    const quiet = process.argv.indexOf('--quiet') !== -1;
+
+    let errorCount   = 0;
+    let warningCount = 0;
 
     Object.keys(errors).forEach(filePath => {
-      let options = {};
+      let options = {
+        quiet: quiet
+      };
       let fileErrors = errors[filePath] || [];
-      count += fileErrors.length;
+
+      errorCount   += fileErrors.filter(error => error.severity === Linter.ERROR_SEVERITY).length;
+      warningCount += fileErrors.filter(error => error.severity === Linter.WARNING_SEVERITY).length;
 
       if (process.argv.indexOf('--verbose') + 1) {
         options.verbose = true;
       }
 
-      console.log(Linter.errorsToMessages(filePath, fileErrors, options));
+      const messages = Linter.errorsToMessages(filePath, fileErrors, options);
+      if (messages !== '') {
+        console.log(messages);
+      }
     });
 
-    console.log(chalk.red(chalk.bold(`✖ ${count} problems`)));
+    if (quiet) {
+      warningCount = 0;
+    }
+
+    const count = errorCount + warningCount;
+
+    if (count > 0) {
+      console.log(chalk.red(chalk.bold(`✖ ${count} problems (${errorCount} errors, ${warningCount} warnings)`)));
+    }
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -167,8 +167,14 @@ class Linter {
     }
 
     let errorsMessages = errors
+      .filter((error) => {
+        if (options.quiet && error.severity < ERROR_SEVERITY) {
+          return false;
+        }
+
+        return true;
+      })
       .map((error) => this._formatError(error, options))
-      .filter(error => error !== '')
       .join('\n');
 
     if (errorsMessages === '') {
@@ -180,10 +186,6 @@ class Linter {
 
   static _formatError(error, options) {
     let message = '';
-
-    if (options.quiet && error.severity === WARNING_SEVERITY) {
-      return message;
-    }
 
     let line = error.line === undefined ? '-' : error.line;
     let column = error.column === undefined ? '-' : error.column;

--- a/lib/index.js
+++ b/lib/index.js
@@ -158,20 +158,32 @@ class Linter {
   static errorsToMessages(filePath, errors, options) {
     errors = errors || [];
     options = options || {
-      verbose: false
+      verbose: false,
+      quiet:   false
     };
 
     if (errors.length === 0) {
       return '';
     }
 
-    let errorsMessages = errors.map((error) => this._formatError(error, options)).join('\n');
+    let errorsMessages = errors
+      .map((error) => this._formatError(error, options))
+      .filter(error => error !== '')
+      .join('\n');
+
+    if (errorsMessages === '') {
+      return '';
+    }
 
     return `${chalk.underline(filePath)}\n${errorsMessages}\n`;
   }
 
   static _formatError(error, options) {
     let message = '';
+
+    if (options.quiet && error.severity === WARNING_SEVERITY) {
+      return message;
+    }
 
     let line = error.line === undefined ? '-' : error.line;
     let column = error.column === undefined ? '-' : error.column;

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const chalk = require('chalk');
 const TransformDotComponentInvocation = require('./plugins/transform-dot-component-invocation');
 
 const WARNING_SEVERITY = 1;
-const ERROR_SEVERITY   = 2;
+const ERROR_SEVERITY = 2;
 
 class Linter {
   constructor(_options) {
@@ -206,8 +206,8 @@ class Linter {
   }
 }
 
-module.exports                  = Linter;
-module.exports.Rule             = require('./rules/base');
-module.exports.ASTHelpers       = require('./helpers/ast-node-info');
+module.exports = Linter;
+module.exports.Rule = require('./rules/base');
+module.exports.ASTHelpers = require('./helpers/ast-node-info');
 module.exports.WARNING_SEVERITY = WARNING_SEVERITY;
-module.exports.ERROR_SEVERITY   = ERROR_SEVERITY;
+module.exports.ERROR_SEVERITY = ERROR_SEVERITY;

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,7 @@ const chalk = require('chalk');
 const TransformDotComponentInvocation = require('./plugins/transform-dot-component-invocation');
 
 const WARNING_SEVERITY = 1;
-const ERROR_SEVERITY = 2;
+const ERROR_SEVERITY   = 2;
 
 class Linter {
   constructor(_options) {
@@ -206,6 +206,8 @@ class Linter {
   }
 }
 
-module.exports = Linter;
-module.exports.Rule = require('./rules/base');
-module.exports.ASTHelpers = require('./helpers/ast-node-info');
+module.exports                  = Linter;
+module.exports.Rule             = require('./rules/base');
+module.exports.ASTHelpers       = require('./helpers/ast-node-info');
+module.exports.WARNING_SEVERITY = WARNING_SEVERITY;
+module.exports.ERROR_SEVERITY   = ERROR_SEVERITY;

--- a/lib/index.js
+++ b/lib/index.js
@@ -158,28 +158,14 @@ class Linter {
   static errorsToMessages(filePath, errors, options) {
     errors = errors || [];
     options = options || {
-      verbose: false,
-      quiet:   false
+      verbose: false
     };
 
     if (errors.length === 0) {
       return '';
     }
 
-    let errorsMessages = errors
-      .filter((error) => {
-        if (options.quiet && error.severity < ERROR_SEVERITY) {
-          return false;
-        }
-
-        return true;
-      })
-      .map((error) => this._formatError(error, options))
-      .join('\n');
-
-    if (errorsMessages === '') {
-      return '';
-    }
+    let errorsMessages = errors.map((error) => this._formatError(error, options)).join('\n');
 
     return `${chalk.underline(filePath)}\n${errorsMessages}\n`;
   }

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -594,19 +594,6 @@ describe('public api', function() {
       );
     });
 
-    it('formats only errors with severity of 2 when quiet is true', function() {
-      let result = Linter.errorsToMessages('file/path', [
-        { rule: 'some rule',  message: 'some message',  line: 11, column: 12, severity: 1 },
-        { rule: 'some rule2', message: 'some message2', line: 13, column: 14, severity: 2 },
-        { rule: 'some rule3', message: 'some message3', line: 14, column: 15, severity: 1 },
-      ], { quiet: true });
-
-      expect(result).to.equal(
-        'file/path\n'+
-        '  13:14  error  some message2  some rule2\n'
-      );
-    });
-
     it('formats empty errors', function() {
       let result = Linter.errorsToMessages('file/path', []);
 

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -594,6 +594,19 @@ describe('public api', function() {
       );
     });
 
+    it('formats only errors with severity of 2 when quiet is true', function() {
+      let result = Linter.errorsToMessages('file/path', [
+        { rule: 'some rule',  message: 'some message',  line: 11, column: 12, severity: 1 },
+        { rule: 'some rule2', message: 'some message2', line: 13, column: 14, severity: 2 },
+        { rule: 'some rule3', message: 'some message3', line: 14, column: 15, severity: 1 },
+      ], { quiet: true });
+
+      expect(result).to.equal(
+        'file/path\n'+
+        '  13:14  error  some message2  some rule2\n'
+      );
+    });
+
     it('formats empty errors', function() {
       let result = Linter.errorsToMessages('file/path', []);
 

--- a/test/fixtures/with-errors-and-warnings/.template-lintrc.js
+++ b/test/fixtures/with-errors-and-warnings/.template-lintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  rules: {
+    'no-bare-strings': true,
+    'no-html-comments': true
+  },
+  pending: [
+    {
+      'moduleId': './app/templates/application',
+      'only': [
+        'no-html-comments'
+      ]
+    }
+  ]
+};

--- a/test/fixtures/with-errors-and-warnings/app/templates/application.hbs
+++ b/test/fixtures/with-errors-and-warnings/app/templates/application.hbs
@@ -1,0 +1,3 @@
+<h2>Here too!!</h2>
+<div>Bare strings are bad...</div>
+<!-- bad html comment! -->

--- a/test/fixtures/with-warnings/.template-lintrc.js
+++ b/test/fixtures/with-warnings/.template-lintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  rules: {
+    'no-html-comments': true
+  },
+  pending: [
+    {
+      'moduleId': './app/templates/application',
+      'only': [
+        'no-html-comments'
+      ]
+    }
+  ]
+};

--- a/test/fixtures/with-warnings/app/templates/application.hbs
+++ b/test/fixtures/with-warnings/app/templates/application.hbs
@@ -1,0 +1,3 @@
+<h2>Here too!!</h2>
+<div>Bare strings are bad...</div>
+<!-- bad html comment! -->

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -188,5 +188,55 @@ describe('ember-template-lint executable', function() {
         });
       });
     });
+
+    describe('with --json param and --quiet', function() {
+      it('should print valid JSON string with errors, omitting warnings', function(done) {
+        execFile('node', ['../../../bin/ember-template-lint.js', '.', '--json', '--quiet'], {
+          cwd: './test/fixtures/with-errors-and-warnings'
+        }, function(err, stdout, stderr) {
+          let fullTemplateFilePath = path.resolve('./test/fixtures/with-errors-and-warnings/app/templates/application.hbs');
+          let expectedOutputData = {};
+          expectedOutputData[fullTemplateFilePath] = [
+            {
+              column: 4,
+              line: 1,
+              message: 'Non-translated string used',
+              moduleId: './app/templates/application',
+              rule: 'no-bare-strings',
+              severity: 2,
+              source: 'Here too!!'
+            }, {
+              column: 5,
+              line: 2,
+              message: 'Non-translated string used',
+              moduleId: './app/templates/application',
+              rule: 'no-bare-strings',
+              severity: 2,
+              source: 'Bare strings are bad...'
+            }
+          ];
+
+          expect(err).to.be.ok;
+          expect(JSON.parse(stdout)).to.deep.equal(expectedOutputData);
+          expect(stderr).to.be.empty;
+          done();
+        });
+      });
+
+      it('should exit without error and empty errors array', function(done) {
+        execFile('node', ['../../../bin/ember-template-lint.js', '.', '--json', '--quiet'], {
+          cwd: './test/fixtures/with-warnings'
+        }, function(err, stdout, stderr) {
+          let fullTemplateFilePath = path.resolve('./test/fixtures/with-warnings/app/templates/application.hbs');
+          let expectedOutputData = {};
+          expectedOutputData[fullTemplateFilePath] = [];
+
+          expect(err).to.be.null;
+          expect(JSON.parse(stdout)).to.deep.equal(expectedOutputData);
+          expect(stderr).to.be.empty;
+          done();
+        });
+      });
+    });
   });
 });

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -95,7 +95,7 @@ describe('ember-template-lint executable', function() {
             '  1:4  error  Non-translated string used  no-bare-strings',
             '  2:5  error  Non-translated string used  no-bare-strings',
             '',
-            '✖ 2 problems',
+            '✖ 2 problems (2 errors, 0 warnings)',
             ''
           ]);
           expect(stderr).to.be.empty;

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -83,9 +83,9 @@ describe('ember-template-lint executable', function() {
     });
   });
 
-  describe('errors formatting', function() {
+  describe('errors and warnings formatting', function() {
     describe('without --json param', function() {
-      it('should print properly formatted verbose error messages', function(done) {
+      it('should print properly formatted error messages', function(done) {
         execFile('node', ['../../../bin/ember-template-lint.js', '.'], {
           cwd: './test/fixtures/with-errors'
         }, function(err, stdout, stderr) {
@@ -103,7 +103,7 @@ describe('ember-template-lint executable', function() {
         });
       });
 
-      it('should print properly formatted verbose error and warning messages', function(done) {
+      it('should print properly formatted error and warning messages', function(done) {
         execFile('node', ['../../../bin/ember-template-lint.js', '.'], {
           cwd: './test/fixtures/with-errors-and-warnings'
         }, function(err, stdout, stderr) {

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -102,6 +102,45 @@ describe('ember-template-lint executable', function() {
           done();
         });
       });
+
+      it('should print properly formatted verbose error and warning messages', function(done) {
+        execFile('node', ['../../../bin/ember-template-lint.js', '.'], {
+          cwd: './test/fixtures/with-errors-and-warnings'
+        }, function(err, stdout, stderr) {
+          expect(err).to.be.ok;
+          expect(stdout.split('\n')).to.deep.equal([
+            path.resolve('./test/fixtures/with-errors-and-warnings/app/templates/application.hbs'),
+            '  1:4  error  Non-translated string used  no-bare-strings',
+            '  2:5  error  Non-translated string used  no-bare-strings',
+            '  3:0  warning  HTML comment detected  no-html-comments',
+            '',
+            '✖ 3 problems (2 errors, 1 warnings)',
+            ''
+          ]);
+          expect(stderr).to.be.empty;
+          done();
+        });
+      });
+    });
+
+    describe('with --quiet param', function() {
+      it('should print properly formatted error messages, omitting any warnings', function(done) {
+        execFile('node', ['../../../bin/ember-template-lint.js', '.', '--quiet'], {
+          cwd: './test/fixtures/with-errors-and-warnings'
+        }, function(err, stdout, stderr) {
+          expect(err).to.be.ok;
+          expect(stdout.split('\n')).to.deep.equal([
+            path.resolve('./test/fixtures/with-errors-and-warnings/app/templates/application.hbs'),
+            '  1:4  error  Non-translated string used  no-bare-strings',
+            '  2:5  error  Non-translated string used  no-bare-strings',
+            '',
+            '✖ 2 problems (2 errors, 0 warnings)',
+            ''
+          ]);
+          expect(stderr).to.be.empty;
+          done();
+        });
+      });
     });
 
     describe('with --json param', function() {

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -141,6 +141,17 @@ describe('ember-template-lint executable', function() {
           done();
         });
       });
+
+      it('should exit without error and any console output', function(done) {
+        execFile('node', ['../../../bin/ember-template-lint.js', '.', '--quiet'], {
+          cwd: './test/fixtures/with-warnings'
+        }, function(err, stdout, stderr) {
+          expect(err).to.be.null;
+          expect(stdout).to.be.empty;
+          expect(stderr).to.be.empty;
+          done();
+        });
+      });
     });
 
     describe('with --json param', function() {


### PR DESCRIPTION
Resolves #428 

If you pass "--quiet" to the CLI, it will now remove warnings from the console output. 

I also updated the console output to show the number of warnings, like how eslint does:

Eg: ✖ 3 problems (2 errors, 1 warnings)

I understand this may not be desirable in this PR, as each PR should probably implement one feature, so feel free to tell me that. 

I'm also new to nodejs (but not javascript) and tests in general, so constructive feedback is welcome! 