### PR TITLE
update no-bare-strings docs to include aria-*

### DIFF
--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -19,5 +19,7 @@ This rule forbids the following:
 
 When the config value of `true` is used the following configuration is used:
  * `whitelist` - `(),.&+-=*/#%!?:[]{}`
- * `globalAttributes` - `title`
+ * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
  * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
+
+


### PR DESCRIPTION
In a previous commit [1], the following aria-* properties
were added to the default no-bare-strings rule:

- aria-label
- aria-placeholder
- aria-roledescription
- aria-valuetext

But the docs for that rule were not updated. This commit
updates the docs to include the additional aria-* properties.

[1]: 4a58a8a2ecc13fec3c42b6303aff4e0e2cf67394

Previous PR: #412