### PR TITLE
Fix issues with `{{false}}` in deprecation related rules.

### DIFF
--- a/lib/rules/deprecations/lint-deprecated-inline-view-helper.js
+++ b/lib/rules/deprecations/lint-deprecated-inline-view-helper.js
@@ -74,7 +74,7 @@ module.exports = class DeprecatedInlineViewHelper extends Rule {
         // this MustachStatement was already processed by ElementNode
         if (node._processedByInlineViewHelper === true) { return; }
 
-        if (node.path.parts[0] === 'view') {
+        if (node.path.type === 'PathExpression' && node.path.parts[0] === 'view') {
           if (node.params.length === 1) {
             this.processWithArgument(node);
           } else if (node.loc.start.line !== null) {

--- a/lib/rules/deprecations/lint-deprecated-render-helper.js
+++ b/lib/rules/deprecations/lint-deprecated-render-helper.js
@@ -22,7 +22,7 @@ module.exports = class DeprecatedRenderHelper extends Rule {
   visitor() {
     return {
       MustacheStatement(node) {
-        if (node.path.parts[0] === 'render') {
+        if (node.path.type === 'PathExpression' && node.path.parts[0] === 'render') {
           if (node.params.length === 1) {
             this.processWithOneArgument(node);
           } else if (node.params.length === 2) {

--- a/test/unit/recommended-config-test.js
+++ b/test/unit/recommended-config-test.js
@@ -40,4 +40,14 @@ describe('recommended config', function() {
 
   // This ensures that we don't face this issue again => https://github.com/rwjblue/ember-template-lint/issues/253
   ensureValid('<img alt="special thing" src={{some-dir/some-thing x}}>');
+
+  // This ensures that we don't face this issue again => https://github.com/rwjblue/ember-template-lint/issues/443
+  ensureValid(`
+<PowerSelect
+  @selected={{@pageSize}}
+  @options={{this.availablePageSizes}}
+  @searchEnabled={{false}}
+  @onchange={{action this.changePageSize}} as |size|>
+  {{size}}
+</PowerSelect>`);
 });

--- a/test/unit/rules/deprecations/lint-deprecated-inline-view-helper-test.js
+++ b/test/unit/rules/deprecations/lint-deprecated-inline-view-helper-test.js
@@ -14,7 +14,12 @@ generateRuleTests({
   good: [
     '{{great-fishsticks}}',
     '{{input placeholder=(t "email") value=email}}',
-    '{{title "CrossCheck Web" prepend=true separator=" | "}}'
+    '{{title "CrossCheck Web" prepend=true separator=" | "}}',
+    '{{false}}',
+    '{{"foo"}}',
+    '{{42}}',
+    '{{null}}',
+    '{{undefined}}',
   ],
 
   bad: [

--- a/test/unit/rules/deprecations/lint-deprecated-render-helper-test.js
+++ b/test/unit/rules/deprecations/lint-deprecated-render-helper-test.js
@@ -13,7 +13,12 @@ generateRuleTests({
     '{{valid-compoennt}}',
     '{{input placeholder=(t "email") value=email}}',
     '{{title "CrossCheck Web" prepent=true separator=" | "}}',
-    '{{hockey-player teamName="Boston Bruins"}}'
+    '{{hockey-player teamName="Boston Bruins"}}',
+    '{{false}}',
+    '{{"foo"}}',
+    '{{42}}',
+    '{{null}}',
+    '{{undefined}}',
   ],
 
   bad: [


### PR DESCRIPTION
These rules expected that all `MustacheStatement`s would have a `PathExpression` as their `node.path` and therefore called `node.path.parts[0]` directly.

Unfortunately, that is not a valid assumption to make as `node.path` on a `MustacheStatement` could be many other things as well (e.g. literals).

Fixes #443