### PR TITLE
Attribute indentation support for HTML

### DIFF
--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -118,4 +118,4 @@ Block form (HTML)
 #### Configuration:
   * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines.
   * object - { 'open-invocation-max-len': n characters } - Maximum length of the opening invocation.
-  * object - { 'parse-html-elements': `true` } - Also validate the indentation of HTML elements.
+  * object - { 'process-elements': `true` } - Also validate the indentation of HTML/SVG elements.

--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -116,6 +116,6 @@ Block form (HTML)
 ```
 
 #### Configuration:
-  * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines.
+  * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines. This will only enforce the rule for handlebar elements and not HTML/SVG elements.
   * object - { 'open-invocation-max-len': n characters } - Maximum length of the opening invocation.
   * object - { 'process-elements': `true` } - Also validate the indentation of HTML/SVG elements.

--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -18,6 +18,18 @@ Block form
   {{/employee-details}}
 ```
 
+Non-Block form (HTML)
+``` html
+
+  <input disabled id="firstName" value={{firstName}} class="input-field first-name" type="text">
+```
+
+Block form (HTML)
+``` html
+
+  <a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>
+```
+
 #### Allowed:
 
 Non-Block form
@@ -58,6 +70,18 @@ Non-Block form with Helper unfolded
   }}
 ```
 
+Non-Block form (HTML)
+``` html
+
+  <input
+    disabled
+    id="firstName"
+    value={{firstName}}
+    class="input-field first-name"
+    type="text"
+  >
+```
+
 Block form
 ``` hbs
 
@@ -79,6 +103,19 @@ Block form (open invocation < 80 characters)
   {{/employee-details}}
 ```
 
+Block form (HTML)
+``` html
+
+  <a
+    href="https://www.emberjs.com"
+    class="emberjs-home link"
+    rel="noopener"
+    target="_blank">
+    Ember JS
+  </a>
+```
+
 #### Configuration:
   * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines.
   * object - { 'open-invocation-max-len': n characters } - Maximum length of the opening invocation.
+  * object - { 'parse-html-elements': `true` } - Also validate the indentation of HTML elements.

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -426,7 +426,8 @@ module.exports = class AttributeSpacing extends Rule {
     let errorMessage = createErrorMessage(this.ruleName, [
       '  * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines',
       '  * { open-invocation-max-len: n characters, indentation: m  } - n : The max length of the opening invocation can be configured',
-      '  *                                                            - m : The desired indentation of attribute'
+      '  *                                                            - m : The desired indentation of attribute',
+      '  * { parse-html-elements: `boolean` }                         - `true` : Also parse HTML attributes'
     ], config);
 
     throw new Error(errorMessage);

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -414,7 +414,7 @@ module.exports = class AttributeSpacing extends Rule {
       if ('indentation' in config) {
         result.indentation = config.indentation;
       }
-      if ('parse-html-elements' in config) {
+      if ('process-elements' in config) {
         result.parseHtmlElements = true;
       }
       return result;
@@ -427,7 +427,7 @@ module.exports = class AttributeSpacing extends Rule {
       '  * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines',
       '  * { open-invocation-max-len: n characters, indentation: m  } - n : The max length of the opening invocation can be configured',
       '  *                                                            - m : The desired indentation of attribute',
-      '  * { parse-html-elements: `boolean` }                         - `true` : Also parse HTML attributes'
+      '  * { process-elements: `boolean` }                         - `true` : Also parse HTML/SVG attributes'
     ], config);
 
     throw new Error(errorMessage);

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -384,7 +384,8 @@ module.exports = class AttributeSpacing extends Rule {
       this.validateParams(node);
     }
     if (node.type === 'ElementNode') {
-      const expectedStartLine = node.children[node.children.length - 1].loc.end.line;
+      const lastChild = node.children[node.children.length - 1];
+      const expectedStartLine = lastChild.type === 'BlockStatement' ? lastChild.loc.end.line + 1 : lastChild.loc.end.line;
       this.validateClosingTag(node, expectedStartLine);
     } else if (node.program.blockParams && node.program.blockParams.length) {
       this.validateBlockParams(node);

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -416,7 +416,7 @@ module.exports = class AttributeSpacing extends Rule {
         result.indentation = config.indentation;
       }
       if ('process-elements' in config) {
-        result.parseHtmlElements = true;
+        result.processElements = config['process-elements'];
       }
       return result;
     }
@@ -425,7 +425,7 @@ module.exports = class AttributeSpacing extends Rule {
     }
 
     let errorMessage = createErrorMessage(this.ruleName, [
-      '  * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines',
+      '  * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines. This will only enforce the rule for handlebar elements and not HTML/SVG elements',
       '  * { open-invocation-max-len: n characters, indentation: m  } - n : The max length of the opening invocation can be configured',
       '  *                                                            - m : The desired indentation of attribute',
       '  * { process-elements: `boolean` }                         - `true` : Also parse HTML/SVG attributes'
@@ -449,7 +449,7 @@ module.exports = class AttributeSpacing extends Rule {
         return node.loc.end.line;
       },
       ElementNode(node) {
-        if (this.config.parseHtmlElements) {
+        if (this.config.processElements) {
           if (canApplyRule(node, node.type, this.config)) {
             if (node.children.length) {
               return this.validateBlockForm(node);

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -12,9 +12,7 @@ const canApplyRule = function(node, type, config) {
   let end;
   let start = node.loc.start;
 
-  if (type === 'NonBlockStatement') {
-    end = node.loc.end;
-  } else {
+  if (type === 'BlockStatement') {
     /*
       For a block statement, the start of the program block is the end of the open invocation.
 
@@ -24,6 +22,8 @@ const canApplyRule = function(node, type, config) {
     */
 
     end = node.program.loc.start;
+  } else {
+    end = node.loc.end;
   }
 
   if (start.line === end.line) {
@@ -438,19 +438,19 @@ module.exports = class AttributeSpacing extends Rule {
 
     return {
       BlockStatement(node) {
-        if (canApplyRule(node, 'BlockStatement', this.config)) {
+        if (canApplyRule(node, node.type, this.config)) {
           this.validateBlockForm(node);
         }
       },
       MustacheStatement(node) {
-        if (canApplyRule(node, 'NonBlockStatement', this.config)) {
+        if (canApplyRule(node, node.type, this.config)) {
           return this.validateNonBlockForm(node);
         }
         return node.loc.end.line;
       },
       ElementNode(node) {
         if (this.config.parseHtmlElements) {
-          if (canApplyRule(node, 'NonBlockStatement', this.config)) {
+          if (canApplyRule(node, node.type, this.config)) {
             if (node.children.length) {
               return this.validateBlockForm(node);
             } else {

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -240,6 +240,9 @@ module.exports = class AttributeSpacing extends Rule {
           node.params[0].loc.start.column--;
         }
       }
+    } else if (type === 'htmlAttribute') {
+      paramType = 'htmlAttribute';
+      namePath = 'name';
     } else {
       paramType = 'attribute';
       namePath = 'key';
@@ -285,8 +288,12 @@ module.exports = class AttributeSpacing extends Rule {
     let expectedColumnStart = node.loc.start.column + this.config.indentation; //params should be after proper positions from component start node
     let expectedLineStart = node.loc.start.line + 1;
 
-    expectedLineStart = this.iterateParams(node.params, 'positional', expectedLineStart, expectedColumnStart, node);
-    expectedLineStart = this.iterateParams(node.hash.pairs, 'attribute', expectedLineStart, expectedColumnStart, node);
+    if (node.type === 'ElementNode') {
+      expectedLineStart = this.iterateParams(node.attributes, 'htmlAttribute', expectedLineStart, expectedColumnStart, node);
+    } else {
+      expectedLineStart = this.iterateParams(node.params, 'positional', expectedLineStart, expectedColumnStart, node);
+      expectedLineStart = this.iterateParams(node.hash.pairs, 'attribute', expectedLineStart, expectedColumnStart, node);
+    }
 
     return expectedLineStart;
   }
@@ -295,9 +302,10 @@ module.exports = class AttributeSpacing extends Rule {
     /*
       Validates the close brace (`}}`) of the non-block form.
     */
+    const actualColumnStartLocation = node.type === 'ElementNode' ? 1 : 2;
     const actualStartLocation = {
       line: node.loc.end.line,
-      column: node.loc.end.column - 2
+      column: node.loc.end.column - actualColumnStartLocation
     };
 
     const expectedStartLocation = {
@@ -305,7 +313,7 @@ module.exports = class AttributeSpacing extends Rule {
       column: node.loc.start.column
     };
 
-    let componentName = node.path.original;
+    let componentName = node.type === 'ElementNode' ? node.tag : node.path.original;
     if (actualStartLocation.line !== expectedStartLocation.line ||
       actualStartLocation.column !== expectedStartLocation.column) {
       let message = `Incorrect indentation of close curly braces '}}' for the component '{{${componentName}}}' beginning at L${actualStartLocation.line}:C${actualStartLocation.column}. Expected '{{${componentName}}}' to be at L${expectedStartLocation.line}:C${expectedStartLocation.column}.`;
@@ -321,10 +329,17 @@ module.exports = class AttributeSpacing extends Rule {
   }
 
   validateNonBlockForm(node) {
-    // no need to validate if no positional and named params are present.
-    if (node.params.length || node.hash.pairs.length) {
-      const expectedStartLine = this.validateParamsAndHashPairs(node);
-      this.validateCloseBrace(node, expectedStartLine);
+    if (node.type === 'ElementNode') {
+      if (node.attributes.length) {
+        const expectedStartLine = this.validateParamsAndHashPairs(node);
+        this.validateCloseBrace(node, expectedStartLine);
+      }
+    } else {
+      // no need to validate if no positional and named params are present.
+      if (node.params.length || node.hash.pairs.length) {
+        const expectedStartLine = this.validateParamsAndHashPairs(node);
+        this.validateCloseBrace(node, expectedStartLine);
+      }
     }
   }
 
@@ -360,6 +375,9 @@ module.exports = class AttributeSpacing extends Rule {
       if ('indentation' in config) {
         result.indentation = config.indentation;
       }
+      if ('parse-html-elements' in config) {
+        result.parseHtmlElements = true;
+      }
       return result;
     }
     case 'undefined':
@@ -388,7 +406,14 @@ module.exports = class AttributeSpacing extends Rule {
         if (canApplyRule(node, 'MustacheStatement', this.config)) {
           this.validateNonBlockForm(node);
         }
+      },
+
+      ElementNode(node) {
+        if (this.config.parseHtmlElements && canApplyRule(node, 'MustacheStatement', this.config)) {
+          this.validateNonBlockForm(node);
+        }
       }
+
     };
   }
 };

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -301,9 +301,9 @@ module.exports = class AttributeSpacing extends Rule {
 
   validateCloseBrace(node, expectedStartLine) {
     /*
-      Validates the close brace `}}` for Handlebars and `>` for HTML elements of the non-block form.
+      Validates the close brace `}}` for Handlebars and `>` for HTML/SVG elements of the non-block form.
     */
-    const actualColumnStartLocation = node.type === 'ElementNode' ? 1 : 2;
+    const actualColumnStartLocation = node.type === 'ElementNode' && !node.selfClosing ? 1 : 2;
     const actualStartLocation = {
       line: node.loc.end.line,
       column: node.loc.end.column - actualColumnStartLocation

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -319,7 +319,7 @@ module.exports = class AttributeSpacing extends Rule {
       actualStartLocation.column !== expectedStartLocation.column) {
       let message = `Incorrect indentation of close curly braces '}}' for the component '{{${componentName}}}' beginning at L${actualStartLocation.line}:C${actualStartLocation.column}. Expected '{{${componentName}}}' to be at L${expectedStartLocation.line}:C${expectedStartLocation.column}.`;
       if (node.type === 'ElementNode') {
-        message = `Incorrect indentation of close tag '>' for the element '<${componentName}>' beginning at L${actualStartLocation.line}:C${actualStartLocation.column}. Expected '<${componentName}>' to be at L${expectedStartLocation.line}:C${expectedStartLocation.column}.`;
+        message = `Incorrect indentation of close bracket '>' for the element '<${componentName}>' beginning at L${actualStartLocation.line}:C${actualStartLocation.column}. Expected '<${componentName}>' to be at L${expectedStartLocation.line}:C${expectedStartLocation.column}.`;
       }
 
       this.log({

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -12,7 +12,7 @@ const canApplyRule = function(node, type, config) {
   let end;
   let start = node.loc.start;
 
-  if (type === 'MustacheStatement') {
+  if (type === 'NonBlockStatement') {
     end = node.loc.end;
   } else {
     /*
@@ -196,7 +196,6 @@ module.exports = class AttributeSpacing extends Rule {
     };
   }
 
-
   validateBlockParams(node) {
     /*
       Validates alignment of the block params.
@@ -268,6 +267,8 @@ module.exports = class AttributeSpacing extends Rule {
         if (param.loc.start.line !== param.loc.end.line) {
           expectedLineStart = param.loc.end.line;
         }
+      } else if (type === 'MustacheStatement') {
+        expectedLineStart = param.value.loc.end.line;
       }
 
       expectedLineStart++;
@@ -275,7 +276,7 @@ module.exports = class AttributeSpacing extends Rule {
     return expectedLineStart;
   }
 
-  validateParamsAndHashPairs (node) {
+  validateParams (node) {
     /*
         Validates both the positional and named params for both block and non-block form.
 
@@ -300,7 +301,7 @@ module.exports = class AttributeSpacing extends Rule {
 
   validateCloseBrace(node, expectedStartLine) {
     /*
-      Validates the close brace (`}}`) of the non-block form.
+      Validates the close brace `}}` for Handlebars and `>` for HTML elements of the non-block form.
     */
     const actualColumnStartLocation = node.type === 'ElementNode' ? 1 : 2;
     const actualStartLocation = {
@@ -317,6 +318,39 @@ module.exports = class AttributeSpacing extends Rule {
     if (actualStartLocation.line !== expectedStartLocation.line ||
       actualStartLocation.column !== expectedStartLocation.column) {
       let message = `Incorrect indentation of close curly braces '}}' for the component '{{${componentName}}}' beginning at L${actualStartLocation.line}:C${actualStartLocation.column}. Expected '{{${componentName}}}' to be at L${expectedStartLocation.line}:C${expectedStartLocation.column}.`;
+      if (node.type === 'ElementNode') {
+        message = `Incorrect indentation of close tag '>' for the element '<${componentName}>' beginning at L${actualStartLocation.line}:C${actualStartLocation.column}. Expected '<${componentName}>' to be at L${expectedStartLocation.line}:C${expectedStartLocation.column}.`;
+      }
+
+      this.log({
+        message,
+        line: actualStartLocation.line,
+        column: actualStartLocation.column,
+        source: this.sourceForNode(node)
+      });
+    }
+
+  }
+
+  validateClosingTag(node, expectedStartLine) {
+    /*
+      Validates the closing tag (`</tag>`) of the block form.
+    */
+    const actualColumnStartLocation = 3 + node.tag.length;
+    const actualStartLocation = {
+      line: node.loc.end.line,
+      column: node.loc.end.column - actualColumnStartLocation
+    };
+
+    const expectedStartLocation = {
+      line: expectedStartLine,
+      column: node.loc.start.column
+    };
+
+    let tagName = node.type === 'ElementNode' ? node.tag : node.path.original;
+    if (actualStartLocation.line !== expectedStartLocation.line ||
+      actualStartLocation.column !== expectedStartLocation.column) {
+      let message = `Incorrect indentation of close tag '</${tagName}>' for element '<${tagName}>' beginning at L${actualStartLocation.line}:C${actualStartLocation.column}. Expected '</${tagName}>' to be at L${expectedStartLocation.line}:C${expectedStartLocation.column}.`;
 
       this.log({
         message,
@@ -331,23 +365,28 @@ module.exports = class AttributeSpacing extends Rule {
   validateNonBlockForm(node) {
     if (node.type === 'ElementNode') {
       if (node.attributes.length) {
-        const expectedStartLine = this.validateParamsAndHashPairs(node);
+        const expectedStartLine = this.validateParams(node);
         this.validateCloseBrace(node, expectedStartLine);
+        return expectedStartLine;
       }
     } else {
       // no need to validate if no positional and named params are present.
       if (node.params.length || node.hash.pairs.length) {
-        const expectedStartLine = this.validateParamsAndHashPairs(node);
+        const expectedStartLine = this.validateParams(node);
         this.validateCloseBrace(node, expectedStartLine);
+        return expectedStartLine;
       }
     }
   }
 
   validateBlockForm(node) {
-    if (node.params.length || node.hash.pairs.length) {
-      this.validateParamsAndHashPairs(node);
+    if ((node.type === 'ElementNode' && node.attributes.length) || node.params.length || node.hash.pairs.length) {
+      this.validateParams(node);
     }
-    if (node.program.blockParams && node.program.blockParams.length) {
+    if (node.type === 'ElementNode') {
+      const expectedStartLine = node.children[node.children.length - 1].loc.end.line;
+      this.validateClosingTag(node, expectedStartLine);
+    } else if (node.program.blockParams && node.program.blockParams.length) {
       this.validateBlockParams(node);
     }
   }
@@ -401,19 +440,24 @@ module.exports = class AttributeSpacing extends Rule {
           this.validateBlockForm(node);
         }
       },
-
       MustacheStatement(node) {
-        if (canApplyRule(node, 'MustacheStatement', this.config)) {
-          this.validateNonBlockForm(node);
+        if (canApplyRule(node, 'NonBlockStatement', this.config)) {
+          return this.validateNonBlockForm(node);
         }
+        return node.loc.end.line;
       },
-
       ElementNode(node) {
-        if (this.config.parseHtmlElements && canApplyRule(node, 'MustacheStatement', this.config)) {
-          this.validateNonBlockForm(node);
+        if (this.config.parseHtmlElements) {
+          if (canApplyRule(node, 'NonBlockStatement', this.config)) {
+            if (node.children.length) {
+              return this.validateBlockForm(node);
+            } else {
+              return this.validateNonBlockForm(node);
+            }
+          }
+          return node.loc.end.line;
         }
       }
-
     };
   }
 };

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -8,6 +8,18 @@ generateRuleTests({
   config: true,
 
   good: [
+    //Angle Bracket Invocation
+    {
+      config: {
+        'process-elements': true
+      },
+      template: '<SiteHeader' + '\n' +
+      '  @selected={{this.user.country}} as |Option|>' + '\n' +
+      '{{#each this.availableCountries as |country|}}'  + '\n' +
+      '<Option @value={{country}}>{{country.name}}</Option>' + '\n' +
+      '{{/each}}' + '\n' +
+      '</SiteHeader>',
+    },
     //Non Block form one line
     '<input disabled>',
     //Non Block with wrong indentation, configuration off
@@ -31,7 +43,23 @@ generateRuleTests({
       template: '<a' + '\n' +
       '  disabled' + '\n' +
       '>' + '\n' +
-      '<span>spam me</span>' + '\n' +
+      '<span' + '\n' +
+      '  class="abc"' + '\n' +
+      '>spam me' + '\n' +
+      '</span>' + '\n' +
+      '</a>',
+    },
+    {
+      config: {
+        'process-elements': true
+      },
+      template: '<a' + '\n' +
+      '  disabled' + '\n' +
+      '>' + '\n' +
+      '{{#each' + '\n' +
+      '  class="abc"' + '\n' +
+      '}}spam me' + '\n' +
+      '{{/each}}' + '\n' +
       '</a>',
     },
     {
@@ -457,6 +485,26 @@ generateRuleTests({
       'message': 'Incorrect indentation of close curly braces \'}}\' for the component \'{{contact-details}}\' beginning at L1:C55. Expected \'{{contact-details}}\' to be at L4:C0.',
       'moduleId': 'layout.hbs',
       'source': '{{contact-details firstName=firstName lastName=lastName}}'
+    }]
+  },{
+    config: {
+      'process-elements': true
+    },
+    template: '<a' + '\n' +
+    '  disabled' + '\n' +
+    '>' + '\n' +
+    '{{#each' + '\n' +
+    '  class="abc"' + '\n' +
+    '}}spam me' + '\n' +
+    '{{/each}}</a>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close tag '</a>' for element '<a>' beginning at L7:C9. Expected '</a>' to be at L8:C0.`,
+      'line': 7,
+      'column': 9,
+      'source': '<a\n  disabled\n>\n{{#each\n  class="abc"\n}}spam me\n{{/each}}</a>'
     }]
   },{
     //Block form with multiple lines

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -309,7 +309,7 @@ generateRuleTests({
       'rule': 'attribute-indentation',
       'severity': 2,
       'moduleId': 'layout.hbs',
-      'message': `Incorrect indentation of close tag '>' for the element '<input>' beginning at L2:C0. Expected '<input>' to be at L3:C0.`,
+      'message': `Incorrect indentation of close bracket '>' for the element '<input>' beginning at L2:C0. Expected '<input>' to be at L3:C0.`,
       'line': 2,
       'column': 0,
       'source': '<input disabled\n>'
@@ -332,7 +332,7 @@ generateRuleTests({
       'rule': 'attribute-indentation',
       'severity': 2,
       'moduleId': 'layout.hbs',
-      'message': `Incorrect indentation of close tag '>' for the element '<div>' beginning at L2:C0. Expected '<div>' to be at L3:C0.`,
+      'message': `Incorrect indentation of close bracket '>' for the element '<div>' beginning at L2:C0. Expected '<div>' to be at L3:C0.`,
       'line': 2,
       'column': 0,
       'source': '<div disabled\n/>'
@@ -387,7 +387,7 @@ generateRuleTests({
       'rule': 'attribute-indentation',
       'severity': 2,
       'moduleId': 'layout.hbs',
-      'message': `Incorrect indentation of close tag '>' for the element '<input>' beginning at L1:C86. Expected '<input>' to be at L7:C0.`,
+      'message': `Incorrect indentation of close bracket '>' for the element '<input>' beginning at L1:C86. Expected '<input>' to be at L7:C0.`,
       'line': 1,
       'column': 86,
       'source': '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">'

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -349,6 +349,52 @@ generateRuleTests({
       'source': '<a\n  disabled={{if\n             true\n             (action "mostPowerfulAction" value=target.value)\n             (action "lessPowerfulAction" value=target.value)\n           }}\n>{{contact-details\n   firstName\n   lastName\n }}</a>'
     }]
   }, {
+    config: {
+      'parse-html-elements': true
+    },
+    template: '<a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'href' beginning at L1:C3. Expected 'href' to be at L2:C2.`,
+      'line': 1,
+      'column': 3,
+      'source': '<a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'class' beginning at L1:C34. Expected 'class' to be at L3:C2.`,
+      'line': 1,
+      'column': 34,
+      'source': '<a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'rel' beginning at L1:C60. Expected 'rel' to be at L4:C2.`,
+      'line': 1,
+      'column': 60,
+      'source': '<a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'target' beginning at L1:C75. Expected 'target' to be at L5:C2.`,
+      'line': 1,
+      'column': 75,
+      'source': '<a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close tag '</a>' for element '<a>' beginning at L1:C99. Expected '</a>' to be at L1:C0.`,
+      'line': 1,
+      'column': 99,
+      'source': '<a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>'
+    }],
+  }, {
     //Non-Block form more than 30 characters
     config: {
       'open-invocation-max-len': 30

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -75,6 +75,22 @@ generateRuleTests({
       ' }}{{foo}}{{/contact-details}}' + '\n' +
       '</a>'
     },
+    // Self closing single line
+    {
+      config: {
+        'process-elements': true
+      },
+      template: '<div disabled />'
+    },
+    // Self closing multi line
+    {
+      config: {
+        'process-elements': true
+      },
+      template: '<div' + '\n' +
+      '  disabled' + '\n' +
+      '/>'
+    },
     //Non Block form multi line
     {
       config: {
@@ -269,6 +285,29 @@ generateRuleTests({
       'line': 2,
       'column': 0,
       'source': '<input disabled\n>'
+    }]
+  },{
+    //Self closing element
+    config: {
+      'process-elements': true
+    },
+    template: '<div disabled' + '\n' + '/>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'disabled' beginning at L1:C5. Expected 'disabled' to be at L2:C2.`,
+      'line': 1,
+      'column': 5,
+      'source': '<div disabled\n/>'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close tag '>' for the element '<div>' beginning at L2:C0. Expected '<div>' to be at L3:C0.`,
+      'line': 2,
+      'column': 0,
+      'source': '<div disabled\n/>'
     }]
   },{
     // Too long for 80 characters line

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -17,7 +17,7 @@ generateRuleTests({
     //Block form multi line
     {
       config: {
-        'parse-html-elements': true
+        'process-elements': true
       },
       template: '<a' + '\n' +
       '  disabled' + '\n' +
@@ -26,7 +26,7 @@ generateRuleTests({
     },
     {
       config: {
-        'parse-html-elements': true
+        'process-elements': true
       },
       template: '<a' + '\n' +
       '  disabled' + '\n' +
@@ -36,7 +36,7 @@ generateRuleTests({
     },
     {
       config: {
-        'parse-html-elements': true
+        'process-elements': true
       },
       template: '<a' + '\n' +
       '  disabled' + '\n' +
@@ -45,7 +45,7 @@ generateRuleTests({
     },
     {
       config: {
-        'parse-html-elements': true
+        'process-elements': true
       },
       template: '<a' + '\n' +
       '  disabled={{if'  + '\n' +
@@ -61,7 +61,7 @@ generateRuleTests({
     },
     {
       config: {
-        'parse-html-elements': true
+        'process-elements': true
       },
       template: '<a' + '\n' +
       '  disabled={{if'  + '\n' +
@@ -78,7 +78,7 @@ generateRuleTests({
     //Non Block form multi line
     {
       config: {
-        'parse-html-elements': true
+        'process-elements': true
       },
       template: '<input' + '\n' +
       '  disabled' + '\n' +
@@ -86,14 +86,14 @@ generateRuleTests({
     },
     {
       config: {
-        'parse-html-elements': true
+        'process-elements': true
       },
       template: '<input disabled>'
     },
     //Non Block form multi line
     {
       config: {
-        'parse-html-elements': true
+        'process-elements': true
       },
       template: '<input' + '\n' +
       '  disabled={{action "mostPowerfulAction" value=target.value}}' + '\n' +
@@ -102,7 +102,7 @@ generateRuleTests({
     //Non Block form multi line
     {
       config: {
-        'parse-html-elements': true
+        'process-elements': true
       },
       template: '<input' + '\n' +
       '  disabled={{if'  + '\n' +
@@ -250,7 +250,7 @@ generateRuleTests({
   bad: [{
     //Non Block HTML element
     config: {
-      'parse-html-elements': true
+      'process-elements': true
     },
     template: '<input disabled' + '\n' + '>',
     results: [{
@@ -273,7 +273,7 @@ generateRuleTests({
   },{
     // Too long for 80 characters line
     config: {
-      'parse-html-elements': true
+      'process-elements': true
     },
     template: '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">',
     results: [{
@@ -327,7 +327,7 @@ generateRuleTests({
     }]
   }, {
     config: {
-      'parse-html-elements': true
+      'process-elements': true
     },
     template: '<a' + '\n' +
     '  disabled={{if'  + '\n' +
@@ -350,7 +350,7 @@ generateRuleTests({
     }]
   }, {
     config: {
-      'parse-html-elements': true
+      'process-elements': true
     },
     template: '<a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>',
     results: [{

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -14,6 +14,67 @@ generateRuleTests({
     '<input' + '\n' +
     'disabled' + '\n' +
     '>',
+    //Block form multi line
+    {
+      config: {
+        'parse-html-elements': true
+      },
+      template: '<a' + '\n' +
+      '  disabled' + '\n' +
+      '>abc'  + '\n' +
+      '</a>',
+    },
+    {
+      config: {
+        'parse-html-elements': true
+      },
+      template: '<a' + '\n' +
+      '  disabled' + '\n' +
+      '>' + '\n' +
+      '<span>spam me</span>' + '\n' +
+      '</a>',
+    },
+    {
+      config: {
+        'parse-html-elements': true
+      },
+      template: '<a' + '\n' +
+      '  disabled' + '\n' +
+      '>{{contact-details firstName lastName}}'  + '\n' +
+      '</a>',
+    },
+    {
+      config: {
+        'parse-html-elements': true
+      },
+      template: '<a' + '\n' +
+      '  disabled={{if'  + '\n' +
+      '             true'  + '\n' +
+      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '             (action "lessPowerfulAction" value=target.value)' + '\n' +
+      '           }}' + '\n' +
+      '>{{contact-details' + '\n' +
+      '   firstName' + '\n' +
+      '   lastName' + '\n' +
+      ' }}' + '\n' +
+      '</a>'
+    },
+    {
+      config: {
+        'parse-html-elements': true
+      },
+      template: '<a' + '\n' +
+      '  disabled={{if'  + '\n' +
+      '             true'  + '\n' +
+      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '             (action "lessPowerfulAction" value=target.value)' + '\n' +
+      '           }}' + '\n' +
+      '>{{#contact-details' + '\n' +
+      '   firstName' + '\n' +
+      '   lastName' + '\n' +
+      ' }}{{foo}}{{/contact-details}}' + '\n' +
+      '</a>'
+    },
     //Non Block form multi line
     {
       config: {
@@ -21,6 +82,34 @@ generateRuleTests({
       },
       template: '<input' + '\n' +
       '  disabled' + '\n' +
+      '>',
+    },
+    {
+      config: {
+        'parse-html-elements': true
+      },
+      template: '<input disabled>'
+    },
+    //Non Block form multi line
+    {
+      config: {
+        'parse-html-elements': true
+      },
+      template: '<input' + '\n' +
+      '  disabled={{action "mostPowerfulAction" value=target.value}}' + '\n' +
+      '>',
+    },
+    //Non Block form multi line
+    {
+      config: {
+        'parse-html-elements': true
+      },
+      template: '<input' + '\n' +
+      '  disabled={{if'  + '\n' +
+      '             true' + '\n' +
+      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '             (action "lessPowerfulAction" value=target.value)' + '\n' +
+      '           }}' + '\n' +
       '>',
     },
     //Non Block form with no params
@@ -159,6 +248,107 @@ generateRuleTests({
   ],
 
   bad: [{
+    //Non Block HTML element
+    config: {
+      'parse-html-elements': true
+    },
+    template: '<input disabled' + '\n' + '>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'disabled' beginning at L1:C7. Expected 'disabled' to be at L2:C2.`,
+      'line': 1,
+      'column': 7,
+      'source': '<input disabled\n>'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close tag '>' for the element '<input>' beginning at L2:C0. Expected '<input>' to be at L3:C0.`,
+      'line': 2,
+      'column': 0,
+      'source': '<input disabled\n>'
+    }]
+  },{
+    // Too long for 80 characters line
+    config: {
+      'parse-html-elements': true
+    },
+    template: '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'disabled' beginning at L1:C7. Expected 'disabled' to be at L2:C2.`,
+      'line': 1,
+      'column': 7,
+      'source': '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'type' beginning at L1:C17. Expected 'type' to be at L3:C2.`,
+      'line': 1,
+      'column': 17,
+      'source': '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'value' beginning at L1:C28. Expected 'value' to be at L4:C2.`,
+      'line': 1,
+      'column': 28,
+      'source': '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'class' beginning at L1:C40. Expected 'class' to be at L5:C2.`,
+      'line': 1,
+      'column': 40,
+      'source': '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of htmlAttribute 'id' beginning at L1:C72. Expected 'id' to be at L6:C2.`,
+      'line': 1,
+      'column': 72,
+      'source': '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">'
+    }, {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close tag '>' for the element '<input>' beginning at L1:C86. Expected '<input>' to be at L7:C0.`,
+      'line': 1,
+      'column': 86,
+      'source': '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">'
+    }]
+  }, {
+    config: {
+      'parse-html-elements': true
+    },
+    template: '<a' + '\n' +
+    '  disabled={{if'  + '\n' +
+    '             true'  + '\n' +
+    '             (action "mostPowerfulAction" value=target.value)' + '\n' +
+    '             (action "lessPowerfulAction" value=target.value)' + '\n' +
+    '           }}' + '\n' +
+    '>{{contact-details' + '\n' +
+    '   firstName' + '\n' +
+    '   lastName' + '\n' +
+    ' }}</a>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close tag '</a>' for element '<a>' beginning at L10:C3. Expected '</a>' to be at L10:C0.`,
+      'line': 10,
+      'column': 3,
+      'source': '<a\n  disabled={{if\n             true\n             (action "mostPowerfulAction" value=target.value)\n             (action "lessPowerfulAction" value=target.value)\n           }}\n>{{contact-details\n   firstName\n   lastName\n }}</a>'
+    }]
+  }, {
     //Non-Block form more than 30 characters
     config: {
       'open-invocation-max-len': 30

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -8,6 +8,21 @@ generateRuleTests({
   config: true,
 
   good: [
+    //Non Block form one line
+    '<input disabled>',
+    //Non Block with wrong indentation, configuration off
+    '<input' + '\n' +
+    'disabled' + '\n' +
+    '>',
+    //Non Block form multi line
+    {
+      config: {
+        'parse-html-elements': true
+      },
+      template: '<input' + '\n' +
+      '  disabled' + '\n' +
+      '>',
+    },
     //Non Block form with no params
     '{{contact-details}}',
     //Default config with open-invocation(< 80 chars)

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -26,6 +26,15 @@ generateRuleTests({
     '<input' + '\n' +
     'disabled' + '\n' +
     '>',
+    //Non Block with wrong indentation, configuration explicitly off
+    {
+      config: {
+        'process-elements': false
+      },
+      template: '<input' + '\n' +
+    'disabled' + '\n' +
+    '>',
+    },
     //Block form multi line
     {
       config: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,38 +3,38 @@
 
 
 "@glimmer/compiler@^0.35.5":
-  version "0.35.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.35.5.tgz#54adb45efafd9b1e174c37c27c46f5cc5e91dc53"
+  version "0.35.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.35.7.tgz#8bc9dc86746fecfbde49e34b0f6ef48557b08f9f"
   dependencies:
-    "@glimmer/interfaces" "^0.35.5"
-    "@glimmer/syntax" "^0.35.5"
-    "@glimmer/util" "^0.35.5"
-    "@glimmer/wire-format" "^0.35.5"
+    "@glimmer/interfaces" "^0.35.7"
+    "@glimmer/syntax" "^0.35.7"
+    "@glimmer/util" "^0.35.7"
+    "@glimmer/wire-format" "^0.35.7"
 
-"@glimmer/interfaces@^0.35.5":
-  version "0.35.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.35.5.tgz#096f5656efaa7aeee0f4e58904e272ea7bed677a"
+"@glimmer/interfaces@^0.35.7":
+  version "0.35.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.35.7.tgz#8430229467f98e4a35d9514fe1dd809558b3b0ab"
   dependencies:
-    "@glimmer/wire-format" "^0.35.5"
+    "@glimmer/wire-format" "^0.35.7"
 
-"@glimmer/syntax@^0.35.5":
-  version "0.35.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.35.5.tgz#66fb4179b63c2f46528f008ceeb177a3c2d2501f"
+"@glimmer/syntax@^0.35.7":
+  version "0.35.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.35.7.tgz#5980ecbcda7b731b970100539518670d84a482d9"
   dependencies:
-    "@glimmer/interfaces" "^0.35.5"
-    "@glimmer/util" "^0.35.5"
+    "@glimmer/interfaces" "^0.35.7"
+    "@glimmer/util" "^0.35.7"
     handlebars "^4.0.6"
     simple-html-tokenizer "^0.5.5"
 
-"@glimmer/util@^0.35.5":
-  version "0.35.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.35.5.tgz#7518078aa5f43d17e1efc138a2d81c67c6ebbc35"
+"@glimmer/util@^0.35.7":
+  version "0.35.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.35.7.tgz#c6dcda4c03690d511bae17658b4e32c8ae222b39"
 
-"@glimmer/wire-format@^0.35.5":
-  version "0.35.5"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.35.5.tgz#2d17e1e8fb69a2a3f2996685e724844900ab6f9e"
+"@glimmer/wire-format@^0.35.7":
+  version "0.35.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.35.7.tgz#5d287467c4adfe71505faeba6d85b05638c54f71"
   dependencies:
-    "@glimmer/util" "^0.35.5"
+    "@glimmer/util" "^0.35.7"
 
 accepts@~1.3.3:
   version "1.3.3"


### PR DESCRIPTION
Implements: https://github.com/ember-template-lint/ember-template-lint/issues/446.

HTML attributes parsing can by activated setting `process-elements` to `true`.