### PR TITLE
Validate close brace location

### DIFF
--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -119,3 +119,5 @@ Block form (HTML)
   * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines.
   * object - { 'open-invocation-max-len': n characters } - Maximum length of the opening invocation.
   * object - { 'process-elements': `true` } - Also validate the indentation of HTML/SVG elements.
+  * object - { 'end-element-open': `new-line`|`last-attribute` } - Enforce the position of the closing brace `>` to be on a new line or next to the last attribute (defaults to `new-line`).
+  * object - { 'mustache-open-end': `new-line`|`last-attribute` } - Enforce the position of the closing braces `}}` to be on a new line or next to the last attribute (defaults to `new-line`).

--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -119,5 +119,5 @@ Block form (HTML)
   * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines.
   * object - { 'open-invocation-max-len': n characters } - Maximum length of the opening invocation.
   * object - { 'process-elements': `true` } - Also validate the indentation of HTML/SVG elements.
-  * object - { 'end-element-open': `new-line`|`last-attribute` } - Enforce the position of the closing brace `>` to be on a new line or next to the last attribute (defaults to `new-line`).
+  * object - { 'element-open-end': `new-line`|`last-attribute` } - Enforce the position of the closing brace `>` to be on a new line or next to the last attribute (defaults to `new-line`).
   * object - { 'mustache-open-end': `new-line`|`last-attribute` } - Enforce the position of the closing braces `}}` to be on a new line or next to the last attribute (defaults to `new-line`).

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -465,7 +465,9 @@ module.exports = class AttributeSpacing extends Rule {
       '  * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines.',
       '  * { open-invocation-max-len: n characters, indentation: m  } - n : The max length of the opening invocation can be configured',
       '  *                                                            - m : The desired indentation of attribute',
-      '  * { process-elements: `boolean` }                         - `true` : Also parse HTML/SVG attributes'
+      '  * { process-elements: `boolean` } - `true` : Also parse HTML/SVG attributes',
+      '  * { end-element-open: `new-line`|`last-attribute` } - Enforce the position of the closing brace `>` to be on a new line or next to the last attribute (defaults to `new-line`)',
+      '  * { mustache-open-end: `new-line`|`last-attribute` } - Enforce the position of the closing braces `}}` to be on a new line or next to the last attribute (defaults to `new-line`)'
     ], config);
 
     throw new Error(errorMessage);

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -434,7 +434,7 @@ module.exports = class AttributeSpacing extends Rule {
         result.blocklessMustacheEnd = config['blockless-mustache-end'];
       }
       if ('elements-end' in config) {
-        // if elements-end is set, assument process-elements=true
+        // if elements-end is set, assume process-elements=true
         result.processElements = true;
         result.elementsEnd = config['elements-end'];
       }

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -237,12 +237,6 @@ module.exports = class AttributeSpacing extends Rule {
     if (type === 'positional') {
       paramType = 'positional param';
       namePath = 'original';
-      if (node.path.loc.source === '(synthetic)') {
-        expectedLineStart--;
-        if (node.type === 'BlockStatement') {
-          node.params[0].loc.start.column--;
-        }
-      }
     } else if (type === 'htmlAttribute') {
       paramType = 'htmlAttribute';
       namePath = 'name';
@@ -251,8 +245,10 @@ module.exports = class AttributeSpacing extends Rule {
       namePath = 'key';
     }
 
+    let nextColumn = expectedColumnStart;
     params.forEach((param) => {
       let actualStartLocation = param.loc.start;
+      nextColumn = param.loc.end.column;
       if (expectedLineStart !== actualStartLocation.line ||
         expectedColumnStart !== actualStartLocation.column) {
         let paramName = param[namePath] ? param[namePath] : param.path.original;
@@ -273,11 +269,16 @@ module.exports = class AttributeSpacing extends Rule {
         }
       } else if (type === 'MustacheStatement') {
         expectedLineStart = param.value.loc.end.line;
+        nextColumn = param.value.loc.end.column;
       }
 
       expectedLineStart++;
     });
-    return expectedLineStart;
+
+    return {
+      nextLine: expectedLineStart,
+      nextColumn,
+    };
   }
 
   validateParams (node) {
@@ -293,17 +294,33 @@ module.exports = class AttributeSpacing extends Rule {
     let expectedColumnStart = node.loc.start.column + this.config.indentation; //params should be after proper positions from component start node
     let expectedLineStart = node.loc.start.line + 1;
 
+    let nextLocation = {
+      nextLine: expectedLineStart,
+      nextColumn: node.loc.start.column,
+    };
     if (node.type === 'ElementNode') {
-      expectedLineStart = this.iterateParams(node.attributes, 'htmlAttribute', expectedLineStart, expectedColumnStart, node);
+      nextLocation = this.iterateParams(node.attributes, 'htmlAttribute', expectedLineStart, expectedColumnStart, node);
     } else {
-      expectedLineStart = this.iterateParams(node.params, 'positional', expectedLineStart, expectedColumnStart, node);
-      expectedLineStart = this.iterateParams(node.hash.pairs, 'attribute', expectedLineStart, expectedColumnStart, node);
+      if (node.params) {
+        if (node.path.loc.source === '(synthetic)') {
+          expectedLineStart--;
+          if (node.type === 'BlockStatement') {
+            node.params[0].loc.start.column--;
+          }
+        }
+      }
+      if (node.params.length > 0) {
+        nextLocation = this.iterateParams(node.params, 'positional', expectedLineStart, expectedColumnStart, node);
+      }
+      if (node.hash.pairs.length > 0) {
+        nextLocation = this.iterateParams(node.hash.pairs, 'attribute', nextLocation.nextLine, expectedColumnStart, node);
+      }
     }
 
-    return expectedLineStart;
+    return nextLocation;
   }
 
-  validateCloseBrace(node, expectedStartLine) {
+  validateCloseBrace(node, nextLocation) {
     /*
       Validates the close brace `}}` for Handlebars and `>` for HTML/SVG elements of the non-block form.
     */
@@ -314,9 +331,10 @@ module.exports = class AttributeSpacing extends Rule {
       column: end.column - actualColumnStartLocation
     };
 
+    const endPosition = node.type === 'ElementNode' ? this.config.elementsEnd : this.config.blocklessMustacheEnd;
     const expectedStartLocation = {
-      line: expectedStartLine,
-      column: node.loc.start.column
+      line: endPosition === 'last-attribute' ? nextLocation.nextLine - 1 : nextLocation.nextLine,
+      column: endPosition === 'last-attribute' ? nextLocation.nextColumn : node.loc.start.column
     };
 
     let componentName = node.type === 'ElementNode' ? node.tag : node.path.original;
@@ -402,6 +420,8 @@ module.exports = class AttributeSpacing extends Rule {
       let result = {
         maxLength: 80,
         indentation: 2,
+        blocklessMustacheEnd: 'new-line',
+        elementsEnd: 'new-line',
       };
       if ('open-invocation-max-len' in config) {
         result.maxLength = config['open-invocation-max-len'];
@@ -411,6 +431,14 @@ module.exports = class AttributeSpacing extends Rule {
       }
       if ('process-elements' in config) {
         result.processElements = config['process-elements'];
+      }
+      if ('blockless-mustache-end' in config) {
+        result.blocklessMustacheEnd = config['blockless-mustache-end'];
+      }
+      if ('elements-end' in config) {
+        // if elements-end is set, assument process-elements=true
+        result.processElements = true;
+        result.elementsEnd = config['elements-end'];
       }
       return result;
     }

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -418,6 +418,7 @@ module.exports = class AttributeSpacing extends Rule {
 
   parseConfig(config) {
     let configType = typeof config;
+    const OPEN_END_CONFIG_VALUES = ['new-line', 'last-attribute'];
 
     switch (configType) {
     case 'boolean':
@@ -448,9 +449,15 @@ module.exports = class AttributeSpacing extends Rule {
         result.processElements = config['process-elements'];
       }
       if ('mustache-open-end' in config) {
+        if (!OPEN_END_CONFIG_VALUES.includes(config['mustache-open-end'])) {
+          break;
+        }
         result.mustacheOpenEnd = config['mustache-open-end'];
       }
       if ('element-open-end' in config) {
+        if (!OPEN_END_CONFIG_VALUES.includes(config['element-open-end'])) {
+          break;
+        }
         // if element-open-end is set, assume process-elements=true
         result.processElements = true;
         result.elementOpenEnd = config['element-open-end'];

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -276,8 +276,8 @@ module.exports = class AttributeSpacing extends Rule {
     });
 
     return {
-      nextLine: expectedLineStart,
-      nextColumn,
+      line: expectedLineStart,
+      column: nextColumn,
     };
   }
 
@@ -295,8 +295,8 @@ module.exports = class AttributeSpacing extends Rule {
     let expectedLineStart = node.loc.start.line + 1;
 
     let nextLocation = {
-      nextLine: expectedLineStart,
-      nextColumn: node.loc.start.column,
+      line: expectedLineStart,
+      column: node.loc.start.column,
     };
     if (node.type === 'ElementNode') {
       nextLocation = this.iterateParams(node.attributes, 'htmlAttribute', expectedLineStart, expectedColumnStart, node);
@@ -311,7 +311,7 @@ module.exports = class AttributeSpacing extends Rule {
         nextLocation = this.iterateParams(node.params, 'positional', expectedLineStart, expectedColumnStart, node);
       }
       if (node.hash.pairs.length > 0) {
-        nextLocation = this.iterateParams(node.hash.pairs, 'attribute', nextLocation.nextLine, expectedColumnStart, node);
+        nextLocation = this.iterateParams(node.hash.pairs, 'attribute', nextLocation.line, expectedColumnStart, node);
       }
     }
 
@@ -329,10 +329,10 @@ module.exports = class AttributeSpacing extends Rule {
       column: end.column - actualColumnStartLocation
     };
 
-    const endPosition = node.type === 'ElementNode' ? this.config.elementsEnd : this.config.blocklessMustacheEnd;
+    const endPosition = node.type === 'ElementNode' ? this.config.endElementOpen : this.config.mustacheOpenEnd;
     const expectedStartLocation = {
-      line: endPosition === 'last-attribute' ? nextLocation.nextLine - 1 : nextLocation.nextLine,
-      column: endPosition === 'last-attribute' ? nextLocation.nextColumn : node.loc.start.column
+      line: endPosition === 'last-attribute' ? nextLocation.line - 1 : nextLocation.line,
+      column: endPosition === 'last-attribute' ? nextLocation.column : node.loc.start.column
     };
 
     let componentName = node.type === 'ElementNode' ? node.tag : node.path.original;
@@ -411,6 +411,8 @@ module.exports = class AttributeSpacing extends Rule {
           maxLength: 80,
           indentation: 2,
           processElements: true,
+          mustacheOpenEnd: 'new-line',
+          endElementOpen: 'new-line',
         };
       }
       return false;
@@ -418,8 +420,8 @@ module.exports = class AttributeSpacing extends Rule {
       let result = {
         maxLength: 80,
         indentation: 2,
-        blocklessMustacheEnd: 'new-line',
-        elementsEnd: 'new-line',
+        mustacheOpenEnd: 'new-line',
+        endElementOpen: 'new-line',
       };
       if ('open-invocation-max-len' in config) {
         result.maxLength = config['open-invocation-max-len'];
@@ -430,13 +432,13 @@ module.exports = class AttributeSpacing extends Rule {
       if ('process-elements' in config) {
         result.processElements = config['process-elements'];
       }
-      if ('blockless-mustache-end' in config) {
-        result.blocklessMustacheEnd = config['blockless-mustache-end'];
+      if ('mustache-open-end' in config) {
+        result.mustacheOpenEnd = config['mustache-open-end'];
       }
-      if ('elements-end' in config) {
-        // if elements-end is set, assume process-elements=true
+      if ('end-element-open' in config) {
+        // if end-element-open is set, assume process-elements=true
         result.processElements = true;
-        result.elementsEnd = config['elements-end'];
+        result.endElementOpen = config['end-element-open'];
       }
       return result;
     }
@@ -472,8 +474,8 @@ module.exports = class AttributeSpacing extends Rule {
         if (this.config.processElements) {
           if (canApplyRule(node, node.type, this.config)) {
             if (node.attributes.length) {
-              let expectedCloseBraceLine = this.validateParams(node);
-              this.validateCloseBrace(node, expectedCloseBraceLine);
+              let expectedCloseBraceLocation = this.validateParams(node);
+              this.validateCloseBrace(node, expectedCloseBraceLocation);
             }
 
             if (node.children.length) {

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -301,12 +301,10 @@ module.exports = class AttributeSpacing extends Rule {
     if (node.type === 'ElementNode') {
       nextLocation = this.iterateParams(node.attributes, 'htmlAttribute', expectedLineStart, expectedColumnStart, node);
     } else {
-      if (node.params) {
-        if (node.path.loc.source === '(synthetic)') {
-          expectedLineStart--;
-          if (node.type === 'BlockStatement') {
-            node.params[0].loc.start.column--;
-          }
+      if (node.path.loc.source === '(synthetic)') {
+        expectedLineStart--;
+        if (node.type === 'BlockStatement') {
+          node.params[0].loc.start.column--;
         }
       }
       if (node.params.length > 0) {

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -42,7 +42,15 @@ module.exports = class AttributeSpacing extends Rule {
 
   getBlockParamStartLoc(node) {
     let actual, expected;
-    let programStartLoc = node.program.loc.start;
+    // This code uses the program start location to determine the actual location
+    // of the block param. All the examples are given with the "}}" at the end
+    // of the block param (e.g.: as |employee|}}). This assumption is incorrect so we need
+    // to verify if the "}}" are on a new line and adjust the program start location accordingly
+    const actualProgramStartLine = this.source[node.program.loc.start.line - 1].startsWith('}}') ? 1 : 0;
+    const programStartLoc = {
+      line: node.program.loc.start.line - actualProgramStartLine,
+      column: node.program.loc.start.column,
+    };
     let nodeStart = node.loc.start;
     if (node.params.length === 0 && node.hash.pairs.length === 0) {
       expected = {
@@ -229,6 +237,11 @@ module.exports = class AttributeSpacing extends Rule {
         source: this.sourceForNode(node)
       });
     }
+    const expectedColumnNextLocation = node.type === 'ElementNode' && !node.selfClosing ? 1 : 2;
+    return {
+      line: expected.line + 1,
+      column: expected.column + node.program.loc.start.column - expectedColumnNextLocation,
+    };
   }
 
   iterateParams(params, type, expectedLineStart, expectedColumnStart, node) {
@@ -393,12 +406,14 @@ module.exports = class AttributeSpacing extends Rule {
   }
 
   validateBlockForm(node) {
+    let nextLocation;
     if (node.params.length || node.hash.pairs.length) {
-      this.validateParams(node);
+      nextLocation = this.validateParams(node);
     }
     if (node.program.blockParams && node.program.blockParams.length) {
-      this.validateBlockParams(node);
+      nextLocation = this.validateBlockParams(node);
     }
+    this.validateCloseBrace(node, nextLocation);
   }
 
   parseConfig(config) {

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -342,7 +342,7 @@ module.exports = class AttributeSpacing extends Rule {
       column: end.column - actualColumnStartLocation
     };
 
-    const endPosition = node.type === 'ElementNode' ? this.config.endElementOpen : this.config.mustacheOpenEnd;
+    const endPosition = node.type === 'ElementNode' ? this.config.elementOpenEnd : this.config.mustacheOpenEnd;
     const expectedStartLocation = {
       line: endPosition === 'last-attribute' ? nextLocation.line - 1 : nextLocation.line,
       column: endPosition === 'last-attribute' ? nextLocation.column : node.loc.start.column
@@ -427,7 +427,7 @@ module.exports = class AttributeSpacing extends Rule {
           indentation: 2,
           processElements: true,
           mustacheOpenEnd: 'new-line',
-          endElementOpen: 'new-line',
+          elementOpenEnd: 'new-line',
         };
       }
       return false;
@@ -436,7 +436,7 @@ module.exports = class AttributeSpacing extends Rule {
         maxLength: 80,
         indentation: 2,
         mustacheOpenEnd: 'new-line',
-        endElementOpen: 'new-line',
+        elementOpenEnd: 'new-line',
       };
       if ('open-invocation-max-len' in config) {
         result.maxLength = config['open-invocation-max-len'];
@@ -450,10 +450,10 @@ module.exports = class AttributeSpacing extends Rule {
       if ('mustache-open-end' in config) {
         result.mustacheOpenEnd = config['mustache-open-end'];
       }
-      if ('end-element-open' in config) {
-        // if end-element-open is set, assume process-elements=true
+      if ('element-open-end' in config) {
+        // if element-open-end is set, assume process-elements=true
         result.processElements = true;
-        result.endElementOpen = config['end-element-open'];
+        result.elementOpenEnd = config['element-open-end'];
       }
       return result;
     }
@@ -466,7 +466,7 @@ module.exports = class AttributeSpacing extends Rule {
       '  * { open-invocation-max-len: n characters, indentation: m  } - n : The max length of the opening invocation can be configured',
       '  *                                                            - m : The desired indentation of attribute',
       '  * { process-elements: `boolean` } - `true` : Also parse HTML/SVG attributes',
-      '  * { end-element-open: `new-line`|`last-attribute` } - Enforce the position of the closing brace `>` to be on a new line or next to the last attribute (defaults to `new-line`)',
+      '  * { element-open-end: `new-line`|`last-attribute` } - Enforce the position of the closing brace `>` to be on a new line or next to the last attribute (defaults to `new-line`)',
       '  * { mustache-open-end: `new-line`|`last-attribute` } - Enforce the position of the closing braces `}}` to be on a new line or next to the last attribute (defaults to `new-line`)'
     ], config);
 

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -11,7 +11,7 @@ generateRuleTests({
     {
       config: {
         'mustache-open-end': 'new-line',
-        'end-element-open': 'new-line'
+        'element-open-end': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -27,7 +27,7 @@ generateRuleTests({
     {
       config: {
         'mustache-open-end': 'new-line',
-        'end-element-open': 'new-line'
+        'element-open-end': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -40,7 +40,7 @@ generateRuleTests({
     {
       config: {
         'mustache-open-end': 'new-line',
-        'end-element-open': 'last-attribute'
+        'element-open-end': 'last-attribute'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -52,7 +52,7 @@ generateRuleTests({
     {
       config: {
         'mustache-open-end': 'last-attribute',
-        'end-element-open': 'last-attribute'
+        'element-open-end': 'last-attribute'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -63,7 +63,7 @@ generateRuleTests({
     {
       config: {
         'mustache-open-end': 'last-attribute',
-        'end-element-open': 'new-line'
+        'element-open-end': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -74,7 +74,7 @@ generateRuleTests({
     },
     {
       config: {
-        'end-element-open': 'new-line'
+        'element-open-end': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -86,7 +86,7 @@ generateRuleTests({
     },
     {
       config: {
-        'end-element-open': 'new-line'
+        'element-open-end': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo={{action some stuff}}' + '\n' +
@@ -95,7 +95,7 @@ generateRuleTests({
     },
     {
       config: {
-        'end-element-open': 'new-line'
+        'element-open-end': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo=bar' + '\n' +
@@ -104,7 +104,7 @@ generateRuleTests({
     },
     {
       config: {
-        'end-element-open': 'last-attribute'
+        'element-open-end': 'last-attribute'
       },
       template: '<div' + '\n' +
       '  foo=bar' + '\n' +
@@ -112,7 +112,7 @@ generateRuleTests({
     },
     {
       config: {
-        'end-element-open': 'new-line'
+        'element-open-end': 'new-line'
       },
       template: '<input' + '\n' +
       '  foo=bar' + '\n' +
@@ -121,7 +121,7 @@ generateRuleTests({
     },
     {
       config: {
-        'end-element-open': 'last-attribute'
+        'element-open-end': 'last-attribute'
       },
       template: '<input' + '\n' +
       '  foo=bar' + '\n' +
@@ -189,7 +189,7 @@ generateRuleTests({
     {
       config: {
         'process-elements': true,
-        'end-element-open': 'last-attribute',
+        'element-open-end': 'last-attribute',
       },
       template: '<a' + '\n' +
       '  disabled>' + '\n' +
@@ -266,7 +266,7 @@ generateRuleTests({
     {
       config: {
         'process-elements': true,
-        'end-element-open': 'last-attribute',
+        'element-open-end': 'last-attribute',
         'mustache-open-end': 'last-attribute'
       },
       template: '<a' + '\n' +
@@ -283,7 +283,7 @@ generateRuleTests({
     {
       config: {
         'process-elements': true,
-        'end-element-open': 'new-line',
+        'element-open-end': 'new-line',
         'mustache-open-end': 'last-attribute'
       },
       template: '<a' + '\n' +
@@ -300,7 +300,7 @@ generateRuleTests({
     {
       config: {
         'process-elements': true,
-        'end-element-open': 'last-attribute',
+        'element-open-end': 'last-attribute',
         'mustache-open-end': 'new-line'
       },
       template: '<a' + '\n' +
@@ -533,7 +533,7 @@ generateRuleTests({
     {
       config: {
         'mustache-open-end': 'new-line',
-        'end-element-open': 'new-line',
+        'element-open-end': 'new-line',
       },
       template: '<div' + '\n' +
       '  class="classy"' + '\n' +
@@ -551,7 +551,7 @@ generateRuleTests({
     {
       config: {
         'mustache-open-end': 'last-attribute',
-        'end-element-open': 'last-attribute',
+        'element-open-end': 'last-attribute',
       },
       template: '<div' + '\n' +
       '  class="classy">' + '\n' +
@@ -567,7 +567,7 @@ generateRuleTests({
     {
       config: {
         'mustache-open-end': 'last-attribute',
-        'end-element-open': 'new-line',
+        'element-open-end': 'new-line',
       },
       template: '<div' + '\n' +
       '  class="classy"' + '\n' +
@@ -584,7 +584,7 @@ generateRuleTests({
     {
       config: {
         'mustache-open-end': 'new-line',
-        'end-element-open': 'last-attribute',
+        'element-open-end': 'last-attribute',
       },
       template: '<div' + '\n' +
       '  class="classy">' + '\n' +
@@ -603,7 +603,7 @@ generateRuleTests({
   bad: [{
     config: {
       'mustache-open-end': 'new-line',
-      'end-element-open': 'new-line'
+      'element-open-end': 'new-line'
     },
     template: '<div' + '\n' +
     '  foo={{action' + '\n' +
@@ -633,7 +633,7 @@ generateRuleTests({
   },{
     config: {
       'mustache-open-end': 'last-attribute',
-      'end-element-open': 'last-attribute'
+      'element-open-end': 'last-attribute'
     },
     template: '<div' + '\n' +
     '  foo={{action' + '\n' +
@@ -724,7 +724,7 @@ generateRuleTests({
     }],
   },{
     config: {
-      'end-element-open': 'last-attribute'
+      'element-open-end': 'last-attribute'
     },
     template: '<input' + '\n' +
     '  foo=bar' + '\n' +
@@ -741,7 +741,7 @@ generateRuleTests({
     }],
   },{
     config: {
-      'end-element-open': 'new-line'
+      'element-open-end': 'new-line'
     },
     template: '<input' + '\n' +
     '  foo=bar' + '\n' +
@@ -1155,7 +1155,7 @@ generateRuleTests({
   },{
     config: {
       'mustache-open-end': 'new-line',
-      'end-element-open': 'new-line',
+      'element-open-end': 'new-line',
     },
     template: '<div' + '\n' +
     '  class="classy">' + '\n' +
@@ -1187,7 +1187,7 @@ generateRuleTests({
   },{
     config: {
       'mustache-open-end': 'last-attribute',
-      'end-element-open': 'last-attribute',
+      'element-open-end': 'last-attribute',
     },
     template: '<div' + '\n' +
     '  class="classy"' + '\n' +
@@ -1221,7 +1221,7 @@ generateRuleTests({
   },{
     config: {
       'mustache-open-end': 'last-attribute',
-      'end-element-open': 'new-line',
+      'element-open-end': 'new-line',
     },
     template: '<div' + '\n' +
     '  class="classy">' + '\n' +
@@ -1254,7 +1254,7 @@ generateRuleTests({
   },{
     config: {
       'mustache-open-end': 'new-line',
-      'end-element-open': 'last-attribute',
+      'element-open-end': 'last-attribute',
     },
     template: '<div' + '\n' +
     '  class="classy"' + '\n' +

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -414,13 +414,15 @@ generateRuleTests({
     '{{#t.body' + '\n' +
     '  canExpand=(helper help)' + '\n' +
     '  multiRowExpansion=false' + '\n' +
-    'as |body|}}' + '\n' +
+    'as |body|' + '\n' +
+    '}}' + '\n' +
     '  {{foo}}' + '\n' +
     '{{/t.body}}',
 
     //Block form with open-invocation more than 80 characters
     {
       config: {
+        'mustache-open-end': 'last-attribute',
         'open-invocation-max-len': 120
       },
       template: '{{#contact-details firstName=firstName lastName=lastName age=age avatarUrl=avatarUrl as |contact|}}' + '\n' +
@@ -431,18 +433,43 @@ generateRuleTests({
     '{{#contact-details' + '\n' +
     '  firstName=firstName' + '\n' +
     '  lastName=lastName' + '\n' +
-    'as |fullName|}}' + '\n' +
+    'as |fullName|' + '\n' +
+    '}}' + '\n' +
     '  {{fullName}}' + '\n' +
     '{{/contact-details}}',
     //Block form with no params
     '{{#contact-details' + '\n' +
-    'as |contact|}}' + '\n' +
+    'as |contact|' + '\n' +
+    '}}' + '\n' +
     '  {{contact.fullName}}' + '\n' +
     '{{/contact-details}}',
     '<div>\n  <p></p>\n</div>',
+    {
+      config: {
+        'mustache-open-end': 'last-attribute',
+      },
+      template: '{{#contact-details' + '\n' +
+      '  param0' + '\n' +
+      '  param1=abc' + '\n' +
+      '  param2=abc' + '\n' +
+      'as |ab cd ef  cd ef |}}' + '\n' +
+      '  {{contact.fullName}}' + '\n' +
+      '{{/contact-details}}',
+      results: [],
+    }
   ],
 
   bad: [{
+    template:     '{{#contact-details' + '\n' +
+    '  firstName=firstName' + '\n' +
+    '  lastName=lastName' + '\n' +
+    'as |fullName|' + '\n' +
+    '}}' + '\n' +
+    '  {{fullName}}' + '\n' +
+    '{{/contact-details}}',
+    results: [],
+  },
+  {
     config: {
       'mustache-open-end': 'new-line',
       'end-element-open': 'new-line'
@@ -844,6 +871,12 @@ generateRuleTests({
       'message': 'Incorrect indentation of block params \'as |contact|}}\' beginning at L2:C38. Expecting the block params to be at L3:C0.',
       'moduleId': 'layout.hbs',
       'source': '{{#contact-details\n firstName=firstName lastName=lastName as |contact|}}\n {{contact.fullName}}\n{{/contact-details}}'
+    }, {
+      'column': 51,
+      'line': 2,
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{contact-details}}' beginning at L2:C51. Expected '{{contact-details}}' to be at L4:C0.`,
+      'moduleId': 'layout.hbs',
+      'source': '{{#contact-details\n firstName=firstName lastName=lastName as |contact|}}\n {{contact.fullName}}\n{{/contact-details}}'
     }]
   }, {
     //Block form (> 80 chars)
@@ -880,6 +913,12 @@ generateRuleTests({
       'message': 'Incorrect indentation of block params \'as |contact|}}\' beginning at L1:C78. Expecting the block params to be at L2:C0.',
       'moduleId': 'layout.hbs',
       'source': '{{#contact-details firstName=firstName lastName=lastName age=age avatar=avatar as |contact|}}\n  {{fullName}}\n{{/contact-details}}'
+    }, {
+      'column': 91,
+      'line': 1,
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{contact-details}}' beginning at L1:C91. Expected '{{contact-details}}' to be at L3:C0.`,
+      'moduleId': 'layout.hbs',
+      'source': '{{#contact-details firstName=firstName lastName=lastName age=age avatar=avatar as |contact|}}\n  {{fullName}}\n{{/contact-details}}'
     }]
   }, {
     //Block form with no params with multiple lines.
@@ -893,6 +932,12 @@ generateRuleTests({
       'column': 0,
       'line': 4,
       'message': `Incorrect indentation of block params 'as |contact|}}' beginning at L4:C0. Expecting the block params to be at L2:C0.`,
+      'moduleId': 'layout.hbs',
+      'source': '{{#contact-details\n\n\nas |contact|}}\n  {{contact.fullName}}\n{{/contact-details}}'
+    }, {
+      'column': 12,
+      'line': 4,
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{contact-details}}' beginning at L4:C12. Expected '{{contact-details}}' to be at L3:C0.`,
       'moduleId': 'layout.hbs',
       'source': '{{#contact-details\n\n\nas |contact|}}\n  {{contact.fullName}}\n{{/contact-details}}'
     }]

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -188,6 +188,16 @@ generateRuleTests({
     },
     {
       config: {
+        'process-elements': true,
+        'end-element-open': 'last-attribute',
+      },
+      template: '<a' + '\n' +
+      '  disabled>' + '\n' +
+      'abc'  + '\n' +
+      '</a>',
+    },
+    {
+      config: {
         'process-elements': true
       },
       template: '<a' + '\n' +
@@ -253,6 +263,58 @@ generateRuleTests({
       ' }}{{foo}}{{/contact-details}}' + '\n' +
       '</a>'
     },
+    {
+      config: {
+        'process-elements': true,
+        'end-element-open': 'last-attribute',
+        'mustache-open-end': 'last-attribute'
+      },
+      template: '<a' + '\n' +
+      '  disabled={{if'  + '\n' +
+      '             true'  + '\n' +
+      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '             (action "lessPowerfulAction" value=target.value)}}>' + '\n' +
+      '{{#contact-details' + '\n' +
+      '  firstName' + '\n' +
+      '  lastName}}' + '\n' +
+      ' {{foo}}{{/contact-details}}' + '\n' +
+      '</a>'
+    },
+    {
+      config: {
+        'process-elements': true,
+        'end-element-open': 'new-line',
+        'mustache-open-end': 'last-attribute'
+      },
+      template: '<a' + '\n' +
+      '  disabled={{if'  + '\n' +
+      '             true'  + '\n' +
+      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '             (action "lessPowerfulAction" value=target.value)}}' + '\n' +
+      '>{{#contact-details' + '\n' +
+      '   firstName' + '\n' +
+      '   lastName}}' + '\n' +
+      ' {{foo}}{{/contact-details}}' + '\n' +
+      '</a>'
+    },
+    {
+      config: {
+        'process-elements': true,
+        'end-element-open': 'last-attribute',
+        'mustache-open-end': 'new-line'
+      },
+      template: '<a' + '\n' +
+      '  disabled={{if'  + '\n' +
+      '             true'  + '\n' +
+      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '             (action "lessPowerfulAction" value=target.value)' + '\n' +
+      '           }}>{{#contact-details' + '\n' +
+      '                firstName' + '\n' +
+      '                lastName' + '\n' +
+      '              }}' + '\n' +
+      ' {{foo}}{{/contact-details}}' + '\n' +
+      '</a>'
+    },
     // Self closing single line
     {
       config: {
@@ -293,7 +355,6 @@ generateRuleTests({
       '  disabled={{action "mostPowerfulAction" value=target.value}}' + '\n' +
       '>',
     },
-    //Non Block form multi line
     {
       config: {
         'process-elements': true
@@ -455,21 +516,91 @@ generateRuleTests({
       'as |ab cd ef  cd ef |}}' + '\n' +
       '  {{contact.fullName}}' + '\n' +
       '{{/contact-details}}',
-      results: [],
+    },
+    {
+      config: {
+        'mustache-open-end': 'new-line',
+      },
+      template: '{{#contact-details' + '\n' +
+      '  param0' + '\n' +
+      '  param1=abc' + '\n' +
+      '  param2=abc' + '\n' +
+      'as |ab cd ef  cd ef |' + '\n' +
+      '}}' + '\n' +
+      '  {{contact.fullName}}' + '\n' +
+      '{{/contact-details}}',
+    },
+    {
+      config: {
+        'mustache-open-end': 'new-line',
+        'end-element-open': 'new-line',
+      },
+      template: '<div' + '\n' +
+      '  class="classy"' + '\n' +
+      '>' + '\n' +
+      '{{#contact-details' + '\n' +
+      '  param0' + '\n' +
+      '  param1=abc' + '\n' +
+      '  param2=abc' + '\n' +
+      'as |ab cd ef  cd ef |' + '\n' +
+      '}}' + '\n' +
+      '  {{contact.fullName}}' + '\n' +
+      '{{/contact-details}}' + '\n' +
+      '</div>',
+    },
+    {
+      config: {
+        'mustache-open-end': 'last-attribute',
+        'end-element-open': 'last-attribute',
+      },
+      template: '<div' + '\n' +
+      '  class="classy">' + '\n' +
+      '{{#contact-details' + '\n' +
+      '  param0' + '\n' +
+      '  param1=abc' + '\n' +
+      '  param2=abc' + '\n' +
+      'as |ab cd ef  cd ef |}}' + '\n' +
+      '  {{contact.fullName}}' + '\n' +
+      '{{/contact-details}}' + '\n' +
+      '</div>',
+    },
+    {
+      config: {
+        'mustache-open-end': 'last-attribute',
+        'end-element-open': 'new-line',
+      },
+      template: '<div' + '\n' +
+      '  class="classy"' + '\n' +
+      '>' + '\n' +
+      '{{#contact-details' + '\n' +
+      '  param0' + '\n' +
+      '  param1=abc' + '\n' +
+      '  param2=abc' + '\n' +
+      'as |ab cd ef  cd ef |}}' + '\n' +
+      '  {{contact.fullName}}' + '\n' +
+      '{{/contact-details}}' + '\n' +
+      '</div>',
+    },
+    {
+      config: {
+        'mustache-open-end': 'new-line',
+        'end-element-open': 'last-attribute',
+      },
+      template: '<div' + '\n' +
+      '  class="classy">' + '\n' +
+      '{{#contact-details' + '\n' +
+      '  param0' + '\n' +
+      '  param1=abc' + '\n' +
+      '  param2=abc' + '\n' +
+      'as |ab cd ef  cd ef |' + '\n' +
+      '}}' + '\n' +
+      '  {{contact.fullName}}' + '\n' +
+      '{{/contact-details}}' + '\n' +
+      '</div>',
     }
   ],
 
   bad: [{
-    template:     '{{#contact-details' + '\n' +
-    '  firstName=firstName' + '\n' +
-    '  lastName=lastName' + '\n' +
-    'as |fullName|' + '\n' +
-    '}}' + '\n' +
-    '  {{fullName}}' + '\n' +
-    '{{/contact-details}}',
-    results: [],
-  },
-  {
     config: {
       'mustache-open-end': 'new-line',
       'end-element-open': 'new-line'
@@ -878,7 +1009,23 @@ generateRuleTests({
       'moduleId': 'layout.hbs',
       'source': '{{#contact-details\n firstName=firstName lastName=lastName as |contact|}}\n {{contact.fullName}}\n{{/contact-details}}'
     }]
-  }, {
+  },{
+    template:     '{{#contact-details' + '\n' +
+    '  firstName=firstName' + '\n' +
+    '  lastName=lastName' + '\n' +
+    'as |fullName|}}' + '\n' +
+    '  {{fullName}}' + '\n' +
+    '{{/contact-details}}',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{contact-details}}' beginning at L4:C13. Expected '{{contact-details}}' to be at L5:C0.`,
+      'line': 4,
+      'column': 13,
+      'source': '{{#contact-details\n  firstName=firstName\n  lastName=lastName\nas |fullName|}}\n  {{fullName}}\n{{/contact-details}}'
+    }]
+  },{
     //Block form (> 80 chars)
     template: '{{#contact-details firstName=firstName lastName=lastName age=age avatar=avatar as |contact|}}' + '\n' +
     '  {{fullName}}' + '\n' +
@@ -1005,5 +1152,137 @@ generateRuleTests({
       line: 2,
       column: 0
     }
+  },{
+    config: {
+      'mustache-open-end': 'new-line',
+      'end-element-open': 'new-line',
+    },
+    template: '<div' + '\n' +
+    '  class="classy">' + '\n' +
+    '{{#contact-details' + '\n' +
+    '  param0' + '\n' +
+    '  param1=abc' + '\n' +
+    '  param2=abc' + '\n' +
+    'as |ab cd ef  cd ef |}}' + '\n' +
+    '  {{contact.fullName}}' + '\n' +
+    '{{/contact-details}}' + '\n' +
+    '</div>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close bracket '>' for the element '<div>' beginning at L2:C16. Expected '<div>' to be at L3:C0.`,
+      'line': 2,
+      'column': 16,
+      'source': '<div\n  class="classy">\n{{#contact-details\n  param0\n  param1=abc\n  param2=abc\nas |ab cd ef  cd ef |}}\n  {{contact.fullName}}\n{{/contact-details}}\n</div>'
+    },{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{contact-details}}' beginning at L7:C21. Expected '{{contact-details}}' to be at L8:C0.`,
+      'line': 7,
+      'column': 21,
+      'source': '{{#contact-details\n  param0\n  param1=abc\n  param2=abc\nas |ab cd ef  cd ef |}}\n  {{contact.fullName}}\n{{/contact-details}}'
+    }],
+  },{
+    config: {
+      'mustache-open-end': 'last-attribute',
+      'end-element-open': 'last-attribute',
+    },
+    template: '<div' + '\n' +
+    '  class="classy"' + '\n' +
+    '>' + '\n' +
+    '{{#contact-details' + '\n' +
+    '  param0' + '\n' +
+    '  param1=abc' + '\n' +
+    '  param2=abc' + '\n' +
+    'as |ab cd ef  cd ef |' + '\n' +
+    '}}' + '\n' +
+    '  {{contact.fullName}}' + '\n' +
+    '{{/contact-details}}' + '\n' +
+    '</div>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close bracket '>' for the element '<div>' beginning at L3:C0. Expected '<div>' to be at L2:C16.`,
+      'line': 3,
+      'column': 0,
+      'source': '<div\n  class="classy"\n>\n{{#contact-details\n  param0\n  param1=abc\n  param2=abc\nas |ab cd ef  cd ef |\n}}\n  {{contact.fullName}}\n{{/contact-details}}\n</div>'
+    },{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{contact-details}}' beginning at L9:C0. Expected '{{contact-details}}' to be at L8:C0.`,
+      'line': 9,
+      'column': 0,
+      'source': '{{#contact-details\n  param0\n  param1=abc\n  param2=abc\nas |ab cd ef  cd ef |\n}}\n  {{contact.fullName}}\n{{/contact-details}}'
+    }],
+  },{
+    config: {
+      'mustache-open-end': 'last-attribute',
+      'end-element-open': 'new-line',
+    },
+    template: '<div' + '\n' +
+    '  class="classy">' + '\n' +
+    '{{#contact-details' + '\n' +
+    '  param0' + '\n' +
+    '  param1=abc' + '\n' +
+    '  param2=abc' + '\n' +
+    'as |ab cd ef  cd ef |' + '\n' +
+    '}}' + '\n' +
+    '  {{contact.fullName}}' + '\n' +
+    '{{/contact-details}}' + '\n' +
+    '</div>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close bracket '>' for the element '<div>' beginning at L2:C16. Expected '<div>' to be at L3:C0.`,
+      'line': 2,
+      'column': 16,
+      'source': '<div\n  class="classy">\n{{#contact-details\n  param0\n  param1=abc\n  param2=abc\nas |ab cd ef  cd ef |\n}}\n  {{contact.fullName}}\n{{/contact-details}}\n</div>'
+    },{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{contact-details}}' beginning at L8:C0. Expected '{{contact-details}}' to be at L7:C0.`,
+      'line': 8,
+      'column': 0,
+      'source': '{{#contact-details\n  param0\n  param1=abc\n  param2=abc\nas |ab cd ef  cd ef |\n}}\n  {{contact.fullName}}\n{{/contact-details}}'
+    }],
+  },{
+    config: {
+      'mustache-open-end': 'new-line',
+      'end-element-open': 'last-attribute',
+    },
+    template: '<div' + '\n' +
+    '  class="classy"' + '\n' +
+    '>' + '\n' +
+    '{{#contact-details' + '\n' +
+    '  param0' + '\n' +
+    '  param1=abc' + '\n' +
+    '  param2=abc' + '\n' +
+    'as |ab cd ef  cd ef |}}' + '\n' +
+    '  {{contact.fullName}}' + '\n' +
+    '{{/contact-details}}' + '\n' +
+    '</div>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close bracket '>' for the element '<div>' beginning at L3:C0. Expected '<div>' to be at L2:C16.`,
+      'line': 3,
+      'column': 0,
+      'source': '<div\n  class="classy"\n>\n{{#contact-details\n  param0\n  param1=abc\n  param2=abc\nas |ab cd ef  cd ef |}}\n  {{contact.fullName}}\n{{/contact-details}}\n</div>'
+    },{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{contact-details}}' beginning at L8:C21. Expected '{{contact-details}}' to be at L9:C0.`,
+      'line': 8,
+      'column': 21,
+      'source': '{{#contact-details\n  param0\n  param1=abc\n  param2=abc\nas |ab cd ef  cd ef |}}\n  {{contact.fullName}}\n{{/contact-details}}'
+    }],
   }]
 });

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -8,6 +8,98 @@ generateRuleTests({
   config: true,
 
   good: [
+    {
+      config: {
+        'blockless-mustache-end': 'last-attribute',
+        'elements-end': 'new-line'
+      },
+      template: '<div' + '\n' +
+      '  foo={{action' + '\n' +
+      '        some' + '\n' +
+      '        stuff}}' + '\n' +
+      '  baz=qux' + '\n' +
+      '/>',
+    },
+    {
+      config: {
+        'elements-end': 'new-line'
+      },
+      template: '<div' + '\n' +
+      '  foo={{action' + '\n' +
+      '        some' + '\n' +
+      '        stuff' + '\n' +
+      '      }}' + '\n' +
+      '  baz=qux' + '\n' +
+      '/>',
+    },
+    {
+      config: {
+        'elements-end': 'new-line'
+      },
+      template: '<div' + '\n' +
+      '  foo={{action some stuff}}' + '\n' +
+      '  baz=qux' + '\n' +
+      '/>',
+    },
+    {
+      config: {
+        'elements-end': 'new-line'
+      },
+      template: '<div' + '\n' +
+      '  foo=bar' + '\n' +
+      '  baz=qux' + '\n' +
+      '/>',
+    },
+    {
+      config: {
+        'elements-end': 'last-attribute'
+      },
+      template: '<div' + '\n' +
+      '  foo=bar' + '\n' +
+      '  baz=qux/>',
+    },
+    {
+      config: {
+        'elements-end': 'new-line'
+      },
+      template: '<input' + '\n' +
+      '  foo=bar' + '\n' +
+      '  baz=qux' + '\n' +
+      '>',
+    },
+    {
+      config: {
+        'elements-end': 'last-attribute'
+      },
+      template: '<input' + '\n' +
+      '  foo=bar' + '\n' +
+      '  baz=qux>', 
+    },
+    {
+      config: {
+        'blockless-mustache-end': 'new-line'
+      },
+      template: '{{my-component' + '\n' +
+      '  foo=bar' + '\n' +
+      '  baz=qux' + '\n' +
+      '  my-attr=(component "my-other-component" data=(hash' + '\n' +
+      '    foo=bar'  + '\n' +
+      '    foo=bar'  + '\n' +
+      '    baz=qux))'  + '\n' +
+      '}}',
+    },
+    {
+      config: {
+        'blockless-mustache-end': 'last-attribute'
+      },
+      template: '{{my-component' + '\n' +
+      '  foo=bar' + '\n' +
+      '  baz=qux' + '\n' +
+      '  my-attr=(component "my-other-component" data=(hash' + '\n' +
+      '    foo=bar'  + '\n' +
+      '    foo=bar'  + '\n' +
+      '    baz=qux))}}',
+    },
     //Angle Bracket Invocation
     {
       config: {
@@ -299,6 +391,101 @@ generateRuleTests({
   ],
 
   bad: [{
+    config: {
+      'blockless-mustache-end': 'last-attribute'
+    },
+    template: '{{my-component' + '\n' +
+    '  foo=bar' + '\n' +
+    '  baz=qux' + '\n' +
+    '  my-attr=(component "my-other-component" data=(hash' + '\n' +
+    '    foo=bar'  + '\n' +
+    '    foo=bar'  + '\n' +
+    '    baz=qux))'  + '\n' +
+    '}}',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{my-component}}' beginning at L8:C0. Expected '{{my-component}}' to be at L7:C13.`,
+      'line': 8,
+      'column': 0,
+      'source': '{{my-component\n  foo=bar\n  baz=qux\n  my-attr=(component "my-other-component" data=(hash\n    foo=bar\n    foo=bar\n    baz=qux))\n}}'
+    }],
+  },{
+    config: {
+      'blockless-mustache-end': 'last-attribute'
+    },
+    template: '{{my-component' + '\n' +
+    '  foo=bar' + '\n' +
+    '  baz=qux' + '\n' +
+    '  my-attr=(component "my-other-component" data=(hash' + '\n' +
+    '    foo=bar'  + '\n' +
+    '    foo=bar'  + '\n' +
+    '    baz=qux))'  + '\n' +
+    '}}',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{my-component}}' beginning at L8:C0. Expected '{{my-component}}' to be at L7:C13.`,
+      'line': 8,
+      'column': 0,
+      'source': `{{my-component\n  foo=bar\n  baz=qux\n  my-attr=(component "my-other-component" data=(hash\n    foo=bar\n    foo=bar\n    baz=qux))\n}}`
+    }],
+  },{
+    config: {
+      'blockless-mustache-end': 'new-line'
+    },
+    template: '{{my-component' + '\n' +
+    '  foo=bar' + '\n' +
+    '  baz=qux' + '\n' +
+    '  my-attr=(component "my-other-component" data=(hash' + '\n' +
+    '    foo=bar'  + '\n' +
+    '    foo=bar'  + '\n' +
+    '    baz=qux))}}',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{my-component}}' beginning at L7:C13. Expected '{{my-component}}' to be at L8:C0.`,
+      'line': 7,
+      'column': 13,
+      'source': `{{my-component\n  foo=bar\n  baz=qux\n  my-attr=(component "my-other-component" data=(hash\n    foo=bar\n    foo=bar\n    baz=qux))}}`
+    }],
+  },{
+    config: {
+      'elements-end': 'last-attribute'
+    },
+    template: '<input' + '\n' +
+    '  foo=bar' + '\n' +
+    '  baz=bar' + '\n' +
+    '>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close bracket '>' for the element '<input>' beginning at L4:C0. Expected '<input>' to be at L3:C9.`,
+      'line': 4,
+      'column': 0,
+      'source': '<input\n  foo=bar\n  baz=bar\n>'
+    }],
+  },{
+    config: {
+      'elements-end': 'new-line'
+    },
+    template: '<input' + '\n' +
+    '  foo=bar' + '\n' +
+    '  baz=qux>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close bracket '>' for the element '<input>' beginning at L3:C9. Expected '<input>' to be at L4:C0.`,
+      'line': 3,
+      'column': 9,
+      'source': '<input\n  foo=bar\n  baz=qux>'
+    }],
+  },{
     //Non Block HTML element
     config: {
       'process-elements': true

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -10,8 +10,8 @@ generateRuleTests({
   good: [
     {
       config: {
-        'blockless-mustache-end': 'new-line',
-        'elements-end': 'new-line'
+        'mustache-open-end': 'new-line',
+        'end-element-open': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -26,8 +26,8 @@ generateRuleTests({
     },
     {
       config: {
-        'blockless-mustache-end': 'new-line',
-        'elements-end': 'new-line'
+        'mustache-open-end': 'new-line',
+        'end-element-open': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -39,8 +39,8 @@ generateRuleTests({
     },
     {
       config: {
-        'blockless-mustache-end': 'new-line',
-        'elements-end': 'last-attribute'
+        'mustache-open-end': 'new-line',
+        'end-element-open': 'last-attribute'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -51,8 +51,8 @@ generateRuleTests({
     },
     {
       config: {
-        'blockless-mustache-end': 'last-attribute',
-        'elements-end': 'last-attribute'
+        'mustache-open-end': 'last-attribute',
+        'end-element-open': 'last-attribute'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -62,8 +62,8 @@ generateRuleTests({
     },
     {
       config: {
-        'blockless-mustache-end': 'last-attribute',
-        'elements-end': 'new-line'
+        'mustache-open-end': 'last-attribute',
+        'end-element-open': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -74,7 +74,7 @@ generateRuleTests({
     },
     {
       config: {
-        'elements-end': 'new-line'
+        'end-element-open': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
@@ -86,7 +86,7 @@ generateRuleTests({
     },
     {
       config: {
-        'elements-end': 'new-line'
+        'end-element-open': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo={{action some stuff}}' + '\n' +
@@ -95,7 +95,7 @@ generateRuleTests({
     },
     {
       config: {
-        'elements-end': 'new-line'
+        'end-element-open': 'new-line'
       },
       template: '<div' + '\n' +
       '  foo=bar' + '\n' +
@@ -104,7 +104,7 @@ generateRuleTests({
     },
     {
       config: {
-        'elements-end': 'last-attribute'
+        'end-element-open': 'last-attribute'
       },
       template: '<div' + '\n' +
       '  foo=bar' + '\n' +
@@ -112,7 +112,7 @@ generateRuleTests({
     },
     {
       config: {
-        'elements-end': 'new-line'
+        'end-element-open': 'new-line'
       },
       template: '<input' + '\n' +
       '  foo=bar' + '\n' +
@@ -121,7 +121,7 @@ generateRuleTests({
     },
     {
       config: {
-        'elements-end': 'last-attribute'
+        'end-element-open': 'last-attribute'
       },
       template: '<input' + '\n' +
       '  foo=bar' + '\n' +
@@ -129,7 +129,7 @@ generateRuleTests({
     },
     {
       config: {
-        'blockless-mustache-end': 'new-line'
+        'mustache-open-end': 'new-line'
       },
       template: '{{my-component' + '\n' +
       '  foo=bar' + '\n' +
@@ -142,7 +142,7 @@ generateRuleTests({
     },
     {
       config: {
-        'blockless-mustache-end': 'last-attribute'
+        'mustache-open-end': 'last-attribute'
       },
       template: '{{my-component' + '\n' +
       '  foo=bar' + '\n' +
@@ -444,8 +444,8 @@ generateRuleTests({
 
   bad: [{
     config: {
-      'blockless-mustache-end': 'new-line',
-      'elements-end': 'new-line'
+      'mustache-open-end': 'new-line',
+      'end-element-open': 'new-line'
     },
     template: '<div' + '\n' +
     '  foo={{action' + '\n' +
@@ -474,8 +474,8 @@ generateRuleTests({
     ],
   },{
     config: {
-      'blockless-mustache-end': 'last-attribute',
-      'elements-end': 'last-attribute'
+      'mustache-open-end': 'last-attribute',
+      'end-element-open': 'last-attribute'
     },
     template: '<div' + '\n' +
     '  foo={{action' + '\n' +
@@ -504,7 +504,7 @@ generateRuleTests({
     }],
   },{
     config: {
-      'blockless-mustache-end': 'last-attribute'
+      'mustache-open-end': 'last-attribute'
     },
     template: '{{my-component' + '\n' +
     '  foo=bar' + '\n' +
@@ -525,7 +525,7 @@ generateRuleTests({
     }],
   },{
     config: {
-      'blockless-mustache-end': 'last-attribute'
+      'mustache-open-end': 'last-attribute'
     },
     template: '{{my-component' + '\n' +
     '  foo=bar' + '\n' +
@@ -546,7 +546,7 @@ generateRuleTests({
     }],
   },{
     config: {
-      'blockless-mustache-end': 'new-line'
+      'mustache-open-end': 'new-line'
     },
     template: '{{my-component' + '\n' +
     '  foo=bar' + '\n' +
@@ -566,7 +566,7 @@ generateRuleTests({
     }],
   },{
     config: {
-      'elements-end': 'last-attribute'
+      'end-element-open': 'last-attribute'
     },
     template: '<input' + '\n' +
     '  foo=bar' + '\n' +
@@ -583,7 +583,7 @@ generateRuleTests({
     }],
   },{
     config: {
-      'elements-end': 'new-line'
+      'end-element-open': 'new-line'
     },
     template: '<input' + '\n' +
     '  foo=bar' + '\n' +

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -10,6 +10,58 @@ generateRuleTests({
   good: [
     {
       config: {
+        'blockless-mustache-end': 'new-line',
+        'elements-end': 'new-line'
+      },
+      template: '<div' + '\n' +
+      '  foo={{action' + '\n' +
+      '        (if' + '\n' +
+      '          abc' + '\n' +
+      '          def' + '\n' +
+      '          ghi)' + '\n' +
+      '        stuff' + '\n' +
+      '      }}' + '\n' +
+      '  baz=qux' + '\n' +
+      '/>',
+    },
+    {
+      config: {
+        'blockless-mustache-end': 'new-line',
+        'elements-end': 'new-line'
+      },
+      template: '<div' + '\n' +
+      '  foo={{action' + '\n' +
+      '        some' + '\n' +
+      '        stuff' + '\n' +
+      '      }}' + '\n' +
+      '  baz=qux' + '\n' +
+      '/>',
+    },
+    {
+      config: {
+        'blockless-mustache-end': 'new-line',
+        'elements-end': 'last-attribute'
+      },
+      template: '<div' + '\n' +
+      '  foo={{action' + '\n' +
+      '        some' + '\n' +
+      '        stuff' + '\n' +
+      '      }}' + '\n' +
+      '  baz=qux/>',
+    },
+    {
+      config: {
+        'blockless-mustache-end': 'last-attribute',
+        'elements-end': 'last-attribute'
+      },
+      template: '<div' + '\n' +
+      '  foo={{action' + '\n' +
+      '        some' + '\n' +
+      '        stuff}}' + '\n' +
+      '  baz=qux/>',
+    },
+    {
+      config: {
         'blockless-mustache-end': 'last-attribute',
         'elements-end': 'new-line'
       },
@@ -391,6 +443,66 @@ generateRuleTests({
   ],
 
   bad: [{
+    config: {
+      'blockless-mustache-end': 'new-line',
+      'elements-end': 'new-line'
+    },
+    template: '<div' + '\n' +
+    '  foo={{action' + '\n' +
+    '        some' + '\n' +
+    '        stuff}}' + '\n' +
+    '  baz=qux/>',
+    results: [
+      {
+        'rule': 'attribute-indentation',
+        'severity': 2,
+        'moduleId': 'layout.hbs',
+        'message': `Incorrect indentation of close bracket '>' for the element '<div>' beginning at L5:C9. Expected '<div>' to be at L6:C0.`,
+        'line': 5,
+        'column': 9,
+        'source': `<div\n  foo={{action\n        some\n        stuff}}\n  baz=qux/>`
+      },
+      {
+        'rule': 'attribute-indentation',
+        'severity': 2,
+        'moduleId': 'layout.hbs',
+        'message': `Incorrect indentation of close curly braces '}}' for the component '{{action}}' beginning at L4:C13. Expected '{{action}}' to be at L5:C6.`,
+        'line': 4,
+        'column': 13,
+        'source': '{{action\n        some\n        stuff}}'
+      }
+    ],
+  },{
+    config: {
+      'blockless-mustache-end': 'last-attribute',
+      'elements-end': 'last-attribute'
+    },
+    template: '<div' + '\n' +
+    '  foo={{action' + '\n' +
+    '        some' + '\n' +
+    '        stuff' + '\n' +
+    '      }}' + '\n' +
+    '  baz=qux' + '\n' +
+    '/>',
+    results: [{
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close bracket '>' for the element '<div>' beginning at L7:C0. Expected '<div>' to be at L6:C9.`,
+      'line': 7,
+      'column': 0,
+      'source': '<div\n  foo={{action\n        some\n        stuff\n      }}\n  baz=qux\n/>'
+    },
+    {
+      'rule': 'attribute-indentation',
+      'severity': 2,
+      'moduleId': 'layout.hbs',
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{action}}' beginning at L5:C6. Expected '{{action}}' to be at L4:C13.`,
+      'line': 5,
+      'column': 6,
+      'source': '{{action\n        some\n        stuff\n      }}'
+    }],
+  },{
     config: {
       'blockless-mustache-end': 'last-attribute'
     },


### PR DESCRIPTION
Implements: https://github.com/ember-template-lint/ember-template-lint/issues/267.

Validates the location of the close brace for mustache/block statements (`mustache-open-end`) and HTML/SVG elements (`end-element-open`).
This can be configured to be on a new line (`new-line`, the current behavior) or next to the last attribute (`last-attribute`).
