### PR TITLE
element containing dot should not be considered ambiguous

### DIFF
--- a/lib/rules/lint-no-shadowed-elements.js
+++ b/lib/rules/lint-no-shadowed-elements.js
@@ -21,8 +21,9 @@ module.exports = class NoShadowedElements extends Rule {
 
         let firstChar = node.tag.charAt(0);
         let startsWithUpperCase = firstChar === firstChar.toUpperCase() && firstChar !== firstChar.toLowerCase();
+        let containsDot = node.tag.includes('.');
 
-        if (!startsWithUpperCase) {
+        if (!startsWithUpperCase && !containsDot) {
           this.log({
             message: `Ambiguous element used (\`${node.tag}\`)`,
             line: node.loc && node.loc.start.line,

--- a/test/unit/rules/lint-no-shadowed-elements-test.js
+++ b/test/unit/rules/lint-no-shadowed-elements-test.js
@@ -11,6 +11,7 @@ generateRuleTests({
     '{{#foo-bar as |Baz|}}<Baz />{{/foo-bar}}',
     '<FooBar as |Baz|><Baz /></FooBar>',
     '{{#with foo=(component "blah-zorz") as |Div|}}<Div></Div>{{/with}}',
+    '<Foo as |bar|><bar.baz /></Foo>',
   ],
 
   bad: [


### PR DESCRIPTION
Before a yielded hash had to start with uppercase char to not violate no-shadowed-elements rule even so it could not shadow any element cause having a dot in path.

Fixes #473