### PR TITLE
Add no bare string failing test

### DIFF
--- a/test/unit/rules/lint-no-bare-strings-test.js
+++ b/test/unit/rules/lint-no-bare-strings-test.js
@@ -62,6 +62,12 @@ generateRuleTests({
     },
 
     {
+      // override the globalAttributes list
+      config: { globalAttributes: [] },
+      template: '<script>var foo = "bar"</script>'
+    },
+
+    {
       // override the elementAttributes list
       config: { elementAttributes: { }},
       template: '<input placeholder="hahaha">'


### PR DESCRIPTION
The rule 'no-bare-string' should not produce an error with `<script>var foo = 'bar';</script>`