### PR TITLE
Allow simple-unless to have _only_ `maxHelpers`.

### DIFF
--- a/lib/rules/lint-simple-unless.js
+++ b/lib/rules/lint-simple-unless.js
@@ -20,7 +20,7 @@ function isValidConfigObjectFormat(config) {
     let valueIsArray = Array.isArray(value);
 
     if (value === undefined) {
-      return false;
+      config[key] = DEFAULT_CONFIG[key];
     } else if (key === 'whitelist' && !valueIsArray){
       return false;
     }

--- a/test/unit/rules/lint-simple-unless-test.js
+++ b/test/unit/rules/lint-simple-unless-test.js
@@ -40,6 +40,12 @@ generateRuleTests({
         maxHelpers: 2
       },
       template: '{{unless (eq (not foo) bar) baz}}'
+    },
+    {
+      config: {
+        maxHelpers: 2
+      },
+      template: '{{unless (eq (not foo) bar) baz}}'
     }
   ],
 


### PR DESCRIPTION
Previously, `simple-unless` required the user to specify **both** the `whitelist` and `maxHelpers` values, and this changes the config parsing to allow either _or_ both to be specified (when one is missing it is defaulted to the default config value for that property).

Addresses https://github.com/ember-template-lint/ember-template-lint/issues/489.