### PR TITLE
Ensure invalid (cannot parse) configs throw a useful error.

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -22,13 +22,16 @@ function resolveConfigPath(configPath, pluginPath) {
 
   }
 
+  let filePath = pluginPath || configPath;
   try {
-    let filePath = pluginPath || configPath;
     return require(filePath);
   } catch(e) {
-    return {};
-  }
+    if (e.code === 'MODULE_NOT_FOUND') {
+      return {};
+    }
 
+    throw e;
+  }
 }
 
 function forEachPluginConfiguration(plugins, callback) {

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -30,6 +30,17 @@ describe('public api', function() {
   });
 
   describe('Linter.prototype.loadConfig', function() {
+    it('throws an error if the config file has an error on parsing', function() {
+      let basePath = path.join(fixturePath, 'config-with-parse-error');
+      process.chdir(basePath);
+
+      expect(() => {
+        new Linter({
+          console: mockConsole,
+        });
+      }).to.throw(/error happening during config loading/);
+    });
+
     it('uses provided config', function() {
       let basePath = path.join(fixturePath, 'config-in-root');
       let expected = require(path.join(basePath, '.template-lintrc'));

--- a/test/fixtures/config-with-parse-error/.template-lintrc.js
+++ b/test/fixtures/config-with-parse-error/.template-lintrc.js
@@ -1,0 +1,1 @@
+throw Error('error happening during config loading');


### PR DESCRIPTION
Prior to this when a config had some syntax error, we would silently fallback to using no configuration.

Fixes https://github.com/ember-template-lint/ember-template-lint/issues/489