### PR TITLE
Ensure nested mustache statement attribute validation is correct.

### DIFF
--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -3,10 +3,10 @@
 const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
 
-const getWhiteSpaceLength = function(statement) {
+function getWhiteSpaceLength(statement) {
   let whiteSpace = statement.match(/^\s+/) || [];
   return (whiteSpace[0] || '').length;
-};
+}
 
 function getEndLocationForOpen(node) {
   if (node.type === 'BlockStatement') {
@@ -39,6 +39,16 @@ const canApplyRule = function(node, type, config) {
 
 
 module.exports = class AttributeSpacing extends Rule {
+  getLineIndentation(node) {
+    let currentLine = this.source[node.loc.start.line - 1];
+    let leadingWhitespace = getWhiteSpaceLength(currentLine);
+
+    if (leadingWhitespace === 0) {
+      return node.loc.start.column;
+    }
+
+    return leadingWhitespace;
+  }
 
   getBlockParamStartLoc(node) {
     let actual, expected;
@@ -304,7 +314,8 @@ module.exports = class AttributeSpacing extends Rule {
           fullName=fullName
         }}
     */
-    let expectedColumnStart = node.loc.start.column + this.config.indentation; //params should be after proper positions from component start node
+    let leadingWhitespace = this.getLineIndentation(node);
+    let expectedColumnStart = leadingWhitespace + this.config.indentation; //params should be after proper positions from component start node
     let expectedLineStart = node.loc.start.line + 1;
 
     let nextLocation = {
@@ -335,6 +346,8 @@ module.exports = class AttributeSpacing extends Rule {
     /*
       Validates the close brace `}}` for Handlebars and `>` for HTML/SVG elements of the non-block form.
     */
+    let openIndentation = this.getLineIndentation(node);
+
     let end = getEndLocationForOpen(node);
     const actualColumnStartLocation = node.type === 'ElementNode' && !node.selfClosing ? 1 : 2;
     const actualStartLocation = {
@@ -342,10 +355,12 @@ module.exports = class AttributeSpacing extends Rule {
       column: end.column - actualColumnStartLocation
     };
 
+
+
     const endPosition = node.type === 'ElementNode' ? this.config.elementOpenEnd : this.config.mustacheOpenEnd;
     const expectedStartLocation = {
       line: endPosition === 'last-attribute' ? nextLocation.line - 1 : nextLocation.line,
-      column: endPosition === 'last-attribute' ? nextLocation.column : node.loc.start.column
+      column: endPosition === 'last-attribute' ? nextLocation.column : openIndentation,
     };
 
     let componentName = node.type === 'ElementNode' ? node.tag : node.path.original;
@@ -510,7 +525,7 @@ module.exports = class AttributeSpacing extends Rule {
           }
           return node.loc.end.line;
         }
-      }
+      },
     };
   }
 };

--- a/package.json
+++ b/package.json
@@ -38,5 +38,8 @@
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"
+  },
+  "resolutions": {
+    "simple-html-tokenizer": "^0.5.6"
   }
 }

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -15,12 +15,12 @@ generateRuleTests({
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
-      '        (if' + '\n' +
-      '          abc' + '\n' +
-      '          def' + '\n' +
-      '          ghi)' + '\n' +
-      '        stuff' + '\n' +
-      '      }}' + '\n' +
+      '    (if' + '\n' +
+      '      abc' + '\n' +
+      '      def' + '\n' +
+      '      ghi)' + '\n' +
+      '    stuff' + '\n' +
+      '  }}' + '\n' +
       '  baz=qux' + '\n' +
       '/>',
     },
@@ -31,9 +31,9 @@ generateRuleTests({
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
-      '        some' + '\n' +
-      '        stuff' + '\n' +
-      '      }}' + '\n' +
+      '    some' + '\n' +
+      '    stuff' + '\n' +
+      '  }}' + '\n' +
       '  baz=qux' + '\n' +
       '/>',
     },
@@ -44,9 +44,9 @@ generateRuleTests({
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
-      '        some' + '\n' +
-      '        stuff' + '\n' +
-      '      }}' + '\n' +
+      '    some' + '\n' +
+      '    stuff' + '\n' +
+      '  }}' + '\n' +
       '  baz=qux/>',
     },
     {
@@ -56,8 +56,8 @@ generateRuleTests({
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
-      '        some' + '\n' +
-      '        stuff}}' + '\n' +
+      '    some' + '\n' +
+      '    stuff}}' + '\n' +
       '  baz=qux/>',
     },
     {
@@ -67,8 +67,8 @@ generateRuleTests({
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
-      '        some' + '\n' +
-      '        stuff}}' + '\n' +
+      '    some' + '\n' +
+      '    stuff}}' + '\n' +
       '  baz=qux' + '\n' +
       '/>',
     },
@@ -78,9 +78,9 @@ generateRuleTests({
       },
       template: '<div' + '\n' +
       '  foo={{action' + '\n' +
-      '        some' + '\n' +
-      '        stuff' + '\n' +
-      '      }}' + '\n' +
+      '    some' + '\n' +
+      '    stuff' + '\n' +
+      '  }}' + '\n' +
       '  baz=qux' + '\n' +
       '/>',
     },
@@ -125,7 +125,7 @@ generateRuleTests({
       },
       template: '<input' + '\n' +
       '  foo=bar' + '\n' +
-      '  baz=qux>', 
+      '  baz=qux>',
     },
     {
       config: {
@@ -237,10 +237,10 @@ generateRuleTests({
       },
       template: '<a' + '\n' +
       '  disabled={{if'  + '\n' +
-      '             true'  + '\n' +
-      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
-      '             (action "lessPowerfulAction" value=target.value)' + '\n' +
-      '           }}' + '\n' +
+      '    true'  + '\n' +
+      '    (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '    (action "lessPowerfulAction" value=target.value)' + '\n' +
+      '  }}' + '\n' +
       '>{{contact-details' + '\n' +
       '   firstName' + '\n' +
       '   lastName' + '\n' +
@@ -253,10 +253,10 @@ generateRuleTests({
       },
       template: '<a' + '\n' +
       '  disabled={{if'  + '\n' +
-      '             true'  + '\n' +
-      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
-      '             (action "lessPowerfulAction" value=target.value)' + '\n' +
-      '           }}' + '\n' +
+      '    true'  + '\n' +
+      '    (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '    (action "lessPowerfulAction" value=target.value)' + '\n' +
+      '  }}' + '\n' +
       '>{{#contact-details' + '\n' +
       '   firstName' + '\n' +
       '   lastName' + '\n' +
@@ -271,9 +271,9 @@ generateRuleTests({
       },
       template: '<a' + '\n' +
       '  disabled={{if'  + '\n' +
-      '             true'  + '\n' +
-      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
-      '             (action "lessPowerfulAction" value=target.value)}}>' + '\n' +
+      '    true'  + '\n' +
+      '    (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '    (action "lessPowerfulAction" value=target.value)}}>' + '\n' +
       '{{#contact-details' + '\n' +
       '  firstName' + '\n' +
       '  lastName}}' + '\n' +
@@ -288,13 +288,15 @@ generateRuleTests({
       },
       template: '<a' + '\n' +
       '  disabled={{if'  + '\n' +
-      '             true'  + '\n' +
-      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
-      '             (action "lessPowerfulAction" value=target.value)}}' + '\n' +
-      '>{{#contact-details' + '\n' +
-      '   firstName' + '\n' +
-      '   lastName}}' + '\n' +
-      ' {{foo}}{{/contact-details}}' + '\n' +
+      '    true'  + '\n' +
+      '    (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '    (action "lessPowerfulAction" value=target.value)}}' + '\n' +
+      '>\n' +
+      '  {{#contact-details' + '\n' +
+      '    firstName' + '\n' +
+      '    lastName}}' + '\n' +
+      '  {{foo}}\n' +
+      '  {{/contact-details}}' + '\n' +
       '</a>'
     },
     {
@@ -305,14 +307,15 @@ generateRuleTests({
       },
       template: '<a' + '\n' +
       '  disabled={{if'  + '\n' +
-      '             true'  + '\n' +
-      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
-      '             (action "lessPowerfulAction" value=target.value)' + '\n' +
-      '           }}>{{#contact-details' + '\n' +
-      '                firstName' + '\n' +
-      '                lastName' + '\n' +
-      '              }}' + '\n' +
-      ' {{foo}}{{/contact-details}}' + '\n' +
+      '    true'  + '\n' +
+      '    (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '    (action "lessPowerfulAction" value=target.value)' + '\n' +
+      '  }}>\n' +
+      '  {{#contact-details' + '\n' +
+      '    firstName' + '\n' +
+      '    lastName' + '\n' +
+      '  }}' + '\n' +
+      '   {{foo}}{{/contact-details}}' + '\n' +
       '</a>'
     },
     // Self closing single line
@@ -361,10 +364,10 @@ generateRuleTests({
       },
       template: '<input' + '\n' +
       '  disabled={{if'  + '\n' +
-      '             true' + '\n' +
-      '             (action "mostPowerfulAction" value=target.value)' + '\n' +
-      '             (action "lessPowerfulAction" value=target.value)' + '\n' +
-      '           }}' + '\n' +
+      '    true' + '\n' +
+      '    (action "mostPowerfulAction" value=target.value)' + '\n' +
+      '    (action "lessPowerfulAction" value=target.value)' + '\n' +
+      '  }}' + '\n' +
       '>',
     },
     //Non Block form with no params
@@ -597,6 +600,36 @@ generateRuleTests({
       '  {{contact.fullName}}' + '\n' +
       '{{/contact-details}}' + '\n' +
       '</div>',
+    },
+    {
+      config: {
+        'mustache-open-end': 'last-attribute',
+      },
+      template: `
+        <SomeThing
+          @long-arg={{hash
+            foo="bar"}}
+        />`
+    },
+    {
+      config: {
+        'mustache-open-end': 'new-line',
+      },
+      template: `
+        <SomeThing
+          @long-arg={{hash
+            foo="bar"
+          }}
+        />`
+    },
+    {
+      template: `
+        <SomeThing
+          @long-arg={{hash
+            foo="bar"
+          }}
+          data-after-long-arg={{true}}
+        />`
     }
   ],
 
@@ -607,8 +640,8 @@ generateRuleTests({
     },
     template: '<div' + '\n' +
     '  foo={{action' + '\n' +
-    '        some' + '\n' +
-    '        stuff}}' + '\n' +
+    '    some' + '\n' +
+    '    stuff}}' + '\n' +
     '  baz=qux/>',
     results: [
       {
@@ -618,16 +651,16 @@ generateRuleTests({
         'message': `Incorrect indentation of close bracket '>' for the element '<div>' beginning at L5:C9. Expected '<div>' to be at L6:C0.`,
         'line': 5,
         'column': 9,
-        'source': `<div\n  foo={{action\n        some\n        stuff}}\n  baz=qux/>`
+        'source': `<div\n  foo={{action\n    some\n    stuff}}\n  baz=qux/>`
       },
       {
         'rule': 'attribute-indentation',
         'severity': 2,
         'moduleId': 'layout.hbs',
-        'message': `Incorrect indentation of close curly braces '}}' for the component '{{action}}' beginning at L4:C13. Expected '{{action}}' to be at L5:C6.`,
+        'message': `Incorrect indentation of close curly braces '}}' for the component '{{action}}' beginning at L4:C9. Expected '{{action}}' to be at L5:C2.`,
         'line': 4,
-        'column': 13,
-        'source': '{{action\n        some\n        stuff}}'
+        'column': 9,
+        'source': '{{action\n    some\n    stuff}}'
       }
     ],
   },{
@@ -637,9 +670,9 @@ generateRuleTests({
     },
     template: '<div' + '\n' +
     '  foo={{action' + '\n' +
-    '        some' + '\n' +
-    '        stuff' + '\n' +
-    '      }}' + '\n' +
+    '    some' + '\n' +
+    '    stuff' + '\n' +
+    '  }}' + '\n' +
     '  baz=qux' + '\n' +
     '/>',
     results: [{
@@ -649,16 +682,16 @@ generateRuleTests({
       'message': `Incorrect indentation of close bracket '>' for the element '<div>' beginning at L7:C0. Expected '<div>' to be at L6:C9.`,
       'line': 7,
       'column': 0,
-      'source': '<div\n  foo={{action\n        some\n        stuff\n      }}\n  baz=qux\n/>'
+      'source': '<div\n  foo={{action\n    some\n    stuff\n  }}\n  baz=qux\n/>'
     },
     {
       'rule': 'attribute-indentation',
       'severity': 2,
       'moduleId': 'layout.hbs',
-      'message': `Incorrect indentation of close curly braces '}}' for the component '{{action}}' beginning at L5:C6. Expected '{{action}}' to be at L4:C13.`,
+      'message': `Incorrect indentation of close curly braces '}}' for the component '{{action}}' beginning at L5:C2. Expected '{{action}}' to be at L4:C9.`,
       'line': 5,
-      'column': 6,
-      'source': '{{action\n        some\n        stuff\n      }}'
+      'column': 2,
+      'source': '{{action\n    some\n    stuff\n  }}'
     }],
   },{
     config: {
@@ -819,9 +852,9 @@ generateRuleTests({
       'rule': 'attribute-indentation',
       'severity': 2,
       'moduleId': 'layout.hbs',
-      'message': `Incorrect indentation of htmlAttribute 'type' beginning at L1:C17. Expected 'type' to be at L3:C2.`,
+      'message': `Incorrect indentation of htmlAttribute 'type' beginning at L1:C16. Expected 'type' to be at L3:C2.`,
       'line': 1,
-      'column': 17,
+      'column': 16,
       'source': '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">'
     }, {
       'rule': 'attribute-indentation',
@@ -862,10 +895,10 @@ generateRuleTests({
     },
     template: '<a' + '\n' +
     '  disabled={{if'  + '\n' +
-    '             true'  + '\n' +
-    '             (action "mostPowerfulAction" value=target.value)' + '\n' +
-    '             (action "lessPowerfulAction" value=target.value)' + '\n' +
-    '           }}' + '\n' +
+    '    true'  + '\n' +
+    '    (action "mostPowerfulAction" value=target.value)' + '\n' +
+    '    (action "lessPowerfulAction" value=target.value)' + '\n' +
+    '  }}' + '\n' +
     '>{{contact-details' + '\n' +
     '   firstName' + '\n' +
     '   lastName' + '\n' +
@@ -877,7 +910,7 @@ generateRuleTests({
       'message': `Incorrect indentation of close tag '</a>' for element '<a>' beginning at L10:C3. Expected '</a>' to be at L10:C0.`,
       'line': 10,
       'column': 3,
-      'source': '<a\n  disabled={{if\n             true\n             (action "mostPowerfulAction" value=target.value)\n             (action "lessPowerfulAction" value=target.value)\n           }}\n>{{contact-details\n   firstName\n   lastName\n }}</a>'
+      'source': '<a\n  disabled={{if\n    true\n    (action "mostPowerfulAction" value=target.value)\n    (action "lessPowerfulAction" value=target.value)\n  }}\n>{{contact-details\n   firstName\n   lastName\n }}</a>'
     }]
   }, {
     config: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2098,9 +2098,9 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-simple-html-tokenizer@^0.5.5:
-  version "0.5.5"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.5.tgz#110e63f2fe095e1f21f2f07e8c259a5ab6d6bebb"
+simple-html-tokenizer@^0.5.5, simple-html-tokenizer@^0.5.6:
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.6.tgz#e1e442b14f5484bf9a7e2924f78f00855e6b3c14"
 
 slash@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Previously when using angle bracket invocation with a multiline mustache statement as an argument, you would be instructed by the attribute-indentation rule to indent the mustache statement content much further than we intended.

The linter previously would require this incorrect formatting:

```hbs
<div
  data-blah="asdf"
  @something={{hash
               foo="bar"
             }}
></div>
```

And after these changes we have the following:

```hbs
<div
  data-blah="asdf"
  @something={{hash
    foo="bar"
  }}
></div>
```

Fixes https://github.com/ember-template-lint/ember-template-lint/issues/471.