### PR TITLE
Refactor linebreak-style rule.

### DIFF
--- a/docs/rule/linebreak-style.md
+++ b/docs/rule/linebreak-style.md
@@ -4,5 +4,5 @@ Having consistent linebreaks is important to make sure that the source code is r
 
 This rule is configured with a boolean, or a string value:
 
-* boolean -- `true` for enabled in `unix` mode / `false` for disabling this rule
-* string -- `unix` for LF linebreaks / `windows` for CRLF linebreaks
+* boolean -- `true` for enforcing consistency (all `CRLF` or all `LF` not both in a single file)
+* string -- `system` for the current platforms default line ending / `unix` for LF linebreaks / `windows` for CRLF linebreaks

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -6,7 +6,7 @@ module.exports = {
     'block-indentation': true,
     'deprecated-render-helper': true,
     'img-alt-attributes': true,
-    'linebreak-style': 'unix',
+    'linebreak-style': true,
     'link-rel-noopener': true,
     'no-attrs-in-components': true,
     'no-debugger': true,

--- a/lib/rules/lint-linebreak-style.js
+++ b/lib/rules/lint-linebreak-style.js
@@ -9,15 +9,12 @@
    * string -- `unix` for LF linebreaks / `windows` for CRLF linebreaks
  */
 
+const os = require('os');
 const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
 
 const reLineEnds = /(\r\n?|\n)/g;
 const reLines = /(.*?(?:\r\n?|\n|$))/gm;
-
-const DEFAULT_CONFIG = {
-  linebreak: '\n'
-};
 
 function toUserString(value) {
   return value.replace('\r', 'CR').replace('\n', 'LF');
@@ -29,14 +26,15 @@ module.exports = class LineBreakStyle extends Rule {
 
     switch (configType) {
     case 'boolean':
-      // if `true` use `DEFAULT_CONFIG`
-      return config ? DEFAULT_CONFIG : false;
+      return config;
     case 'string':
       switch (config) {
+      case 'system':
+        return os.EOL;
       case 'unix':
-        return DEFAULT_CONFIG;
+        return '\n';
       case 'windows':
-        return {linebreak: '\r\n'};
+        return '\r\n';
       }
       break;
     case 'undefined':
@@ -44,8 +42,8 @@ module.exports = class LineBreakStyle extends Rule {
     }
 
     let errorMessage = createErrorMessage(this.ruleName, [
-      '  * boolean - `true` to enable (unix style) / `false` to disable',
-      '  * string -- `unix` for LF linebreaks / `windows` for CRLF linebreaks'
+      '* boolean -- `true` for enforcing consistency (all `CRLF` or all `LF` not both in a single file)',
+      '* string -- `system` for the current platforms default line ending / `unix` for LF linebreaks / `windows` for CRLF linebreaks'
     ], config);
 
     throw new Error(errorMessage);
@@ -78,12 +76,17 @@ module.exports = class LineBreakStyle extends Rule {
   }
 
   _getWrongLinebreakFromLine(source) {
-    let goodLinebreak = this.config.linebreak;
     let linebreaks = source.match(reLineEnds);
 
     if(linebreaks) {
       let linebreak = linebreaks[0];
-      if(linebreak && linebreak !== goodLinebreak) {
+      if (!linebreak) { return null; }
+
+      if (this.config === true) {
+        this.config = linebreak;
+      }
+
+      if (linebreak !== this.config) {
         return linebreak;
       }
     }
@@ -101,7 +104,7 @@ module.exports = class LineBreakStyle extends Rule {
       let wrongLineBreak = this._getWrongLinebreakFromLine(sourceLine);
       if (wrongLineBreak) {
         let wrongLineBreakForDisplay = toUserString(wrongLineBreak);
-        let goodLineBreakForDisplay = toUserString(this.config.linebreak);
+        let goodLineBreakForDisplay = toUserString(this.config);
 
         this.log({
           message: `Wrong linebreak used. Expected ${goodLineBreakForDisplay} but found ${wrongLineBreakForDisplay}`,

--- a/test/unit/rules/lint-linebreak-style-test.js
+++ b/test/unit/rules/lint-linebreak-style-test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const os = require('os');
 const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
@@ -10,6 +11,11 @@ generateRuleTests({
   good: [
     'testing this',
     'testing \n this',
+    'testing \r\n this',
+    {
+      config: 'system',
+      template: os.EOL === '\n' ? 'testing\nthis' : 'testing\r\nthis',
+    },
     {
       config: 'windows',
       template: 'testing\r\nthis'
@@ -18,14 +24,22 @@ generateRuleTests({
       config: 'unix',
       template: 'testing\nthis'
     },
-    {
-      config: true,
-      template: 'testing\nthis'
-    },
   ],
 
   bad: [
     {
+      template: 'something\ngoes\r\n',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message: 'Wrong linebreak used. Expected LF but found CRLF',
+        line: 2,
+        column: 4,
+        source: '\r\n'
+      }
+    },
+    {
+      config: 'unix',
       template: '\r\n',
 
       result: {
@@ -37,6 +51,7 @@ generateRuleTests({
       }
     },
     {
+      config: 'unix',
       template: '{{#if test}}\r\n{{/if}}',
 
       result: {
@@ -48,6 +63,7 @@ generateRuleTests({
       }
     },
     {
+      config: 'unix',
       template: '{{blah}}\r\n{{blah}}',
 
       result: {
@@ -59,6 +75,7 @@ generateRuleTests({
       }
     },
     {
+      config: 'unix',
       template: '{{blah}}\r\n',
 
       result: {
@@ -70,6 +87,7 @@ generateRuleTests({
       }
     },
     {
+      config: 'unix',
       template: '{{blah arg="\r\n"}}',
 
       result: {


### PR DESCRIPTION
* Change default config for `linebreak-style` to enforce consistency (not
a specific line ending). Mixing `\n` and `\r\n` is evil.
* Add `system` config setting which uses `os.EOL` as default

Fixes https://github.com/ember-template-lint/ember-template-lint/issues/490