### PR TITLE
Fix an error when a route has a name ending in "components".

### DIFF
--- a/lib/helpers/is-route-template.js
+++ b/lib/helpers/is-route-template.js
@@ -20,6 +20,6 @@ module.exports = function isRouteTemplate(moduleName) {
 
   return (
     !isPartial &&
-    moduleName.indexOf('components/') === -1 // classic component
+    moduleName.indexOf('templates/components/') === -1 // classic component
   );
 };

--- a/test/unit/rules/lint-no-outlet-outside-routes-test.js
+++ b/test/unit/rules/lint-no-outlet-outside-routes-test.js
@@ -25,6 +25,19 @@ generateRuleTests({
       }
     },
     {
+      template: '{{#outlet}}Route with "components" name{{/outlet}}',
+      meta: {
+        moduleId: 'app/templates/components.hbs',
+      },
+      result: {
+        message,
+        moduleId: 'app/templates/components.hbs',
+        source: '{{outlet}}',
+        line: 1,
+        column: 0
+      }
+    },
+    {
       template: '{{outlet}}',
       meta: {
         moduleId: 'app/templates/routes/foo.hbs'

--- a/test/unit/rules/lint-no-outlet-outside-routes-test.js
+++ b/test/unit/rules/lint-no-outlet-outside-routes-test.js
@@ -14,11 +14,11 @@ generateRuleTests({
     {
       template: '{{outlet}}',
       meta: {
-        moduleId: 'foo/route.hbs',
+        moduleId: 'app/templates/foo/route.hbs',
       },
       result: {
         message,
-        moduleId: 'foo/route.hbs',
+        moduleId: 'app/templates/foo/route.hbs',
         source: '{{outlet}}',
         line: 1,
         column: 0
@@ -27,11 +27,11 @@ generateRuleTests({
     {
       template: '{{outlet}}',
       meta: {
-        moduleId: 'routes/foo.hbs'
+        moduleId: 'app/templates/routes/foo.hbs'
       },
       result: {
         message,
-        moduleId: 'routes/foo.hbs',
+        moduleId: 'app/templates/routes/foo.hbs',
         source: '{{outlet}}',
         line: 1,
         column: 0
@@ -40,11 +40,11 @@ generateRuleTests({
     {
       template: '{{#outlet}}Why?!{{/outlet}}',
       meta: {
-        moduleId: 'foo/route.hbs'
+        moduleId: 'app/templates/foo/route.hbs'
       },
       result: {
         message,
-        moduleId: 'foo/route.hbs',
+        moduleId: 'app/templates/foo/route.hbs',
         source: '{{#outlet}}Why?!{{/outlet}}',
         line: 1,
         column: 0
@@ -53,11 +53,11 @@ generateRuleTests({
     {
       template: '{{#outlet}}Why?!{{/outlet}}',
       meta: {
-        moduleId: 'routes/foo.hbs'
+        moduleId: 'app/templates/routes/foo.hbs'
       },
       result: {
         message,
-        moduleId: 'routes/foo.hbs',
+        moduleId: 'app/templates/routes/foo.hbs',
         source: '{{#outlet}}Why?!{{/outlet}}',
         line: 1,
         column: 0
@@ -66,11 +66,11 @@ generateRuleTests({
     {
       template: '{{#outlet}}Works because ambiguous{{/outlet}}',
       meta: {
-        moduleId: 'something/foo.hbs'
+        moduleId: 'app/templates/something/foo.hbs'
       },
       result: {
         message,
-        moduleId: 'something/foo.hbs',
+        moduleId: 'app/templates/something/foo.hbs',
         source: '{{#outlet}}Works because ambiguous{{/outlet}}',
         line: 1,
         column: 0
@@ -82,12 +82,12 @@ generateRuleTests({
       template: '{{outlet}}',
 
       meta: {
-        moduleId: 'components/foo/layout.hbs'
+        moduleId: 'app/templates/components/foo/layout.hbs'
       },
 
       result: {
         message,
-        moduleId: 'components/foo/layout.hbs',
+        moduleId: 'app/templates/components/foo/layout.hbs',
         source: '{{outlet}}',
         line: 1,
         column: 0
@@ -97,12 +97,12 @@ generateRuleTests({
       template: '{{outlet}}',
 
       meta: {
-        moduleId: 'foo/-mything.hbs'
+        moduleId: 'app/templates/foo/-mything.hbs'
       },
 
       result: {
         message,
-        moduleId: 'foo/-mything.hbs',
+        moduleId: 'app/templates/foo/-mything.hbs',
         source: '{{outlet}}',
         line: 1,
         column: 0


### PR DESCRIPTION
This test fails when the application (or addon) has a route with a name ending in "components"
It's necessary to specified the parent folder name "templates/"