### PR TITLE
Ensure element modifiers are handled by attribute-indentation rule.

### DIFF
--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -255,7 +255,8 @@ module.exports = class AttributeSpacing extends Rule {
   }
 
   iterateParams(params, type, expectedLineStart, expectedColumnStart, node) {
-    let paramType, namePath;
+    let paramType = type;
+    let namePath;
 
     if (type === 'positional') {
       paramType = 'positional param';
@@ -263,8 +264,10 @@ module.exports = class AttributeSpacing extends Rule {
     } else if (type === 'htmlAttribute') {
       paramType = 'htmlAttribute';
       namePath = 'name';
+    } else if (type === 'element modifier') {
+      paramType = 'element modifier';
     } else {
-      paramType = 'attribute';
+      paramType = type;
       namePath = 'key';
     }
 
@@ -323,7 +326,13 @@ module.exports = class AttributeSpacing extends Rule {
       column: node.loc.start.column,
     };
     if (node.type === 'ElementNode') {
-      nextLocation = this.iterateParams(node.attributes, 'htmlAttribute', expectedLineStart, expectedColumnStart, node);
+      if (node.attributes.length > 0) {
+        nextLocation = this.iterateParams(node.attributes, 'htmlAttribute', expectedLineStart, expectedColumnStart, node);
+      }
+
+      if (node.modifiers.length > 0) {
+        nextLocation = this.iterateParams(node.modifiers, 'element modifier', nextLocation.line, expectedColumnStart, node);
+      }
     } else {
       if (node.path.loc.source === '(synthetic)') {
         expectedLineStart--;
@@ -354,8 +363,6 @@ module.exports = class AttributeSpacing extends Rule {
       line: end.line,
       column: end.column - actualColumnStartLocation
     };
-
-
 
     const endPosition = node.type === 'ElementNode' ? this.config.elementOpenEnd : this.config.mustacheOpenEnd;
     const expectedStartLocation = {
@@ -414,9 +421,9 @@ module.exports = class AttributeSpacing extends Rule {
   validateNonBlockForm(node) {
     // no need to validate if no positional and named params are present.
     if (node.params.length || node.hash.pairs.length) {
-      const expectedStartLine = this.validateParams(node);
-      this.validateCloseBrace(node, expectedStartLine);
-      return expectedStartLine;
+      const nextLocation = this.validateParams(node);
+      this.validateCloseBrace(node, nextLocation);
+      return nextLocation;
     }
   }
 
@@ -512,7 +519,7 @@ module.exports = class AttributeSpacing extends Rule {
       ElementNode(node) {
         if (this.config.processElements) {
           if (canApplyRule(node, node.type, this.config)) {
-            if (node.attributes.length) {
+            if (node.modifiers.length > 0 || node.attributes.length > 0) {
               let expectedCloseBraceLocation = this.validateParams(node);
               this.validateCloseBrace(node, expectedCloseBraceLocation);
             }

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -638,7 +638,15 @@ generateRuleTests({
           }}
           data-after-long-arg={{true}}
         />`
-    }
+    },
+    {
+      template: `
+        <form
+          class='form-signin'
+          {{action 'authenticate' email password}}
+        >
+        </form>`
+    },
   ],
 
   bad: [{
@@ -1325,5 +1333,34 @@ generateRuleTests({
       'column': 21,
       'source': '{{#contact-details\n  param0\n  param1=abc\n  param2=abc\nas |ab cd ef  cd ef |}}\n  {{contact.fullName}}\n{{/contact-details}}'
     }],
-  }]
+  },
+  {
+    template: `
+      <form
+        {{action 'authenticate' email password}}
+        class='form-signin'
+      >
+      </form>`,
+    results: [
+      {
+        'rule': 'attribute-indentation',
+        'severity': 2,
+        'moduleId': 'layout.hbs',
+        'message': `Incorrect indentation of htmlAttribute 'class' beginning at L4:C8. Expected 'class' to be at L3:C8.`,
+        'line': 4,
+        'column': 8,
+        'source': `<form\n        {{action 'authenticate' email password}}\n        class='form-signin'\n      >\n      </form>`
+      },
+      {
+        'rule': 'attribute-indentation',
+        'severity': 2,
+        'moduleId': 'layout.hbs',
+        'message': `Incorrect indentation of element modifier 'action' beginning at L3:C8. Expected 'action' to be at L4:C8.`,
+        'line': 3,
+        'column': 8,
+        'source': `<form\n        {{action 'authenticate' email password}}\n        class='form-signin'\n      >\n      </form>`
+      },
+    ]
+  },
+  ]
 });


### PR DESCRIPTION
* Adds validation to element modifiers
* Requires element modifier to be _after_ all attributes
* Added tests to ensure both cases continue to work...

Fixes #467