### PR TITLE
Add blacklist support to simple-unless rule

### DIFF
--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -58,7 +58,8 @@ The following values are valid configuration:
   * boolean -- `true` for enabled / `false` for disabled
   * object --
     * `whitelist` -- array - `['or']` for specific helpers / `[]` for wildcard
-    * `maxHelpers` -- number
+    * `blacklist` -- array - `['or']` for specific helpers / `[]` for none
+    * `maxHelpers` -- number - use -1 for no limit
 
 ### Related Rules
 

--- a/lib/rules/lint-simple-unless.js
+++ b/lib/rules/lint-simple-unless.js
@@ -12,6 +12,7 @@ const messages = {
 
 const DEFAULT_CONFIG = {
   whitelist: [],
+  blacklist: [],
   maxHelpers: 0,
 };
 
@@ -23,6 +24,8 @@ function isValidConfigObjectFormat(config) {
     if (value === undefined) {
       config[key] = DEFAULT_CONFIG[key];
     } else if (key === 'whitelist' && !valueIsArray) {
+      return false;
+    } else if (key === 'blacklist' && !valueIsArray) {
       return false;
     }
   }
@@ -53,7 +56,8 @@ module.exports = class LintSimpleUnless extends Rule {
         '  * boolean -- `true` for enabled / `false` for disabled\n' +
           '  * object --\n' +
           "    *  `whitelist` -- array - `['or']` for specific helpers / `[]` for wildcard\n" +
-          '    *  `maxHelpers` -- number',
+          "    *  `blacklist` -- array - `['or']` for specific helpers / `[]` for none\n" +
+          '    *  `maxHelpers` -- number - use -1 for no limit',
       ],
       config
     );
@@ -114,7 +118,8 @@ module.exports = class LintSimpleUnless extends Rule {
   }
 
   _withHelper(node) {
-    const whitelist = this.config.whitelist; // let { whitelist, maxHelpers } = this.config;
+    const whitelist = this.config.whitelist; // let { whitelist, blacklist, maxHelpers } = this.config;
+    const blacklist = this.config.blacklist;
     const maxHelpers = this.config.maxHelpers;
 
     let params;
@@ -128,7 +133,7 @@ module.exports = class LintSimpleUnless extends Rule {
 
       params.forEach(param => {
         if (param.type === 'SubExpression') {
-          if (++helperCount > maxHelpers) {
+          if (++helperCount > maxHelpers && maxHelpers > -1) {
             let loc = param.loc.start;
             let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
             let message = `${messages.withHelper} MaxHelpers: ${maxHelpers}`;
@@ -136,13 +141,22 @@ module.exports = class LintSimpleUnless extends Rule {
             this._logMessage(message, loc.line, loc.column, actual);
           }
 
-          if (whitelist.length > 0 && whitelist.indexOf(param.path.original) === -1) {
-            // whitelist.includes(param.path.original)
+          if (whitelist.length > 0 && !whitelist.includes(param.path.original)) {
             let loc = param.loc.start;
             let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
             let message = `${messages.withHelper} Allowed helper${
               whitelist.length > 1 ? 's' : ''
             }: ${whitelist.toString()}`;
+
+            this._logMessage(message, loc.line, loc.column, actual);
+          }
+
+          if (blacklist.length > 0 && blacklist.includes(param.path.original)) {
+            let loc = param.loc.start;
+            let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
+            let message = `${messages.withHelper} Restricted helper${
+              blacklist.length > 1 ? 's' : ''
+            }: ${blacklist.toString()}`;
 
             this._logMessage(message, loc.line, loc.column, actual);
           }

--- a/test/unit/rules/lint-simple-unless-test.js
+++ b/test/unit/rules/lint-simple-unless-test.js
@@ -45,6 +45,26 @@ generateRuleTests({
       },
       template: '{{unless (eq (not foo) bar) baz}}',
     },
+    {
+      config: {
+        maxHelpers: -1,
+      },
+      template: '{{unless (eq (not foo) bar) baz}}',
+    },
+    {
+      config: {
+        maxHelpers: -1,
+        blacklist: [],
+      },
+      template: '{{unless (eq (not foo) bar) baz}}',
+    },
+    {
+      config: {
+        maxHelpers: -1,
+        blacklist: ['or'],
+      },
+      template: '{{unless (eq (not foo) bar) baz}}',
+    },
   ],
 
   bad: [
@@ -322,6 +342,53 @@ generateRuleTests({
         line: 1,
         column: 27,
       },
+    },
+    {
+      config: {
+        blacklist: ['two'],
+        maxHelpers: -1,
+      },
+      template: [
+        '{{#unless (one (two three) (four five))}}',
+        '  I think I am a brown stick',
+        '{{/unless}}',
+      ].join('\n'),
+
+      result: {
+        message:
+          'Using {{unless}} in combination with other helpers should be avoided. Restricted helper: two',
+        source: '{{unless (... (two ...',
+        line: 1,
+        column: 15,
+      },
+    },
+    {
+      config: {
+        blacklist: ['two', 'four'],
+        maxHelpers: -1,
+      },
+      template: [
+        '{{#unless (one (two three) (four five))}}',
+        '  I think I am a brown stick',
+        '{{/unless}}',
+      ].join('\n'),
+
+      results: [
+        {
+          message:
+            'Using {{unless}} in combination with other helpers should be avoided. Restricted helpers: two,four',
+          source: '{{unless (... (two ...',
+          line: 1,
+          column: 15,
+        },
+        {
+          message:
+            'Using {{unless}} in combination with other helpers should be avoided. Restricted helpers: two,four',
+          source: '{{unless (... (four ...',
+          line: 1,
+          column: 27,
+        },
+      ],
     },
   ],
 });


### PR DESCRIPTION
A project I'm working on has need of a `blacklist` feature in conjunction with the 'simple-unless' rule. We would like to allow most cases for `{{unless}}`, but prevent certain helpers from being used with them.

Code changes include adding that blacklist support, as well as modifying `maxHelpers` to treat a value of `-1` as 'no limit'. This is useful because otherwise, to use the `blacklist`, one would need to specify an arbitrarily large number for `maxHelpers` (as it would raise errors on helpers _not_ in the `blacklist` when the limit, defaulted to 0, was reached).