### PR TITLE
[ISSUE-527] Add option for config-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Example usage:
 
 # ignore warnings / only report errors
 ./node_modules/.bin/ember-template-lint app/templates/application.hbs --quiet
+
+# define custom config path
+./node_modules/.bin/ember-template-lint app/templates/application.hbs --config-path .my-template-lintrc.js
 ```
 
 ### ESLint
@@ -83,7 +86,8 @@ ember-template-lint into your normal eslint workflow.
 ### Project Wide
 
 You can turn on specific rules by toggling them in a
-`.template-lintrc.js` file at the base of your project:
+`.template-lintrc.js` file at the base of your project, or at a custom relative
+path which may be identified using the CLI:
 
 ```javascript
 module.exports = {

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -238,5 +238,40 @@ describe('ember-template-lint executable', function() {
         });
       });
     });
+
+    describe('with --config-path param', function() {
+      describe('given a directory with errors and a lintrc with rules', function() {
+        it('should print properly formatted error messages', function(done) {
+          execFile('node', ['../../../bin/ember-template-lint.js', '.', '--config-path', '../with-errors/.template-lintrc'], {
+            cwd: './test/fixtures/without-errors'
+          }, function(err, stdout, stderr) {
+            expect(err).to.be.ok;
+            expect(stdout.split('\n')).to.deep.equal([
+              path.resolve('./test/fixtures/without-errors/app/templates/application.hbs'),
+              '  1:4  error  Non-translated string used  no-bare-strings',
+              '  2:5  error  Non-translated string used  no-bare-strings',
+              '',
+              '✖ 2 problems (2 errors, 0 warnings)',
+              ''
+            ]);
+            expect(stderr).to.be.empty;
+            done();
+          });
+        });
+      });
+
+      describe('given a directory with errors but a lintrc without any rules', function() {
+        it('should exit without error and any console output', function(done) {
+          execFile('node', ['../../../bin/ember-template-lint.js', '.', '--config-path', '../without-errors/.template-lintrc'], {
+            cwd: './test/fixtures/with-errors'
+          }, function(err, stdout, stderr) {
+            expect(err).to.be.null;
+            expect(stdout).to.be.empty;
+            expect(stderr).to.be.empty;
+            done();
+          });
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
## Problem:
If someone wants to use or share a single lintrc file across multiple in-repo addons, there is no way to do so without symlinking or creating a separate repo to share configs, which could be overkill for some folks. Most of the necessary code is already in place to enable this feature, we just need a place to define the variable.

----

## Current Behavior:
No way to set a custom `configPath`.

## Solution:
Updated the `./bin/ember-template-lint.js` to allow a user to pass in a `--config-path` argument followed by the relative path to the desired location. Doing so will result in the defining of the `configPath` option on the `Linter` Class.

Note: To do this, I had to move where `Linter` is invoked, which required me to add the `linter` to the list of arguments that gets passed to the `lintFile` function.

Example: `ember-template-lint . --config-path ../../.my-template-lintrc.js`

Fixes https://github.com/ember-template-lint/ember-template-lint/issues/527