### PR TITLE
Make example pass rule

### DIFF
--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -110,7 +110,8 @@ Block form (HTML)
     href="https://www.emberjs.com"
     class="emberjs-home link"
     rel="noopener"
-    target="_blank">
+    target="_blank"
+  >
     Ember JS
   </a>
 ```


### PR DESCRIPTION
Example as it is written does not pass the rule `attribute-indentation`. This makes the example passing.