### PR TITLE
Make block example pass default rule

### DIFF
--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -90,7 +90,8 @@ Block form
     lastName=lastName
     age=age
     avatarUrl=avatarUrl
-  as |employee|}}
+  as |employee|
+  }}
     {{employee.fullName}}
   {{/employee-details}}
 ```


### PR DESCRIPTION
Similar to #541, default setting for `mustache-open-end` requires the closing braces to be on a new line.