### PR TITLE
Allow RegExp's with no-implicit-this 

### DIFF
--- a/docs/rule/no-implicit-this.md
+++ b/docs/rule/no-implicit-this.md
@@ -95,4 +95,4 @@ much easier to implement since we have semantics that mean "property on class".
   * boolean - `true` to enable / `false` to disable
   * object -- An object with the following keys:
     * `allow` -- An array of component / helper names for that may be called
-      without arguments
+      without arguments (string or regular expression)

--- a/lib/rules/lint-no-implicit-this.js
+++ b/lib/rules/lint-no-implicit-this.js
@@ -16,6 +16,14 @@ function isString(value) {
   return typeof value === 'string';
 }
 
+function isRegExp(value) {
+  return value instanceof RegExp;
+}
+
+function allowedFormat(value){
+  return isString(value) || isRegExp(value);
+}
+
 // Allow Ember's builtin argless syntaxes
 const ARGLESS_BUILTINS = [
   'debugger',
@@ -55,7 +63,7 @@ module.exports = class StrictPaths extends Rule {
       }
 
     case 'object':
-      if (Array.isArray(config.allow) && config.allow.every(isString)) {
+      if (Array.isArray(config.allow) && config.allow.every(allowedFormat)) {
         return {
           allow: [].concat(
             ARGLESS_BUILTINS,
@@ -94,8 +102,9 @@ module.exports = class StrictPaths extends Rule {
           let valid = path.data ||
                       path.this ||
                       this.isLocal(path) ||
-                      this.config.allow.indexOf(path.original) > -1;
-
+                      this.config.allow.some((item) => {
+                        return isRegExp(item) ? item.test(path.original) : item === path.original;
+                      });
 
           if (!valid) {
             this.log({

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -643,30 +643,4 @@ describe('public api', function() {
       expect(result).to.equal('');
     });
   });
-
-  describe('Linter accepts RegExp in rules[\'no-implicit-this\'].allow', function() {
-    let basePath = path.join(fixturePath, 'no-implicit-this-allow-with-regexp');
-    let linter;
-
-    beforeEach(function() {
-      linter = new Linter({
-        console: mockConsole,
-        configPath: path.join(basePath, '.template-lintrc.js')
-      });
-    });
-
-    it('accepts Strings and RegExps in allow array', function() {
-      let templatePath = path.join(basePath, 'app', 'templates', 'application.hbs');
-      let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
-      let expected = [];
-
-      let result = linter.verify({
-        source: templateContents,
-        moduleId: templatePath
-      });
-
-      expect(result).to.deep.equal(expected);
-    });
-
-  });
 });

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -643,4 +643,30 @@ describe('public api', function() {
       expect(result).to.equal('');
     });
   });
+
+  describe('Linter accepts RegExp in rules[\'no-implicit-this\'].allow', function() {
+    let basePath = path.join(fixturePath, 'no-implicit-this-allow-with-regexp');
+    let linter;
+
+    beforeEach(function() {
+      linter = new Linter({
+        console: mockConsole,
+        configPath: path.join(basePath, '.template-lintrc.js')
+      });
+    });
+
+    it('accepts Strings and RegExps in allow array', function() {
+      let templatePath = path.join(basePath, 'app', 'templates', 'application.hbs');
+      let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
+      let expected = [];
+
+      let result = linter.verify({
+        source: templateContents,
+        moduleId: templatePath
+      });
+
+      expect(result).to.deep.equal(expected);
+    });
+
+  });
 });

--- a/test/fixtures/no-implicit-this-allow-with-regexp/.template-lintrc.js
+++ b/test/fixtures/no-implicit-this-allow-with-regexp/.template-lintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  rules: {
+    'no-implicit-this': {
+      allow: [
+        /^data-test-/,
+        'book'
+      ]
+    }
+  }
+};

--- a/test/fixtures/no-implicit-this-allow-with-regexp/app/templates/application.hbs
+++ b/test/fixtures/no-implicit-this-allow-with-regexp/app/templates/application.hbs
@@ -1,0 +1,2 @@
+{{input data-test-input}}
+{{book}}

--- a/test/unit/rules/lint-no-implicit-this-test.js
+++ b/test/unit/rules/lint-no-implicit-this-test.js
@@ -25,6 +25,10 @@ let good = [
   {
     config: { allow: ['book-details'] },
     template: '{{book-details}}'
+  },
+  {
+    config: { allow: [/^data-test-.+/] },
+    template: '{{foo-bar data-test-foo}}'
   }
 ];
 


### PR DESCRIPTION
The rule that permits `rules['no-implicit-this'].allow` array to include only strings prevents efficient work with ember-test-selectors (it is necessary to put all of `data-test-*` attributes in allow array, but this list may be large)