### PR TITLE
Rejects invalid configPath configuration

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -72,8 +72,7 @@ function checkConfigPath() {
   var configPathIndex = process.argv.indexOf('--config-path');
   var configPath = null;
   if (configPathIndex > -1) {
-    var configPathValue = process.argv[configPathIndex + 1];
-    configPath = path.join(process.cwd(), configPathValue);
+    configPath = process.argv[configPathIndex + 1];
   }
 
   return configPath;
@@ -83,7 +82,14 @@ function run() {
   var exitCode = 0;
 
   var configPath = checkConfigPath();
-  var linter = new Linter({ configPath });
+  var linter;
+  try {
+    linter = new Linter({ configPath });
+  } catch (e) {
+    console.error(e.message);
+    // eslint-disable-next-line no-process-exit
+    return process.exit(1);
+  }
 
   var errors = getRelativeFilePaths().reduce((errors, relativeFilePath) => {
     var filePath = path.resolve(relativeFilePath);

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -12,25 +12,27 @@ const KNOWN_ROOT_PROPERTIES = ['extends', 'rules', 'pending', 'ignore', 'plugins
 
 function resolveConfigPath(configPath, pluginPath) {
 
-  configPath = configPath || path.join(process.cwd(), '.template-lintrc');
-
+  var usedPath = path.resolve(process.cwd(), configPath || '.template-lintrc');
 
   if (pluginPath) {
 
     //throws exception if not found
-    pluginPath = resolve.sync(pluginPath, { basedir: path.dirname(configPath) });
+    pluginPath = resolve.sync(pluginPath, { basedir: path.dirname(usedPath) });
 
   }
 
-  let filePath = pluginPath || configPath;
+  let filePath = pluginPath || usedPath;
   try {
     return require(filePath);
   } catch(e) {
-    if (e.code === 'MODULE_NOT_FOUND') {
+    if (!e.code) {
+      throw e;
+    }
+    if (e.code === 'MODULE_NOT_FOUND' && !configPath) {
       return {};
     }
 
-    throw e;
+    throw new Error(`The configuration file specified (${configPath}) could not be found. Aborting.`);
   }
 }
 

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -41,6 +41,14 @@ describe('public api', function() {
       }).to.throw(/error happening during config loading/);
     });
 
+    it('uses an empty set of rules if no .template-lintrc is present', function() {
+      let linter = new Linter({
+        console: mockConsole
+      });
+
+      expect(linter.config.rules).to.deep.equal({});
+    });
+
     it('uses provided config', function() {
       let basePath = path.join(fixturePath, 'config-in-root');
       let expected = require(path.join(basePath, '.template-lintrc'));
@@ -79,6 +87,15 @@ describe('public api', function() {
       });
 
       expect(linter.config.rules).to.deep.equal(expected.rules);
+    });
+
+    it('breaks if the specified configPath does not exist', function() {
+      expect(() => {
+        new Linter({
+          console: mockConsole,
+          configPath: 'does/not/exist'
+        });
+      }).to.throw('The configuration file specified (does/not/exist) could not be found. Aborting.');
     });
 
     it('with deprecated rule config', function() {


### PR DESCRIPTION
This PR ensures that the process breaks (with an informative message) when the user provides a path to a config file that does not exist.

The current (read: before the PR) behaviour is that, because the module fails to load, it is replaced by a default configuration (empty set of rules), which is disconcerting when you're editing a config file and see no result because you typo'ed the path :p