### PR TITLE
Makes statusForModule compatible with absolute paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ const Minimatch = require('minimatch').Minimatch;
 const getConfig = require('./get-config');
 const stripBom = require('strip-bom');
 const chalk = require('chalk');
+var path = require('path');
 
 const TransformDotComponentInvocation = require('./plugins/transform-dot-component-invocation');
 
@@ -78,17 +79,26 @@ class Linter {
 
   statusForModule(type, moduleId) {
     let list = this.config[type];
+    let configPath = this.options.configPath || '';
     if (!list) { return false; }
 
     for (let i = 0; i < list.length; i++) {
       let item = list[i];
 
+      let fullPathModuleId = path.resolve(process.cwd(), moduleId);
+
       if (item instanceof Minimatch && item.match(moduleId)) {
         return true;
-      } else if (typeof item === 'string' && moduleId === item) {
-        return true;
-      } else if (item.moduleId === moduleId){
-        return item;
+      } else if (typeof item === 'string' ) {
+        let fullPathItem = path.resolve(process.cwd(), path.dirname(configPath), item);
+        if (fullPathModuleId === fullPathItem) {
+          return true;
+        }
+      } else if (item.moduleId) {
+        let fullPathItem = path.resolve(process.cwd(), path.dirname(configPath), item.moduleId);
+        if (fullPathModuleId === fullPathItem) {
+          return item;
+        }
       }
     }
 

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -540,6 +540,21 @@ describe('public api', function() {
       expect(linter.statusForModule('pending', 'foo/bar/baz')).to.be.ok;
       expect(linter.statusForModule('pending', 'some/other/path')).to.not.be.ok;
     });
+
+    it('matches with absolute paths for modules', function() {
+      let linter = new Linter({
+        console: mockConsole,
+        config: {
+          pending: [
+            'some/path/here',
+            { moduleId: 'foo/bar/baz', only: ['no-bare-strings']}
+          ]
+        }
+      });
+
+      expect(linter.statusForModule('pending', process.cwd() + '/some/path/here')).to.be.ok;
+      expect(linter.statusForModule('pending', process.cwd() + '/foo/bar/baz')).to.be.ok;
+    });
   });
 
   describe('Linter.errorsToMessages', function() {


### PR DESCRIPTION
This PR allows to define pending statuses with relative paths (as before)
and unifies the paths when the files to be checked are given with absolute paths.

In other words, this allows to define pending modules as `pending: ['relative/path/to/module']`
whil calling `ember-template-lint /home/user/app/relative/path/to/module` from `/home/user/app`.