### PR TITLE
feat: add rule 'no-extra-mut-helper-argument'.

### DIFF
--- a/docs/rule/no-extra-mut-helper-argument.md
+++ b/docs/rule/no-extra-mut-helper-argument.md
@@ -1,0 +1,19 @@
+## no-extra-mut-helper-argument
+
+A common mistake when using the Ember handlebars template `mut(attr)` helper is to pass an extra `value` parameter to it when only `attr` should be passed. Instead, the `value` should be passed outside of `mut`.
+
+Examples of **incorrect** code for this rule:
+
+```hbs
+{{my-component click=(action (mut isClicked true))}}
+```
+
+Examples of **correct** code for this rule:
+
+```hbs
+{{my-component click=(action (mut isClicked) true)}}
+```
+
+### References
+
+* See the [documentation](https://emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut) for the Ember handlebars template `mut` helper

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -14,6 +14,7 @@
 * [no-bare-strings](rule/no-bare-strings.md)
 * [no-debugger](rule/no-debugger.md)
 * [no-duplicate-attributes](rule/no-duplicate-attributes.md)
+* [no-extra-mut-helper-argument](rule/no-extra-mut-helper-argument.md)
 * [no-html-comments](rule/no-html-comments.md)
 * [no-implicit-this](rule/no-implicit-this.md)
 * [no-inline-styles](rule/no-inline-styles.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -18,6 +18,7 @@ module.exports = {
   'no-bare-strings': require('./lint-no-bare-strings'),
   'no-debugger': require('./lint-no-debugger'),
   'no-duplicate-attributes': require('./lint-duplicate-attributes'),
+  'no-extra-mut-helper-argument': require('./lint-no-extra-mut-helper-argument'),
   'no-html-comments': require('./lint-no-html-comments'),
   'no-implicit-this': require('./lint-no-implicit-this'),
   'no-inline-styles': require('./lint-no-inline-styles'),

--- a/lib/rules/lint-no-extra-mut-helper-argument.js
+++ b/lib/rules/lint-no-extra-mut-helper-argument.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const Rule = require('./base');
+
+const ERROR_MESSAGE = 'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.';
+
+module.exports = class MutSingleArg extends Rule {
+  visitor() {
+    return {
+      SubExpression(node) {
+        if (node.path.original !== 'mut') {
+          return;
+        }
+
+        if (node.params.length === 1) {
+          // Correct usage.
+          return;
+        }
+
+        this.log({
+          message: ERROR_MESSAGE,
+          line: node.loc && node.loc.start.line,
+          column: node.loc && node.loc.start.column,
+          source: this.sourceForNode(node)
+        });
+      }
+    };
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/lint-no-extra-mut-helper-argument-test.js
+++ b/test/unit/rules/lint-no-extra-mut-helper-argument-test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+const ERROR_MESSAGE = require('../../../lib/rules/lint-no-extra-mut-helper-argument').ERROR_MESSAGE;
+
+generateRuleTests({
+  name: 'no-extra-mut-helper-argument',
+
+  config: true,
+
+  good: [
+    '{{my-component click=(action (mut isClicked))}}',
+    '{{my-component click=(action (mut isClicked) true)}}',
+    '{{my-component isClickedMutable=(mut isClicked)}}',
+    '<button {{action (mut isClicked)}}></button>',
+    '<button {{action (mut isClicked) true}}></button>'
+  ],
+
+  bad: [
+    {
+      template: '{{my-component click=(action (mut isClicked true))}}',
+
+      result: {
+        message: ERROR_MESSAGE,
+        moduleId: 'layout.hbs',
+        source: '(mut isClicked true)',
+        line: 1,
+        column: 29
+      }
+    },
+    {
+      template: '{{my-component isClickedMutable=(mut isClicked true)}}',
+
+      result: {
+        message: ERROR_MESSAGE,
+        moduleId: 'layout.hbs',
+        source: '(mut isClicked true)',
+        line: 1,
+        column: 32
+      }
+    },
+    {
+      template: '<button {{action (mut isClicked true)}}></button>',
+
+      result: {
+        message: ERROR_MESSAGE,
+        moduleId: 'layout.hbs',
+        source: '(mut isClicked true)',
+        line: 1,
+        column: 17
+      }
+    }
+  ]
+});


### PR DESCRIPTION
Adds new rule to catch the common mistake of passing an extra `value` argument to the `mut(attr)` helper.