### PR TITLE
Lints from stdin

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -8,8 +8,17 @@ var globby = require('globby');
 var Linter = require('../lib/index');
 const chalk = require('chalk');
 
+let [templatePatterns, args] = process.argv.slice(2).reduce(function([files, options], arg) {
+  if (options.length || (arg.slice(0, 2) === '--')) {
+    options = options.concat(arg);
+  } else {
+    files = files.concat(arg);
+  }
+  return [files, options];
+}, [[], []]);
+
 function printErrors(errors) {
-  const quiet = process.argv.indexOf('--quiet') !== -1;
+  const quiet = args.indexOf('--quiet') !== -1;
 
   let errorCount = 0;
   let warningCount = 0;
@@ -28,14 +37,14 @@ function printErrors(errors) {
     errors[filePath] = errorsFiltered.concat(warnings);
   });
 
-  if (process.argv.indexOf('--json') + 1) {
+  if (args.indexOf('--json') + 1) {
     console.log(JSON.stringify(errors, null, 2));
   } else {
     Object.keys(errors).forEach(filePath => {
       let options = {};
       let fileErrors = errors[filePath] || [];
 
-      if (process.argv.indexOf('--verbose') + 1) {
+      if (args.indexOf('--verbose') + 1) {
         options.verbose = true;
       }
 
@@ -63,7 +72,7 @@ function lintFile(linter, filePath, moduleId) {
 }
 
 function getRelativeFilePaths() {
-  var fileArgs = process.argv.slice(2).filter(arg => arg.slice(0, 2) !== '--');
+  var fileArgs = templatePatterns;
 
   var relativeFilePaths = fileArgs
     .reduce((filePaths, fileArg) => {
@@ -75,10 +84,11 @@ function getRelativeFilePaths() {
 }
 
 function checkConfigPath() {
-  var configPathIndex = process.argv.indexOf('--config-path');
+  var configPathIndex = args.indexOf('--config-path');
   var configPath = null;
   if (configPathIndex > -1) {
-    configPath = process.argv[configPathIndex + 1];
+    var configPathValue = args[configPathIndex + 1];
+    configPath = path.join(process.cwd(), configPathValue);
   }
 
   return configPath;

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -141,12 +141,13 @@ function run() {
     stdinPromise = getStdin().then((stdin)=> {
       var filePath = tmp.fileSync().name;
       fs.writeFileSync(filePath, stdin);
+      let modulePath = path.resolve(process.cwd(), path.dirname(checkConfigPath() || ''), stdinFilename.slice(0, -4));
 
-      var fileErrors = lintFile(linter, filePath, stdinFilename.slice(-1, -4));
+      var fileErrors = lintFile(linter, filePath, modulePath);
 
       if (fileErrors.some(function(err) { return err.severity > 1; })) exitCode = 1;
 
-      if (fileErrors.length) errors[filePath] = fileErrors;
+      if (fileErrors.length) errors[stdinFilename] = fileErrors;
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
   "dependencies": {
     "@glimmer/compiler": "^0.38.0",
     "chalk": "^2.0.0",
+    "get-stdin": "^6.0.0",
     "globby": "^8.0.1",
     "minimatch": "^3.0.4",
     "resolve": "^1.1.3",
-    "strip-bom": "^3.0.0"
+    "strip-bom": "^3.0.0",
+    "tmp": "^0.0.33"
   },
   "devDependencies": {
     "chai": "^4.0.0",


### PR DESCRIPTION
Hi!
Similar to ESLint, this PR allows `ember-template-lint` to lint from stdin, considering the argument `--stdin-filename` (as used in ESLint) is present with a value.

This is ver useful for editors that often allow linting to happen during edition, _ie_ before the file is actually saved to disk.