### PR TITLE
fix: errors from 'simple-unless' rule

### DIFF
--- a/lib/rules/lint-simple-unless.js
+++ b/lib/rules/lint-simple-unless.js
@@ -70,7 +70,7 @@ module.exports = class LintSimpleUnless extends Rule {
 
         if (nodeInverse) {
           if (nodePathOriginal === 'unless') {
-            if (nodeInverse.body[0].path) {
+            if (nodeInverse.body[0] && nodeInverse.body[0].path && nodeInverse.body[0].path.original === 'if') {
               this._followingElseIfBlock(node);
             } else {
               this._followingElseBlock(node);

--- a/test/unit/rules/lint-simple-unless-test.js
+++ b/test/unit/rules/lint-simple-unless-test.js
@@ -107,6 +107,38 @@ generateRuleTests({
     {
       template: [
         '{{#unless bandwagoner}}',
+        '{{else}}',
+        '{{/unless}}'
+      ].join('\n'),
+
+      result: {
+        message: messages.followingElseBlock,
+        moduleId: 'layout.hbs',
+        source: '{{else}}',
+        line: 2,
+        column: 0
+      }
+    },
+    {
+      template: [
+        '{{#unless bandwagoner}}',
+        '{{else}}',
+        '  {{#my-component}}',
+        '  {{/my-component}}',
+        '{{/unless}}'
+      ].join('\n'),
+
+      result: {
+        message: messages.followingElseBlock,
+        moduleId: 'layout.hbs',
+        source: '{{else}}',
+        line: 2,
+        column: 0
+      }
+    },
+    {
+      template: [
+        '{{#unless bandwagoner}}',
         '  Go Niners!',
         '{{else if goHawks}}',
         '  Go Seahawks!',


### PR DESCRIPTION
### Bug 1

Template:
```
{{#unless bandwagoner}}
{{else}}
{{/unless}}
```
Linter error:
```
  -:-  error  Cannot read property 'path' of undefined  undefined
```

### Bug 2

Template:
```
{{#unless bandwagoner}}
{{else}}
  {{#my-component}}
  {{/my-component}}
{{/unless}}
```
Linter error:
```
  -:-  error  Cannot read property 'original' of undefined  undefined
```