### PR TITLE
Remove attribute-indentation from recommended config.

### DIFF
--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -2,7 +2,6 @@
 
 module.exports = {
   rules: {
-    'attribute-indentation': true,
     'block-indentation': true,
     'deprecated-render-helper': true,
     'img-alt-attributes': true,


### PR DESCRIPTION
There are a large number of outstanding issues with the attribute-indentation rule, and at this point it is causing more pain than help.

I'd _really_ like to get this re-enabled in the future...