### PR TITLE
Add {{welcome-page}} to default allowed list for no-implicit-this.

### DIFF
--- a/lib/rules/lint-no-implicit-this.js
+++ b/lib/rules/lint-no-implicit-this.js
@@ -27,6 +27,11 @@ const ARGLESS_BUILTINS = [
   'yield',
 ];
 
+// arg'less Components / Helpers in default ember-cli blueprint
+const ARGLESS_DEFAULT_BLUEPRINT = [
+  'welcome-page',
+];
+
 module.exports = class StrictPaths extends Rule {
   parseConfig(config) {
     if (config === false || config === undefined) {
@@ -40,7 +45,10 @@ module.exports = class StrictPaths extends Rule {
     case 'boolean':
       if (config) {
         return {
-          allow: ARGLESS_BUILTINS
+          allow: [].concat(
+            ARGLESS_BUILTINS,
+            ARGLESS_DEFAULT_BLUEPRINT
+          )
         };
       } else {
         return false;
@@ -49,7 +57,11 @@ module.exports = class StrictPaths extends Rule {
     case 'object':
       if (Array.isArray(config.allow) && config.allow.every(isString)) {
         return {
-          allow: ARGLESS_BUILTINS.concat(config.allow)
+          allow: [].concat(
+            ARGLESS_BUILTINS,
+            ARGLESS_DEFAULT_BLUEPRINT,
+            config.allow
+          )
         };
       }
       break;

--- a/test/unit/rules/lint-no-implicit-this-test.js
+++ b/test/unit/rules/lint-no-implicit-this-test.js
@@ -21,6 +21,7 @@ let good = [
   '{{outlet}}',
   '{{textarea}}',
   '{{yield}}',
+  '{{welcome-page}}',
   {
     config: { allow: ['book-details'] },
     template: '{{book-details}}'


### PR DESCRIPTION
This will fix issues seen during testing of enabling `no-implicit-this` by default.

Specifically this scenario:

```
ember new foo
cd foo
ember test
```

Prior to this change would flag `{{welcome-page}}` in the default blueprint.