### PR TITLE
docs: fix typo in 'no-unnecessary-concat' doc migration regexp.

### DIFF
--- a/docs/rule/no-unnecessary-concat.md
+++ b/docs/rule/no-unnecessary-concat.md
@@ -27,4 +27,4 @@ Use regexp find-and-replace to fix existing violations of this rule:
 
 | Before | After |
 | --- | --- |
-| `="{{([^{]+)}}"` | `={{$1}}` |
+| `="{{([^}]+)}}"` | `={{$1}}` |


### PR DESCRIPTION
Fixing a minor typo to ensure this regexp only catches the desired cases in order to fix violations of this rule.

### Regexp should catch:

```hbs
<div class="{{hello}}"></div>
```

```hbs
<div class="{{if (not some.property) "my-class"}}"></div>
```

### Regexp should not catch:

```hbs
<div class="my-class"></div>
```

```hbs
<div class="{{hello}} world"></div>
```

```hbs
<div class="hello {{world}}"></div>
```

```hbs
<div class="{{hello}} {{world}}"></div>
```