### PR TITLE
docs: improve clarity of descriptions and examples in rule docs.

### DIFF
--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -1,6 +1,6 @@
 ## attribute-indentation
 
-This rule requires the positional params, attributes and block params of the helper/component to be indented by moving them to multiple lines when the open invocation has more than 80 characters (configurable).
+This rule requires the positional params, attributes, and block params of the helper/component to be indented by moving them to multiple lines when the open invocation has more than 80 characters (configurable).
 
 ### Forbidden
 
@@ -19,13 +19,13 @@ Block form
 ```
 
 Non-Block form (HTML)
-``` html
+``` hbs
 
   <input disabled id="firstName" value={{firstName}} class="input-field first-name" type="text">
 ```
 
 Block form (HTML)
-``` html
+``` hbs
 
   <a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>
 ```
@@ -71,7 +71,7 @@ Non-Block form with Helper unfolded
 ```
 
 Non-Block form (HTML)
-``` html
+``` hbs
 
   <input
     disabled
@@ -127,4 +127,4 @@ Block form (HTML)
 
 ### Related Rules
 
-* [attribute-indentation](attribute-indentation.md)
+* [block-indentation](block-indentation.md)

--- a/docs/rule/block-indentation.md
+++ b/docs/rule/block-indentation.md
@@ -1,22 +1,34 @@
 ## block-indentation
 
-Good indentation is crucial for long term maintenance of templates. For example, having blocks misaligned is a common cause of logic errors...
+Good indentation is crucial for long-term maintenance of templates. For example, having blocks misaligned is a common cause of logic errors.
 
 This rule **forbids** the following:
 
-``` hbs
-  {{#each foo as |bar}}
+```hbs
+{{#each foo as |bar|}}
 
-    {{/each}}
-
-  <div>
-  <p>{{t "greeting"}}</p>
-  </div>
+  {{/each}}
 ```
 
-``` html
+```hbs
+<div>
+<p>{{t "greeting"}}</p>
+</div>
+```
+
+```hbs
 <div>
   <p>{{t 'Stuff here!'}}</p></div>
+```
+
+This rule **allows** the following:
+
+```hbs
+{{#my-component}}
+  <div>
+    <p>{{t "greeting"}}</p>
+  </div>
+{{/my-component}}
 ```
 
 ### Configuration
@@ -29,4 +41,4 @@ The following values are valid configuration:
 
 ### Related Rules
 
-  * [block-indentation](block-indentation.md)
+  * [attribute-indentation](attribute-indentation.md)

--- a/docs/rule/eol-last.md
+++ b/docs/rule/eol-last.md
@@ -2,17 +2,17 @@
 
 Require or disallow newline at the end of files.
 
-Enforce either:
+Enforce either (without newline at end):
 
 ```hbs
 <div>test</div>
 ```
 
-or:
+or this (with newline at end):
 
 ```hbs
 <div>test</div>
-
+{{! newline would be here }}
 ```
 
 ### Configuration

--- a/docs/rule/img-alt-attributes.md
+++ b/docs/rule/img-alt-attributes.md
@@ -1,8 +1,8 @@
 ## img-alt-attributes
 
-An `<img>` without an `alt` attribute is essentially invisible to assistive technology (i.e. screen readers).
+An `<img>` without an `alt` attribute is essentially invisible to assistive/accessibility technology (i.e. screen readers).
 In order to ensure that screen readers can provide useful information, we need to ensure that all `<img>` elements
-have an `alt` specified. See [WCAG Suggestion H37](https://www.w3.org/TR/WCAG20-TECHS/H37.html).
+have an `alt` attribute specified.
 
 This rule **forbids** the following:
 
@@ -15,3 +15,7 @@ This rule **allows** the following:
 ```hbs
 <img src="rwjblue.png" alt="picture of Robert Jackson">
 ```
+
+### References
+
+* See [WCAG Suggestion H37](https://www.w3.org/TR/WCAG20-TECHS/H37.html)

--- a/docs/rule/link-href-attributes.md
+++ b/docs/rule/link-href-attributes.md
@@ -1,8 +1,6 @@
 ## link-href-attributes
 
-It's common to treat anchor tags as a button: `<a {{action 'handleClick'}}>Submit</a>`.
-
-However, this is typically considered bad practice as an anchor tag without an `href` is unfocusable which break accessability.
+It's common to treat anchor tags as buttons. However, this is typically considered bad practice, as an anchor tag without an `href` is unfocusable which breaks accessibility.
 
 This rule **forbids** the following:
 

--- a/docs/rule/link-rel-noopener.md
+++ b/docs/rule/link-rel-noopener.md
@@ -1,12 +1,14 @@
 ## link-rel-noopener
 
-When you want to link in your app to some external page it is very common to use `<a href="url" target="_blank"></a>`
+When you want to link to an external page from your app, it is very common to use `<a href="url" target="_blank"></a>`
 to make the browser open this link in a new tab.
-However, this practice has performance problems (see [https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/](https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/))
+
+However, this practice has [performance problems](https://jakearchibald.com/2016/performance-benefits-of-rel-noopener/)
 and also opens a door to some security attacks because the opened page can redirect the opener app
 to a malicious clone to perform phishing on your users.
+
 Adding `rel="noopener noreferrer"` closes that door and avoids javascript in the opened tab to block the main
-thread in the opener. Also note that Firefox versions prior 52 do not implement `noopener` and `rel="noreferrer"` should be used instead [ see Firefox issue ](https://bugzilla.mozilla.org/show_bug.cgi?id=1222516) and https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer.
+thread in the opener. Also note that Firefox versions prior 52 do not implement `noopener`, so `rel="noreferrer"` should be used instead ([see Firefox issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1222516)).
 
 This rule **forbids** the following:
 
@@ -27,3 +29,7 @@ The following values are valid configuration:
   * string -- `strict` for enabled and validating both noopener `and` noreferrer
   * boolean `true` to maintain backwards compatibility with previous versions of `ember-template-lint` that validate noopener `or` noreferrer
   If you are supporting Firefox, you should use `strict`.
+
+### References
+
+* [Link type "noreferrer"](https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer) spec

--- a/docs/rule/no-attrs-in-components.md
+++ b/docs/rule/no-attrs-in-components.md
@@ -4,19 +4,17 @@ This rule prevents the usage of `attrs` property to access values passed to the 
 
 This rule **forbids** the following:
 
-```components/templates/layout.hbs
+```hbs
 {{attr.foo}}
 ```
 This rule **allows** the following:
 
-The correct way would be to directly consume `foo` in the template like:
-
-```components/templates/layout.hbs
+```hbs
 {{foo}}
 ```
 
 or if you using Ember 3.1 and above:
 
-```components/templates/layout.hbs
+```hbs
 {{@foo}}
 ```

--- a/docs/rule/no-debugger.md
+++ b/docs/rule/no-debugger.md
@@ -1,9 +1,14 @@
 ## no-debugger
 
-`{{debugger}}` will inject `debugger` statement into compiled template code and will pause its rendering if developer tools are open. That is undesirable in a production environment.
+The `{{debugger}}` helper is equivalent to a JavaScript `debugger` statement. This will halt execution if the browser developer tools are open. That is undesirable in a production environment.
 
 This rule **forbids** the following:
 
 ```hbs
 {{debugger}}
 ```
+
+### References
+
+* Ember's template [Development Helpers](https://guides.emberjs.com/release/templates/development-helpers/) guide
+* Ember's template [debugger](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper documentation

--- a/docs/rule/no-duplicate-attributes.md
+++ b/docs/rule/no-duplicate-attributes.md
@@ -1,8 +1,8 @@
 ## no-duplicate-attributes
 
-This rule forbids multiple attributes passed to a Component, Helper or an ElementNode with the same name.
+This rule forbids multiple attributes passed to a Component, Helper, or an ElementNode with the same name.
 
-This rule **forbids** the following (multiple attributes with the same name):
+This rule **forbids** the following:
 
 ```hbs
 {{employee-details name=name age=age name=name}}

--- a/docs/rule/no-html-comments.md
+++ b/docs/rule/no-html-comments.md
@@ -1,6 +1,6 @@
 ## no-html-comments
 
-HTML comments in your templates will get compiled and rendered into the DOM at runtime. Instead you can annotate your templates using Handlebars comments, which will be stripped out when the template is compiled and have no effect at runtime.
+HTML comments in your templates will get compiled and rendered into the DOM at runtime. This is undesirable in a production environment. Instead, you can annotate your templates using Handlebars comments, which will be stripped out when the template is compiled and have no effect at runtime.
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-input-block.md
+++ b/docs/rule/no-input-block.md
@@ -1,11 +1,15 @@
 ## no-input-block
 
-`{{#input}}Some Content{{/input}}` will result in an error during render. This rule
-provides a helpful error at build time that otherwise might not be caught quickly at
-runtime.
+Use of the block form of the handlebars `input` helper will result in an error at runtime.
 
 This rule **forbids** the following:
 
 ```hbs
-{{#input}}{{/input}}
+{{#input}}Some Content{{/input}}
+```
+
+This rule **allows** the following:
+
+```hbs
+{{input type="text" value=this.firstName disabled=this.entryNotAllowed size="50"}}
 ```

--- a/docs/rule/no-input-tagname.md
+++ b/docs/rule/no-input-tagname.md
@@ -1,9 +1,6 @@
 ## no-input-tagname
 
-`{{input tagName=x}}` will result in obtuse errors. Typically the input will simply
-fail to render, whether used in block form or inline. The only valid tagName for the
-input helper is `input`. For `textarea`, `button` and other input-like elements create
-a new component or better use the DOM!
+`{{input tagName=x}}` will result in obtuse errors. Typically, the input will simply fail to render, whether used in block form or inline. The only valid `tagName` for the input helper is `input`. For `textarea`, `button`, and other input-like elements, you should instead create a new component or better use the DOM!
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-invalid-interactive.md
+++ b/docs/rule/no-invalid-interactive.md
@@ -11,8 +11,6 @@ This rule **forbids** the following:
 
 This rule **allows** the following:
 
-Instead, you should add a `role` to the element in question so that the A/T is aware that it is interactive:
-
 ```hbs
 <div role="button" {{action "foo"}}></div>
 ```
@@ -26,4 +24,4 @@ The following values are valid configuration (same as the `no-nested-interactive
     * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.
     * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
     * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
-    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.'
+    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.

--- a/docs/rule/no-nested-interactive.md
+++ b/docs/rule/no-nested-interactive.md
@@ -1,17 +1,21 @@
 ## no-nested-interactive
 
-Usage of nested `interactive content` can lead to UX problems, accessibility
-problems, bugs and in some cases to DOM errors. You should not put interactive
-content elements nested inside other interactive content elements. Instead using
-nested interactive content elements you should separate them and put them one
-after the other.
+Usage of nested, interactive content can lead to UX problems, accessibility problems, bugs, and in some cases DOM errors. You should not put interactive content elements nested inside other interactive content elements. Instead of using nested interactive content elements, you should separate them, or use styling on a single element.
 
-This rule **forbids** the following:
+This rule **forbids** the following (button nested inside a link):
 
 ```hbs
-<button type="button">
-  Click here and <a href="/">go to home here</a>
-</button>
+<a href="/contact-us">
+  <button type="button">
+    Contact Us
+  </button>
+</a>
+```
+
+This rule **allows** the following (link with button styling):
+
+```hbs
+<a href="/contact-us" class="button">Contact Us</a>
 ```
 
 ### Configuration
@@ -23,4 +27,4 @@ The following values are valid configuration:
     * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.
     * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
     * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
-    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.'
+    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.

--- a/docs/rule/no-outlet-outside-routes.md
+++ b/docs/rule/no-outlet-outside-routes.md
@@ -1,8 +1,6 @@
 ## no-outlet-outside-routes
 
-`{{outlet}}` is used to specify locations into which routes may be rendered. Typically, to keep routing clear only
-route templates should make use of `{{outlet}}`. Using `{{outlet}}` outside of a route template, e.g. in a component
- or a partial, will often lead to unexpected rendering locations for child routes.
+The `{{outlet}}` helper is used to specify locations into which routes may be rendered. Typically, to keep routing clear, only route templates should make use of `{{outlet}}`. Using `{{outlet}}` outside of a route template, e.g. in a component or a partial, will often lead to unexpected rendering locations for child routes.
 
 This rule **forbids** the following (except in routes):
 

--- a/docs/rule/no-partial.md
+++ b/docs/rule/no-partial.md
@@ -1,14 +1,11 @@
 ## no-partial
 
-`{{partial}}` is a legacy hold over from the days in which Ember had little to
-no mechanism for sharing "template snippets". Today we can use "contextual
-components" (and soon "named blocks"), which serves the original need for
-`{{partial`.
+Partials are a legacy hold over from the days in which Ember had little to no mechanism for sharing "template snippets". Today, we can use "contextual components" (and soon "named blocks"), which serves the original need for partials.
 
-In addition to having a better solution for the original problem, there are also a number of issues when using `{{partial`:
+In addition to having a better solution for the original problem, there are also a number of issues with partials:
 
-* `{{partial` usage is essentially "eval", which means that Ember's template rendering system can make little to no optimizations
-* `{{partial` usage provides the partial template with unrestricted access to the local scope which leads to extreme confusion and "scope creep"
+* The `partial` helper is essentially an `eval`, which means that Ember's template rendering system can make little to no optimizations
+* The `partial` helper provides the partial template with unrestricted access to the local scope which leads to extreme confusion and "scope creep", as it's not clear what data/actions are coming in and out
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-quoteless-attributes.md
+++ b/docs/rule/no-quoteless-attributes.md
@@ -1,6 +1,6 @@
 ## no-quoteless-attributes
 
-In HTML all attribute values are considered strings, regardless if they were quoted or not initially.
+In HTML, all attribute values are considered strings, regardless of whether they are quoted or not.
 
 The following two examples are _identical_ from the perspective of the browser:
 
@@ -15,15 +15,24 @@ This fact makes the following HTML very confusing:
 <input disabled=false>
 ```
 
-In this case, the simple _presence_ of the `disabled` attribute means that the
-`<input>` is disabled and setting the value to `false` doesn't do the obvious
-thing.
+In this case, the simple _presence_ of the `disabled` attribute means that the `<input>` is disabled and setting the value to `false` doesn't do the obvious thing.
 
-This is just _one_ (of many) cases where the default "string" based parsing of
-attributes in HTML can trip folks up.
+This is just _one_ (of many) cases where the default "string" based parsing of attributes in HTML can trip folks up.
 
-The `no-quoteless-attributes` rule attempts to make this situation _slightly_
-better by at least ensuring that all attribute values are quoted. This
-obviously doesn't fix the :troll:y nature of HTML here but it does ensure that
-you still **see** the quotes (which should hopefully help remind you that
-these are strings and not values).
+This rule attempts to make this situation _slightly_ better by at least ensuring that all attribute values are quoted. This obviously doesn't fix the :troll:y nature of HTML here but it does ensure that you still **see** the quotes (which should hopefully help remind you that these are strings and not values).
+
+This rule **forbids** the following (note that `someValue` could have been intended either as a string or expression):
+
+```html
+<div data-foo=someValue></div>
+```
+
+This rule **allows** the following:
+
+```html
+<div data-foo="someValue"></div>
+```
+
+```hbs
+<div data-foo={{someValue}}></div>
+```

--- a/docs/rule/no-trailing-dot-in-path-expression.md
+++ b/docs/rule/no-trailing-dot-in-path-expression.md
@@ -5,23 +5,23 @@ This rule doesn't allow trailing dot(s) on a path expression. Since the trailing
 For instance:
 
 ```hbs
-  /application.hbs
+{{! application.hbs }}
 
-  <span class={{if contact. 'bg-success'}}>{{contact.name}}</span>
+<span class={{if contact. 'bg-success'}}>{{contact.name}}</span>
 ```
 
 is interpreted as
 
 ```hbs
-  /application.hbs
+{{! application.hbs }}
 
-  <span class={{if contact . 'bg-success'}}>{{contact.name}}</span>
+<span class={{if contact . 'bg-success'}}>{{contact.name}}</span>
 ```
 
 hence results in
 
 ```html
-  <span class="<my-app@controller:application::ember223>">John</span>
+<span class="<my-app@controller:application::ember223>">John</span>
 ```
 
 This rule **forbids** the following:

--- a/docs/rule/no-triple-curlies.md
+++ b/docs/rule/no-triple-curlies.md
@@ -1,9 +1,19 @@
 ## no-triple-curlies
 
-Usage of triple curly braces to allow raw HTML to be injected into the DOM is large vector for exploits of your application (especially when the raw HTML is user controllable ). Instead of using `{{{foo}}}`, you should use appropriate helpers or computed properties that return a `SafeString` (via `Ember.String.htmlSafe` generally) and ensure that user supplied data is properly escaped.
+Usage of triple curly braces to allow raw HTML to be injected into the DOM is a large vector for exploits of your application (especially when the raw HTML is user-controllable). Instead of using `{{{foo}}}`, you should use appropriate helpers or computed properties that return a `SafeString` (via `Ember.String.htmlSafe` generally) and ensure that user-supplied data is properly escaped.
 
 This rule **forbids** the following:
 
 ``` hbs
 {{{foo}}}
 ```
+
+This rule **allows** the following:
+
+``` hbs
+{{foo}}
+```
+
+### References
+
+* See the [documentation](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe) for Ember's `htmlSafe` function

--- a/docs/rule/no-unbound.md
+++ b/docs/rule/no-unbound.md
@@ -1,7 +1,9 @@
 ## no-unbound
 
-`{{unbound}}` is a legacy hold over from the days in which Ember's template engine was less performant. It's use today
+`{{unbound}}` is a legacy hold over from the days in which Ember's template engine was less performant. Its use today
 is vestigial, and it no longer offers performance benefits.
+
+It is also a poor practice to use it for rendering only the initial value of a property that may later change. 
 
 This rule **forbids** the following:
 
@@ -9,8 +11,6 @@ This rule **forbids** the following:
 {{unbound aVar}}
 ```
 
-And
-
 ```hbs
-{{a-thing foo=(unbound aVar)}}
+{{some-component foo=(unbound aVar)}}
 ```

--- a/docs/rule/self-closing-void-elements.md
+++ b/docs/rule/self-closing-void-elements.md
@@ -1,9 +1,7 @@
 ## self-closing-void-elements
 
-HTML has no self-closing tags. The HTML 5 parser will ignore self-closing tag in
-the case of [`void elements`](https://www.w3.org/TR/html-markup/syntax.html#void-element)
-(tags that shouldn't have a `closing tag`). Although the parser will ignore it's
-unnecessary and can lead to confusing with SVG/XML code.
+HTML has no self-closing tags. The HTML5 parser will ignore self-closing tag in the case of [void elements](https://www.w3.org/TR/html-markup/syntax.html#void-element) (tags that shouldn't have a "closing tag"). Although the parser will ignore it, it's
+unnecessary and can lead to confusion with SVG/XML code.
 
 This rule **forbids** the following:
 

--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -1,7 +1,8 @@
-## simple-unless (default === true)
+## simple-unless
 
-This rule strongly advises against `{{unless}}` blocks used in conjunction with other
-block helpers (e.g. `{{else}}`, `{{else if}}`), and template helpers.
+This rule strongly advises against `{{unless}}` blocks used in conjunction with other block helpers (e.g. `{{else}}`, `{{else if}}`), and template helpers.
+
+Common solutions are to use an `{{if}}` block, or refactor potentially confusing logic within the template.
 
 This rule **forbids** the following:
 
@@ -21,8 +22,7 @@ This rule **forbids** the following:
 {{/unless}}
 ```
 
-Common solutions are to use an `{{if}}` block, or refactor potentially confusing
-logic within the template.
+This rule **allows** the following:
 
 ``` hbs
 {{#if bandwagoner}}

--- a/docs/rule/table-groups.md
+++ b/docs/rule/table-groups.md
@@ -1,6 +1,12 @@
 ## table-groups
 
-A table row should always be grouped into either a `thead`, `tbody` or `tfoot` to avoid a very nuanced (and possibly deprecated in the future) feature of glimmer that auto-inserts these tags.
+It is best practice to group table rows into one of:
+
+* `thead`
+* `tbody`
+* `tfoot`
+
+This helps avoid a very nuanced (and possibly deprecated in the future) feature of glimmer that auto-inserts these tags.
 
 This rule **forbids** the following:
 
@@ -38,11 +44,11 @@ This rule **allows** the following:
 </table>
 ```
 
-If you have a component which `tagName` is either `thead`, `tbody` or `tfoot`, you should disable the rule inline:
+If you have a component with one of the table groups specified as its `tagName`, you should disable the rule inline:
 
 ```hbs
 <table>
   {{! template-lint-disable table-groups }}
-  {{some-thing-with-tagName-tbody}}
+  {{some-component-with-tagName-tbody}}
 </table>
 ```

--- a/docs/rule/template-length.md
+++ b/docs/rule/template-length.md
@@ -4,11 +4,11 @@ Some ember shops try to put some guard-rails on the length of templates for the 
 
 - Templates that are extremely long are often a sign that code should be
   factored into several different components. Be aware that sometimes breaking
-  a template up just because it's long in order to satisfy linting-errors can
+  a template up just because it's long in order to fix a linting violation can
   potentially make the code harder to reason about: splitting up a single
   logical unit into multiple files simply because it is "long" roughly means that
   to find where some HTML snippet is you have to solve a murder mystery. So while
-  this check is helpful to help with sanity-checking, `{{! template-disable template-length }}`
+  this check is helpful to help with sanity-checking, `{{! template-lint-disable template-length }}`
   might be the right answer if a long template does in fact represent a logical unit.
 
 - Templates that are extremely short might be better off inlined into the


### PR DESCRIPTION
Follow-up to the cleanup I did in #590.