### PR TITLE
fix: allow `{{else}} {{#unless ...}}` in the 'simple-unless' rule and make corresponding update to 'no-negated-condition' rule.

### DIFF
--- a/docs/rule/no-negated-condition.md
+++ b/docs/rule/no-negated-condition.md
@@ -33,14 +33,6 @@ This rule **forbids** the following:
 {{/unless}}
 ```
 
-```hbs
-{{#unless (not condition)}}
-  ...
-{{else}}
-  ...
-{{/unless}}
-```
-
 And similar examples with non-block forms like:
 
 ```hbs

--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -1,24 +1,37 @@
 ## simple-unless
 
-This rule strongly advises against `{{unless}}` blocks used in conjunction with other block helpers (e.g. `{{else}}`, `{{else if}}`), and template helpers.
+This rule strongly advises against `{{unless}}` blocks in the following situations:
+
+* With other block helpers (e.g. `{{else}}`, `{{else if}}`)
+* With template helpers in the condition
 
 Common solutions are to use an `{{if}}` block, or refactor potentially confusing logic within the template.
 
 This rule **forbids** the following:
 
 ``` hbs
-{{! `if` template helper}}
+{{! `unless` condition has a template helper }}
 
 {{unless (if true) "This is not recommended"}}
 ```
 
 ``` hbs
-{{! `else` block}}
+{{! `unless` statement has an `else` block }}
 
 {{#unless bandwagoner}}
   Go Niners!
 {{else}}
   Go Seahawks!
+{{/unless}}
+```
+
+``` hbs
+{{! conditional statement has an `else unless` block }}
+
+{{#if condition}}
+  Hello
+{{else unless otherCondition}}
+  World
 {{/unless}}
 ```
 
@@ -30,6 +43,12 @@ This rule **allows** the following:
 {{else}}
   Go Mariners!
 {{/if}}
+```
+
+``` hbs
+{{#unless condition}}
+  Hello World
+{{/unless}}
 ```
 
 ### Configuration

--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -48,6 +48,14 @@ function isBlockStatement(node) {
   return node.type === 'BlockStatement';
 }
 
+function isIf(node) {
+  return node.path && node.path.original === 'if';
+}
+
+function isUnless(node) {
+  return node.path && node.path.original === 'unless';
+}
+
 function hasAttribute(node, attributeName) {
   var attribute = findAttribute(node, attributeName);
 
@@ -98,6 +106,8 @@ module.exports = {
   hasAttribute: hasAttribute,
   hasChildren: hasChildren,
   isBlockStatement: isBlockStatement,
+  isIf: isIf,
+  isUnless: isUnless,
   isCommentStatement: isCommentStatement,
   isConcatStatement: isConcatStatement,
   isMustacheCommentStatement: isMustacheCommentStatement,

--- a/lib/rules/lint-no-negated-condition.js
+++ b/lib/rules/lint-no-negated-condition.js
@@ -10,33 +10,27 @@ const ERROR_MESSAGE_USE_UNLESS = 'Use `unless` instead of `if !condition`.';
 module.exports = class NoNegatedCondition extends Rule {
   visitor() {
     function checkNode(node) {
-      const isIf = node.path && node.path.original === 'if';
-      const isUnless = node.path && node.path.original === 'unless';
+      const isIf = AstNodeInfo.isIf(node);
+      const isUnless = AstNodeInfo.isUnless(node);
       if (!isIf && !isUnless) {
         // Not a conditional statement.
         return;
       }
 
       if (AstNodeInfo.isBlockStatement(node)) {
-        if (node.inverse && node.inverse.body.length > 0) {
-          // Conditional block statement has an `else` / `else if`
-
-          const firstNode = findFirstNonTextNonCommentNode(node.inverse.body);
-          if (firstNode && AstNodeInfo.isBlockStatement(firstNode)) {
-            // If there's BlockStatement directly inside the body of the `else`,
-            // we need to mark it so we can ignore it later,
-            // to avoid potentially suggesting an `unless` after an `else`.
-            firstNode.isAtBeginningOfElseBody = true;
-
-            if (isIf && firstNode.path.original === 'if') {
-              // Ignore `if ... else if ...` statements as there's nothing wrong with them.
-              return;
-            }
-          }
+        if (this.sourceForNode(node).startsWith('{{else ')) {
+          // We only care about the beginning of the overall `if` / `unless` statement so ignore the `else` parts.
+          return;
         }
 
-        if (isIf && node.isAtBeginningOfElseBody) {
-          // Ignore `if` statements directly following an `else` due to complexity.
+        if (
+          node.inverse &&
+          node.inverse.body.length > 0 &&
+          AstNodeInfo.isBlockStatement(node.inverse.body[0]) &&
+          isIf &&
+          AstNodeInfo.isIf(node.inverse.body[0])
+        ) {
+          // Ignore `if ... else if ...` statements as there may be no way to avoid negated conditions inside them.
           return;
         }
       }
@@ -47,6 +41,7 @@ module.exports = class NoNegatedCondition extends Rule {
         !AstNodeInfo.isPathExpression(node.params[0].path) ||
         node.params[0].path.original !== 'not'
       ) {
+        // No negation present.
         return;
       }
 
@@ -82,19 +77,6 @@ module.exports = class NoNegatedCondition extends Rule {
     };
   }
 };
-
-function findFirstNonTextNonCommentNode(nodes) {
-  for (let i = 0; i < nodes.length; i++) {
-    const currentNode = nodes[i];
-    if (
-      !AstNodeInfo.isTextNode(currentNode) &&
-      !AstNodeInfo.isMustacheCommentStatement(currentNode)
-    ) {
-      return currentNode;
-    }
-  }
-  return null;
-}
 
 module.exports.ERROR_MESSAGE_FLIP_IF = ERROR_MESSAGE_FLIP_IF;
 module.exports.ERROR_MESSAGE_USE_IF = ERROR_MESSAGE_USE_IF;

--- a/lib/rules/lint-simple-unless.js
+++ b/lib/rules/lint-simple-unless.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Rule = require('./base');
+const AstNodeInfo = require('../helpers/ast-node-info');
 const createErrorMessage = require('../helpers/create-error-message');
 
 const messages = {
@@ -69,26 +70,19 @@ module.exports = class LintSimpleUnless extends Rule {
       },
 
       BlockStatement(node) {
-        let nodeInverse = node.inverse;
-        let nodePathOriginal = node.path.original;
+        const nodeInverse = node.inverse;
 
         if (nodeInverse) {
-          if (nodePathOriginal === 'unless') {
-            if (
-              nodeInverse.body[0] &&
-              nodeInverse.body[0].path &&
-              nodeInverse.body[0].path.original === 'if'
-            ) {
+          if (AstNodeInfo.isUnless(node)) {
+            if (nodeInverse.body[0] && AstNodeInfo.isIf(nodeInverse.body[0])) {
               this._followingElseIfBlock(node);
             } else {
               this._followingElseBlock(node);
             }
-          } else if (nodePathOriginal === 'if' && nodeInverse.body[0]) {
-            if (nodeInverse.body[0].path && nodeInverse.body[0].path.original === 'unless') {
-              this._asElseUnlessBlock(node);
-            }
+          } else if (this._isElseUnlessBlock(nodeInverse.body[0])) {
+            this._asElseUnlessBlock(node);
           }
-        } else if (nodePathOriginal === 'unless' && node.params[0].path) {
+        } else if (AstNodeInfo.isUnless(node) && node.params[0].path) {
           this._withHelper(node);
         }
       },
@@ -159,6 +153,15 @@ module.exports = class LintSimpleUnless extends Rule {
 
       containsSubexpression = nextParams.some(param => param.type === 'SubExpression');
     } while (containsSubexpression);
+  }
+
+  _isElseUnlessBlock(node) {
+    return (
+      node &&
+      node.path &&
+      node.path.original === 'unless' &&
+      this.sourceForNode(node).startsWith('{{else ')
+    );
   }
 
   _logMessage(message, line, column, source) {

--- a/test/unit/rules/lint-simple-unless-test.js
+++ b/test/unit/rules/lint-simple-unless-test.js
@@ -16,6 +16,8 @@ generateRuleTests({
     '<div class="{{if foo \'foo\'}}"></div>',
     '{{unrelated-mustache-without-params}}',
     '{{#if foo}}{{else}}{{/if}}',
+    '{{#if foo}}{{else}}{{#unless bar}}{{/unless}}{{/if}}',
+    '{{#if foo}}{{else}}{{unless bar someProperty}}{{/if}}',
     '{{#unless (or foo bar)}}order whiskey{{/unless}}',
     '{{#unless (eq (or foo bar) baz)}}order whiskey{{/unless}}',
     ['{{#unless hamburger}}', '  HOT DOG!', '{{/unless}}'].join('\n'),


### PR DESCRIPTION
There are two relevant cases:
1. `{{#if condition}} ... {{else unless condition}} ... {{/if}}`
2. `{{#if condition}} ... {{else}} {{#unless condition}} ... {{/unless}} {{/if}}`

Currently, they are both banned by the 'simple-unless' rule, but I suspect that (2) was not originally intended to be banned (banning (2) may have been a mistake).

Here are the reasons why I don't think (2) was intended to be banned:
1. These two cases are difficult to distinguish with the AST.
2. The error message returned by both of these cases mentions (1) but not (2): 'Using an `{{else unless}}` block should be avoided.'
3. (1) is obviously undesirable whereas (2) isn't. In fact, I've heard multiple engineers voice surprise that (2) is currently banned.

As a result, I have updated 'simple-unless' to allow (2).

In addition, I have also update the related 'no-negated-condition' rule to allow suggesting (2), whereas previously it specifically avoided suggesting (2) to avoid conflicting with the 'simple-unless' rule.