### PR TITLE
Add rule: [a11y] no-static-element-interactions

### DIFF
--- a/docs/rule/no-static-element-interactions.md
+++ b/docs/rule/no-static-element-interactions.md
@@ -1,0 +1,74 @@
+## no-static-element-interactions
+
+Static HTML elements do not have semantic meaning. This is clear in the case of `<div>` and `<span>`. It is less so clear in the case of elements that _seem_ semantic, but that do not have a semantic mapping in the accessibility layer. For example `<a>`, `<big>`, `<blockquote>`, `<footer>`, `<picture>`, `<strike>` and `<time>` -- to name a few -- have no semantic layer mapping. They are as void of meaning as `<div>`.
+
+The [WAI-ARIA `role` attribute](https://www.w3.org/TR/wai-aria-1.1/#usage_intro) confers a semantic mapping to an element. The semantic value can then be expressed to a user via assistive technology.
+
+In order to add interactivity such as a mouse or key event listener to a static element, that element must be given a role value as well.
+
+## How do I resolve this error?
+
+### Case: This element acts like a button, link, menuitem, etc.
+
+Indicate the element's role with the `role` attribute:
+
+```hbs
+<div
+  onclick={{action 'onClickHandler'}}
+  onkeypress={{action 'onKeyPressHandler'}}
+  role="button"
+  tabindex="0">
+  Save
+</div>
+```
+
+Common interactive roles include:
+
+  1. `button`
+  1. `link`
+  1. `checkbox`
+  1. `menuitem`
+  1. `menuitemcheckbox`
+  1. `menuitemradio`
+  1. `option`
+  1. `radio`
+  1. `searchbox`
+  1. `switch`
+  1. `textbox`
+
+Note: Adding a role to your element does **not** add behavior. When a semantic HTML element like `<button>` is used, then it will also respond to Enter key presses when it has focus. The developer is responsible for providing the expected behavior of an element that the role suggests it would have: focusability and key press support.
+
+### Case: This element is not a button, link, menuitem, etc. It is catching bubbled events from elements that it contains
+
+If your element is catching bubbled click or key events from descendant elements, then the proper role for this element is `presentation`.
+
+```hbs
+<div
+  onclick={{action 'onClickHandler'}}
+  role="presentation">
+  <button>Save</button>
+</div>
+```
+
+Marking an element with the role `presentation` indicates to assistive technology that this element should be ignored; it exists to support the web application and is not meant for humans to interact with directly.
+
+
+This rule **allows** the following:
+```hbs
+<button onclick={{action 'onButtonClick'}} class="foo" />
+<div class="foo" onclick={{action 'onButtonClick'}} role="button" />
+<input type="text" {{action 'onButtonClick'}} />
+```
+
+This rule **forbids** the following:
+```hbs
+<div onclick={{action 'foo-bar'}} ></div>
+<div {{action 'foo-bar'}} ></div>
+```
+
+### References
+  1. [WAI-ARIA `role` attribute](https://www.w3.org/TR/wai-aria-1.1/#usage_intro)
+  2. [WAI-ARIA Authoring Practices Guide - Design Patterns and Widgets](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_ex)
+  3. [Fundamental Keyboard Navigation Conventions](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav)
+  4. [Mozilla Developer Network - ARIA Techniques](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Keyboard_and_focus)
+  5. [eslint-plugin-jsx-a11y/no-static-element-interaction](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interaction.md)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -28,6 +28,7 @@
 * [no-partial](rule/no-partial.md)
 * [no-quoteless-attributes](rule/no-quoteless-attributes.md)
 * [no-shadowed-elements](rule/no-shadowed-elements.md)
+* [no-static-element-interactions](rule/no-static-element-interactions.md)
 * [no-trailing-dot-in-path-expression](rule/no-trailing-dot-in-path-expression.md)
 * [no-trailing-spaces](rule/no-trailing-spaces.md)
 * [no-triple-curlies](rule/no-triple-curlies.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -32,6 +32,7 @@ module.exports = {
   'no-partial': require('./lint-no-partial'),
   'no-quoteless-attributes': require('./lint-no-quoteless-attributes'),
   'no-shadowed-elements': require('./lint-no-shadowed-elements'),
+  'no-static-element-interactions': require('./lint-no-static-element-interactions'),
   'no-trailing-dot-in-path-expression': require('./lint-trailing-dot-in-path-expression'),
   'no-trailing-spaces': require('./lint-no-trailing-spaces'),
   'no-triple-curlies': require('./lint-no-triple-curlies'),

--- a/lib/rules/lint-no-static-element-interactions.js
+++ b/lib/rules/lint-no-static-element-interactions.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
+
+const errorMessage = 'Static HTML elements with event handlers require a role.';
+
+// const COMMON_INTERACTIVE_ROLES = [
+//   'button',
+//   'link',
+//   'checkbox',
+//   'menuitem',
+//   'menuitemcheckbox',
+//   'menuitemradio',
+//   'option',
+//   'radio',
+//   'searchbox',
+//   'switch',
+//   'textbox',
+// ];
+
+// role || aria-
+
+const handlers = ['onclick', 'onmousedown', 'onmouseup', 'onkeypress', 'onkeydown', 'onkeyup'];
+const actionHandlers = ['click', 'mouseDown', 'mouseUp', 'keyPress', 'keyDown', 'keyUp'];
+const NOT_INTERACTIVE_ELEMENTS = [
+  'div',
+  'span',
+  'a',
+  'big',
+  'blockquote',
+  'footer',
+  'picture',
+  'strike',
+  'time',
+];
+
+module.exports = class NoStaticElementInteractions extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        if (!NOT_INTERACTIVE_ELEMENTS.includes(node.tag)) {
+          return;
+        }
+        const ariaHidden = AstNodeInfo.hasAttribute(node, 'aria-hidden');
+        if (ariaHidden) {
+          return;
+        }
+        const attributeActionBindings = node.attributes.filter(attr =>
+          handlers.includes(attr.name)
+        );
+
+        const actionModifiers = node.modifiers.filter(
+          modifier =>
+            modifier.type === 'ElementModifierStatement' && modifier.path.original === 'action'
+        );
+        const modifiersWithOn = actionModifiers.filter(modifier => {
+          return (
+            (modifier.hash.pairs || []).filter(pair => {
+              return pair.key === 'on';
+            }).length > 0
+          );
+        });
+        const modifiersWithStringedOn = modifiersWithOn.filter(modifier => {
+          return (
+            (modifier.hash.pairs || []).filter(pair => {
+              return (
+                pair.value.type === 'StringLiteral' &&
+                pair.key === 'on' &&
+                actionHandlers.includes(pair.value.original)
+              );
+            }).length > 0
+          );
+        });
+        const hasActionModifiersWithoutOn = actionModifiers.length !== modifiersWithOn.length;
+        if (modifiersWithOn.length !== modifiersWithStringedOn.length) {
+          // <div {{action 'foo-bar' on="click"}}  {{action 'foo-bar'}}></div>
+          return;
+        }
+        if (
+          !attributeActionBindings.length &&
+          !modifiersWithOn.length &&
+          !hasActionModifiersWithoutOn
+        ) {
+          return;
+        }
+        const hasAccessibleAttributes = node.attributes.some(
+          attr => attr.name === 'role' || attr.name.indexOf('aria-') === 0
+        );
+        if (hasAccessibleAttributes) {
+          return;
+        }
+        this.log({
+          message: errorMessage,
+          line: node.loc && node.loc.start.line,
+          column: node.loc && node.loc.start.column,
+          source: this.sourceForNode(node),
+        });
+      },
+    };
+  }
+};

--- a/lib/rules/lint-no-static-element-interactions.js
+++ b/lib/rules/lint-no-static-element-interactions.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const AstNodeInfo = require('../helpers/ast-node-info');
+const isInteractiveElement = require('../helpers/is-interactive-element');
 const Rule = require('./base');
 
 const errorMessage = 'Static HTML elements with event handlers require a role.';
@@ -23,23 +24,12 @@ const errorMessage = 'Static HTML elements with event handlers require a role.';
 
 const handlers = ['onclick', 'onmousedown', 'onmouseup', 'onkeypress', 'onkeydown', 'onkeyup'];
 const actionHandlers = ['click', 'mouseDown', 'mouseUp', 'keyPress', 'keyDown', 'keyUp'];
-const NOT_INTERACTIVE_ELEMENTS = [
-  'div',
-  'span',
-  'a',
-  'big',
-  'blockquote',
-  'footer',
-  'picture',
-  'strike',
-  'time',
-];
 
 module.exports = class NoStaticElementInteractions extends Rule {
   visitor() {
     return {
       ElementNode(node) {
-        if (!NOT_INTERACTIVE_ELEMENTS.includes(node.tag)) {
+        if (isInteractiveElement(node)) {
           return;
         }
         const ariaHidden = AstNodeInfo.hasAttribute(node, 'aria-hidden');

--- a/lib/rules/lint-no-static-element-interactions.js
+++ b/lib/rules/lint-no-static-element-interactions.js
@@ -42,7 +42,16 @@ module.exports = class NoStaticElementInteractions extends Rule {
 
         const actionModifiers = node.modifiers.filter(
           modifier =>
-            modifier.type === 'ElementModifierStatement' && modifier.path.original === 'action'
+            modifier.type === 'ElementModifierStatement' && 'action' === modifier.path.original
+        );
+
+        const onModifiers = node.modifiers.filter(
+          modifier =>
+            modifier.type === 'ElementModifierStatement' &&
+            'on' === modifier.path.original &&
+            modifier.params.length &&
+            modifier.params[0].type === 'StringLiteral' &&
+            actionHandlers.includes(modifier.params[0].original)
         );
         const modifiersWithOn = actionModifiers.filter(modifier => {
           return (
@@ -63,13 +72,14 @@ module.exports = class NoStaticElementInteractions extends Rule {
           );
         });
         const hasActionModifiersWithoutOn = actionModifiers.length !== modifiersWithOn.length;
-        if (modifiersWithOn.length !== modifiersWithStringedOn.length) {
+        if (modifiersWithOn.length !== modifiersWithStringedOn.length && onModifiers.length === 0) {
           // <div {{action 'foo-bar' on="click"}}  {{action 'foo-bar'}}></div>
           return;
         }
         if (
           !attributeActionBindings.length &&
           !modifiersWithOn.length &&
+          !onModifiers.length &&
           !hasActionModifiersWithoutOn
         ) {
           return;

--- a/test/unit/rules/lint-no-static-element-interactions-test.js
+++ b/test/unit/rules/lint-no-static-element-interactions-test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+const message = 'Static HTML elements with event handlers require a role.';
+
+generateRuleTests({
+  name: 'no-static-element-interactions',
+
+  config: true,
+
+  good: [
+    '<button onclick={{action "onButtonClick"}} class="foo"></button>',
+    '<input type="text" {{action "onButtonClick"}}>',
+    '<div {{action "foo-bar"}} role="button"></div>',
+    '<div {{action "foo-bar"}} aria-interactive="button"></div>',
+    '<div {{action "foo-bar" on=someValue}}></div>',
+    '<div {{action "foo-bar" on="click"}} role="primary"></div>',
+    '<div {{action "foo-bar" on="unknown"}}></div>',
+  ],
+
+  bad: [
+    {
+      template: '<div onclick={{action "foo-bar"}}></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div onclick={{action "foo-bar"}}></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div {{action "foo-bar"}} ></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div {{action "foo-bar"}} ></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div {{action "foo-bar" on="click"}} ></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div {{action "foo-bar" on="click"}} ></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div {{action "foo-bar" on="mouseDown"}} ></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div {{action "foo-bar" on="mouseDown"}} ></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div {{action "foo-bar" on="mouseUp"}} ></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div {{action "foo-bar" on="mouseUp"}} ></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div {{action "foo-bar" on="keyPress"}} ></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div {{action "foo-bar" on="keyPress"}} ></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div {{action "foo-bar" on="keyDown"}} ></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div {{action "foo-bar" on="keyDown"}} ></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div {{action "foo-bar" on="keyUp"}} ></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div {{action "foo-bar" on="keyUp"}} ></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div {{action "click"}} {{action "foo-bar" on="keyUp"}} ></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div {{action "click"}} {{action "foo-bar" on="keyUp"}} ></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div onclick={{action "click"}}></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div onclick={{action "click"}}></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+  ],
+});

--- a/test/unit/rules/lint-no-static-element-interactions-test.js
+++ b/test/unit/rules/lint-no-static-element-interactions-test.js
@@ -16,6 +16,11 @@ generateRuleTests({
     '<div {{action "foo-bar" on=someValue}}></div>',
     '<div {{action "foo-bar" on="click"}} role="primary"></div>',
     '<div {{action "foo-bar" on="unknown"}}></div>',
+    '<input type="text" {{on "click" (fn this.onButtonClick)}}>',
+    '<div {{on "click" (fn this.onButtonClick)}} role="button"></div>',
+    '<div {{on "click" (fn this.onButtonClick)}} aria-interactive="button"></div>',
+    '<div {{on "click" (fn this.onButtonClick)}} role="primary"></div>',
+    '<div {{on "mouseenter" (fn this.onButtonClick)}}></div>',
   ],
 
   bad: [
@@ -115,6 +120,28 @@ generateRuleTests({
         message,
         moduleId: 'layout.hbs',
         source: '<div onclick={{action "click"}}></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div {{on "click" (fn this.onButtonClick)}}></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<div {{on "click" (fn this.onButtonClick)}}></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template:
+        '<div {{on "mouseenter" (fn this.onButtonClick)}} {{on "click" (fn this.onButtonClick)}}></div>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source:
+          '<div {{on "mouseenter" (fn this.onButtonClick)}} {{on "click" (fn this.onButtonClick)}}></div>',
         line: 1,
         column: 0,
       },


### PR DESCRIPTION
1. [WAI-ARIA `role` attribute](https://www.w3.org/TR/wai-aria-1.1/#usage_intro)
  2. [WAI-ARIA Authoring Practices Guide - Design Patterns and Widgets](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_ex)
  3. [Fundamental Keyboard Navigation Conventions](https://www.w3.org/TR/wai-aria-practices-1.1/#kbd_generalnav)
  4. [Mozilla Developer Network - ARIA Techniques](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#Keyboard_and_focus)
  5. [eslint-plugin-jsx-a11y/no-static-element-interaction](https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/no-static-element-interaction.md)