### PR TITLE
Added a related rules section

### DIFF
--- a/docs/rule/no-element-event-actions.md
+++ b/docs/rule/no-element-event-actions.md
@@ -28,3 +28,8 @@ This rule **allows** the following:
 * [List of DOM Events](https://developer.mozilla.org/en-US/docs/Web/Events)
 
 [Deep Dive on Ember Events]: https://medium.com/square-corner-blog/deep-dive-on-ember-events-cf684fd3b808
+
+
+### Related Rules
+
+* [no-action-modifiers](no-action-modifiers.md)


### PR DESCRIPTION
`no-element-event-actions` and `no-action-modifiers` appear to be duplicate rules. I am adding a `related rules` section below.