### PR TITLE
Documentation Adjustment: `no-element-event-actions` and `no-action-modifiers` are now related rules

### DIFF
--- a/docs/rule/no-action-modifiers.md
+++ b/docs/rule/no-action-modifiers.md
@@ -20,3 +20,7 @@ The following values are valid configuration:
 
   * boolean -- `true` for enabled / `false` for disabled
   * array -- an array of whitelisted element tag names, which will accept action modifiers
+
+### Related Rules
+
+* [no-element-event-actions](no-element-event-actions.md)

--- a/docs/rule/no-element-event-actions.md
+++ b/docs/rule/no-element-event-actions.md
@@ -28,3 +28,7 @@ This rule **allows** the following:
 * [List of DOM Events](https://developer.mozilla.org/en-US/docs/Web/Events)
 
 [Deep Dive on Ember Events]: https://medium.com/square-corner-blog/deep-dive-on-ember-events-cf684fd3b808
+
+### Related Rules
+
+* [no-action-modifiers](no-action-modifiers.md)


### PR DESCRIPTION
Both `no-element-event-actions` and `no-action-modifiers` essentially do the same thing. I'm adding a note at the bottom of both rules that says they are related.

See:

https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-action-modifiers.md

https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-element-event-actions.md

