### PR TITLE
feat(bin/ember-template-lint.js): Add toggle flag for ignored files

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Example usage:
 
 # define custom config path
 ./node_modules/.bin/ember-template-lint app/templates/application.hbs --config-path .my-template-lintrc.js
+
+# dont ignore `['**/dist/**', '**/tmp/**', '**/node_modules/**']` by default
+./node_modules/.bin/ember-template-lint app/templates/application.hbs --no-ignore .my-template-lintrc.js
 ```
 
 ### ESLint

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -69,7 +69,10 @@ function getRelativeFilePaths() {
     .reduce((filePaths, fileArg) => {
       return filePaths.concat(
         globby.sync(fileArg, {
-          ignore: ['**/dist/**', '**/tmp/**', '**/node_modules/**'],
+          ignore:
+            process.argv.indexOf('--no-ignore') + 1
+              ? []
+              : ['**/dist/**', '**/tmp/**', '**/node_modules/**'],
           gitignore: true,
         })
       );


### PR DESCRIPTION
Add a flag to the command so the by default ignored files `['**/dist/**', '**/tmp/**', '**/node_modules/**']` can be toggled. This is usefull if for instance your editor lint plugin (vim/ale) copies the file to be linted into `/tmp`. This prevents the template from beeing linted as `'**/tmp/**'` applies.