### PR TITLE
Add command for generating pending list to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The following properties are allowed in the root of the `.template-lintrc.js` co
   An array of module id's that are still pending. The goal of this array is to allow incorporating template linting
   into an existing project, without changing every single template file. You can add all existing templates to this `pending` listing
   and slowly work through them, while at the same time ensuring that new templates added to the project pass all defined rules.
+  * If you are using `ember-cli-template-lint` you can generate this list with: `ember template-lint:print-failing`
 * `ignore` -- `string[]|glob[]`
   An array of module id's that are to be completely ignored.
 * `plugins` -- `(string|Object)[]`


### PR DESCRIPTION
I had to track this command down multiple times for multiple projects. It is super useful, but hard to find - only mentioned in issues, commits, not docs.

I know it is only in the `ember-cli-template-lint` package, but the docs redirect here to look for config and rules. Happy to update the readme for the other package instead.