### PR TITLE
feat: add `ignoreDummyTestApp` option to `no-bare-strings` rule

### DIFF
--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -18,8 +18,10 @@ This rule **forbids** the following:
      * `whitelist` -- An array of whitelisted strings
      * `globalAttributes` -- An array of attributes to check on every element.
      * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
+     * `ignoreDummyTestApp` -- A boolean indicating whether the rule should ignore templates in the dummy test app inside Ember addons as translations may not be needed there (defaults to `false`)
 
 When the config value of `true` is used the following configuration is used:
  * `whitelist` - `(),.&+-=*/#%!?:[]{}`
  * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
  * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
+ * `ignoreDummyTestApp` - `false`

--- a/lib/rules/lint-no-bare-strings.js
+++ b/lib/rules/lint-no-bare-strings.js
@@ -20,6 +20,7 @@
      * `whitelist` -- An array of whitelisted strings
      * `globalAttributes` -- An array of attributes to check on every element.
      * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
+     * `ignoreDummyTestApp` -- A boolean indicating whether the rule should ignore templates in the dummy test app inside Ember addons as translations may not be needed there (defaults to `false`)',
  */
 
 const Rule = require('./base');
@@ -68,6 +69,7 @@ const DEFAULT_CONFIG = {
   ],
   globalAttributes: GLOBAL_ATTRIBUTES,
   elementAttributes: TAG_ATTRIBUTES,
+  ignoreDummyTestApp: false,
 };
 
 function isValidConfigObjectFormat(config) {
@@ -84,7 +86,9 @@ function isValidConfigObjectFormat(config) {
       if (valueIsArray) {
         return false;
       }
-    } else if (!DEFAULT_CONFIG[key]) {
+    } else if (key === 'ignoreDummyTestApp' && valueType !== 'boolean') {
+      return false;
+    } else if (!DEFAULT_CONFIG.hasOwnProperty(key)) {
       return false;
     }
   }
@@ -110,6 +114,7 @@ module.exports = class LogStaticStrings extends Rule {
             whitelist: sanitizeConfigArray(config),
             globalAttributes: GLOBAL_ATTRIBUTES,
             elementAttributes: TAG_ATTRIBUTES,
+            ignoreDummyTestApp: DEFAULT_CONFIG.ignoreDummyTestApp,
           };
         } else if (isValidConfigObjectFormat(config)) {
           // default any missing keys to empty values
@@ -117,6 +122,7 @@ module.exports = class LogStaticStrings extends Rule {
             whitelist: sanitizeConfigArray(config.whitelist || []),
             globalAttributes: config.globalAttributes || [],
             elementAttributes: config.elementAttributes || {},
+            ignoreDummyTestApp: config.ignoreDummyTestApp || DEFAULT_CONFIG.ignoreDummyTestApp,
           };
         }
         break;
@@ -133,6 +139,7 @@ module.exports = class LogStaticStrings extends Rule {
         '    * `whitelist` -- An array of whitelisted strings',
         '    * `globalAttributes` -- An array of attributes to check on every element',
         '    * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name',
+        '    * `ignoreDummyTestApp` -- A boolean indicating whether the rule should ignore templates in the dummy test app inside Ember addons as translations may not be needed there (defaults to `false`)',
       ],
       config
     );
@@ -141,6 +148,13 @@ module.exports = class LogStaticStrings extends Rule {
   }
 
   visitor() {
+    if (
+      this.config.ignoreDummyTestApp &&
+      this.templateEnvironmentData.moduleName.startsWith('tests/dummy/app/templates/')
+    ) {
+      return {}; // Ignore dummy test app template files when this option is enabled.
+    }
+
     return {
       TextNode(node) {
         if (!node.loc) {

--- a/test/unit/rules/lint-no-bare-strings-test.js
+++ b/test/unit/rules/lint-no-bare-strings-test.js
@@ -85,6 +85,17 @@ generateRuleTests({
 <i class="material-icons">folder_open</i>
 {{!-- template-lint-enable bare-strings --}}`,
     '<div data-test-foo-bar></div>',
+
+    {
+      config: {
+        ignoreDummyTestApp: true,
+      },
+      meta: {
+        moduleId: 'tests/dummy/app/templates/my-page.hbs',
+      },
+      template:
+        '<div>Bare string which is allowed because `ignoreDummyTestApp` option is enabled.</div>',
+    },
   ],
 
   bad: [
@@ -241,6 +252,22 @@ generateRuleTests({
           source: 'trolol',
         },
       ],
+    },
+
+    {
+      meta: {
+        moduleId: 'tests/dummy/app/templates/my-page.hbs',
+      },
+      template:
+        '<div>Bare string not allowed in dummy test app unless `ignoreDummyTestApp` option enabled.</div>',
+      result: {
+        moduleId: 'tests/dummy/app/templates/my-page.hbs',
+        message: 'Non-translated string used',
+        line: 1,
+        column: 5,
+        source:
+          'Bare string not allowed in dummy test app unless `ignoreDummyTestApp` option enabled.',
+      },
     },
   ],
 });


### PR DESCRIPTION
This change solves the common blocker of not being able to enable this rule inside an Ember addon when its dummy test app has lots of untranslated strings that don't need to be translated.