### PR TITLE
no-bare-strings: Allow options to be specified without losing the default values of the other options

### DIFF
--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -16,10 +16,8 @@ This rule **forbids** the following:
    * array -- an array of whitelisted strings
    * object -- An object with the following keys:
      * `whitelist` -- An array of whitelisted strings
-     * `globalAttributes` -- An array of attributes to check on every element.
-     * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
-
-When the config value of `true` is used the following configuration is used:
- * `whitelist` - `(),.&+-=*/#%!?:[]{}`
- * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
- * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
+       * Default: `['(', ')', ',', '.', '&', '+', '-', '=', '*', '/', '#', '%', '!', '?', ':', '[', ']', '{', '}', '<', '>', '•', '—', ' ', '|']`
+     * `globalAttributes` -- An array of attributes to check on every element
+       * Default: `['title', 'aria-label', 'aria-placeholder', 'aria-roledescription', 'aria-valuetext']`
+     * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name
+       * Default: `{ img: ['alt'], input: ['placeholder'] }`

--- a/lib/rules/lint-no-bare-strings.js
+++ b/lib/rules/lint-no-bare-strings.js
@@ -84,7 +84,7 @@ function isValidConfigObjectFormat(config) {
       if (valueIsArray) {
         return false;
       }
-    } else if (!DEFAULT_CONFIG[key]) {
+    } else if (!DEFAULT_CONFIG.hasOwnProperty(key)) {
       return false;
     }
   }
@@ -108,15 +108,14 @@ module.exports = class LogStaticStrings extends Rule {
         if (Array.isArray(config)) {
           return {
             whitelist: sanitizeConfigArray(config),
-            globalAttributes: GLOBAL_ATTRIBUTES,
-            elementAttributes: TAG_ATTRIBUTES,
+            globalAttributes: DEFAULT_CONFIG.globalAttributes,
+            elementAttributes: DEFAULT_CONFIG.elementAttributes,
           };
         } else if (isValidConfigObjectFormat(config)) {
-          // default any missing keys to empty values
           return {
-            whitelist: sanitizeConfigArray(config.whitelist || []),
-            globalAttributes: config.globalAttributes || [],
-            elementAttributes: config.elementAttributes || {},
+            whitelist: sanitizeConfigArray(config.whitelist || DEFAULT_CONFIG.whitelist),
+            globalAttributes: config.globalAttributes || DEFAULT_CONFIG.globalAttributes,
+            elementAttributes: config.elementAttributes || DEFAULT_CONFIG.elementAttributes,
           };
         }
         break;

--- a/test/unit/rules/lint-no-bare-strings-test.js
+++ b/test/unit/rules/lint-no-bare-strings-test.js
@@ -79,6 +79,12 @@ generateRuleTests({
       template: '<input placeholder="{{foo}}X">',
     },
 
+    {
+      // Still should use default `whitelist` when other option is specified.
+      config: { elementAttributes: {} },
+      template: '<img alt="some text"> * / #',
+    },
+
     '{{! template-lint-disable bare-strings}}LOL{{! template-lint-enable bare-strings}}',
 
     `{{!-- template-lint-disable bare-strings --}}
@@ -239,6 +245,28 @@ generateRuleTests({
           line: 2,
           column: 9,
           source: 'trolol',
+        },
+      ],
+    },
+
+    {
+      // Still should use default `elementAttributes` and default `globalAttributes` when other option is specified.
+      config: { whitelist: ['X'] },
+      template: '<img title="some title" alt="some alt text"> X',
+      results: [
+        {
+          moduleId: 'layout.hbs',
+          message: 'Non-translated string used in `title` attribute',
+          line: 1,
+          column: 5,
+          source: 'some title',
+        },
+        {
+          moduleId: 'layout.hbs',
+          message: 'Non-translated string used in `alt` attribute',
+          line: 1,
+          column: 24,
+          source: 'some alt text',
         },
       ],
     },


### PR DESCRIPTION
For example, I might want to set the `whitelist` option, but let the other options retain their default values. Before this change, that was not possible, as the rule would either use all the defaults or none of them.

The old behavior was not scalable and was a blocker to adding new options to this rule, as it would become very tedious to specify any single option without affecting the other options.