### PR TITLE
Fixed 404 URL in `sourceForNode` comment

### DIFF
--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -568,7 +568,7 @@ module.exports = class BaseRule {
   }
 
   // mostly copy/pasta from tildeio/htmlbars with a few tweaks:
-  // https://github.com/tildeio/htmlbars/blob/v0.4.17/packages/htmlbars-syntax/lib/parser.js#L59-L90
+  // https://github.com/tildeio/htmlbars/blob/v0.14.17/packages/htmlbars-syntax/lib/parser.js#L59-L90
   sourceForNode(node) {
     if (!node.loc) {
       return;


### PR DESCRIPTION
no issue

Only a comment tweak so that the referenced source URL is working.