### PR TITLE
Fix being able to inline disabling of plugin rules

### DIFF
--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -68,13 +68,30 @@ module.exports = class BaseRule {
     this.source = env.rawSource.match(reLines);
   }
 
+  _isPluginRule(name) {
+    let getConfig = require('../get-config');
+    let config = getConfig({
+      // configPath: '.template-lintrc.js',
+      configPath: './test/fixtures/with-plugins/.template-lintrc.js',
+    });
+    let keys = Object.keys(config.plugins);
+    return keys.some(key => {
+      return config.plugins[key].rules[name];
+    });
+  }
+
   // The `name !== this.ruleName` check isn't strictly necessary, but allows
   // unit tests to register test rules
   _isRuleName(name) {
     // must be required lazily so that rules can be populated
     let rules = require('./index');
 
-    return rules[name] || name === this.ruleName || DEPRECATED_RULES.has(name);
+    return (
+      rules[name] ||
+      name === this.ruleName ||
+      DEPRECATED_RULES.has(name) ||
+      this._isPluginRule(name)
+    );
   }
 
   _refersToCurrentRule(name) {

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -392,6 +392,19 @@ describe('public api', function() {
 
       expect(result).to.deep.equal(expected);
     });
+
+    it('allow you to disable plugin rules inline', function() {
+      let templatePath = path.join(basePath, 'app', 'templates', 'disabled-rule.hbs');
+      let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
+      let expected = [];
+
+      let result = linter.verify({
+        source: templateContents,
+        moduleId: templatePath,
+      });
+
+      expect(result).to.deep.equal(expected);
+    });
   });
 
   describe('Linter using plugin with extends', function() {

--- a/test/fixtures/with-plugins/app/templates/disabled-rule.hbs
+++ b/test/fixtures/with-plugins/app/templates/disabled-rule.hbs
@@ -1,0 +1,2 @@
+{{! template-lint-disable inline-component }}
+<h2>{{component value="Hej"}}</h2>


### PR DESCRIPTION
Working towards #261 

This is a spike to fix the issue where we currently can't inline disable plugin rules.

@rwjblue currently this works in an extremely janky way (hard-coded config) as a way to validate that it works but not 100% sure how to proceed. Any suggestions for how to get the correct config path when getting the plugin rules from `getConfig`?