### PR TITLE
Wait for console output before exit

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -90,8 +90,6 @@ function checkConfigPath() {
 }
 
 function run() {
-  var exitCode = 0;
-
   var configPath = checkConfigPath();
   var linter;
   try {
@@ -111,15 +109,13 @@ function run() {
         return err.severity > 1;
       })
     )
-      exitCode = 1;
+      process.exitCode = 1;
 
     if (fileErrors.length) errors[filePath] = fileErrors;
     return errors;
   }, {});
 
   if (Object.keys(errors).length) printErrors(errors);
-  // eslint-disable-next-line no-process-exit
-  if (exitCode) return process.exit(exitCode);
 }
 
 run();


### PR DESCRIPTION
Follows ESLint's [`no-process-exit`](https://eslint.org/docs/rules/no-process-exit) suggestion. Exiting immediately can interrupt async like `console.log`.

I noticed this with the `--json` flag and 70+ errors. Exiting early produced incomplete JSON, which didn't parse.