### PR TITLE
Update `table-groups` rule to allow `{{#some-component tagName="tbody"}}{{/some-component}}` to be a child of `table`

### DIFF
--- a/docs/rule/table-groups.md
+++ b/docs/rule/table-groups.md
@@ -44,6 +44,12 @@ This rule **allows** the following:
 </table>
 ```
 
+```hbs
+<table>
+  {{some-component tagName="tbody"}}
+</table>
+```
+
 If you have a component with one of the table groups specified as its `tagName`, you should disable the rule inline:
 
 ```hbs

--- a/lib/rules/lint-table-groups.js
+++ b/lib/rules/lint-table-groups.js
@@ -31,6 +31,7 @@ function isAllowedTableChild(node) {
   let tagNamePair;
   let tagNameAttribute;
   switch (node.type) {
+    case 'BlockStatement':
     case 'MustacheStatement':
       tagNamePair = node.hash.pairs.find(pair => pair.key === 'tagName');
       if (tagNamePair) {

--- a/test/unit/rules/lint-table-groups-test.js
+++ b/test/unit/rules/lint-table-groups-test.js
@@ -44,15 +44,32 @@ generateRuleTests({
     {{/unless}}
     </table>
     `,
+
+    // Component with tag:
     '<table>{{some-component tagName="tbody"}}</table>',
     '<table>{{some-component tagName="thead"}}</table>',
     '<table>{{some-component tagName="tfoot"}}</table>',
+
+    // Block statement component with tag:
+    '<table>{{#some-component tagName="tbody"}}{{/some-component}}</table>',
+    '<table>{{#some-component tagName="thead"}}{{/some-component}}</table>',
+    '<table>{{#some-component tagName="tfoot"}}{{/some-component}}</table>',
+
+    // Component helper with tag:
     '<table>{{component "some-component" tagName="tbody"}}</table>',
     '<table>{{component "some-component" tagName="thead"}}</table>',
     '<table>{{component "some-component" tagName="tfoot"}}</table>',
+
+    // Angle bracket component (self-closing) with tag:
     '<table><SomeComponent @tagName="tbody" /></table>',
     '<table><SomeComponent @tagName="thead" /></table>',
     '<table><SomeComponent @tagName="tfoot" /></table>',
+
+    // Angle bracket component (NOT self-closing) with tag:
+    '<table><SomeComponent @tagName="tbody"></SomeComponent></table>',
+    '<table><SomeComponent @tagName="thead"></SomeComponent></table>',
+    '<table><SomeComponent @tagName="tfoot"></SomeComponent></table>',
+
     ` <table>{{yield}}</table> `,
     '<table><!-- this --></table>',
     '<table>{{! or this }}</table>',


### PR DESCRIPTION
Follow-up to this PR: https://github.com/ember-template-lint/ember-template-lint/pull/721

CC: @raycohen