### PR TITLE
Add failing test for tabindex rule

### DIFF
--- a/test/unit/rules/lint-no-positive-tabindex-test.js
+++ b/test/unit/rules/lint-no-positive-tabindex-test.js
@@ -14,6 +14,7 @@ generateRuleTests({
     '<span tabindex={{"-1"}}>baz</span>',
     '<span tabindex="{{-1}}">baz</span>',
     '<span tabindex="{{"-1"}}">baz</span>',
+    '<span tabindex="{{if this.show "-1" "0"}}">baz</span>',
   ],
 
   bad: [


### PR DESCRIPTION
I need to support `tabindex="{{if this.show "-1" "0"}}"`

My use case for this is an expandable/collapsable component.

When it is collapsed it should be possible to _tab_ to it. (The focus causes expansion)

When it is expanded the first input inside is focused.

Therefore, I do not _also_ want it to be possible to focus the expanded container.