### PR TITLE
Ensure custom rules can be disabled with inline comments.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,6 +59,7 @@ class Linter {
         console: this.console,
         log: addToResults,
         defaultSeverity: this._defaultSeverityForRule(pluginName, config.pending),
+        ruleNames: Object.keys(rules),
       });
 
       astPlugins.push(env => {

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -43,6 +43,7 @@ module.exports = class BaseRule {
     this.ruleName = options.name;
     this._console = options.console || console;
     this._log = options.log;
+    this._ruleNames = options.ruleNames;
     this.severity = options.defaultSeverity;
 
     // To support DOM-scoped configuration instructions, we need to maintain
@@ -68,30 +69,10 @@ module.exports = class BaseRule {
     this.source = env.rawSource.match(reLines);
   }
 
-  _isPluginRule(name) {
-    let getConfig = require('../get-config');
-    let config = getConfig({
-      // configPath: '.template-lintrc.js',
-      configPath: './test/fixtures/with-plugins/.template-lintrc.js',
-    });
-    let keys = Object.keys(config.plugins);
-    return keys.some(key => {
-      return config.plugins[key].rules[name];
-    });
-  }
-
   // The `name !== this.ruleName` check isn't strictly necessary, but allows
   // unit tests to register test rules
   _isRuleName(name) {
-    // must be required lazily so that rules can be populated
-    let rules = require('./index');
-
-    return (
-      rules[name] ||
-      name === this.ruleName ||
-      DEPRECATED_RULES.has(name) ||
-      this._isPluginRule(name)
-    );
+    return this._ruleNames.includes(name) || name === this.ruleName || DEPRECATED_RULES.has(name);
   }
 
   _refersToCurrentRule(name) {

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -68,13 +68,30 @@ module.exports = class BaseRule {
     this.source = env.rawSource.match(reLines);
   }
 
+  _isPluginRule(name) {
+    let getConfig = require('../get-config');
+    let config = getConfig({
+      // configPath: '.template-lintrc.js',
+      configPath: './test/fixtures/with-plugins/.template-lintrc.js',
+    });
+    let keys = Object.keys(config.plugins);
+    return keys.some(key => {
+      return config.plugins[key].rules[name];
+    });
+  }
+
   // The `name !== this.ruleName` check isn't strictly necessary, but allows
   // unit tests to register test rules
   _isRuleName(name) {
     // must be required lazily so that rules can be populated
     let rules = require('./index');
 
-    return rules[name] || name === this.ruleName || DEPRECATED_RULES.has(name);
+    return (
+      rules[name] ||
+      name === this.ruleName ||
+      DEPRECATED_RULES.has(name) ||
+      this._isPluginRule(name)
+    );
   }
 
   _refersToCurrentRule(name) {

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -392,6 +392,19 @@ describe('public api', function() {
 
       expect(result).to.deep.equal(expected);
     });
+
+    it('allow you to disable plugin rules inline', function() {
+      let templatePath = path.join(basePath, 'app', 'templates', 'disabled-rule.hbs');
+      let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
+      let expected = [];
+
+      let result = linter.verify({
+        source: templateContents,
+        moduleId: templatePath,
+      });
+
+      expect(result).to.deep.equal(expected);
+    });
   });
 
   describe('Linter using plugin with extends', function() {

--- a/test/fixtures/with-plugins/app/templates/disabled-rule.hbs
+++ b/test/fixtures/with-plugins/app/templates/disabled-rule.hbs
@@ -1,0 +1,2 @@
+{{! template-lint-disable inline-component }}
+<h2>{{component value="Hej"}}</h2>

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -3,6 +3,7 @@
 const expect = require('chai').expect;
 const _precompile = require('@glimmer/compiler').precompile;
 const Rule = require('./../../lib/rules/base');
+const ruleNames = Object.keys(require('../../lib/rules'));
 
 describe('base plugin', function() {
   function precompileTemplate(template, ast) {
@@ -45,7 +46,7 @@ describe('base plugin', function() {
   }
 
   function plugin(Rule, name, config) {
-    let plugin = new Rule({ name, config });
+    let plugin = new Rule({ name, config, ruleNames });
 
     return env => {
       plugin.templateEnvironmentData = env;


### PR DESCRIPTION
Builds off of @patocallaghan's work in #718 (thank you!), but tweaks the implementation a bit to avoid re-parsing configuration.

Closes #718
Fixes #261