### PR TITLE
Deprecate `img-alt-attributes` rule in favor of `require-valid-alt-text`

### DIFF
--- a/docs/rule/img-alt-attributes.md
+++ b/docs/rule/img-alt-attributes.md
@@ -1,5 +1,7 @@
 ## img-alt-attributes
 
+**NOTE**: This rule is deprecated in favor of the more comprehensive rule [require-valid-alt-text](./require-valid-alt-text.md).
+
 An `<img>` without an `alt` attribute is essentially invisible to assistive/accessibility technology (i.e. screen readers).
 In order to ensure that screen readers can provide useful information, we need to ensure that all `<img>` elements
 have an `alt` attribute specified.

--- a/lib/helpers/deprecated-rules.js
+++ b/lib/helpers/deprecated-rules.js
@@ -10,6 +10,7 @@ let DEPRECATED_RULES = new Map([
   ['triple-curlies', 'no-triple-curlies'],
   ['unused-block-params', 'no-unused-block-params'],
   ['no-attr-in-components', 'no-attrs-in-components'],
+  ['img-alt-attributes', 'require-valid-alt-text'],
 ]);
 
 module.exports = DEPRECATED_RULES;


### PR DESCRIPTION
Fixes #739.

CC: @MelSumner 