### PR TITLE
Fix false positive of no-outlet-outside-routes

### DIFF
--- a/lib/helpers/is-route-template.js
+++ b/lib/helpers/is-route-template.js
@@ -19,6 +19,10 @@ module.exports = function isRouteTemplate(moduleName) {
   var isPartial = baseName.indexOf('-') === 0;
 
   return (
-    !isPartial && moduleName.indexOf('/templates/components/') === -1 // classic component
+    !isPartial &&
+    // check that this is not a component template - [^/]+ is the app's module name
+    // which we don't know here
+    !/^[^/]+\/templates\/components\//.test(moduleName) && // classic component
+    !/^[^/]+\/components\//.test(moduleName) // co-located component template
   );
 };

--- a/lib/helpers/is-route-template.js
+++ b/lib/helpers/is-route-template.js
@@ -19,6 +19,6 @@ module.exports = function isRouteTemplate(moduleName) {
   var isPartial = baseName.indexOf('-') === 0;
 
   return (
-    !isPartial && moduleName.indexOf('components/') === -1 // classic component
+    !isPartial && moduleName.indexOf('/templates/components/') === -1 // classic component
   );
 };

--- a/test/unit/rules/lint-no-outlet-outside-routes-test.js
+++ b/test/unit/rules/lint-no-outlet-outside-routes-test.js
@@ -121,5 +121,20 @@ generateRuleTests({
         column: 0,
       },
     },
+    {
+      template: '{{outlet}}',
+
+      meta: {
+        moduleId: 'app/components/foo/layout.hbs',
+      },
+
+      result: {
+        message,
+        moduleId: 'app/components/foo/layout.hbs',
+        source: '{{outlet}}',
+        line: 1,
+        column: 0,
+      },
+    },
   ],
 });

--- a/test/unit/rules/lint-no-outlet-outside-routes-test.js
+++ b/test/unit/rules/lint-no-outlet-outside-routes-test.js
@@ -14,7 +14,7 @@ generateRuleTests({
     {
       template: '{{outlet}}',
       meta: {
-        moduleId: 'foo/route.hbs',
+        moduleId: 'app/templates/foo/route.hbs',
       },
       result: {
         message,
@@ -27,7 +27,7 @@ generateRuleTests({
     {
       template: '{{outlet}}',
       meta: {
-        moduleId: 'routes/foo.hbs',
+        moduleId: 'app/templates/routes/foo.hbs',
       },
       result: {
         message,
@@ -40,11 +40,11 @@ generateRuleTests({
     {
       template: '{{#outlet}}Why?!{{/outlet}}',
       meta: {
-        moduleId: 'foo/route.hbs',
+        moduleId: 'app/templates/foo/route.hbs',
       },
       result: {
         message,
-        moduleId: 'foo/route.hbs',
+        moduleId: 'app/templates/foo/route.hbs',
         source: '{{#outlet}}Why?!{{/outlet}}',
         line: 1,
         column: 0,
@@ -57,7 +57,7 @@ generateRuleTests({
       },
       result: {
         message,
-        moduleId: 'routes/foo.hbs',
+        moduleId: 'app/templates/routes/foo.hbs',
         source: '{{#outlet}}Why?!{{/outlet}}',
         line: 1,
         column: 0,
@@ -66,12 +66,25 @@ generateRuleTests({
     {
       template: '{{#outlet}}Works because ambiguous{{/outlet}}',
       meta: {
-        moduleId: 'something/foo.hbs',
+        moduleId: 'app/templates/something/foo.hbs',
       },
       result: {
         message,
         moduleId: 'something/foo.hbs',
         source: '{{#outlet}}Works because ambiguous{{/outlet}}',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '{{outlet}}',
+      meta: {
+        moduleId: 'components/templates/application.hbs',
+      },
+      result: {
+        message,
+        moduleId: 'components/templates/application.hbs',
+        source: '{{outlet}}',
         line: 1,
         column: 0,
       },
@@ -82,12 +95,12 @@ generateRuleTests({
       template: '{{outlet}}',
 
       meta: {
-        moduleId: 'components/foo/layout.hbs',
+        moduleId: 'app/templates/components/foo/layout.hbs',
       },
 
       result: {
         message,
-        moduleId: 'components/foo/layout.hbs',
+        moduleId: 'app/templates/components/foo/layout.hbs',
         source: '{{outlet}}',
         line: 1,
         column: 0,
@@ -97,12 +110,12 @@ generateRuleTests({
       template: '{{outlet}}',
 
       meta: {
-        moduleId: 'foo/-mything.hbs',
+        moduleId: 'app/templates/foo/-mything.hbs',
       },
 
       result: {
         message,
-        moduleId: 'foo/-mything.hbs',
+        moduleId: 'app/templates/foo/-mything.hbs',
         source: '{{outlet}}',
         line: 1,
         column: 0,


### PR DESCRIPTION
This checks the module name includes `templates/components` and thus makes sure the template is actually a component template vs. any templates where the app names happens to be _"components"_ (e.g. `components/templates/application`).

closes #761 