### PR TITLE
fix: `no-invalid-interactive` rule should consider any DOM event attribute usage as adding interactivity to an element

### DIFF
--- a/lib/rules/lint-no-invalid-interactive.js
+++ b/lib/rules/lint-no-invalid-interactive.js
@@ -5,6 +5,29 @@ const isInteractiveElement = require('../helpers/is-interactive-element');
 const isAngleBracketComponent = require('../helpers/is-angle-bracket-component');
 const parseConfig = require('../helpers/parse-interactive-element-config');
 
+const DISALLOWED_DOM_EVENTS = [
+  // Mouse events:
+  'click',
+  'dblclick',
+  'mousedown',
+  'mousemove',
+  'mouseover',
+  'mouseout',
+  'mouseup',
+
+  // Keyboard events:
+  'keydown',
+  'keypress',
+  'keyup',
+
+  // TODO: add any more relevant events.
+];
+
+function isDisallowedDomEvent(name) {
+  const nameLower = name.toLowerCase();
+  return nameLower.startsWith('on') && DISALLOWED_DOM_EVENTS.includes(name.substring(2));
+}
+
 module.exports = class InvalidInteractive extends Rule {
   parseConfig(config) {
     return parseConfig(this.ruleName, config);
@@ -78,22 +101,29 @@ module.exports = class InvalidInteractive extends Rule {
 
         let helperName = node.value.path.original;
 
+        // Allow onsubmit={{action "foo"}} on form tags
+        if (this._element.tag === 'form' && node.name === 'onsubmit') {
+          return;
+        }
+
+        // Allow onreset={{action "foo"}} on form tags
+        if (this._element.tag === 'form' && node.name === 'onreset') {
+          return;
+        }
+
+        // Allow onerror={{action "foo"}} on img tags
+        if (this._element.tag === 'img' && node.name === 'onerror') {
+          return;
+        }
+
         if (helperName === 'action') {
-          // Allow onsubmit={{action "foo"}} on form tags
-          if (this._element.tag === 'form' && node.name === 'onsubmit') {
-            return;
-          }
-
-          // Allow onreset={{action "foo"}} on form tags
-          if (this._element.tag === 'form' && node.name === 'onreset') {
-            return;
-          }
-
-          // Allow onerror={{action "foo"}} on img tags
-          if (this._element.tag === 'img' && node.name === 'onerror') {
-            return;
-          }
-
+          this.log({
+            message: 'Interaction added to non-interactive element',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(this._element),
+          });
+        } else if (isDisallowedDomEvent(node.name)) {
           this.log({
             message: 'Interaction added to non-interactive element',
             line: node.loc && node.loc.start.line,

--- a/test/unit/rules/lint-no-invalid-interactive-test.js
+++ b/test/unit/rules/lint-no-invalid-interactive-test.js
@@ -10,6 +10,7 @@ generateRuleTests({
   good: [
     '<button {{action "foo"}}></button>',
     '<div role="button" {{action "foo"}}></div>',
+    '<div randomProperty={{myValue}}></div>',
     '<li><button {{action "foo"}}></button></li>',
     '<form {{action "foo" on="submit"}}></form>',
     '<form onsubmit={{action "foo"}}></form>',
@@ -57,6 +58,18 @@ generateRuleTests({
     },
 
     {
+      // This example is detected solely based on the DOM event attribute name.
+      template: '<div onclick={{pipe-action "foo"}}></div>',
+
+      result: {
+        message: 'Interaction added to non-interactive element',
+        line: 1,
+        column: 5,
+        source: '<div onclick={{pipe-action "foo"}}></div>',
+      },
+    },
+
+    {
       template: '<div onsubmit={{action "foo"}}></div>',
 
       result: {
@@ -64,6 +77,18 @@ generateRuleTests({
         line: 1,
         column: 5,
         source: '<div onsubmit={{action "foo"}}></div>',
+      },
+    },
+
+    {
+      // Any usage of the `action` helper will be caught, regardless of the attribute name.
+      template: '<div randomAttribute={{action "foo"}}></div>',
+
+      result: {
+        message: 'Interaction added to non-interactive element',
+        line: 1,
+        column: 5,
+        source: '<div randomAttribute={{action "foo"}}></div>',
       },
     },
 


### PR DESCRIPTION
This fix allows the rule to catch the following violation where `pipe-action` is a third-party helper from `ember-composable-helpers` (previously, only using the first-party `action` helper would be caught):

```
<div onclick={{pipe-action "doSomething"}}></div>
```

Fixes #769. CC: @artemgurzhii