### PR TITLE
Allow <img onload={{action 'foo'}}> in no-invalid-interactive rule

### DIFF
--- a/lib/rules/lint-no-invalid-interactive.js
+++ b/lib/rules/lint-no-invalid-interactive.js
@@ -111,8 +111,8 @@ module.exports = class InvalidInteractive extends Rule {
           return;
         }
 
-        // Allow onerror={{action "foo"}} on img tags
-        if (this._element.tag === 'img' && node.name === 'onerror') {
+        // Allow onerror={{action "foo"}} and onload={{action "foo"}} on any tag
+        if (this._element.tag === 'img' && ['onerror', 'onload'].includes(node.name)) {
           return;
         }
 


### PR DESCRIPTION
This PR does three things which I believe improve the consistency of the `no-invalid-interactive` rule:

1. Currently it is allowed to add `onerror={{action "foo"}}` on non-interactive elements. Which makes perfect sense, since this is not a user interaction. However, `{{action "foo" on="error"}}` is not allowed. This PR allows both forms.

2. It no longer treats the `load` events as interactions. They are now allowed - same as with `error` events.

3. It removes the limitation for `img` tag. The `load` and `error` events can be used with various other tags.