### PR TITLE
Spike template-lint-disable-next-line behaviour

### DIFF
--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -233,14 +233,25 @@ module.exports = class BaseRule {
 
       pluginContext._pushConfig(config.value);
 
-      // Pop the config once we exit the comment's siblings
-      let parentNode = scope.currentNode;
-      astHandlers.ElementNode.keys.children.exit.before.unshift(function(elementNode) {
-        if (elementNode === parentNode) {
-          pluginContext._popConfig(config.value);
-          return REMOVE_HANDLER;
-        }
-      });
+      if (config.disableUntil) {
+        // Pop the disable-next-line config once we enter an element whose loc
+        // starts on a line number greater than or equal to config.disableUntil
+        astHandlers.ElementNode.enter.before.unshift(function(elementNode) {
+          if (elementNode.loc && elementNode.loc.start.line >= config.disableUntil) {
+            pluginContext._popConfig(config.value);
+            return REMOVE_HANDLER;
+          }
+        });
+      } else {
+        // Pop the config once we exit the comment's siblings
+        let parentNode = scope.currentNode;
+        astHandlers.ElementNode.keys.children.exit.before.unshift(function(elementNode) {
+          if (elementNode === parentNode) {
+            pluginContext._popConfig(config.value);
+            return REMOVE_HANDLER;
+          }
+        });
+      }
     });
 
     // Handle in-element config statements
@@ -479,26 +490,8 @@ module.exports = class BaseRule {
         }
       }
 
-      console.log('matched reDisableRuleForNextLine', {
-        currentLineNum,
-        instructionName,
-        instructionArgs,
-        node,
-      });
-      // if we're in here, we need some way of not processing all the nodes on
-      // the next line. it looks like we need to modify `config` in some way
-      // such that this would occur. i don't know how `config.tree` works yet
-      // but perhaps we could set a `config.nextLine` to instruct the visitor
-      // to accomplish this?
-      //
-      // perhaps we can trick the visitor into perceiving this disableUntil as
-      //   config.value = false;
-      //
-      // I'm not sure how to "persist" what rules we want to be disabled for
-      // the next line
-
       config.value = false;
-      config.disableUntil = currentLineNum + 1;
+      config.disableUntil = currentLineNum + 2;
       return config;
     } else if (instructionName === 'template-lint-configure') {
       // This instruction must list exactly one rule

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -19,6 +19,7 @@ const reLines = /(.*?(?:\r\n?|\n|$))/gm;
 const reWhitespace = /\s+/;
 const reTree = /^(.*)-tree$/;
 const reToggleRule = /^template-lint-(enable|disable)$/;
+const reDisableRuleForNextLine = /^template-lint-disable-next-line$/;
 
 function last(array) {
   return array[array.length - 1];
@@ -385,6 +386,17 @@ module.exports = class BaseRule {
     let config = { tree: false };
     let m;
 
+    m = reDisableRuleForNextLine.exec(instructionName);
+    if (m) {
+      // we're currently processing a node
+      //
+      // if we're in here, we need some way of not processing all the nodes on
+      // the next line. it looks like we need to modify `config` in some way
+      // such that this would occur. i don't know how `config.tree` works yet
+      // but perhaps we could set a `config.nextLine` to instruct the visitor
+      // to accomplish this?
+    }
+
     m = reTree.exec(instructionName);
     if (m) {
       config.tree = true;
@@ -409,7 +421,9 @@ module.exports = class BaseRule {
 
           for (let i = 0; i < badNames.length; i++) {
             this.log({
-              message: `unrecognized rule name \`${badNames[i]}\` in ${instructionName} instruction`,
+              message: `unrecognized rule name \`${
+                badNames[i]
+              }\` in ${instructionName} instruction`,
               line: node.loc && node.loc.start.line,
               column: node.loc && node.loc.start.column,
               source: this.sourceForNode(node),

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -234,8 +234,10 @@ module.exports = class BaseRule {
       pluginContext._pushConfig(config.value);
 
       if (config.disableUntil) {
-        // Pop the disable-next-line config once we enter an element whose loc
-        // starts on a line number greater than or equal to config.disableUntil
+        // Pop the disable-next-line config once we enter a node (currently
+        // only working for ElementNode, but should be extended to support
+        // BlockStatement + MustacheStatement) whose loc starts on a line
+        // number greater than or equal to config.disableUntil
         astHandlers.ElementNode.enter.before.unshift(function(elementNode) {
           if (elementNode.loc && elementNode.loc.start.line >= config.disableUntil) {
             pluginContext._popConfig(config.value);
@@ -403,7 +405,7 @@ module.exports = class BaseRule {
     }
 
     m = reToggleRule.exec(instructionName);
-    if (m) {
+    if (m || instructionName === 'template-lint-disable-next-line') {
       // If no instructionArgs, it's just disabling everything, so apply the
       // config
       if (instructionArgs) {
@@ -439,59 +441,30 @@ module.exports = class BaseRule {
         }
       }
 
-      if (m[1] === 'disable') {
+      if (instructionName === 'template-lint-disable-next-line') {
+        let currentLineNum = node.loc.end.line;
+        // the current line is {{!-- template-lint-disable-next-line no-foo --}}
+        // +1 will be the line we wish to disable `no-foo` for, so +2 is when we
+        // should re-enable the rule
+        config.disableUntil = currentLineNum + 2;
+        // as it currently stands, we have no use for -enable-next-line so this
+        // is always false
         config.value = false;
       } else {
-        // Enable means set to the default config, i.e. the bottom of our
-        // config stack...unless it was originally disabled, and then just
-        // enable it.
-        if (this._configStack[0] === false) {
-          config.value = true;
+        if (m[1] === 'disable') {
+          config.value = false;
         } else {
-          config.value = this._configStack[0];
+          // Enable means set to the default config, i.e. the bottom of our
+          // config stack...unless it was originally disabled, and then just
+          // enable it.
+          if (this._configStack[0] === false) {
+            config.value = true;
+          } else {
+            config.value = this._configStack[0];
+          }
         }
       }
 
-      return config;
-    } else if (instructionName === 'template-lint-disable-next-line') {
-      let currentLineNum = node.loc.end.line;
-
-      // If no instructionArgs, it's just disabling everything, so apply the
-      // config
-      if (instructionArgs) {
-        // It includes an explicit list of rules, so not just disabling
-        // everything. So, let's validate the rule names, and then see if it
-        // contains us.
-        let names = instructionArgs.split(reWhitespace).map(unquote);
-        // Validate rule names. If one or more fail to validate, don't return,
-        // though, because if we can still find our rule name in the list, we
-        // can process the instruction just fine.
-        if (loggedNodes.indexOf(node) === -1) {
-          let badNames = names.filter(name => !this._isRuleName(name));
-
-          for (let i = 0; i < badNames.length; i++) {
-            this.log({
-              message: `unrecognized rule name \`${badNames[i]}\` in ${instructionName} instruction`,
-              line: node.loc && node.loc.start.line,
-              column: node.loc && node.loc.start.column,
-              source: this.sourceForNode(node),
-              rule: 'global',
-            });
-          }
-
-          if (badNames.length > 0) {
-            loggedNodes.push(node);
-          }
-        }
-
-        if (names.every(name => !this._refersToCurrentRule(name))) {
-          // Explicit list that doesn't include us
-          return null;
-        }
-      }
-
-      config.value = false;
-      config.disableUntil = currentLineNum + 2;
       return config;
     } else if (instructionName === 'template-lint-configure') {
       // This instruction must list exactly one rule

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -19,7 +19,6 @@ const reLines = /(.*?(?:\r\n?|\n|$))/gm;
 const reWhitespace = /\s+/;
 const reTree = /^(.*)-tree$/;
 const reToggleRule = /^template-lint-(enable|disable)$/;
-const reDisableRuleForNextLine = /^template-lint-disable-next-line$/;
 
 function last(array) {
   return array[array.length - 1];
@@ -386,17 +385,6 @@ module.exports = class BaseRule {
     let config = { tree: false };
     let m;
 
-    m = reDisableRuleForNextLine.exec(instructionName);
-    if (m) {
-      // we're currently processing a node
-      //
-      // if we're in here, we need some way of not processing all the nodes on
-      // the next line. it looks like we need to modify `config` in some way
-      // such that this would occur. i don't know how `config.tree` works yet
-      // but perhaps we could set a `config.nextLine` to instruct the visitor
-      // to accomplish this?
-    }
-
     m = reTree.exec(instructionName);
     if (m) {
       config.tree = true;
@@ -421,9 +409,7 @@ module.exports = class BaseRule {
 
           for (let i = 0; i < badNames.length; i++) {
             this.log({
-              message: `unrecognized rule name \`${
-                badNames[i]
-              }\` in ${instructionName} instruction`,
+              message: `unrecognized rule name \`${badNames[i]}\` in ${instructionName} instruction`,
               line: node.loc && node.loc.start.line,
               column: node.loc && node.loc.start.column,
               source: this.sourceForNode(node),
@@ -455,6 +441,64 @@ module.exports = class BaseRule {
         }
       }
 
+      return config;
+    } else if (instructionName === 'template-lint-disable-next-line') {
+      let currentLineNum = node.loc.end.line;
+
+      // If no instructionArgs, it's just disabling everything, so apply the
+      // config
+      if (instructionArgs) {
+        // It includes an explicit list of rules, so not just disabling
+        // everything. So, let's validate the rule names, and then see if it
+        // contains us.
+        let names = instructionArgs.split(reWhitespace).map(unquote);
+        // Validate rule names. If one or more fail to validate, don't return,
+        // though, because if we can still find our rule name in the list, we
+        // can process the instruction just fine.
+        if (loggedNodes.indexOf(node) === -1) {
+          let badNames = names.filter(name => !this._isRuleName(name));
+
+          for (let i = 0; i < badNames.length; i++) {
+            this.log({
+              message: `unrecognized rule name \`${badNames[i]}\` in ${instructionName} instruction`,
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(node),
+              rule: 'global',
+            });
+          }
+
+          if (badNames.length > 0) {
+            loggedNodes.push(node);
+          }
+        }
+
+        if (names.every(name => !this._refersToCurrentRule(name))) {
+          // Explicit list that doesn't include us
+          return null;
+        }
+      }
+
+      console.log('matched reDisableRuleForNextLine', {
+        currentLineNum,
+        instructionName,
+        instructionArgs,
+        node,
+      });
+      // if we're in here, we need some way of not processing all the nodes on
+      // the next line. it looks like we need to modify `config` in some way
+      // such that this would occur. i don't know how `config.tree` works yet
+      // but perhaps we could set a `config.nextLine` to instruct the visitor
+      // to accomplish this?
+      //
+      // perhaps we can trick the visitor into perceiving this disableUntil as
+      //   config.value = false;
+      //
+      // I'm not sure how to "persist" what rules we want to be disabled for
+      // the next line
+
+      config.value = false;
+      config.disableUntil = currentLineNum + 1;
       return config;
     } else if (instructionName === 'template-lint-configure') {
       // This instruction must list exactly one rule


### PR DESCRIPTION
Hey folks, following on from https://github.com/ember-template-lint/ember-template-lint/issues/354#issuecomment-499115812 I've spiked out what the implementation for `{{!— template-lint-disable-next-line no-foo —}}` could look like. We're interested in the functionality because it neatly brings ember-template-lint to parity with eslint and stylelint.

Here we introduce the notion of `config.disableUntil` to make the handlers aware of what "next line" means so that they're able to pop the temporary config off the stack at the right time.

There are a number of quirks this spike doesn't tackle:
- [ ] Support attaching this temporal pop handler to `before.enter` on BlockStatement and MustacheStatement, not just ElementNode
- [ ] Consider value of adding support for an accompanying `temlate-lint-enable-next-line` construct

If we were to iron out the remaining quirks with this implementation and back it up with some specs, is this something that you think would be valuable to add to this addon?

