### PR TITLE
Add support for handling `<button tabindex={{if this.foo 0 -1}}><button>` to no-positive-tabindex rule

### DIFF
--- a/lib/rules/lint-no-positive-tabindex.js
+++ b/lib/rules/lint-no-positive-tabindex.js
@@ -6,6 +6,23 @@ const Rule = require('./base');
 const errorMessage = 'Avoid positive integer values for tabindex.';
 const errorMessageForNaNCase = 'Tabindex values must be negative numeric.';
 
+function literalValueToNumber(astNode) {
+  if (astNode.type === 'NumberLiteral') {
+    return astNode.original;
+  } else if (astNode.type === 'StringLiteral') {
+    return parseInt(astNode.original, 10);
+  } else {
+    return NaN;
+  }
+}
+
+function maybeLiteralValue(astNode, defaultValue) {
+  if (['NumberLiteral', 'StringLiteral'].includes(astNode.type)) {
+    return literalValueToNumber(astNode);
+  } else {
+    return defaultValue;
+  }
+}
 module.exports = class NoPositiveTabindex extends Rule {
   visitor() {
     return {
@@ -20,19 +37,23 @@ module.exports = class NoPositiveTabindex extends Rule {
 
         if (tabindex.value.type === 'MustacheStatement') {
           if (tabindex.value.path) {
-            if (tabindex.value.path.type === 'NumberLiteral') {
-              tabindexValue = tabindex.value.path.original;
-            } else if (tabindex.value.path.type === 'StringLiteral') {
-              tabindexValue = parseInt(tabindex.value.path.original, 10);
-            }
+            tabindexValue = maybeLiteralValue(tabindex.value.path, tabindexValue);
           }
         } else if (tabindex.value.type === 'ConcatStatement') {
           let part = tabindex.value.parts[0];
           if (part.type === 'MustacheStatement') {
-            if (part.path.type === 'NumberLiteral') {
-              tabindexValue = part.path.original;
-            } else if (part.path.type === 'StringLiteral') {
-              tabindexValue = parseInt(part.path.original, 10);
+            if (['NumberLiteral', 'StringLiteral'].includes(part.path.type)) {
+              tabindexValue = literalValueToNumber(part.path);
+            } else if (part.path.type === 'PathExpression' && part.path.original === 'if') {
+              if (part.params.length === 2 || part.params.length === 3) {
+                tabindexValue = maybeLiteralValue(part.params[1], tabindexValue);
+              }
+              if (part.params.length === 3) {
+                let maybeTabindexValue = maybeLiteralValue(part.params[2], tabindexValue);
+                if (maybeTabindexValue > tabindexValue) {
+                  tabindexValue = maybeTabindexValue;
+                }
+              }
             }
           }
         } else if (tabindex.value.type === 'TextNode') {

--- a/lib/rules/lint-no-positive-tabindex.js
+++ b/lib/rules/lint-no-positive-tabindex.js
@@ -23,6 +23,27 @@ function maybeLiteralValue(astNode, defaultValue) {
     return defaultValue;
   }
 }
+
+function parseTabIndexFromMustache(mustacheNode) {
+  let tabindexValue;
+
+  if (['NumberLiteral', 'StringLiteral'].includes(mustacheNode.path.type)) {
+    tabindexValue = literalValueToNumber(mustacheNode.path);
+  } else if (mustacheNode.path.type === 'PathExpression' && mustacheNode.path.original === 'if') {
+    if (mustacheNode.params.length === 2 || mustacheNode.params.length === 3) {
+      tabindexValue = maybeLiteralValue(mustacheNode.params[1], tabindexValue);
+    }
+    if (mustacheNode.params.length === 3) {
+      let maybeTabindexValue = maybeLiteralValue(mustacheNode.params[2], tabindexValue);
+      if (maybeTabindexValue > tabindexValue) {
+        tabindexValue = maybeTabindexValue;
+      }
+    }
+  }
+
+  return tabindexValue;
+}
+
 module.exports = class NoPositiveTabindex extends Rule {
   visitor() {
     return {
@@ -37,24 +58,12 @@ module.exports = class NoPositiveTabindex extends Rule {
 
         if (tabindex.value.type === 'MustacheStatement') {
           if (tabindex.value.path) {
-            tabindexValue = maybeLiteralValue(tabindex.value.path, tabindexValue);
+            tabindexValue = parseTabIndexFromMustache(tabindex.value);
           }
         } else if (tabindex.value.type === 'ConcatStatement') {
           let part = tabindex.value.parts[0];
           if (part.type === 'MustacheStatement') {
-            if (['NumberLiteral', 'StringLiteral'].includes(part.path.type)) {
-              tabindexValue = literalValueToNumber(part.path);
-            } else if (part.path.type === 'PathExpression' && part.path.original === 'if') {
-              if (part.params.length === 2 || part.params.length === 3) {
-                tabindexValue = maybeLiteralValue(part.params[1], tabindexValue);
-              }
-              if (part.params.length === 3) {
-                let maybeTabindexValue = maybeLiteralValue(part.params[2], tabindexValue);
-                if (maybeTabindexValue > tabindexValue) {
-                  tabindexValue = maybeTabindexValue;
-                }
-              }
-            }
+            tabindexValue = parseTabIndexFromMustache(part);
           }
         } else if (tabindex.value.type === 'TextNode') {
           tabindexValue = parseInt(tabindex.value.chars, 10);

--- a/test/unit/rules/lint-no-positive-tabindex-test.js
+++ b/test/unit/rules/lint-no-positive-tabindex-test.js
@@ -14,6 +14,9 @@ generateRuleTests({
     '<span tabindex={{"-1"}}>baz</span>',
     '<span tabindex="{{-1}}">baz</span>',
     '<span tabindex="{{"-1"}}">baz</span>',
+    '<span tabindex="{{if this.show -1}}">baz</span>',
+    '<span tabindex="{{if this.show "-1" "0"}}">baz</span>',
+    '<span tabindex="{{if (not this.show) "-1" "0"}}">baz</span>',
   ],
 
   bad: [
@@ -79,6 +82,50 @@ generateRuleTests({
         message: 'Avoid positive integer values for tabindex.',
         moduleId: 'layout.hbs',
         source: 'tabindex="{{5}}"',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<button tabindex="{{if a 1 -1}}"></button>',
+
+      result: {
+        message: 'Avoid positive integer values for tabindex.',
+        moduleId: 'layout.hbs',
+        source: 'tabindex="{{if a 1 -1}}"',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<button tabindex="{{if a -1 1}}"></button>',
+
+      result: {
+        message: 'Avoid positive integer values for tabindex.',
+        moduleId: 'layout.hbs',
+        source: 'tabindex="{{if a -1 1}}"',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<button tabindex="{{if a 1}}"></button>',
+
+      result: {
+        message: 'Avoid positive integer values for tabindex.',
+        moduleId: 'layout.hbs',
+        source: 'tabindex="{{if a 1}}"',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<button tabindex="{{if (not a) 1}}"></button>',
+
+      result: {
+        message: 'Avoid positive integer values for tabindex.',
+        moduleId: 'layout.hbs',
+        source: 'tabindex="{{if (not a) 1}}"',
         line: 1,
         column: 0,
       },

--- a/test/unit/rules/lint-no-positive-tabindex-test.js
+++ b/test/unit/rules/lint-no-positive-tabindex-test.js
@@ -17,6 +17,9 @@ generateRuleTests({
     '<button tabindex="{{if this.show -1}}">baz</button>',
     '<button tabindex="{{if this.show "-1" "0"}}">baz</button>',
     '<button tabindex="{{if (not this.show) "-1" "0"}}">baz</button>',
+    '<button tabindex={{if this.show -1}}>baz</button>',
+    '<button tabindex={{if this.show "-1" "0"}}>baz</button>',
+    '<button tabindex={{if (not this.show) "-1" "0"}}>baz</button>',
   ],
 
   bad: [

--- a/test/unit/rules/lint-no-positive-tabindex-test.js
+++ b/test/unit/rules/lint-no-positive-tabindex-test.js
@@ -10,13 +10,13 @@ generateRuleTests({
   good: [
     '<button tabindex="0"></button>',
     '<button tabindex="-1"></button>',
-    '<span tabindex={{-1}}>baz</span>',
-    '<span tabindex={{"-1"}}>baz</span>',
-    '<span tabindex="{{-1}}">baz</span>',
-    '<span tabindex="{{"-1"}}">baz</span>',
-    '<span tabindex="{{if this.show -1}}">baz</span>',
-    '<span tabindex="{{if this.show "-1" "0"}}">baz</span>',
-    '<span tabindex="{{if (not this.show) "-1" "0"}}">baz</span>',
+    '<button tabindex={{-1}}>baz</button>',
+    '<button tabindex={{"-1"}}>baz</button>',
+    '<button tabindex="{{-1}}">baz</button>',
+    '<button tabindex="{{"-1"}}">baz</button>',
+    '<button tabindex="{{if this.show -1}}">baz</button>',
+    '<button tabindex="{{if this.show "-1" "0"}}">baz</button>',
+    '<button tabindex="{{if (not this.show) "-1" "0"}}">baz</button>',
   ],
 
   bad: [


### PR DESCRIPTION
https://github.com/ember-template-lint/ember-template-lint/pull/743