### PR TITLE
Ensure table-group rule allows `each`, `each-in`, `let`, and comments

### DIFF
--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -64,6 +64,28 @@ function isUnless(node) {
   return node.path && node.path.original === 'unless';
 }
 
+function isEach(node) {
+  return node.path && node.path.original === 'each';
+}
+
+function isEachIn(node) {
+  return node.path && node.path.original === 'each-in';
+}
+
+function isLet(node) {
+  return node.path && node.path.original === 'let';
+}
+
+function isWith(node) {
+  return node.path && node.path.original === 'with';
+}
+
+function isControlFlowHelper(node) {
+  return (
+    isIf(node) || isUnless(node) || isEach(node) || isEachIn(node) || isLet(node) || isWith(node)
+  );
+}
+
 function hasAttribute(node, attributeName) {
   var attribute = findAttribute(node, attributeName);
   return !!attribute;
@@ -162,6 +184,11 @@ module.exports = {
   isStringLiteral: isStringLiteral,
   isIf: isIf,
   isUnless: isUnless,
+  isEach: isEach,
+  isEachIn: isEachIn,
+  isLet: isLet,
+  isWith: isWith,
+  isControlFlowHelper: isControlFlowHelper,
   isCommentStatement: isCommentStatement,
   isConcatStatement: isConcatStatement,
   isMustacheCommentStatement: isMustacheCommentStatement,

--- a/lib/rules/lint-table-groups.js
+++ b/lib/rules/lint-table-groups.js
@@ -1,30 +1,23 @@
 'use strict';
 
+const AstNodeInfo = require('../helpers/ast-node-info');
 const Rule = require('./base');
 const message = 'Tables must have a table group (thead, tbody or tfoot).';
 
 const ALLOWED_TABLE_CHILDREN = ['thead', 'tbody', 'tfoot', 'caption', 'colgroup'];
 
-function hasDisallowedChildren(tableNode) {
-  const validBlocks = tableNode.children.filter(node => {
-    const isBlock = node.type === 'BlockStatement';
-    if (!isBlock) {
-      return false;
+// For effective children, we skip over any control flow helpers,
+// since we know that they don't render anything on their own
+function getEffectiveChildren(node) {
+  const unflattenedEffectiveChildren = AstNodeInfo.childrenFor(node).map(node => {
+    if (AstNodeInfo.isControlFlowHelper(node)) {
+      return getEffectiveChildren(node);
+    } else {
+      return [node];
     }
-    const isIf = node.path.original === 'if';
-    const isUnless = node.path.original === 'unless';
-    return isIf || isUnless;
   });
-  const childrenFromValidBlocks = [].concat.apply(
-    [],
-    validBlocks.map(block => [].concat(block.program.body, block.inverse ? block.inverse.body : []))
-  );
-  return ![]
-    .concat(
-      childrenFromValidBlocks,
-      tableNode.children.filter(item => validBlocks.indexOf(item) === -1)
-    )
-    .every(isAllowedTableChild);
+
+  return [].concat.apply([], unflattenedEffectiveChildren);
 }
 
 function isAllowedTableChild(node) {
@@ -49,6 +42,9 @@ function isAllowedTableChild(node) {
         return ALLOWED_TABLE_CHILDREN.includes(tagNameAttribute.value.chars);
       }
       break;
+    case 'CommentStatement':
+    case 'MustacheCommentStatement':
+      return true;
     case 'TextNode':
       return !/\S/.test(node.chars);
   }
@@ -56,24 +52,12 @@ function isAllowedTableChild(node) {
   return false;
 }
 
-function hasChildTags(tableNode) {
-  const contentNodes = tableNode.children.filter(child => {
-    return ['TextNode', 'CommentStatement', 'MustacheCommentStatement'].indexOf(child.type) === -1;
-  });
-
-  return contentNodes.length > 0;
-}
-
 module.exports = class TableGroups extends Rule {
   visitor() {
     return {
       ElementNode(node) {
         if (node.tag === 'table') {
-          if (!hasChildTags(node)) {
-            return;
-          }
-
-          if (hasDisallowedChildren(node)) {
+          if (!getEffectiveChildren(node).every(isAllowedTableChild)) {
             this.log({
               message,
               line: node.loc && node.loc.start.line,

--- a/test/unit/rules/lint-table-groups-test.js
+++ b/test/unit/rules/lint-table-groups-test.js
@@ -44,6 +44,55 @@ generateRuleTests({
     {{/unless}}
     </table>
     `,
+    `
+    <table>
+    {{#each foo as |bar|}}
+      <tfoot>
+        <tr>bar</tr>
+      </tfoot>
+    {{/each}}
+    </table>
+    `,
+    `
+    <table>
+    {{#each-in foo as |bar|}}
+      <tfoot>
+        <tr>bar</tr>
+      </tfoot>
+    {{/each-in}}
+    </table>
+    `,
+    `
+    <table>
+    {{#let foo as |bar|}}
+      <tfoot>
+        <tr>bar</tr>
+      </tfoot>
+    {{/let}}
+    </table>
+    `,
+    `
+    <table>
+    {{#with foo as |bar|}}
+      <tfoot>
+        <tr>bar</tr>
+      </tfoot>
+    {{/with}}
+    </table>
+    `,
+    `
+    <table>
+    {{#each foo as |bar|}}
+      {{#if bar}}
+        {{#unless baz}}
+          <tfoot>
+            <tr>bar</tr>
+          </tfoot>
+        {{/unless}}
+      {{/if}}
+    {{/each}}
+    </table>
+    `,
 
     // Component with tag:
     '<table>{{some-component tagName="tbody"}}</table>',
@@ -80,6 +129,7 @@ generateRuleTests({
     '<table><tbody><tr><td>Body</td></tr></tbody></table>',
     '<table><tfoot><tr><td>Footer</td></tr></tfoot></table>',
     '<table>' +
+      '{{! this is a comment }}' +
       '<thead>' +
       '<tr><td>Header</td></tr>' +
       '</thead>' +
@@ -222,6 +272,23 @@ generateRuleTests({
       },
     },
     {
+      template: `
+      <table>
+      {{#something foo}}
+        <tbody></tbody>
+      {{/something}}
+      </table>
+      `,
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source:
+          '<table>\n      {{#something foo}}\n        <tbody></tbody>\n      {{/something}}\n      </table>',
+        line: 2,
+        column: 6,
+      },
+    },
+    {
       template: '<table><tr><td>Foo</td></tr></table>',
 
       result: {
@@ -312,6 +379,16 @@ generateRuleTests({
         message,
         moduleId: 'layout.hbs',
         source: '<table><SomeComponent @otherProp="tbody" /></table>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<table>some text</table>',
+      result: {
+        message,
+        moduleId: 'layout.hbs',
+        source: '<table>some text</table>',
         line: 1,
         column: 0,
       },


### PR DESCRIPTION
With this change, we allow for `#each` and nesting `#each`, `#if`, and `#unless` blocks in a table (as long as the children are valid). It also allows for comments (the previous rule for allowing comments only worked if there were no other children).