### PR TITLE
Allow `{{#-in-element}}` and `{{#in-element}}` for `no-curly-component-invocation` rule

### DIFF
--- a/lib/rules/lint-no-curly-component-invocation.js
+++ b/lib/rules/lint-no-curly-component-invocation.js
@@ -31,6 +31,8 @@ const BUILT_IN_HELPERS = [
   'unless',
   'with',
   'yield',
+  '-in-element',
+  'in-element',
 ];
 const DEFAULT_CONFIG = {
   allow: [],

--- a/test/unit/rules/lint-no-curly-component-invocation-test.js
+++ b/test/unit/rules/lint-no-curly-component-invocation-test.js
@@ -27,6 +27,8 @@ generateRuleTests({
     `{{#each items as |item|}}
         {{item}}
      {{/each}}`,
+    `{{#-in-element}}Hello{{/-in-element}}`,
+    `{{#in-element}}Hello{{/in-element}}`,
   ],
 
   bad: [


### PR DESCRIPTION
This PR ensures that the following code does not break when linting:

```hbs
{{#-in-element targetElement}}
  Content
{{/-in-element}}
```

Fixes #795 