### PR TITLE
Don't require `alt` on `<img ...attributes>`

### DIFF
--- a/lib/rules/lint-img-alt-attributes.js
+++ b/lib/rules/lint-img-alt-attributes.js
@@ -28,9 +28,10 @@ module.exports = class ImgAltAttributes extends Rule {
         }
 
         let ariaHidden = AstNodeInfo.hasAttribute(node, 'aria-hidden');
+        let splattributes = AstNodeInfo.hasAttribute(node, '...attributes');
         let altPresent = isAltPresent(node);
 
-        if (!ariaHidden && !altPresent) {
+        if (!ariaHidden && !splattributes && !altPresent) {
           this.log({
             message: 'img tags must have an alt attribute',
             line: node.loc && node.loc.start.line,

--- a/test/unit/rules/lint-img-alt-attributes-test.js
+++ b/test/unit/rules/lint-img-alt-attributes-test.js
@@ -14,6 +14,7 @@ generateRuleTests({
     '<img aria-hidden="true">',
     '<img alt="">',
     '<img alt>',
+    '<img ...attributes>',
   ],
 
   bad: [


### PR DESCRIPTION
Fixes #800