### PR TITLE
[rule] add new no-class-concat rule

### DIFF
--- a/docs/rule/no-class-concat.md
+++ b/docs/rule/no-class-concat.md
@@ -1,0 +1,15 @@
+## no-class-concat
+
+Concating class names causes issues with maintainability. Disallowing concating class names will help ensure that class names are defined statically. 
+
+This rule **forbids** the following:
+
+```hbs
+<div class={{concat "foo" bar}}>
+```
+
+This rule **allows** the following:
+
+```hbs
+<div class="foo">
+```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -15,6 +15,7 @@
 * [no-bare-strings](rule/no-bare-strings.md)
 * [no-debugger](rule/no-debugger.md)
 * [no-curly-component-invocation](rule/no-curly-component-invocation.md)
+* [no-class-concat](rule/no-class-concat.md)
 * [no-duplicate-attributes](rule/no-duplicate-attributes.md)
 * [no-element-event-actions](rule/no-element-event-actions.md)
 * [no-extra-mut-helper-argument](rule/no-extra-mut-helper-argument.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -18,6 +18,7 @@ module.exports = {
   'no-attrs-in-components': require('./lint-no-attrs-in-components'),
   'no-bare-strings': require('./lint-no-bare-strings'),
   'no-curly-component-invocation': require('./lint-no-curly-component-invocation'),
+  'no-class-concat': require('./lint-no-class-concat'),
   'no-debugger': require('./lint-no-debugger'),
   'no-duplicate-attributes': require('./lint-no-duplicate-attributes'),
   'no-element-event-actions': require('./lint-no-element-event-actions'),

--- a/lib/rules/lint-no-class-concat.js
+++ b/lib/rules/lint-no-class-concat.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
+
+const ERROR_MESSAGE = 'Please do not concat class names';
+
+module.exports = class NoClassConcat extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        let className = AstNodeInfo.findAttribute(node, 'class');
+        if (
+          className &&
+          (AstNodeInfo.isConcatStatement(className.value) ||
+            (AstNodeInfo.isMustacheStatement(className.value) &&
+              isConcatHelper(className.value.path)))
+        ) {
+          this.log({
+            message: ERROR_MESSAGE,
+            line: className.loc && className.loc.start.line,
+            column: className.loc && className.loc.start.column,
+            source: this.sourceForNode(className),
+          });
+        }
+      },
+    };
+  }
+};
+
+function isConcatHelper(node) {
+  return node && AstNodeInfo.isPathExpression(node) && node.original === 'concat';
+}
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/lint-no-class-concat-test.js
+++ b/test/unit/rules/lint-no-class-concat-test.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+const { ERROR_MESSAGE } = require('../../../lib/rules/lint-no-class-concat');
+
+generateRuleTests({
+  name: 'no-class-concat',
+
+  config: true,
+
+  good: ['<img>', '<img class="foo">'],
+
+  bad: [
+    {
+      template: '<div class="{{concat "pv2 " headerClasses}}"></div>',
+
+      result: {
+        message: ERROR_MESSAGE,
+        moduleId: 'layout.hbs',
+        source: 'class="{{concat "pv2 " headerClasses}}"',
+        line: 1,
+        column: 5,
+      },
+    },
+  ],
+});


### PR DESCRIPTION
*Why?*

We have had a lot of issues with people using concat for classes because finding and replacing class is extremely difficult. 

Since there is a lint rule against styles being concated, this seems like a natural fit.