### PR TITLE
Add CI check to ensure yarn.lock is up-to-date

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - export PATH=$HOME/.yarn/bin:$PATH
 
 install:
-  - yarn install --ignore-engines
+  - yarn install --ignore-engines --frozen-lockfile --non-interactive
 
 script:
   - yarn test


### PR DESCRIPTION
This will ensure `yarn install` is run after any changes to package.json.

Example output of the CI failure caused by forgetting to run `yarn install`:

```
error Your lockfile needs to be updated, but yarn was run with `--frozen-lockfile`.
```

Similar example: https://github.com/ember-cli/eslint-plugin-ember/pull/519