### PR TITLE
Add eslint-plugin-eslint-comments internally

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,12 +6,15 @@ module.exports = {
     node: true
   },
   plugins: [
+    'eslint-comments',
     'filenames',
     'node',
     'prettier'
   ],
   extends: ['eslint:recommended', 'plugin:node/recommended', 'prettier'],
   rules: {
+    'eslint-comments/no-unused-disable': 'error',
+
     'filenames/match-regex': ['error', '^[a-z0-9-]+$'], // Kebab-case.
 
     'prettier/prettier': 'error',

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "common-tags": "^1.8.0",
     "eslint": "^6.0.1",
     "eslint-config-prettier": "^6.0.0",
+    "eslint-plugin-eslint-comments": "^3.1.2",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-prettier": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,6 +1321,14 @@ eslint-plugin-es@^1.4.1:
     eslint-utils "^1.4.2"
     regexpp "^2.0.1"
 
+eslint-plugin-eslint-comments@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-eslint-comments/-/eslint-plugin-eslint-comments-3.1.2.tgz#4ef6c488dbe06aa1627fea107b3e5d059fc8a395"
+  integrity sha512-QexaqrNeteFfRTad96W+Vi4Zj1KFbkHHNMMaHZEYcovKav6gdomyGzaxSDSL3GoIyUOo078wRAdYlu1caiauIQ==
+  dependencies:
+    escape-string-regexp "^1.0.5"
+    ignore "^5.0.5"
+
 eslint-plugin-filenames@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-filenames/-/eslint-plugin-filenames-1.3.2.tgz#7094f00d7aefdd6999e3ac19f72cea058e590cf7"
@@ -2198,6 +2206,11 @@ ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.0.5:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 ignore@^5.1.1:
   version "5.1.2"


### PR DESCRIPTION
This neat plugin checks for poor practices around `// eslint-disable` comments.

In particular, it prevents adding unnecessary disable comments, among other things.

https://github.com/mysticatea/eslint-plugin-eslint-comments