### PR TITLE
Expose internal errors from erroneous config when consuming it

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -27,8 +27,9 @@ function resolveConfigPath(configPath, pluginPath) {
   }
 
   let filePath = pluginPath || usedPath;
+  // Making sure that the filePath exists
   try {
-    return require(filePath); // eslint-disable-line import/no-dynamic-require
+    require.resolve(filePath);
   } catch (e) {
     let isModuleMissingError = ALLOWED_ERROR_CODES.includes(e.code);
     if (!isModuleMissingError) {
@@ -43,6 +44,7 @@ function resolveConfigPath(configPath, pluginPath) {
       return {};
     }
   }
+  return require(filePath); // eslint-disable-line import/no-dynamic-require
 }
 
 function forEachPluginConfiguration(plugins, callback) {

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -397,4 +397,21 @@ describe('get-config', function() {
       .be.empty;
     expect(config, 'assert object matches its original clone').to.deep.equal(cloned);
   });
+
+  it('error thrown when consuming erroneous config', function() {
+    expect(function() {
+      getConfig({
+        config: {
+          plugins: [
+            {
+              name: 'bad',
+              rules: {
+                bad: require('./bad-path'), // eslint-disable-line node/no-missing-require
+              },
+            },
+          ],
+        },
+      });
+    }).to.throw(Error, `Cannot find module './bad-path'`);
+  });
 });


### PR DESCRIPTION
- Modified `get-config.js` to now throw properly if the consumed config has errors.
- Added a test.

Closes #833 