### PR TITLE
Test interactivity of onload for img tags

### DIFF
--- a/test/unit/rules/lint-no-invalid-interactive-test.js
+++ b/test/unit/rules/lint-no-invalid-interactive-test.js
@@ -17,6 +17,7 @@ generateRuleTests({
     '<form {{action "foo" on="reset"}}></form>',
     '<form onreset={{action "foo"}}></form>',
     '<img onerror={{action "foo"}}>',
+    '<img onload={{action "foo"}}>',
     '<InputSearch @onInput={{action "foo"}} />',
     '<InputSearch @onInput={{action "foo"}}></InputSearch>',
     '{{#with (hash bar=(component "foo")) as |foo|}}<foo.bar @onInput={{action "foo"}}></foo.bar>{{/with}}',


### PR DESCRIPTION
With quite a delay - this implements a test for the already merged #779. It was requested in this [comment](https://github.com/ember-template-lint/ember-template-lint/pull/779#issuecomment-517054035).