### PR TITLE
Remove HTML comment config

### DIFF
--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const chalk = require('chalk');
-const calculateLocationDisplay = require('../helpers/calculate-location-display');
 const DEPRECATED_RULES = require('../helpers/deprecated-rules');
 const Scope = require('./internal/scope');
 
@@ -192,34 +190,6 @@ module.exports = class BaseRule {
         throw new Error('Element comments state out of sync with AST!');
       }
       inElementComments = false;
-    });
-
-    // Handle legacy config statements
-    astHandlers.CommentStatement.enter.after.push(function(node) {
-      if (node.value.indexOf('template-lint') === -1) {
-        return;
-      }
-
-      if (loggedNodes.indexOf(node) === -1) {
-        let locationInfo = calculateLocationDisplay(pluginContext._moduleName, {
-          line: node.loc.start.line,
-          column: node.loc.start.column,
-        });
-
-        pluginContext._console.log(
-          chalk.yellow(
-            [
-              'HTML comment rule instructions are deprecated. ',
-              'Please switch to Handlebars comments. ',
-              `(${locationInfo})\n`,
-              pluginContext.sourceForNode(node),
-            ].join('')
-          )
-        );
-        loggedNodes.push(node);
-      }
-
-      pluginContext._processLegacyConfigNode(node);
     });
 
     // Handle element-child config statements
@@ -503,42 +473,6 @@ module.exports = class BaseRule {
     }
 
     return null;
-  }
-
-  _processLegacyConfigNode(node) {
-    let hashParts = node.value
-      .trim()
-      .slice(14)
-      .split(reWhitespace);
-
-    let hash = hashParts.reduce((memo, part) => {
-      let parts = part.split('=');
-
-      memo[parts[0]] = parts[1];
-
-      return memo;
-    }, {});
-
-    for (let key in hash) {
-      let value = hash[key];
-      let i;
-
-      // handle <!-- template-lint disabled=true -->
-      if (key === 'disable' && value === 'true') {
-        for (i = 0; i < this._configStack.length; i++) {
-          this._configStack[i] = false;
-        }
-        this.config = false;
-      }
-
-      // handle <!-- template-lint block-indentation=false -->
-      if (this._refersToCurrentRule(key) && value === 'false') {
-        for (i = 0; i < this._configStack.length; i++) {
-          this._configStack[i] = false;
-        }
-        this.config = false;
-      }
-    }
   }
 
   isDisabled() {


### PR DESCRIPTION
Removed the code handling a legacy way of using HTML comments to configure the linter.

Fixes #749