### PR TITLE
Fixed `attribute-indentation` when using triple curlies (non-escaped `MustacheStatement`)

### DIFF
--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -384,7 +384,13 @@ module.exports = class AttributeSpacing extends Rule {
     let openIndentation = this.getLineIndentation(node);
 
     let end = getEndLocationForOpen(node);
-    const actualColumnStartLocation = node.type === 'ElementNode' && !node.selfClosing ? 1 : (node.type === 'MustacheStatement' && !node.escaped ? 3 : 2);
+    const actualColumnStartLocation =
+      node.type === 'ElementNode' && !node.selfClosing
+        ? 1
+        : node.type === 'MustacheStatement' && !node.escaped
+        ? 3
+        : 2;
+
     const actualStartLocation = {
       line: end.line,
       column: end.column - actualColumnStartLocation,

--- a/lib/rules/lint-attribute-indentation.js
+++ b/lib/rules/lint-attribute-indentation.js
@@ -379,12 +379,12 @@ module.exports = class AttributeSpacing extends Rule {
 
   validateCloseBrace(node, nextLocation) {
     /*
-      Validates the close brace `}}` for Handlebars and `>` for HTML/SVG elements of the non-block form.
+      Validates the close brace `}}` (`}}}` for non-escaped) for Handlebars and `>` for HTML/SVG elements of the non-block form.
     */
     let openIndentation = this.getLineIndentation(node);
 
     let end = getEndLocationForOpen(node);
-    const actualColumnStartLocation = node.type === 'ElementNode' && !node.selfClosing ? 1 : 2;
+    const actualColumnStartLocation = node.type === 'ElementNode' && !node.selfClosing ? 1 : (node.type === 'MustacheStatement' && !node.escaped ? 3 : 2);
     const actualStartLocation = {
       line: end.line,
       column: end.column - actualColumnStartLocation,

--- a/test/unit/rules/lint-attribute-indentation-test.js
+++ b/test/unit/rules/lint-attribute-indentation-test.js
@@ -890,6 +890,15 @@ generateRuleTests({
         >
         </form>`,
     },
+    {
+      template: `
+        <div>
+          {{{i18n
+            param=true
+            otherParam=false
+          }}}
+        </div>`,
+    },
   ],
 
   bad: [


### PR DESCRIPTION
Attribute-indentation rule now correctly considers whether a block is an non-escaped Mustache statement, e.g., {{{foo}}}.

Fixes #572