### PR TITLE
Improve `require-valid-alt-text` rule to catch additional common failure scenarios

### DIFF
--- a/docs/rule/require-valid-alt-text.md
+++ b/docs/rule/require-valid-alt-text.md
@@ -16,6 +16,8 @@ If it's not a meaningful image, it should have an empty alt attribute value and 
 
 `img` alt attribute does not contain the word image, picture, or photo. Screenreaders already announce `img` elements as an image. There is no need to use words such as *image*, *photo*, and/or *picture*.
 
+Numbers are not considered valid alt text, and this rule disallows using only numbers in alt text.
+
 
 This rule **forbids** the following:
 
@@ -24,6 +26,7 @@ This rule **forbids** the following:
 <img src="foo" alt="Photo of foo being weird." />
 <img src="bar" alt="Image of me at a bar!" />
 <img src="baz" alt="Picture of baz fixing a bug." />
+<img src="b52.jpg" alt="52" />
 ```
 
 This rule **allows** the following:
@@ -32,6 +35,7 @@ This rule **allows** the following:
 <img src="rwjblue.png" alt="A man standing in front of a room of people, giving a presentation about Ember.">
 <img src="bar" aria-hidden alt="Picture of me taking a photo of an image" /> // Will pass because it is hidden.
 <img src="baz" alt="Baz taking a {{photo}}" /> // This is valid since photo is a variable name.
+<img src="b52.jpg" alt="b52 bomber jet" />
 ```
 
 ### `<object>`

--- a/lib/rules/lint-require-valid-alt-text.js
+++ b/lib/rules/lint-require-valid-alt-text.js
@@ -8,8 +8,6 @@ function hasAccessibleChild(node) {
 }
 
 const REDUNDANT_WORDS = ['image', 'photo', 'picture', 'logo', 'spacer'];
-//TODO check for numbers in alt text
-
 
 const ERROR_MESSAGE =
   'Invalid alt attribute. Screen-readers already announce `img` tags as an image. Words such as `image`, `photo,` or `picture` (or any specified custom words) are considered placeholder text and as such are not valid.';
@@ -89,16 +87,25 @@ module.exports = class A11yLintAltText extends Rule {
               }
 
               if (normalizedAltValue !== null) {
-                const existingWords = REDUNDANT_WORDS.filter(
-                  word => normalizedAltValue.indexOf(word) !== -1
-                );
-                if (existingWords.length) {
+                if (normalizedAltValue.match(/^[0-9]+$/g)){
                   this.log({
-                    message: ERROR_MESSAGE,
+                    message: 'a number is not valid alt text',
                     line: node.loc && node.loc.start.line,
                     column: node.loc && node.loc.start.column,
                     source: this.sourceForNode(node),
                   });
+                } else {
+                  const existingWords = REDUNDANT_WORDS.filter(
+                    word => normalizedAltValue.indexOf(word) !== -1
+                  );
+                  if (existingWords.length) {
+                    this.log({
+                      message: ERROR_MESSAGE,
+                      line: node.loc && node.loc.start.line,
+                      column: node.loc && node.loc.start.column,
+                      source: this.sourceForNode(node),
+                    });
+                  }
                 }
               }
             }

--- a/lib/rules/lint-require-valid-alt-text.js
+++ b/lib/rules/lint-require-valid-alt-text.js
@@ -10,7 +10,7 @@ function hasAccessibleChild(node) {
 const REDUNDANT_WORDS = ['image', 'photo', 'picture', 'logo', 'spacer'];
 
 const ERROR_MESSAGE =
-  'Invalid alt attribute. Screen-readers already announce `img` tags as an image. Words such as `image`, `photo,` or `picture` (or any specified custom words) are considered placeholder text and as such are not valid.';
+  'Invalid alt attribute. Words such as `image`, `photo,` or `picture` are already announced by screen readers.';
 
 module.exports = class A11yLintAltText extends Rule {
   logNode({ node, message }) {
@@ -46,12 +46,12 @@ module.exports = class A11yLintAltText extends Rule {
 
           if (!hasAltAttribute) {
             this.logNode({
-              message: 'img tags must have an alt attribute',
+              message: 'All `<img>` tags must have an alt attribute',
               node,
             });
           } else if (altValue === srcValue) {
             this.logNode({
-              message: 'the alt text must not be the same as the image source',
+              message: 'The alt text must not be the same as the image source',
               node,
             });
           } else {
@@ -80,30 +80,26 @@ module.exports = class A11yLintAltText extends Rule {
                 }
                 this.logNode({
                   message:
-                    'if the `alt` attribute is present and the value is an empty string, `role="presentation"` or `role="none"` must be present',
+                    'If the `alt` attribute is present and the value is an empty string, `role="presentation"` or `role="none"` must be present',
                   node,
                 });
                 return;
               }
 
               if (normalizedAltValue !== null) {
-                if (normalizedAltValue.match(/^[0-9]+$/g)){
-                  this.log({
-                    message: 'a number is not valid alt text',
-                    line: node.loc && node.loc.start.line,
-                    column: node.loc && node.loc.start.column,
-                    source: this.sourceForNode(node),
+                if (normalizedAltValue.match(/^[0-9]+$/g)) {
+                  this.logNode({
+                    message: 'A number is not valid alt text',
+                    node,
                   });
                 } else {
                   const existingWords = REDUNDANT_WORDS.filter(
                     word => normalizedAltValue.indexOf(word) !== -1
                   );
                   if (existingWords.length) {
-                    this.log({
+                    this.logNode({
                       message: ERROR_MESSAGE,
-                      line: node.loc && node.loc.start.line,
-                      column: node.loc && node.loc.start.column,
-                      source: this.sourceForNode(node),
+                      node,
                     });
                   }
                 }
@@ -124,7 +120,7 @@ module.exports = class A11yLintAltText extends Rule {
           if (!hasValidAttributes) {
             this.logNode({
               message:
-                '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` attribute.',
+                'All <input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` attribute.',
               node,
             });
           }

--- a/lib/rules/lint-require-valid-alt-text.js
+++ b/lib/rules/lint-require-valid-alt-text.js
@@ -7,10 +7,12 @@ function hasAccessibleChild(node) {
   return AstNodeInfo.hasChildren(node);
 }
 
-const REDUNDANT_WORDS = ['image', 'photo', 'picture'];
+const REDUNDANT_WORDS = ['image', 'photo', 'picture', 'logo', 'spacer'];
+//TODO check for numbers in alt text
 
-const errorMessage =
-  'Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt attribute.';
+
+const ERROR_MESSAGE =
+  'Invalid alt attribute. Screen-readers already announce `img` tags as an image. Words such as `image`, `photo,` or `picture` (or any specified custom words) are considered placeholder text and as such are not valid.';
 
 module.exports = class A11yLintAltText extends Rule {
   logNode({ node, message }) {
@@ -40,11 +42,18 @@ module.exports = class A11yLintAltText extends Rule {
 
         if (isImg) {
           const hasAltAttribute = AstNodeInfo.hasAttribute(node, 'alt');
+          const altValue = AstNodeInfo.elementAttributeValue(node, 'alt');
           const roleValue = AstNodeInfo.elementAttributeValue(node, 'role');
+          const srcValue = AstNodeInfo.elementAttributeValue(node, 'src');
 
           if (!hasAltAttribute) {
             this.logNode({
               message: 'img tags must have an alt attribute',
+              node,
+            });
+          } else if (altValue === srcValue) {
+            this.logNode({
+              message: 'the alt text must not be the same as the image source',
               node,
             });
           } else {
@@ -85,7 +94,7 @@ module.exports = class A11yLintAltText extends Rule {
                 );
                 if (existingWords.length) {
                   this.log({
-                    message: errorMessage,
+                    message: ERROR_MESSAGE,
                     line: node.loc && node.loc.start.line,
                     column: node.loc && node.loc.start.column,
                     source: this.sourceForNode(node),
@@ -146,3 +155,5 @@ module.exports = class A11yLintAltText extends Rule {
     };
   }
 };
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/lint-require-valid-alt-text-test.js
+++ b/test/unit/rules/lint-require-valid-alt-text-test.js
@@ -202,5 +202,16 @@ generateRuleTests({
         column: 0,
       },
     },
+    {
+      template: '<img alt="52" src="b52.jpg">',
+
+      result: {
+        message: 'a number is not valid alt text',
+        moduleId: 'layout.hbs',
+        source: '<img alt="52" src="b52.jpg">',
+        line: 1,
+        column: 0,
+      },
+    },
   ],
 });

--- a/test/unit/rules/lint-require-valid-alt-text-test.js
+++ b/test/unit/rules/lint-require-valid-alt-text-test.js
@@ -50,7 +50,7 @@ generateRuleTests({
       template: '<img>',
 
       result: {
-        message: 'img tags must have an alt attribute',
+        message: 'All `<img>` tags must have an alt attribute',
         moduleId: 'layout.hbs',
         source: '<img>',
         line: 1,
@@ -61,7 +61,7 @@ generateRuleTests({
       template: '<img src="zoey.jpg">',
 
       result: {
-        message: 'img tags must have an alt attribute',
+        message: 'All `<img>` tags must have an alt attribute',
         moduleId: 'layout.hbs',
         source: '<img src="zoey.jpg">',
         line: 1,
@@ -73,7 +73,7 @@ generateRuleTests({
 
       result: {
         message:
-          'if the `alt` attribute is present and the value is an empty string, `role="presentation"` or `role="none"` must be present',
+          'If the `alt` attribute is present and the value is an empty string, `role="presentation"` or `role="none"` must be present',
         moduleId: 'layout.hbs',
         source: '<img alt="" src="zoey.jpg">',
         line: 1,
@@ -85,7 +85,7 @@ generateRuleTests({
 
       result: {
         message:
-          'if the `alt` attribute is present and the value is an empty string, `role="presentation"` or `role="none"` must be present',
+          'If the `alt` attribute is present and the value is an empty string, `role="presentation"` or `role="none"` must be present',
         moduleId: 'layout.hbs',
         source: '<img alt src="zoey.jpg">',
         line: 1,
@@ -95,7 +95,7 @@ generateRuleTests({
     {
       template: '<img alt="path/to/zoey.jpg" src="path/to/zoey.jpg">',
       result: {
-        message: 'the alt text must not be the same as the image source',
+        message: 'The alt text must not be the same as the image source',
         moduleId: 'layout.hbs',
         source: '<img alt="path/to/zoey.jpg" src="path/to/zoey.jpg">',
         line: 1,
@@ -107,7 +107,7 @@ generateRuleTests({
 
       result: {
         message:
-          '<input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` attribute.',
+          'All <input> elements with type="image" must have a text alternative through the `alt`, `aria-label`, or `aria-labelledby` attribute.',
         moduleId: 'layout.hbs',
         source: '<input type="image">',
         line: 1,
@@ -206,7 +206,7 @@ generateRuleTests({
       template: '<img alt="52" src="b52.jpg">',
 
       result: {
-        message: 'a number is not valid alt text',
+        message: 'A number is not valid alt text',
         moduleId: 'layout.hbs',
         source: '<img alt="52" src="b52.jpg">',
         line: 1,

--- a/test/unit/rules/lint-require-valid-alt-text-test.js
+++ b/test/unit/rules/lint-require-valid-alt-text-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const generateRuleTests = require('../../helpers/rule-test-harness');
+const ERROR_MESSAGE = require('../../../lib/rules/lint-require-valid-alt-text').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'require-valid-alt-text',
@@ -92,6 +93,16 @@ generateRuleTests({
       },
     },
     {
+      template: '<img alt="path/to/zoey.jpg" src="path/to/zoey.jpg">',
+      result: {
+        message: 'the alt text must not be the same as the image source',
+        moduleId: 'layout.hbs',
+        source: '<img alt="path/to/zoey.jpg" src="path/to/zoey.jpg">',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
       template: '<input type="image">',
 
       result: {
@@ -140,8 +151,7 @@ generateRuleTests({
       template: '<img alt="picture">',
 
       result: {
-        message:
-          'Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt attribute.',
+        message: ERROR_MESSAGE,
         moduleId: 'layout.hbs',
         source: '<img alt="picture">',
         line: 1,
@@ -152,8 +162,7 @@ generateRuleTests({
       template: '<img alt="photo">',
 
       result: {
-        message:
-          'Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt attribute.',
+        message: ERROR_MESSAGE,
         moduleId: 'layout.hbs',
         source: '<img alt="photo">',
         line: 1,
@@ -164,8 +173,7 @@ generateRuleTests({
       template: '<img alt="image">',
 
       result: {
-        message:
-          'Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt attribute.',
+        message: ERROR_MESSAGE,
         moduleId: 'layout.hbs',
         source: '<img alt="image">',
         line: 1,
@@ -176,8 +184,7 @@ generateRuleTests({
       template: '<img alt="  IMAGE ">',
 
       result: {
-        message:
-          'Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt attribute.',
+        message: ERROR_MESSAGE,
         moduleId: 'layout.hbs',
         source: '<img alt="  IMAGE ">',
         line: 1,
@@ -188,8 +195,7 @@ generateRuleTests({
       template: '<img alt="  IMAGE {{picture}} {{word}} ">',
 
       result: {
-        message:
-          'Redundant alt attribute. Screen-readers already announce `img` tags as an image. You don’t need to use the words `image`, `photo,` or `picture` (or any specified custom words) in the alt attribute.',
+        message: ERROR_MESSAGE,
         moduleId: 'layout.hbs',
         source: '<img alt="  IMAGE {{picture}} {{word}} ">',
         line: 1,


### PR DESCRIPTION
If merged, this PR updates the `require-valid-alt-text` rule to catch common failures as listed in https://www.w3.org/WAI/WCAG21/Techniques/failures/F30.html 

- catches number-only alt text
- adds a few new words to the redundant words list
- catches instances where the src value is equal to the alt value