### PR TITLE
Use @glimmer/syntax directly.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const precompile = require('@glimmer/compiler').precompile;
+const preprocess = require('@glimmer/syntax').preprocess;
 const Minimatch = require('minimatch').Minimatch;
 const getConfig = require('./get-config');
 const stripBom = require('strip-bom');
@@ -122,7 +122,7 @@ class Linter {
     };
 
     try {
-      precompile(stripBom(options.source), {
+      preprocess(stripBom(options.source), {
         moduleName: options.moduleId,
         rawSource: stripBom(options.source),
         plugins: {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "mocha"
   },
   "dependencies": {
-    "@glimmer/compiler": "^0.42.0",
+    "@glimmer/syntax": "^0.42.2",
     "chalk": "^2.0.0",
     "globby": "^9.0.0",
     "minimatch": "^3.0.4",

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const _precompile = require('@glimmer/compiler').precompile;
+const _preprocess = require('@glimmer/syntax').preprocess;
 const Rule = require('./../../lib/rules/base');
 const { readdirSync, existsSync, readFileSync } = require('fs');
 const { join } = require('path');
@@ -9,7 +9,7 @@ const ruleNames = Object.keys(require('../../lib/rules'));
 
 describe('base plugin', function() {
   function precompileTemplate(template, ast) {
-    _precompile(template, {
+    _preprocess(template, {
       rawSource: template,
       moduleName: 'layout.hbs',
       plugins: {

--- a/test/unit/helpers/ast-node-info-test.js
+++ b/test/unit/helpers/ast-node-info-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const preprocess = require('./parse');
+const preprocess = require('@glimmer/syntax').preprocess;
 const AstNodeInfo = require('../../../lib/helpers/ast-node-info');
 
 describe('isImgElement', function() {

--- a/test/unit/helpers/is-interactive-element-test.js
+++ b/test/unit/helpers/is-interactive-element-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const expect = require('chai').expect;
-const preprocess = require('./parse');
+const preprocess = require('@glimmer/syntax').preprocess;
 const isInteractiveElement = require('../../../lib/helpers/is-interactive-element');
 
 describe('isInteractiveElement', function() {

--- a/test/unit/helpers/parse.js
+++ b/test/unit/helpers/parse.js
@@ -1,8 +1,0 @@
-'use strict';
-
-const compilerPath = require.resolve('@glimmer/compiler');
-
-// eslint-disable-next-line node/no-extraneous-require
-const syntaxPath = require.resolve('@glimmer/syntax', { paths: [compilerPath] });
-
-module.exports = require(syntaxPath).preprocess;

--- a/test/unit/linting-compiler-test.js
+++ b/test/unit/linting-compiler-test.js
@@ -1,13 +1,13 @@
 'use strict';
 
 const expect = require('chai').expect;
-const _precompile = require('@glimmer/compiler').precompile;
+const _preprocess = require('@glimmer/syntax').preprocess;
 
 describe('template compiler', function() {
   let astPlugins;
 
   function precompile(template) {
-    return _precompile(template, {
+    return _preprocess(template, {
       rawSource: template,
       plugins: {
         ast: astPlugins,

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,16 +18,6 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@glimmer/compiler@^0.42.0":
-  version "0.42.2"
-  resolved "https://registry.yarnpkg.com/@glimmer/compiler/-/compiler-0.42.2.tgz#505778ab9dc66f65307dfd450e1ae075dfe33581"
-  integrity sha512-/NSp8sAlvRjMwa/4c35/m7W+E5xRohzN0Fwc7t+7rrSYwbZD/B9T5n4oXZjwWrXpGOYaIrzXSGGTbozqbRIIag==
-  dependencies:
-    "@glimmer/interfaces" "^0.42.2"
-    "@glimmer/syntax" "^0.42.2"
-    "@glimmer/util" "^0.42.2"
-    "@glimmer/wire-format" "^0.42.2"
-
 "@glimmer/interfaces@^0.42.2":
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.42.2.tgz#9cf8d6f8f5eee6bfcfa36919ca68ae716e1f78db"
@@ -47,14 +37,6 @@
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.42.2.tgz#9ca1631e42766ea6059f4b49d0bdfb6095aad2c4"
   integrity sha512-Heck0baFSaWDanCYtmOcLeaz7v+rSqI8ovS7twrp2/FWEteb3Ze5sWQ2BEuSAG23L/k/lzVwYM/MY7ZugxBpaA==
-
-"@glimmer/wire-format@^0.42.2":
-  version "0.42.2"
-  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.42.2.tgz#b95062b594dddeb8bd11cba3a6a0accbfabc9930"
-  integrity sha512-IqUo6mdJ7GRsK7KCyZxrc17ioSg9RBniEnb418ZMQxsV/WBv9NQ359MuClUck2M24z1AOXo4TerUw0U7+pb1/A==
-  dependencies:
-    "@glimmer/interfaces" "^0.42.2"
-    "@glimmer/util" "^0.42.2"
 
 "@iarna/toml@2.2.3":
   version "2.2.3"


### PR DESCRIPTION
I'm not 100% sure why I originally used `@glimmer/compiler` here, using `@glimmer/syntax` directly seems perfectly fine (and in fact we don't really _want_ to precompile, just parse the templates).