### PR TITLE
Update `no-curly-component-invocation` to allow non-component yielded values to be used with mustaches

### DIFF
--- a/lib/rules/lint-no-curly-component-invocation.js
+++ b/lib/rules/lint-no-curly-component-invocation.js
@@ -80,7 +80,7 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
 
   getCurlyInvocationSyntaxError(node) {
     let name = node.path.original;
-    if (node.path.type !== 'PathExpression') {
+    if (node.path.type !== 'PathExpression' || this.isLocal(node)) {
       return '';
     }
     if (

--- a/lib/rules/lint-no-curly-component-invocation.js
+++ b/lib/rules/lint-no-curly-component-invocation.js
@@ -78,9 +78,14 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
     });
   }
 
+  isAmbiguousLocalInvocation(node) {
+    let hasArguments = node.params.length > 0 || node.hash.pairs.length > 0;
+    return this.isLocal(node) && !hasArguments;
+  }
+
   getCurlyInvocationSyntaxError(node) {
     let name = node.path.original;
-    if (node.path.type !== 'PathExpression' || this.isLocal(node)) {
+    if (node.path.type !== 'PathExpression' || this.isAmbiguousLocalInvocation(node)) {
       return '';
     }
     if (

--- a/test/unit/rules/lint-no-curly-component-invocation-test.js
+++ b/test/unit/rules/lint-no-curly-component-invocation-test.js
@@ -112,17 +112,25 @@ generateRuleTests({
         ),
       ],
     },
+    {
+      template: '{{#each items as |item|}} {{item value}} {{/each}}',
+      results: [getErrorResult(generateError('item'), '{{item value}}', 26)],
+    },
+    {
+      template: '{{#each items as |item|}} {{item some=args}} {{/each}}',
+      results: [getErrorResult(generateError('item'), '{{item some=args}}', 26)],
+    },
   ],
 });
 
-function getErrorResult(message, source) {
+function getErrorResult(message, source, column = 0) {
   return {
     rule: 'no-curly-component-invocation',
     severity: 2,
     moduleId: 'layout.hbs',
     message,
     line: 1,
-    column: 0,
+    column,
     source,
   };
 }

--- a/test/unit/rules/lint-no-curly-component-invocation-test.js
+++ b/test/unit/rules/lint-no-curly-component-invocation-test.js
@@ -81,6 +81,7 @@ generateRuleTests({
     `{{@someArg}}`,
     `{{this.someProperty}}`,
     `{{#each items as |item|}}
+       {{item}}
      {{/each}}`,
   ],
 


### PR DESCRIPTION
Potential fix for #857 

Opt out block param variables from curly invocation checks.

@rwjblue I noticed in that issue you mention

> We could tweak things a bit so that the rule does not apply to block params when used without any arguments (e.g. {{foo}} vs either {{foo whatever}} or {{foo some=thing}}). 

Is just checking if it's a block param enough or should we do additional checks?