### PR TITLE
✨Add option --print-pending from ember-cli-template-lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ Example usage:
 
 # read from stdin
 ./node_modules/.bin/ember-template-lint --filename app/templates/application.hbs < app/templates/application.hbs
+
+# print list of formated rules for use with `pending` in config file
+./node_modules/.bin/ember-template-lint app/templates/application.hbs --print-pending
 ```
 
 ### ESLint
@@ -130,7 +133,7 @@ The following properties are allowed in the root of the `.template-lintrc.js` co
   An array of module id's that are still pending. The goal of this array is to allow incorporating template linting
   into an existing project, without changing every single template file. You can add all existing templates to this `pending` listing
   and slowly work through them, while at the same time ensuring that new templates added to the project pass all defined rules.
-  * If you are using `ember-cli-template-lint` you can generate this list with: `ember template-lint:print-failing`
+  * You can generate this list with the: `./node_modules/.bin/ember-template-lint * --print-pending`
 * `ignore` -- `string[]|glob[]`
   An array of module id's that are to be completely ignored. See [ignore documentation](docs/ignore.md) for more details.
 * `plugins` -- `(string|Object)[]`

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -446,6 +446,52 @@ describe('ember-template-lint executable', function() {
         });
       });
     });
+
+    describe('with --print-pending param', function() {
+      it('should print a list of pending modules', function(done) {
+        execFile(
+          'node',
+          ['../../../bin/ember-template-lint.js', '.', '--print-pending'],
+          {
+            cwd: './test/fixtures/with-errors-and-warnings',
+          },
+          function(err, stdout, stderr) {
+            let expectedOutputData =
+              'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings",\n      "no-html-comments"\n    ]\n  }\n]\n';
+
+            expect(err).to.be.ok;
+            expect(stdout).to.equal(expectedOutputData);
+            expect(stderr).to.be.empty;
+            done();
+          }
+        );
+      });
+    });
+
+    describe('with --print-pending and --json params', function() {
+      it('should print json of pending modules', function(done) {
+        execFile(
+          'node',
+          ['../../../bin/ember-template-lint.js', '.', '--print-pending', '--json'],
+          {
+            cwd: './test/fixtures/with-errors-and-warnings',
+          },
+          function(err, stdout, stderr) {
+            let expectedOutputData = [
+              {
+                moduleId: 'app/templates/application',
+                only: ['no-bare-strings', 'no-html-comments'],
+              },
+            ];
+
+            expect(err).to.be.ok;
+            expect(JSON.parse(stdout)).to.deep.equal(expectedOutputData);
+            expect(stderr).to.be.empty;
+            done();
+          }
+        );
+      });
+    });
   });
 
   describe('parseArgv', function() {
@@ -490,6 +536,15 @@ describe('ember-template-lint executable', function() {
 
       let actual = BinScript._parseArgv(argv);
       let expected = { named: { json: true }, positional: [] };
+
+      expect(actual).to.deep.equal(expected);
+    });
+
+    it('handles --print-pending', function() {
+      let argv = ['--print-pending'];
+
+      let actual = BinScript._parseArgv(argv);
+      let expected = { named: { printPending: true }, positional: [] };
 
       expect(actual).to.deep.equal(expected);
     });


### PR DESCRIPTION
This task was previously mentioned when the docs were updated earlier this year to port over the ability to print a pending list by @rwjblue https://github.com/ember-template-lint/ember-template-lint/pull/671#pullrequestreview-213931116

> Seems good to me, but I'd really like to migrate that to our built-in bin script (perhaps with a flag like `--print-pending`). Any chance you'd want to work on it?

This adds the option to easily populate your `.template-lintrc.js` file without needing [ember-cli-template-lint](https://github.com/ember-template-lint/ember-cli-template-lint). Should make adopting and getting started a lot easier.

To easily run against your whole project you can now do: 
```
./node_modules/.bin/ember-template-lint app/templates/** --print-pending
```

This is mostly copied over from the existing logic here https://github.com/ember-template-lint/ember-cli-template-lint/blob/master/lib/commands/print-failing.js