### PR TITLE
Add `no-meta-redirect-with-time-limit` rule

### DIFF
--- a/docs/rule/no-meta-redirect-with-time-limit.md
+++ b/docs/rule/no-meta-redirect-with-time-limit.md
@@ -24,6 +24,7 @@ This rule **allows** the following:
 
 ### References
 
+* [F40: Failure due to using meta redirect with a time limit](https://www.w3.org/WAI/WCAG21/Techniques/failures/F40)
 * [Success Criterion 2.2.1: Timing Adjustable](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable)
 * [Success Criterion 2.2.4: Interruptions](https://www.w3.org/WAI/WCAG21/Understanding/interruptions)
 * [Success Criterion 3.2.5: Change on Request](https://www.w3.org/WAI/WCAG21/Understanding/change-on-request)

--- a/docs/rule/no-meta-redirect-with-time-limit.md
+++ b/docs/rule/no-meta-redirect-with-time-limit.md
@@ -1,0 +1,29 @@
+## (no-meta-redirect-with-time-limit)
+
+Sometimes a page automatically redirects to a different page. When this happens after a timed delay, it is an unexpected change of context that may interrupt the user. Redirects without timed delays are okay, but pleasae consider a server-side method for redirecting instead (method will vary based on your server type).
+
+This rule checks for the meta tag with a redirect; if it exists, it checks for a timed delay greater than 0.
+
+### Examples
+
+This rule **forbids** the following:
+
+```hbs
+<meta http-equiv="refresh" content="5; url=http://www.example.com" />
+```
+
+This rule **allows** the following:
+
+```hbs
+<meta http-equiv="refresh" content="0; url=http://www.example.com" />
+```
+
+### Migration
+
+* To fix, reduce the timed delay to zero, or use the appropriate server-side redirect method for your server type.
+
+### References
+
+* [Success Criterion 2.2.1: Timing Adjustable](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable)
+* [Success Criterion 2.2.4: Interruptions](https://www.w3.org/WAI/WCAG21/Understanding/interruptions)
+* [Success Criterion 3.2.5: Change on Request](https://www.w3.org/WAI/WCAG21/Understanding/change-on-request)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -26,6 +26,7 @@
 * [no-input-tagname](rule/no-input-tagname.md)
 * [no-invalid-interactive](rule/no-invalid-interactive.md)
 * [no-log](rule/no-log.md)
+* [no-meta-redirect-with-time-limit](rule/no-meta-redirect-with-time-limit.md)
 * [no-negated-condition](rule/no-negated-condition.md)
 * [no-nested-interactive](rule/no-nested-interactive.md)
 * [no-obsolete-elements](rule/no-obsolete-elements.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -30,6 +30,7 @@ module.exports = {
   'no-input-tagname': require('./lint-no-input-tagname'),
   'no-invalid-interactive': require('./lint-no-invalid-interactive'),
   'no-log': require('./lint-no-log'),
+  'no-meta-redirect-with-time-limit': require('./lint-no-meta-redirect-with-time-limit'),
   'no-negated-condition': require('./lint-no-negated-condition'),
   'no-nested-interactive': require('./lint-no-nested-interactive'),
   'no-obsolete-elements': require('./lint-no-obsolete-elements'),

--- a/lib/rules/lint-no-meta-redirect-with-time-limit.js
+++ b/lib/rules/lint-no-meta-redirect-with-time-limit.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
+
+module.exports = class noMetaRedirectWithTimeLimit extends Rule {
+  logNode({ node, message }) {
+    return this.log({
+      message,
+      line: node.loc && node.loc.start.line,
+      column: node.loc && node.loc.start.column,
+      source: this.sourceForNode(node),
+    });
+  }
+  visitor() {
+    return {
+      ElementNode(node) {
+        if (AstNodeInfo.hasAttribute(node, 'hidden')) {
+          return;
+        }
+
+        if (AstNodeInfo.hasAttributeValue(node, 'aria-hidden', 'true')) {
+          return;
+        }
+
+        const isMeta = AstNodeInfo.isElementNode(node, 'meta');
+        const hasMetaRedirect = AstNodeInfo.hasAttribute(node, 'http-equiv');
+
+        if (isMeta && hasMetaRedirect) {
+          const contentAttr = AstNodeInfo.hasAttribute(node, 'content');
+          const contentAttrValue = AstNodeInfo.elementAttributeValue(node, 'content');
+          if (contentAttr) {
+            if (contentAttrValue.charAt(0) > 0) {
+              this.log({
+                message: 'a meta redirect should not have a delay value greater than zero',
+                line: node.loc && node.loc.start.line,
+                column: node.loc && node.loc.start.column,
+                source: this.sourceForNode(node),
+              });
+            }
+          }
+        }
+      },
+    };
+  }
+};

--- a/lib/rules/lint-no-meta-redirect-with-time-limit.js
+++ b/lib/rules/lint-no-meta-redirect-with-time-limit.js
@@ -3,7 +3,7 @@
 const AstNodeInfo = require('../helpers/ast-node-info');
 const Rule = require('./base');
 
-module.exports = class noMetaRedirectWithTimeLimit extends Rule {
+module.exports = class NoMetaRedirectWithTimeLimit extends Rule {
   logNode({ node, message }) {
     return this.log({
       message,

--- a/lib/rules/lint-no-meta-redirect-with-time-limit.js
+++ b/lib/rules/lint-no-meta-redirect-with-time-limit.js
@@ -15,14 +15,6 @@ module.exports = class NoMetaRedirectWithTimeLimit extends Rule {
   visitor() {
     return {
       ElementNode(node) {
-        if (AstNodeInfo.hasAttribute(node, 'hidden')) {
-          return;
-        }
-
-        if (AstNodeInfo.hasAttributeValue(node, 'aria-hidden', 'true')) {
-          return;
-        }
-
         const isMeta = node.tag === 'meta';
         const hasMetaRedirect = AstNodeInfo.hasAttribute(node, 'http-equiv');
 

--- a/lib/rules/lint-no-meta-redirect-with-time-limit.js
+++ b/lib/rules/lint-no-meta-redirect-with-time-limit.js
@@ -23,7 +23,7 @@ module.exports = class noMetaRedirectWithTimeLimit extends Rule {
           return;
         }
 
-        const isMeta = AstNodeInfo.isElementNode(node, 'meta');
+        const isMeta = node.tag === 'meta';
         const hasMetaRedirect = AstNodeInfo.hasAttribute(node, 'http-equiv');
 
         if (isMeta && hasMetaRedirect) {

--- a/lib/rules/lint-no-meta-redirect-with-time-limit.js
+++ b/lib/rules/lint-no-meta-redirect-with-time-limit.js
@@ -30,7 +30,8 @@ module.exports = class noMetaRedirectWithTimeLimit extends Rule {
           const contentAttr = AstNodeInfo.hasAttribute(node, 'content');
           const contentAttrValue = AstNodeInfo.elementAttributeValue(node, 'content');
           if (contentAttr) {
-            if (contentAttrValue.charAt(0) > 0) {
+            // since the content attribute will have both the delay (in seconds) and the new URL, we only need to check the first character in the value string.
+            if (contentAttrValue.charAt(0) !== '0') {
               this.log({
                 message: 'a meta redirect should not have a delay value greater than zero',
                 line: node.loc && node.loc.start.line,

--- a/test/unit/rules/lint-no-meta-redirect-with-time-limit-test.js
+++ b/test/unit/rules/lint-no-meta-redirect-with-time-limit-test.js
@@ -7,18 +7,18 @@ generateRuleTests({
 
   config: true,
 
-  good: ['<meta http-equiv="refresh" content="0; url=http://www.example.com" />'],
+  good: ['<meta http-equiv="refresh" content="0; url=http://www.example.com">'],
 
   bad: [
     {
-      template: '<meta http-equiv="refresh" content="1; url=http://www.example.com" />',
+      template: '<meta http-equiv="refresh" content="1; url=http://www.example.com">',
 
       result: {
         moduleId: 'layout.hbs',
         message: 'a meta redirect should not have a delay value greater than zero',
         line: 1,
         column: 0,
-        source: '<meta http-equiv="refresh" content="1; url=http://www.example.com" />',
+        source: '<meta http-equiv="refresh" content="1; url=http://www.example.com">',
       },
     },
   ],

--- a/test/unit/rules/lint-no-meta-redirect-with-time-limit-test.js
+++ b/test/unit/rules/lint-no-meta-redirect-with-time-limit-test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'no-meta-redirect-with-time-limit',
+
+  config: true,
+
+  good: ['<meta http-equiv="refresh" content="0; url=http://www.example.com" />'],
+
+  bad: [
+    {
+      template: '<meta http-equiv="refresh" content="1; url=http://www.example.com" />',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message: 'a meta redirect should not have a delay value greater than zero',
+        line: 1,
+        column: 0,
+        source: '<meta http-equiv="refresh" content="1; url=http://www.example.com" />',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
When merged, this PR will provide a check to prevent the use of a timed delay on `<meta http-equiv="refresh"/>' where the `content` delay value is greater than 0. 