### PR TITLE
lib/index: Split buildASTPlugins() to prepare ember-template-recast usage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,7 +55,7 @@ class Linter {
     return 2;
   }
 
-  buildASTPlugins(config) {
+  buildASTPlugins(config, pluginConfig) {
     function addToResults(result) {
       config.results.push(result);
     }
@@ -74,7 +74,7 @@ class Linter {
         ruleNames: Object.keys(rules),
       });
 
-      astPlugins.push(buildPlugin(rule, config));
+      astPlugins.push(buildPlugin(rule, pluginConfig));
     }
 
     return astPlugins;
@@ -121,17 +121,19 @@ class Linter {
 
     let source = stripBom(options.source);
 
+    let rulesConfig = {
+      results: messages,
+      pending: pendingStatus,
+    };
     let pluginConfig = {
       moduleName: options.moduleId,
       rawSource: source,
-      results: messages,
-      pending: pendingStatus,
     };
 
     try {
       preprocess(source, {
         plugins: {
-          ast: this.buildASTPlugins(pluginConfig),
+          ast: this.buildASTPlugins(rulesConfig, pluginConfig),
         },
       });
     } catch (error) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,15 +9,15 @@ let path = require('path');
 
 const TransformDotComponentInvocation = require('./plugins/transform-dot-component-invocation');
 
-function buildPlugin(plugin, { moduleName, rawSource }) {
+function buildPlugin(rule, { moduleName, rawSource }) {
   return function(env) {
     let envData = Object.assign({}, env, { moduleName, rawSource });
-    plugin.templateEnvironmentData = envData;
+    rule.templateEnvironmentData = envData;
 
-    let visitor = plugin.getVisitor();
+    let visitor = rule.getVisitor();
 
     return {
-      name: plugin.pluginName,
+      name: rule.ruleName,
       visitor,
     };
   };
@@ -25,6 +25,10 @@ function buildPlugin(plugin, { moduleName, rawSource }) {
 
 const WARNING_SEVERITY = 1;
 const ERROR_SEVERITY = 2;
+
+function buildASTPlugins(rules, config) {
+  return rules.map(rule => buildPlugin(rule, config));
+}
 
 class Linter {
   constructor(_options) {
@@ -55,29 +59,29 @@ class Linter {
     return 2;
   }
 
-  buildASTPlugins(config, pluginConfig) {
+  buildRules(config) {
+    let rules = [];
+
+    let loadedRules = this.config.loadedRules;
+
     function addToResults(result) {
       config.results.push(result);
     }
 
-    let rules = this.config.loadedRules;
-    let astPlugins = [TransformDotComponentInvocation];
-
-    for (let pluginName in rules) {
-      let Rule = rules[pluginName];
+    for (let ruleName in loadedRules) {
+      let Rule = loadedRules[ruleName];
       let rule = new Rule({
-        name: pluginName,
-        config: this.config.rules[pluginName],
+        name: ruleName,
+        config: this.config.rules[ruleName],
         console: this.console,
         log: addToResults,
-        defaultSeverity: this._defaultSeverityForRule(pluginName, config.pending),
-        ruleNames: Object.keys(rules),
+        defaultSeverity: this._defaultSeverityForRule(ruleName, config.pending),
+        ruleNames: Object.keys(loadedRules),
       });
-
-      astPlugins.push(buildPlugin(rule, pluginConfig));
+      rules.push(rule);
     }
 
-    return astPlugins;
+    return rules;
   }
 
   statusForModule(type, moduleId) {
@@ -125,17 +129,18 @@ class Linter {
       results: messages,
       pending: pendingStatus,
     };
+
     let pluginConfig = {
       moduleName: options.moduleId,
       rawSource: source,
     };
 
     try {
-      preprocess(source, {
-        plugins: {
-          ast: this.buildASTPlugins(rulesConfig, pluginConfig),
-        },
-      });
+      let rules = this.buildRules(rulesConfig);
+      let ast = buildASTPlugins(rules, pluginConfig);
+      ast.unshift(TransformDotComponentInvocation);
+
+      preprocess(source, { plugins: { ast } });
     } catch (error) {
       let message = {
         fatal: true,

--- a/lib/index.js
+++ b/lib/index.js
@@ -116,15 +116,17 @@ class Linter {
       return messages;
     }
 
+    let source = stripBom(options.source);
+
     let pluginConfig = {
       moduleName: options.moduleId,
-      rawSource: stripBom(options.source),
+      rawSource: source,
       results: messages,
       pending: pendingStatus,
     };
 
     try {
-      preprocess(stripBom(options.source), {
+      preprocess(source, {
         plugins: {
           ast: this.buildASTPlugins(pluginConfig),
         },

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,20 @@ class Linter {
     let rules = this.config.loadedRules;
     let astPlugins = [TransformDotComponentInvocation];
 
+    function buildPlugin(plugin, { moduleName, rawSource }) {
+      return function(env) {
+        let envData = Object.assign({}, env, { moduleName, rawSource });
+        plugin.templateEnvironmentData = envData;
+
+        let visitor = plugin.getVisitor();
+
+        return {
+          name: plugin.pluginName,
+          visitor,
+        };
+      };
+    }
+
     for (let pluginName in rules) {
       let Plugin = rules[pluginName];
       let plugin = new Plugin({
@@ -60,18 +74,7 @@ class Linter {
         ruleNames: Object.keys(rules),
       });
 
-      let { moduleName, rawSource } = config;
-      astPlugins.push(env => {
-        let envData = Object.assign({}, env, { moduleName, rawSource });
-        plugin.templateEnvironmentData = envData;
-
-        let visitor = plugin.getVisitor();
-
-        return {
-          name: pluginName,
-          visitor,
-        };
-      });
+      astPlugins.push(buildPlugin(plugin, config));
     }
 
     return astPlugins;

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,20 @@ let path = require('path');
 
 const TransformDotComponentInvocation = require('./plugins/transform-dot-component-invocation');
 
+function buildPlugin(plugin, { moduleName, rawSource }) {
+  return function(env) {
+    let envData = Object.assign({}, env, { moduleName, rawSource });
+    plugin.templateEnvironmentData = envData;
+
+    let visitor = plugin.getVisitor();
+
+    return {
+      name: plugin.pluginName,
+      visitor,
+    };
+  };
+}
+
 const WARNING_SEVERITY = 1;
 const ERROR_SEVERITY = 2;
 
@@ -48,20 +62,6 @@ class Linter {
 
     let rules = this.config.loadedRules;
     let astPlugins = [TransformDotComponentInvocation];
-
-    function buildPlugin(plugin, { moduleName, rawSource }) {
-      return function(env) {
-        let envData = Object.assign({}, env, { moduleName, rawSource });
-        plugin.templateEnvironmentData = envData;
-
-        let visitor = plugin.getVisitor();
-
-        return {
-          name: plugin.pluginName,
-          visitor,
-        };
-      };
-    }
 
     for (let pluginName in rules) {
       let Plugin = rules[pluginName];

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,8 +64,8 @@ class Linter {
     let astPlugins = [TransformDotComponentInvocation];
 
     for (let pluginName in rules) {
-      let Plugin = rules[pluginName];
-      let plugin = new Plugin({
+      let Rule = rules[pluginName];
+      let rule = new Rule({
         name: pluginName,
         config: this.config.rules[pluginName],
         console: this.console,
@@ -74,7 +74,7 @@ class Linter {
         ruleNames: Object.keys(rules),
       });
 
-      astPlugins.push(buildPlugin(plugin, config));
+      astPlugins.push(buildPlugin(rule, config));
     }
 
     return astPlugins;

--- a/lib/index.js
+++ b/lib/index.js
@@ -42,10 +42,8 @@ class Linter {
   }
 
   buildASTPlugins(config) {
-    let results = config.results;
-
     function addToResults(result) {
-      results.push(result);
+      config.results.push(result);
     }
 
     let rules = this.config.loadedRules;
@@ -62,8 +60,10 @@ class Linter {
         ruleNames: Object.keys(rules),
       });
 
+      let { moduleName, rawSource } = config;
       astPlugins.push(env => {
-        plugin.templateEnvironmentData = env;
+        let envData = Object.assign({}, env, { moduleName, rawSource });
+        plugin.templateEnvironmentData = envData;
 
         let visitor = plugin.getVisitor();
 
@@ -117,14 +117,14 @@ class Linter {
     }
 
     let pluginConfig = {
+      moduleName: options.moduleId,
+      rawSource: stripBom(options.source),
       results: messages,
       pending: pendingStatus,
     };
 
     try {
       preprocess(stripBom(options.source), {
-        moduleName: options.moduleId,
-        rawSource: stripBom(options.source),
         plugins: {
           ast: this.buildASTPlugins(pluginConfig),
         },


### PR DESCRIPTION
`ember-template-recast` won't take `ASTPlugin`s. Instead it will take `ASTPluginBuilder`s.

```
export interface ASTPluginBuilder {
  (env: ASTPluginEnvironment): NodeVisitor;
}
```

vs.

```
export interface ASTPlugin {
  name: string;
  visitor: NodeVisitor;
}
```

To prepare the switch, this PR proposes a refactoring: 
- split `this.buildASTPlugins` method into `this.buildRules`, `buildPlugin` and `buildASTPlugins`
- remove `preprocess`'s options.metadata usage