### PR TITLE
test-harness: Make it available for (external) plugins

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -54,6 +54,7 @@ function parseMeta(item) {
  * @param  {Function} testMethod          - function to call when test block is to be run (mocha - it, qunit - test)
  * @param  {Boolean}  skipDisabledTests   - boolean to skip disabled tests or not
  * @param  {Object}   config
+ * @param  {Array}    plugins             - an array of plugins to load
  */
 module.exports = function generateRuleTests({
   bad = [],
@@ -65,6 +66,7 @@ module.exports = function generateRuleTests({
   testMethod,
   skipDisabledTests,
   config: passedConfig,
+  plugins,
 }) {
   groupingMethod(name, function() {
     let DISABLE_ALL = '{{! template-lint-disable }}';
@@ -79,6 +81,7 @@ module.exports = function generateRuleTests({
 
     groupMethodBefore(function() {
       let fullConfig = {
+        plugins,
         rules: {},
       };
       fullConfig.rules[name] = config = passedConfig;


### PR DESCRIPTION
With this PR, external plugins may be able to use the test-harness.

An example of usage can be found here: https://github.com/dcyriller/ember-template-lint-plugin-prettier/pull/41

side-note: I would not be opposed to move `ember-template-lint-plugin-prettier` to ember-template-lint organization.