### PR TITLE
Fix issues when converting dasherized curly component invocation into angle bracket invocation

### DIFF
--- a/lib/helpers/curly-component-invocation.js
+++ b/lib/helpers/curly-component-invocation.js
@@ -16,18 +16,23 @@ function transformNestedTagName(tagName) {
   return paths.map(name => capitalizedTagName(name)).join('::');
 }
 
-function capitalizedTagName(tagname) {
-  if (tagname.includes('@')) {
-    tagname = tagname
-      .split('@')
-      .map(upperCase)
-      .join('@');
-  }
+function capitalizedTagName(tagName) {
+  const SIMPLE_DASHERIZE_REGEXP = /[a-z]|\//g;
+  const ALPHA = /[A-Za-z0-9]/;
 
-  return tagname
-    .split('-')
-    .map(upperCase)
-    .join('');
+  tagName = tagName.replace(SIMPLE_DASHERIZE_REGEXP, (char, index) => {
+    if (char === '/') {
+      return '::';
+    }
+
+    if (index === 0 || !ALPHA.test(tagName[index - 1])) {
+      return char.toUpperCase();
+    }
+
+    return char.toLowerCase();
+  });
+  // Remove all occurances of '-'s from the tagName
+  return tagName.replace(/-/g, '');
 }
 
 function upperCase(text) {

--- a/lib/helpers/curly-component-invocation.js
+++ b/lib/helpers/curly-component-invocation.js
@@ -35,10 +35,6 @@ function capitalizedTagName(tagName) {
   return tagName.replace(/-/g, '');
 }
 
-function upperCase(text) {
-  return text[0].toUpperCase() + text.slice(1);
-}
-
 module.exports = {
   transformTagName,
   isNestedComponentTagName,

--- a/test/unit/helpers/curly-invocation-component-test.js
+++ b/test/unit/helpers/curly-invocation-component-test.js
@@ -10,6 +10,7 @@ describe('#transformTagName', function() {
   it(`it works as expected`, function() {
     expect(transformTagName('foo')).to.equal('Foo');
     expect(transformTagName('foo-bar')).to.equal('FooBar');
+    expect(transformTagName('Foo-Bar')).to.equal('FooBar');
     expect(transformTagName('f3-bar')).to.equal('F3Bar');
     expect(transformTagName('foo3-bar')).to.equal('Foo3Bar');
     expect(transformTagName('foo3bar-baz')).to.equal('Foo3barBaz');

--- a/test/unit/helpers/curly-invocation-component-test.js
+++ b/test/unit/helpers/curly-invocation-component-test.js
@@ -18,6 +18,10 @@ describe('#transformTagName', function() {
     expect(transformTagName('foo@bar-baz')).to.equal('Foo@BarBaz');
     expect(transformTagName('foo/bar-baz')).to.equal('Foo::BarBaz');
     expect(transformTagName('foo/bar-baz/bang')).to.equal('Foo::BarBaz::Bang');
+    expect(transformTagName('foo$bar-bang')).to.equal('Foo$BarBang');
+    expect(transformTagName('foo$bar-bang::baz::foo3bar')).to.equal('Foo$BarBang::Baz::Foo3bar');
+    expect(transformTagName('foo$bar-bang::baz??foo3bar')).to.equal('Foo$BarBang::Baz??Foo3bar');
+    expect(transformTagName('foo$bar-bang::baz/foo3bar')).to.equal('Foo$BarBang::Baz::Foo3bar');
   });
 });
 


### PR DESCRIPTION
This fixes the capitalization issues caused due to nonAlphanumeric characters.
- `/` would be converted to `::`
- any alpha-numeric character encountered after a non-alpha-numeric character would be capitalized.
- Removes all occurrences of `-`