### PR TITLE
Fix `no-curly-component-invocation` to not warn about invocations within an existing angle bracket invocation

### DIFF
--- a/lib/rules/lint-no-curly-component-invocation.js
+++ b/lib/rules/lint-no-curly-component-invocation.js
@@ -118,10 +118,21 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
     let angleBracketName = transformTagName(name);
     return `You are using the component {{${name}}} with curly component syntax. You should use <${angleBracketName}> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['${name}'] }\`.`;
   }
-
   visitor() {
+    let inElementNode = false;
     return {
+      ElementNode: {
+        enter() {
+          inElementNode = true;
+        },
+        exit() {
+          inElementNode = false;
+        },
+      },
       MustacheStatement(node) {
+        if (inElementNode) {
+          return;
+        }
         let message = this.getCurlyInvocationSyntaxError(node);
         if (message) {
           this.logNode({ message, node });

--- a/lib/rules/lint-no-curly-component-invocation.js
+++ b/lib/rules/lint-no-curly-component-invocation.js
@@ -119,18 +119,26 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
     return `You are using the component {{${name}}} with curly component syntax. You should use <${angleBracketName}> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['${name}'] }\`.`;
   }
   visitor() {
-    let inElementNode = false;
+    let inSafeNamespace = false;
     return {
-      ElementNode: {
+      ElementModifierStatement: {
         enter() {
-          inElementNode = true;
+          inSafeNamespace = true;
         },
         exit() {
-          inElementNode = false;
+          inSafeNamespace = false;
+        },
+      },
+      AttrNode: {
+        enter() {
+          inSafeNamespace = true;
+        },
+        exit() {
+          inSafeNamespace = false;
         },
       },
       MustacheStatement(node) {
-        if (inElementNode) {
+        if (inSafeNamespace) {
           return;
         }
         let message = this.getCurlyInvocationSyntaxError(node);

--- a/test/unit/rules/lint-no-curly-component-invocation-test.js
+++ b/test/unit/rules/lint-no-curly-component-invocation-test.js
@@ -29,6 +29,9 @@ generateRuleTests({
      {{/each}}`,
     `{{#-in-element}}Hello{{/-in-element}}`,
     `{{#in-element}}Hello{{/in-element}}`,
+    '<MyComponent @arg={{my-helper this.foobar}} />',
+    '<MyComponent @arg="{{my-helper this.foobar}}" />',
+    '<MyComponent {{my-modifier this.foobar}} />',
   ],
 
   bad: [

--- a/test/unit/rules/lint-no-curly-component-invocation-test.js
+++ b/test/unit/rules/lint-no-curly-component-invocation-test.js
@@ -36,6 +36,12 @@ generateRuleTests({
 
   bad: [
     {
+      template: '<div>{{bad-code}}</div>',
+      results: [
+        Object.assign(getErrorResult(generateError('bad-code'), '{{bad-code}}'), { column: 5 }),
+      ],
+    },
+    {
       template: '{{bad-code}}',
       results: [getErrorResult(generateError('bad-code'), '{{bad-code}}')],
     },


### PR DESCRIPTION
https://github.com/ember-template-lint/ember-template-lint/issues/883