### PR TITLE
Drop support for NodeJs v6 and v11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,6 @@ jobs:
 
     - name: "Node 12"
       node_js: "12"
+
+    - name: "Node 13"
+      node_js: "13"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10"
+  - "12"
 
 branches:
   only:
@@ -26,7 +26,7 @@ jobs:
 
   include:
     - stage: tests
-      name: "Node 10"
+      name: "Node 12"
       script:
         - yarn lint:js
         - yarn test
@@ -36,10 +36,10 @@ jobs:
       install: yarn install --no-lockfile --ignore-engines
 
     - name: "Node 6"
-      node_js: "6"
+      node_js: "8"
 
     - name: "Node 8"
-      node_js: "8"
+      node_js: "10"
 
     - name: "Node 12"
       node_js: "12"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install ember-template-lint
 npm install --save-dev ember-template-lint
 ```
 
-Node.js `>= 6` is required.
+Node.js `8 || 10 || 12` (at the time of writting LTS) or `13` (latest) is required.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "release-it-lerna-changelog": "^1.0.3"
   },
   "engines": {
-    "node": "6.* || 8.* || >= 10.*"
+    "node": "8.* || 10.* || >= 12.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Close https://github.com/ember-template-lint/ember-template-lint/issues/724

Will be required for https://github.com/ember-template-lint/ember-template-lint/pull/873 (see https://github.com/ember-template-lint/ember-template-recast/blob/master/package.json#L56)

It will unblock https://github.com/ember-template-lint/ember-template-lint/pull/766 and https://github.com/ember-template-lint/ember-template-lint/pull/707 