### PR TITLE
Ensure `no-action` does not error when encountering literals (StringLiteral, BooleanLiteral, etc).

### DIFF
--- a/lib/rules/internal/scope.js
+++ b/lib/rules/internal/scope.js
@@ -10,8 +10,13 @@ function getLocalName(node) {
     case 'SubExpression':
     case 'MustacheStatement':
     case 'BlockStatement':
-      return node.path.parts[0];
+      return node.path.type === 'PathExpression' ? node.path.parts[0] : getLocalName(node.path);
 
+    case 'UndefinedLiteral':
+    case 'NullLiteral':
+    case 'BooleanLiteral':
+    case 'StringLiteral':
+      return undefined;
     case 'PathExpression':
     default:
       return node.parts[0];

--- a/lib/rules/internal/scope.js
+++ b/lib/rules/internal/scope.js
@@ -10,7 +10,7 @@ function getLocalName(node) {
     case 'SubExpression':
     case 'MustacheStatement':
     case 'BlockStatement':
-      return node.path.type === 'PathExpression' ? node.path.parts[0] : getLocalName(node.path);
+      return getLocalName(node.path);
 
     case 'UndefinedLiteral':
     case 'NullLiteral':
@@ -19,7 +19,7 @@ function getLocalName(node) {
       return undefined;
     case 'PathExpression':
     default:
-      return node.parts[0];
+      return node.parts.length ? node.parts[0] : undefined;
   }
 }
 

--- a/lib/rules/lint-no-action.js
+++ b/lib/rules/lint-no-action.js
@@ -16,6 +16,9 @@ module.exports = class NoAction extends Rule {
         return;
       }
       let maybeAction = node.path.original;
+      if (node.path.type === 'StringLiteral') {
+        return;
+      }
       if (maybeAction !== 'action') {
         return;
       }

--- a/test/unit/rules/lint-no-action-test.js
+++ b/test/unit/rules/lint-no-action-test.js
@@ -13,6 +13,12 @@ generateRuleTests({
     '<MyScope as |action|><Component @baz={{action}} /></MyScope>',
     '<button {{on "submit" @action}}>Click Me</button>',
     '<button {{on "submit" this.action}}>Click Me</button>',
+    // check for scope.getLocalName working for primitives and locals #881
+    '<PButton @naked={{true}} />',
+    '<PButton @naked={{undefined}} />',
+    '<PButton @naked={{null}} />',
+    '<PButton @naked={{this}} />',
+    '<PButton @naked={{"action"}} />',
   ],
 
   bad: [


### PR DESCRIPTION
error from 
```hbs
 <PButton
      @naked={{true}}
 />
```
and in `getLocalName` from `rules/internal/scope`

`no-action` uses `isLocal` method, and it's fails for Bool, String, Undef, Null paths

// https://github.com/ember-template-lint/ember-template-lint/issues/881

* pathExpression has empty parts if it's `{{this}}`