### PR TITLE
Update `block-indentation` to ignore children of `<template>` and `<textarea>`

### DIFF
--- a/lib/rules/lint-block-indentation.js
+++ b/lib/rules/lint-block-indentation.js
@@ -71,7 +71,7 @@ const VOID_TAGS = {
   track: true,
   wbr: true,
 };
-const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'template']);
+const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'template', 'textarea']);
 
 function isControlChar(char) {
   return char === '~' || char === '{' || char === '}';

--- a/lib/rules/lint-block-indentation.js
+++ b/lib/rules/lint-block-indentation.js
@@ -71,7 +71,7 @@ const VOID_TAGS = {
   track: true,
   wbr: true,
 };
-const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style']);
+const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'template']);
 
 function isControlChar(char) {
   return char === '~' || char === '{' || char === '}';

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -108,11 +108,14 @@ generateRuleTests({
     '<pre>\nsome text</pre>',
     '<script>\nsome text</script>',
     '<template>\nsome text</template>',
+    '<textarea>\nsome text</textarea>',
+    '<textarea> \n<div>\nsome text   \n \n </div></textarea>',
     '<style>\nsome text</style>',
     '<pre>\n{{#foo}}\n {{#baz}}  hi!\n   {{derp}}{{/baz}}{{/foo}}\n </pre>',
     '<script>\n{{#foo}}\n {{#baz}}  hi!\n   {{derp}}{{/baz}}{{/foo}}\n </script>',
     '<template>\n{{#foo}}\n {{#baz}}  hi!\n   {{derp}}{{/baz}}{{/foo}}\n </template>',
     '<style>\n{{#foo}}\n {{#baz}}  hi!\n   {{derp}}{{/baz}}{{/foo}}\n </style>',
+    '<textarea>\n{{#foo}}\n {{#baz}}  hi!\n   {{derp}}{{/baz}}{{/foo}}\n </textarea>',
   ],
 
   bad: [

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -106,7 +106,13 @@ generateRuleTests({
     ].join('\n'),
     ['{{#if foo}}', '  &nbsp;bar', '{{/if}}'].join('\n'),
     '<pre>\nsome text</pre>',
+    '<script>\nsome text</script>',
+    '<template>\nsome text</template>',
+    '<style>\nsome text</style>',
     '<pre>\n{{#foo}}\n {{#baz}}  hi!\n   {{derp}}{{/baz}}{{/foo}}\n </pre>',
+    '<script>\n{{#foo}}\n {{#baz}}  hi!\n   {{derp}}{{/baz}}{{/foo}}\n </script>',
+    '<template>\n{{#foo}}\n {{#baz}}  hi!\n   {{derp}}{{/baz}}{{/foo}}\n </template>',
+    '<style>\n{{#foo}}\n {{#baz}}  hi!\n   {{derp}}{{/baz}}{{/foo}}\n </style>',
   ],
 
   bad: [


### PR DESCRIPTION
https://github.com/ember-template-lint/ember-template-lint/pull/902
https://github.com/ember-template-lint/ember-template-lint/issues/702