### PR TITLE
Ensure configuration ordering does not matter with `no-bare-strings`

### DIFF
--- a/lib/rules/lint-no-bare-strings.js
+++ b/lib/rules/lint-no-bare-strings.js
@@ -38,8 +38,6 @@ const TAG_ATTRIBUTES = {
   img: ['alt'],
 };
 
-const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'template', 'textarea']);
-
 // Character entity reference chart: https://dev.w3.org/html5/html-author/charref
 const DEFAULT_CONFIG = {
   whitelist: [
@@ -138,13 +136,6 @@ function sanitizeConfigArray(whitelist = []) {
 }
 
 module.exports = class LogStaticStrings extends Rule {
-  constructor(options) {
-    super(options);
-    this._elementStack = [];
-  }
-  isWithinIgnoredElement() {
-    return this._elementStack.some(n => IGNORED_ELEMENTS.has(n.tag));
-  }
   parseConfig(config) {
     let configType = typeof config;
 
@@ -202,14 +193,8 @@ module.exports = class LogStaticStrings extends Rule {
         }
       },
 
-      ElementNode: {
-        enter(node) {
-          this._currentElementNode = node;
-          this._elementStack.push(node);
-        },
-        exit() {
-          this._elementStack.pop();
-        },
+      ElementNode(node) {
+        this._currentElementNode = node;
       },
 
       AttrNode: {
@@ -256,9 +241,6 @@ module.exports = class LogStaticStrings extends Rule {
     return string.trim() !== '' ? _string : null;
   }
   _checkNodeAndLog(node, additionalDescription, loc) {
-    if (this._currentElementNode && this.isWithinIgnoredElement()) {
-      return;
-    }
     if (node.type === 'TextNode') {
       let bareStringText = this._getBareString(node.chars);
 

--- a/lib/rules/lint-no-bare-strings.js
+++ b/lib/rules/lint-no-bare-strings.js
@@ -38,7 +38,7 @@ const TAG_ATTRIBUTES = {
   img: ['alt'],
 };
 
-const IGNORE_TAGS = ['pre', 'script', 'style', 'template', 'textarea'];
+const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'template', 'textarea']);
 
 // Character entity reference chart: https://dev.w3.org/html5/html-author/charref
 const DEFAULT_CONFIG = {
@@ -140,7 +140,10 @@ function sanitizeConfigArray(whitelist = []) {
 module.exports = class LogStaticStrings extends Rule {
   constructor(options) {
     super(options);
-    this.tagNamesStack = [];
+    this._elementStack = [];
+  }
+  isWithinIgnoredElement() {
+    return this._elementStack.some(n => IGNORED_ELEMENTS.has(n.tag));
   }
   parseConfig(config) {
     let configType = typeof config;
@@ -202,10 +205,10 @@ module.exports = class LogStaticStrings extends Rule {
       ElementNode: {
         enter(node) {
           this._currentElementNode = node;
-          this.addTagNameToStack(node.tag);
+          this._elementStack.push(node);
         },
         exit() {
-          this.removeTagNameFromStack();
+          this._elementStack.pop();
         },
       },
 
@@ -252,20 +255,8 @@ module.exports = class LogStaticStrings extends Rule {
 
     return string.trim() !== '' ? _string : null;
   }
-
-  addTagNameToStack(tag) {
-    this.tagNamesStack.push(tag);
-  }
-
-  removeTagNameFromStack() {
-    this.tagNamesStack.pop();
-  }
-
   _checkNodeAndLog(node, additionalDescription, loc) {
-    if (
-      this._currentElementNode &&
-      this.tagNamesStack.filter(name => IGNORE_TAGS.includes(name)).length
-    ) {
+    if (this._currentElementNode && this.isWithinIgnoredElement()) {
       return;
     }
     if (node.type === 'TextNode') {

--- a/lib/rules/lint-no-bare-strings.js
+++ b/lib/rules/lint-no-bare-strings.js
@@ -240,6 +240,7 @@ module.exports = class LogStaticStrings extends Rule {
 
     return string.trim() !== '' ? _string : null;
   }
+  
   _checkNodeAndLog(node, additionalDescription, loc) {
     if (node.type === 'TextNode') {
       let bareStringText = this._getBareString(node.chars);

--- a/lib/rules/lint-no-bare-strings.js
+++ b/lib/rules/lint-no-bare-strings.js
@@ -240,7 +240,7 @@ module.exports = class LogStaticStrings extends Rule {
 
     return string.trim() !== '' ? _string : null;
   }
-  
+
   _checkNodeAndLog(node, additionalDescription, loc) {
     if (node.type === 'TextNode') {
       let bareStringText = this._getBareString(node.chars);

--- a/lib/rules/lint-no-bare-strings.js
+++ b/lib/rules/lint-no-bare-strings.js
@@ -38,6 +38,8 @@ const TAG_ATTRIBUTES = {
   img: ['alt'],
 };
 
+const IGNORE_TAGS = ['pre', 'script', 'style', 'template', 'textarea'];
+
 // Character entity reference chart: https://dev.w3.org/html5/html-author/charref
 const DEFAULT_CONFIG = {
   whitelist: [
@@ -132,10 +134,14 @@ function isValidConfigObjectFormat(config) {
 }
 
 function sanitizeConfigArray(whitelist = []) {
-  return whitelist.filter(option => option !== '');
+  return whitelist.filter(option => option !== '').sort((a, b) => b.length - a.length);
 }
 
 module.exports = class LogStaticStrings extends Rule {
+  constructor(options) {
+    super(options);
+    this.tagNamesStack = [];
+  }
   parseConfig(config) {
     let configType = typeof config;
 
@@ -193,8 +199,14 @@ module.exports = class LogStaticStrings extends Rule {
         }
       },
 
-      ElementNode(node) {
-        this._currentElementNode = node;
+      ElementNode: {
+        enter(node) {
+          this._currentElementNode = node;
+          this.addTagNameToStack(node.tag);
+        },
+        exit() {
+          this.removeTagNameFromStack();
+        },
       },
 
       AttrNode: {
@@ -241,7 +253,21 @@ module.exports = class LogStaticStrings extends Rule {
     return string.trim() !== '' ? _string : null;
   }
 
+  addTagNameToStack(tag) {
+    this.tagNamesStack.push(tag);
+  }
+
+  removeTagNameFromStack() {
+    this.tagNamesStack.pop();
+  }
+
   _checkNodeAndLog(node, additionalDescription, loc) {
+    if (
+      this._currentElementNode &&
+      this.tagNamesStack.filter(name => IGNORE_TAGS.includes(name)).length
+    ) {
+      return;
+    }
     if (node.type === 'TextNode') {
       let bareStringText = this._getBareString(node.chars);
 

--- a/test/unit/rules/lint-no-bare-strings-test.js
+++ b/test/unit/rules/lint-no-bare-strings-test.js
@@ -29,13 +29,33 @@ generateRuleTests({
       config: ['/', '"'],
       template: '{{t "foo"}} / "{{name}}"',
     },
+    {
+      config: ['&', '&times;', '4', '3=12'],
+      template: '4 &times; 3=12',
+    },
+    {
+      config: ['&', '&times;', 'Tom', 'Jerry'],
+      template: 'Tom & Jerry',
+    },
+    {
+      config: ['&', '&times;'],
+      template: '& &times;',
+    },
     '{{t "foo"}}',
     '{{t "foo"}}, {{t "bar"}} ({{length}})',
     '(),.&+-=*/#%!?:[]{}',
     '&lpar;&rpar;&comma;&period;&amp;&nbsp;',
     '{{! template-lint-disable no-bare-strings }}',
     '{{! template-lint-disable }}',
-
+    '<script> fdff sf sf f </script>',
+    '<style> fdff sf sf f </style>',
+    '<pre> fdff sf sf f </pre>',
+    '<template> fdff sf sf f </template>',
+    '<script> fdff sf sf <div> aaa </div> f </script>',
+    '<style> fdff sf sf <div> aaa </div> f </style>',
+    '<pre> fdff sf sf <div> aaa </div> f </pre>',
+    '<template> fdff sf sf <div> aaa </div> f </template>',
+    '<textarea> this is an input</textarea>',
     // placeholder is a <input> specific attribute
     '<div placeholder="wat?"></div>',
 

--- a/test/unit/rules/lint-no-bare-strings-test.js
+++ b/test/unit/rules/lint-no-bare-strings-test.js
@@ -47,15 +47,7 @@ generateRuleTests({
     '&lpar;&rpar;&comma;&period;&amp;&nbsp;',
     '{{! template-lint-disable no-bare-strings }}',
     '{{! template-lint-disable }}',
-    '<script> fdff sf sf f </script>',
-    '<style> fdff sf sf f </style>',
-    '<pre> fdff sf sf f </pre>',
-    '<template> fdff sf sf f </template>',
-    '<script> fdff sf sf <div> aaa </div> f </script>',
-    '<style> fdff sf sf <div> aaa </div> f </style>',
-    '<pre> fdff sf sf <div> aaa </div> f </pre>',
-    '<template> fdff sf sf <div> aaa </div> f </template>',
-    '<textarea> this is an input</textarea>',
+
     // placeholder is a <input> specific attribute
     '<div placeholder="wat?"></div>',
 


### PR DESCRIPTION
https://github.com/ember-template-lint/ember-template-lint/issues/903

//cc @boris-petrov 