### PR TITLE
Update `no-bare-strings` to ignore contents within elements that are not translated (e.g. `<script>`,`<style>`, and `<pre>`).

### DIFF
--- a/lib/rules/lint-no-bare-strings.js
+++ b/lib/rules/lint-no-bare-strings.js
@@ -38,6 +38,8 @@ const TAG_ATTRIBUTES = {
   img: ['alt'],
 };
 
+const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'template', 'textarea']);
+
 // Character entity reference chart: https://dev.w3.org/html5/html-author/charref
 const DEFAULT_CONFIG = {
   whitelist: [
@@ -136,6 +138,13 @@ function sanitizeConfigArray(whitelist = []) {
 }
 
 module.exports = class LogStaticStrings extends Rule {
+  constructor(options) {
+    super(options);
+    this._elementStack = [];
+  }
+  isWithinIgnoredElement() {
+    return this._elementStack.some(n => IGNORED_ELEMENTS.has(n.tag));
+  }
   parseConfig(config) {
     let configType = typeof config;
 
@@ -193,8 +202,14 @@ module.exports = class LogStaticStrings extends Rule {
         }
       },
 
-      ElementNode(node) {
-        this._currentElementNode = node;
+      ElementNode: {
+        enter(node) {
+          this._currentElementNode = node;
+          this._elementStack.push(node);
+        },
+        exit() {
+          this._elementStack.pop();
+        },
       },
 
       AttrNode: {
@@ -242,6 +257,9 @@ module.exports = class LogStaticStrings extends Rule {
   }
 
   _checkNodeAndLog(node, additionalDescription, loc) {
+    if (this._currentElementNode && this.isWithinIgnoredElement()) {
+      return;
+    }
     if (node.type === 'TextNode') {
       let bareStringText = this._getBareString(node.chars);
 

--- a/test/unit/rules/lint-no-bare-strings-test.js
+++ b/test/unit/rules/lint-no-bare-strings-test.js
@@ -35,7 +35,15 @@ generateRuleTests({
     '&lpar;&rpar;&comma;&period;&amp;&nbsp;',
     '{{! template-lint-disable no-bare-strings }}',
     '{{! template-lint-disable }}',
-
+    '<script> fdff sf sf f </script>',
+    '<style> fdff sf sf f </style>',
+    '<pre> fdff sf sf f </pre>',
+    '<template> fdff sf sf f </template>',
+    '<script> fdff sf sf <div> aaa </div> f </script>',
+    '<style> fdff sf sf <div> aaa </div> f </style>',
+    '<pre> fdff sf sf <div> aaa </div> f </pre>',
+    '<template> fdff sf sf <div> aaa </div> f </template>',
+    '<textarea> this is an input</textarea>',
     // placeholder is a <input> specific attribute
     '<div placeholder="wat?"></div>',
 


### PR DESCRIPTION
https://github.com/ember-template-lint/ember-template-lint/pull/905