### PR TITLE
Update `no-unnecessary-component-helper` rule to allow the `component` helper as an angle bracket component argument

### DIFF
--- a/docs/rule/no-unnecessary-component-helper.md
+++ b/docs/rule/no-unnecessary-component-helper.md
@@ -27,6 +27,7 @@ This rule **allows** the following:
 
 ```hbs
 {{my-component close=(component "link-to" "index")}}
+<MyComponent @close={{component "link-to" "index"}} />
 ```
 
 ### References

--- a/lib/rules/lint-no-unnecessary-component-helper.js
+++ b/lib/rules/lint-no-unnecessary-component-helper.js
@@ -7,6 +7,16 @@ const ERROR_MESSAGE = 'Invoke component directly instead of using `component` he
 
 module.exports = class NoUnnecessaryComponentHelper extends Rule {
   visitor() {
+    let inSafeNamespace = false;
+    const markAsSafeNamespace = {
+      enter() {
+        inSafeNamespace = true;
+      },
+      exit() {
+        inSafeNamespace = false;
+      },
+    };
+
     function isComponentHelper(node) {
       return (
         node &&
@@ -17,19 +27,12 @@ module.exports = class NoUnnecessaryComponentHelper extends Rule {
       );
     }
 
-    const allowedUsages = new Set();
-    function recordAngleBracketArguments(node) {
-      node.attributes
-        .filter(attribute => attribute.name.startsWith('@') && isComponentHelper(attribute.value))
-        .forEach(attribute => allowedUsages.add(attribute.value));
-    }
-
     function checkNode(node) {
       if (
         isComponentHelper(node) &&
         AstNodeInfo.isStringLiteral(node.params[0]) &&
         !node.params[0].value.includes('@') &&
-        !allowedUsages.has(node)
+        !inSafeNamespace
       ) {
         this.log({
           message: ERROR_MESSAGE,
@@ -41,7 +44,7 @@ module.exports = class NoUnnecessaryComponentHelper extends Rule {
     }
 
     return {
-      ElementNode: recordAngleBracketArguments,
+      AttrNode: markAsSafeNamespace,
       BlockStatement: checkNode,
       MustacheStatement: checkNode,
     };

--- a/lib/rules/lint-no-unnecessary-component-helper.js
+++ b/lib/rules/lint-no-unnecessary-component-helper.js
@@ -19,8 +19,6 @@ module.exports = class NoUnnecessaryComponentHelper extends Rule {
 
     function isComponentHelper(node) {
       return (
-        node &&
-        node.path &&
         AstNodeInfo.isPathExpression(node.path) &&
         node.path.original === 'component' &&
         node.params.length > 0

--- a/lib/rules/lint-no-unnecessary-component-helper.js
+++ b/lib/rules/lint-no-unnecessary-component-helper.js
@@ -7,13 +7,27 @@ const ERROR_MESSAGE = 'Invoke component directly instead of using `component` he
 
 module.exports = class NoUnnecessaryComponentHelper extends Rule {
   visitor() {
-    function checkNode(node) {
-      if (
+    function isComponentHelper(node) {
+      return (
         AstNodeInfo.isPathExpression(node.path) &&
         node.path.original === 'component' &&
-        node.params.length > 0 &&
+        node.params.length > 0
+      );
+    }
+
+    const allowedUsages = new Set();
+    function recordAngleBracketArguments(node) {
+      node.attributes
+        .filter(attribute => attribute.name.startsWith('@') && isComponentHelper(attribute.value))
+        .forEach(attribute => allowedUsages.add(attribute.value));
+    }
+
+    function checkNode(node) {
+      if (
+        isComponentHelper(node) &&
         AstNodeInfo.isStringLiteral(node.params[0]) &&
-        !node.params[0].value.includes('@')
+        !node.params[0].value.includes('@') &&
+        !allowedUsages.has(node)
       ) {
         this.log({
           message: ERROR_MESSAGE,
@@ -25,6 +39,7 @@ module.exports = class NoUnnecessaryComponentHelper extends Rule {
     }
 
     return {
+      ElementNode: recordAngleBracketArguments,
       BlockStatement: checkNode,
       MustacheStatement: checkNode,
     };

--- a/lib/rules/lint-no-unnecessary-component-helper.js
+++ b/lib/rules/lint-no-unnecessary-component-helper.js
@@ -9,6 +9,8 @@ module.exports = class NoUnnecessaryComponentHelper extends Rule {
   visitor() {
     function isComponentHelper(node) {
       return (
+        node &&
+        node.path &&
         AstNodeInfo.isPathExpression(node.path) &&
         node.path.original === 'component' &&
         node.params.length > 0

--- a/test/unit/rules/lint-no-unnecessary-component-helper-test.js
+++ b/test/unit/rules/lint-no-unnecessary-component-helper-test.js
@@ -42,8 +42,11 @@ generateRuleTests({
     '<Foo class="foo" />',
     '<Foo data-test-bar="foo" />',
 
-    // `if` expressions are allowed
-    '<Foo @arg={{if this.user.isAdmin "admin"}}/>',
+    // `if` expressions without `(component)` are allowed:
+    '<Foo @arg={{if this.user.isAdmin "admin"}} />',
+
+    // `if` expression with `(component)` are allowed:
+    '<Foo @arg={{if this.user.isAdmin (component "my-component")}} />',
 
     // Component names of the form `addon-name@component-name` are exempt:
     "{{component 'addon-name@component-name'}}",

--- a/test/unit/rules/lint-no-unnecessary-component-helper-test.js
+++ b/test/unit/rules/lint-no-unnecessary-component-helper-test.js
@@ -78,5 +78,17 @@ generateRuleTests({
         column: 0,
       },
     },
+    {
+      template:
+        '<Foo @arg={{component "allowed-component"}}>{{component "forbidden-component"}}</Foo>',
+
+      result: {
+        message: ERROR_MESSAGE,
+        moduleId: 'layout.hbs',
+        source: '{{component "forbidden-component"}}',
+        line: 1,
+        column: 44,
+      },
+    },
   ],
 });

--- a/test/unit/rules/lint-no-unnecessary-component-helper-test.js
+++ b/test/unit/rules/lint-no-unnecessary-component-helper-test.js
@@ -31,6 +31,12 @@ generateRuleTests({
     '(component SOME_COMPONENT_NAME)',
     '(component "my-component")',
 
+    // Curly inline usage in an angle bracket component:
+    '<Foo @bar={{component SOME_COMPONENT_NAME}} />',
+    '<Foo @bar={{component "my-component"}} />',
+    '<Foo @bar={{component SOME_COMPONENT_NAME}}></Foo>',
+    '<Foo @bar={{component "my-component"}}></Foo>',
+
     // Component names of the form `addon-name@component-name` are exempt:
     "{{component 'addon-name@component-name'}}",
     "{{#component 'addon-name@component-name'}}{{/component}}",

--- a/test/unit/rules/lint-no-unnecessary-component-helper-test.js
+++ b/test/unit/rules/lint-no-unnecessary-component-helper-test.js
@@ -39,6 +39,11 @@ generateRuleTests({
 
     // Static arguments in angle bracket components don't crash the rule:
     '<Foo @arg="foo" />',
+    '<Foo class="foo" />',
+    '<Foo data-test-bar="foo" />',
+
+    // `if` expressions are allowed
+    '<Foo @arg={{if this.user.isAdmin "admin"}}/>',
 
     // Component names of the form `addon-name@component-name` are exempt:
     "{{component 'addon-name@component-name'}}",

--- a/test/unit/rules/lint-no-unnecessary-component-helper-test.js
+++ b/test/unit/rules/lint-no-unnecessary-component-helper-test.js
@@ -37,6 +37,9 @@ generateRuleTests({
     '<Foo @bar={{component SOME_COMPONENT_NAME}}></Foo>',
     '<Foo @bar={{component "my-component"}}></Foo>',
 
+    // Static arguments in angle bracket components don't crash the rule:
+    '<Foo @arg="foo" />',
+
     // Component names of the form `addon-name@component-name` are exempt:
     "{{component 'addon-name@component-name'}}",
     "{{#component 'addon-name@component-name'}}{{/component}}",


### PR DESCRIPTION
This adds a failing test case for `no-unnecessary-component-helper` for the usage of the curly `{{component}}` helper as an argument to an angle bracket component invocation.

```hbs
<Foo @bar={{component "my-component"}} />
```

It fixes the test by recording all valid usages of the `{{component}}` helper as attributes to an `ElementNode` in a Set and then exempting these nodes in `checkNode`.

I'm not sure whether this is the best / most elegant solution, but I did not find a different way to get the parent of the node passed to `checkNode`. I'm happy to implement this a different way, if you can point me towards a better solution.