### PR TITLE
Use `.editorconfig` to choose default value for `block-indentation`

### DIFF
--- a/docs/rule/block-indentation.md
+++ b/docs/rule/block-indentation.md
@@ -39,6 +39,8 @@ The following values are valid configuration:
   * numeric -- the number of spaces to require for indentation
   * "tab" -- To indicate tab style indentation (1 char)
 
+If `.editorconfig` file present, rule configuration will be inherit from it.
+
 ### Related Rules
 
   * [attribute-indentation](attribute-indentation.md)

--- a/lib/rules/lint-block-indentation.js
+++ b/lib/rules/lint-block-indentation.js
@@ -78,6 +78,13 @@ function isControlChar(char) {
 }
 
 module.exports = class BlockIndentation extends Rule {
+  constructor(options) {
+    super(options);
+    const editorIdentation = this.editorConfig['indent_size'];
+    if (typeof editorIdentation === 'number') {
+      this.config = editorIdentation;
+    }
+  }
   parseConfig(config) {
     let configType = typeof config;
 

--- a/test/unit/rules/lint-block-indentation-test.js
+++ b/test/unit/rules/lint-block-indentation-test.js
@@ -8,6 +8,12 @@ generateRuleTests({
   config: 2,
 
   good: [
+    {
+      template: '<div>\n' + '    <p>Hi!</p>\n' + '</div>',
+      meta: {
+        editorConfig: { indent_size: 4 },
+      },
+    },
     ['  this is fine'].join('\n'),
     ['<h1>Header</h1>', '<div>', '  \\{{example}}', '</div>'].join('\n'),
     ['<div>', '  \\{{example}}', '</div>'].join('\n'),
@@ -83,7 +89,6 @@ generateRuleTests({
     },
     {
       config: 'tab',
-
       template: '' + '<div>\n' + '\t<p>Hi!</p>\n' + '</div>',
     },
     '{{! template-lint-disable no-bare-strings }}',


### PR DESCRIPTION
ref: https://github.com/ember-template-lint/ember-template-lint/pull/906

fix: https://github.com/ember-template-lint/ember-template-lint/issues/901