### PR TITLE
Use `.editorconfig` to choose default value for `linebreak-style`

### DIFF
--- a/docs/rule/linebreak-style.md
+++ b/docs/rule/linebreak-style.md
@@ -8,3 +8,5 @@ This rule is configured with a boolean, or a string value:
 
 * boolean -- `true` for enforcing consistency (all `CRLF` or all `LF` not both in a single file)
 * string -- `system` for the current platforms default line ending / `unix` for LF linebreaks / `windows` for CRLF linebreaks
+
+If `.editorconfig` file present, rule configuration will be inherit from it.

--- a/lib/rules/lint-linebreak-style.js
+++ b/lib/rules/lint-linebreak-style.js
@@ -20,7 +20,20 @@ function toUserString(value) {
   return value.replace('\r', 'CR').replace('\n', 'LF');
 }
 
+const matchMap = {
+  lf: '\n',
+  cr: '\r',
+  crlf: '\r\n',
+};
+
 module.exports = class LineBreakStyle extends Rule {
+  constructor(options) {
+    super(options);
+    const configuredIndent = this.editorConfig['end_of_line'];
+    if (['lf', 'cr', 'crlf'].includes(configuredIndent)) {
+      this.config = matchMap[configuredIndent];
+    }
+  }
   parseConfig(config) {
     let configType = typeof config;
 

--- a/test/unit/rules/lint-linebreak-style-test.js
+++ b/test/unit/rules/lint-linebreak-style-test.js
@@ -24,6 +24,13 @@ generateRuleTests({
       config: 'unix',
       template: 'testing\nthis',
     },
+    {
+      meta: {
+        editorConfig: { end_of_line: 'crlf' },
+      },
+      config: 'unix',
+      template: 'testing\r\nthis',
+    },
   ],
 
   bad: [


### PR DESCRIPTION
ref: https://github.com/ember-template-lint/ember-template-lint/pull/906

fix: https://github.com/ember-template-lint/ember-template-lint/issues/284