### PR TITLE
Ensure `no-bare-strings` consider literals in mustaches (e.g. `{{"foo"}}`)

### DIFF
--- a/lib/rules/lint-no-bare-strings.js
+++ b/lib/rules/lint-no-bare-strings.js
@@ -211,7 +211,11 @@ module.exports = class LogStaticStrings extends Rule {
           this._elementStack.pop();
         },
       },
-
+      MustacheStatement(node) {
+        if (!this._currentAttrNode) {
+          this._checkNodeAndLog(node.path, '', node.loc);
+        }
+      },
       AttrNode: {
         enter(node) {
           this._currentAttrNode = node;
@@ -275,6 +279,17 @@ module.exports = class LogStaticStrings extends Rule {
       for (let i = 0; i < node.parts.length; i++) {
         let subNode = node.parts[i];
         this._checkNodeAndLog(subNode, additionalDescription, loc);
+      }
+    } else if (node.type === 'StringLiteral') {
+      let bareStringText = this._getBareString(node.value);
+
+      if (bareStringText) {
+        this.log({
+          message: `Non-translated string used${additionalDescription}`,
+          line: loc.start.line,
+          column: loc.start.column,
+          source: bareStringText,
+        });
       }
     }
   }

--- a/test/unit/rules/lint-no-bare-strings-test.js
+++ b/test/unit/rules/lint-no-bare-strings-test.js
@@ -9,6 +9,7 @@ generateRuleTests({
 
   good: [
     '{{t "howdy"}}',
+    '<CustomInput @type={{"range"}} />',
     {
       config: [''],
       template: '\n {{translate "greeting"}}',
@@ -109,6 +110,16 @@ generateRuleTests({
   ],
 
   bad: [
+    {
+      template: '<p>{{"Hello!"}}</p>',
+      result: {
+        moduleId: 'layout.hbs',
+        message: 'Non-translated string used',
+        line: 1,
+        column: 3,
+        source: 'Hello!',
+      },
+    },
     {
       template: '\n howdy',
 


### PR DESCRIPTION
ref: https://github.com/ember-template-lint/ember-template-lint/issues/914