### PR TITLE
fix: allow `getLocalName` to work with numbers

### DIFF
--- a/lib/rules/internal/scope.js
+++ b/lib/rules/internal/scope.js
@@ -16,6 +16,7 @@ function getLocalName(node) {
     case 'NullLiteral':
     case 'BooleanLiteral':
     case 'StringLiteral':
+    case 'NumberLiteral':
       return undefined;
     case 'PathExpression':
     default:

--- a/test/unit/rules/lint-no-action-test.js
+++ b/test/unit/rules/lint-no-action-test.js
@@ -14,6 +14,7 @@ generateRuleTests({
     '<button {{on "submit" @action}}>Click Me</button>',
     '<button {{on "submit" this.action}}>Click Me</button>',
     // check for scope.getLocalName working for primitives and locals #881
+    '<PButton @naked={{42}} />',
     '<PButton @naked={{true}} />',
     '<PButton @naked={{undefined}} />',
     '<PButton @naked={{null}} />',


### PR DESCRIPTION
While many types of literals were handled within `getLocalName`, numbers were forgotten!

Closes #922