### PR TITLE
Linter class: Use named severity

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -12,7 +12,7 @@ const ERROR_SEVERITY = 2;
 function buildErrorMessage(moduleId, error) {
   let message = {
     fatal: true,
-    severity: 2,
+    severity: ERROR_SEVERITY,
     moduleId,
     message: error.message,
     source: error.stack,
@@ -54,7 +54,7 @@ class Linter {
       }
     }
 
-    return 2;
+    return ERROR_SEVERITY;
   }
 
   buildRules(config) {
@@ -173,7 +173,7 @@ class Linter {
       messages.push({
         message: `Pending module (\`${options.moduleId}\`) passes all rules. Please remove \`${options.moduleId}\` from pending list.`,
         moduleId: options.moduleId,
-        severity: 2,
+        severity: ERROR_SEVERITY,
       });
     }
 


### PR DESCRIPTION
In the main Linter class, switch : `2` for `ERROR_SEVERITY` variable.

I'm targetting `next` branch. This is a https://github.com/ember-template-lint/ember-template-lint/pull/932 follow-up.