### PR TITLE
Implement more plumbing for `--fix` support (add `Linter.prototype.verifyAndFix`)

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -15,7 +15,8 @@ function lintFile(linter, filePath, moduleId, shouldFix) {
   // TODO: swap to using get-stdin when we can leverage async/await
   let source = fs.readFileSync(toRead, { encoding: 'utf8' });
 
-  return linter.verifyAndFix({ source, moduleId, shouldFix });
+  let result = linter.verifyAndFix({ source, moduleId, shouldFix });
+  return result.messages;
 }
 
 function expandFileGlobs(positional) {

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -9,13 +9,13 @@ const Linter = require('../lib/index');
 
 const STDIN = '/dev/stdin';
 
-function lintFile(linter, filePath, moduleId) {
+function lintFile(linter, filePath, moduleId, shouldFix) {
   let toRead = filePath === STDIN ? process.stdin.fd : filePath;
 
   // TODO: swap to using get-stdin when we can leverage async/await
   let source = fs.readFileSync(toRead, { encoding: 'utf8' });
 
-  return linter.verify({ source, moduleId });
+  return linter.verifyAndFix({ source, moduleId, shouldFix });
 }
 
 function expandFileGlobs(positional) {
@@ -88,7 +88,7 @@ function run() {
   let options = parseArgv(process.argv.slice(2));
 
   let {
-    named: { configPath, filename: filePathFromArgs = '', printPending, json },
+    named: { configPath, filename: filePathFromArgs = '', fix, printPending, json },
     positional,
   } = options;
 
@@ -115,7 +115,7 @@ function run() {
     let filePath = path.resolve(relativeFilePath);
     let fileName = relativeFilePath === STDIN ? filePathFromArgs : relativeFilePath;
     let moduleId = fileName.slice(0, -4);
-    let fileErrors = lintFile(linter, filePath, moduleId);
+    let fileErrors = lintFile(linter, filePath, moduleId, fix);
 
     if (printPending) {
       const ignoredPendingRules = ['invalid-pending-module', 'invalid-pending-module-rule'];

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -14,9 +14,15 @@ function lintFile(linter, filePath, moduleId, shouldFix) {
 
   // TODO: swap to using get-stdin when we can leverage async/await
   let source = fs.readFileSync(toRead, { encoding: 'utf8' });
+  let options = { source, moduleId };
 
-  let result = linter.verifyAndFix({ source, moduleId, shouldFix });
-  return result.messages;
+  if (shouldFix) {
+    let result = linter.verifyAndFix(options);
+
+    return result.messages;
+  } else {
+    return linter.verify(options);
+  }
 }
 
 function expandFileGlobs(positional) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -10,12 +10,13 @@ const WARNING_SEVERITY = 1;
 const ERROR_SEVERITY = 2;
 
 /**
- * @param {string} source - The source code to fix.
+ * @param {Object} options
+ * @param {string} options.source - The source code to fix.
  * @param {Object[]} messages - The lint messages.
  * @returns {string} output - The fixed source.
  */
-function applyFixes(source /* messages */) {
-  return source;
+function applyFixes(options /* messages */) {
+  return options.source;
 }
 
 function buildErrorMessage(moduleId, error) {
@@ -150,7 +151,8 @@ class Linter {
   }
 
   /**
-   * Takes the source to lint and fix it. It makes use of `verify` function.
+   * Takes the source to lint and fix it. It makes use of the `verify` function.
+   *
    * @param {Object} options
    * @param {string} options.source - The source code to verify.
    * @param {string} options.moduleId
@@ -161,42 +163,35 @@ class Linter {
    * source has been fixed.
    * @returns {string} result.output - The fixed source.
    */
-  verifyAndFix(params) {
-    let options = params;
-    let currentSource = stripBom(options.source);
+  verifyAndFix(options) {
+    const originalSource = stripBom(options.source);
 
+    let currentSource = originalSource;
+    let shouldVerify = true;
     let iterations = 0;
     let messages = [];
-    let isFixed = false;
-    let fixed = false;
 
     do {
       iterations++;
 
       options = Object.assign({}, options, { source: currentSource });
       messages = this.verify(options);
+      shouldVerify = false;
 
-      // TODO: here we will apply fixes
-      // for now it simply returns the currentSource
-      const output = applyFixes(currentSource, messages);
-      fixed = output !== currentSource;
+      if (iterations < MAX_AUTOFIX_PASSES) {
+        const output = applyFixes(options, messages);
 
-      // has a fix ever been applied?
-      isFixed = isFixed || output !== currentSource;
+        // let's lint one more time if source was modified
+        shouldVerify = output !== currentSource;
 
-      currentSource = output;
-    } while (options.shouldFix && fixed && iterations < MAX_AUTOFIX_PASSES);
-
-    // let's lint one more time (as source was modified on last iteration)
-    if (fixed) {
-      options = Object.assign({}, options, { source: currentSource });
-      messages = this.verify(options);
-    }
+        currentSource = output;
+      }
+    } while (shouldVerify);
 
     return {
-      isFixed,
-      messages,
+      isFixed: currentSource !== originalSource,
       output: currentSource,
+      messages,
     };
   }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -4,8 +4,19 @@ const stripBom = require('strip-bom');
 const EditorConfigResolver = require('./get-editor-config');
 let path = require('path');
 
+const MAX_AUTOFIX_PASSES = 10;
+
 const WARNING_SEVERITY = 1;
 const ERROR_SEVERITY = 2;
+
+/**
+ * @param {string} source - The source code to fix.
+ * @param {Object[]} messages - The lint messages.
+ * @returns {string} output - The fixed source.
+ */
+function applyFixes(source /* messages */) {
+  return source;
+}
 
 function buildErrorMessage(moduleId, error) {
   let message = {
@@ -139,7 +150,40 @@ class Linter {
   }
 
   verifyAndFix(options) {
-    return this.verify(options);
+    let currentSource = stripBom(options.source);
+
+    let iterations = 0;
+    let messages = [];
+    let isFixed = false;
+    let fixed = false;
+
+    do {
+      iterations++;
+
+      const currentOptions = Object.assign({}, options, { source: currentSource });
+      messages = this.verify(currentOptions);
+
+      // TODO: here we will apply fixes
+      // for now it simply returns the currentSource
+      const output = applyFixes(currentSource, messages);
+      fixed = output !== currentSource;
+
+      // has a fix ever been applied?
+      isFixed = isFixed || output !== currentSource;
+
+      currentSource = output;
+    } while (options.shouldFix && fixed && iterations < MAX_AUTOFIX_PASSES);
+
+    // let's lint one more time (as source was modified on last iteration)
+    if (fixed) {
+      messages = this.verify(options);
+    }
+
+    return {
+      isFixed,
+      messages,
+      output: currentSource,
+    };
   }
 
   verify(options) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -149,6 +149,18 @@ class Linter {
     return false;
   }
 
+  /**
+   * Takes the source to lint and fix it. It makes use of `verify` function.
+   * @param {Object} options
+   * @param {string} options.source - The source code to verify.
+   * @param {string} options.moduleId
+   * @param {string} options.configResolver
+   * @returns {Object} result
+   * @returns {boolean} result.isFixed - Whether a fix has been applied or not.
+   * @returns {Object[]} result.messages - The remaining lint messages after
+   * source has been fixed.
+   * @returns {string} result.output - The fixed source.
+   */
   verifyAndFix(options) {
     let currentSource = stripBom(options.source);
 
@@ -186,6 +198,15 @@ class Linter {
     };
   }
 
+  /**
+   * The main function for the Linter class.
+   * It takes the source code to lint and returns the lint messages.
+   * @param {Object} options
+   * @param {string} options.source - The source code to verify.
+   * @param {string} options.moduleId
+   * @param {string} options.configResolver
+   * @returns {Object[]} result.messages - The lint messages.
+   */
   verify(options) {
     let messages = [];
     let pendingStatus = this.statusForModule('pending', options.moduleId);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -138,6 +138,10 @@ class Linter {
     return false;
   }
 
+  verifyAndFix(options) {
+    return this.verify(options);
+  }
+
   verify(options) {
     let messages = [];
     let pendingStatus = this.statusForModule('pending', options.moduleId);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -161,7 +161,8 @@ class Linter {
    * source has been fixed.
    * @returns {string} result.output - The fixed source.
    */
-  verifyAndFix(options) {
+  verifyAndFix(params) {
+    let options = params;
     let currentSource = stripBom(options.source);
 
     let iterations = 0;
@@ -172,8 +173,8 @@ class Linter {
     do {
       iterations++;
 
-      const currentOptions = Object.assign({}, options, { source: currentSource });
-      messages = this.verify(currentOptions);
+      options = Object.assign({}, options, { source: currentSource });
+      messages = this.verify(options);
 
       // TODO: here we will apply fixes
       // for now it simply returns the currentSource
@@ -188,6 +189,7 @@ class Linter {
 
     // let's lint one more time (as source was modified on last iteration)
     if (fixed) {
+      options = Object.assign({}, options, { source: currentSource });
       messages = this.verify(options);
     }
 

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -222,17 +222,19 @@ describe('public api', function() {
   describe('Linter.prototype.verifyAndFix', function() {
     let basePath = null;
     let linter;
-    let expected = {
-      rules: {
-        quotes: 'double',
-      },
-    };
 
     beforeAll(async function() {
       project = await createTempDir();
       basePath = project.path();
+
+      let linterConfig = {
+        rules: {
+          quotes: 'double',
+        },
+      };
+
       project.write({
-        '.template-lintrc.js': `module.exports = ${JSON.stringify(expected)};`,
+        '.template-lintrc.js': `module.exports = ${JSON.stringify(linterConfig)};`,
         app: {
           templates: {
             'application.hbs': "<input class='mb4'>",
@@ -241,7 +243,7 @@ describe('public api', function() {
       });
     });
 
-    this.afterAll(async function() {
+    afterAll(async function() {
       await project.dispose();
     });
 

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -252,7 +252,7 @@ describe('public api', function() {
       });
     });
 
-    it('returns an array of issues with the provided template', function() {
+    it('returns whether the source has been fixed + an array of remaining issues with the provided template', function() {
       let templatePath = path.join(basePath, 'app', 'templates', 'application.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
       let expected = [
@@ -272,7 +272,8 @@ describe('public api', function() {
         moduleId: templatePath,
       });
 
-      expect(result).toEqual(expected);
+      expect(result.messages).toEqual(expected);
+      expect(result.isFixed).toEqual(false);
     });
   });
 

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -216,6 +216,66 @@ describe('public api', function() {
     });
   });
 
+  // TODO: extract this module in a file
+  // most of the tests will be here
+  // (incl. BOM)
+  describe('Linter.prototype.verifyAndFix', function() {
+    let basePath = null;
+    let linter;
+    let expected = {
+      rules: {
+        quotes: 'double',
+      },
+    };
+
+    beforeAll(async function() {
+      project = await createTempDir();
+      basePath = project.path();
+      project.write({
+        '.template-lintrc.js': `module.exports = ${JSON.stringify(expected)};`,
+        app: {
+          templates: {
+            'application.hbs': "<input class='mb4'>",
+          },
+        },
+      });
+    });
+
+    this.afterAll(async function() {
+      await project.dispose();
+    });
+
+    beforeEach(function() {
+      linter = new Linter({
+        console: mockConsole,
+        configPath: path.join(basePath, '.template-lintrc.js'),
+      });
+    });
+
+    it('returns an array of issues with the provided template', function() {
+      let templatePath = path.join(basePath, 'app', 'templates', 'application.hbs');
+      let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
+      let expected = [
+        {
+          column: 7,
+          line: 1,
+          message: 'you must use double quotes in templates',
+          moduleId: templatePath,
+          rule: 'quotes',
+          severity: 2,
+          source: "class='mb4'",
+        },
+      ];
+
+      let result = linter.verifyAndFix({
+        source: templateContents,
+        moduleId: templatePath,
+      });
+
+      expect(result).toEqual(expected);
+    });
+  });
+
   describe('Linter.prototype.verify', function() {
     let basePath = null;
     let linter;


### PR DESCRIPTION
This PR implements the `verifyAndFix` function. Next step will be to implement the `applyFixes` function.

### Tests
I've added an acceptance test for `verifyAndFix`.

### Manual tests
I've manually tested the PR in our codebases (in which we use template-lint@2-beta).

### Related
From this PR, I've extracted these three small PRs that may be reviewed / merged first: https://github.com/ember-template-lint/ember-template-lint/pull/932, https://github.com/ember-template-lint/ember-template-lint/pull/933, https://github.com/ember-template-lint/ember-template-lint/pull/934 (EDIT: ✅)