### PR TITLE
Add cli param to disable default ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ Example usage:
 
 # print list of formated rules for use with `pending` in config file
 ./node_modules/.bin/ember-template-lint app/templates/application.hbs --print-pending
+
+# dont ignore `['**/dist/**', '**/tmp/**', '**/node_modules/**']` by default
+./node_modules/.bin/ember-template-lint /tmp/template.hbs --no-default-ignores
 ```
 
 ### ESLint


### PR DESCRIPTION
This is a second attempt for #659 

Add flag so the by default ignored files
`['**/dist/**', '**/tmp/**', '**/node_modules/**']` and `.gitignore`
can be toggled. This is useful if for instance your editor lint plugin
(vim/ale) copies the file to be linted into /tmp . This prevents the
template from being linted as '**/tmp/**' applies.

Also add `--help` command to list available options.