### PR TITLE
Fix `no-invalid-interactive` to allow `{{on "load"...}}` and `{{on "error"...}}` for `<img>`

### DIFF
--- a/lib/rules/lint-no-invalid-interactive.js
+++ b/lib/rules/lint-no-invalid-interactive.js
@@ -71,16 +71,19 @@ module.exports = class InvalidInteractive extends Rule {
         let modifierName = node.path.original;
 
         if (modifierName === 'action' || modifierName === 'on') {
-          // Allow {{action "foo" on="submit"}} on form tags
-          if (this._element.tag === 'form' && isSubmitEventBinding(node)) {
-            return;
+          if (this._element.tag === 'img') {
+            if (isOnLoadEventBinding(node) || isOnErrorEventBinding(node)) {
+              return;
+            }
           }
 
           // Allow {{action "foo" on="reset"}} on form tags
-          if (this._element.tag === 'form' && isResetEventBinding(node)) {
-            return;
+          // Allow {{action "foo" on="submit"}} on form tags
+          if (this._element.tag === 'form') {
+            if (isSubmitEventBinding(node) || isResetEventBinding(node)) {
+              return;
+            }
           }
-
           this.log({
             message: 'Interaction added to non-interactive element',
             line: node.loc && node.loc.start.line,
@@ -180,4 +183,12 @@ function isSubmitEventBinding(node) {
 
 function isResetEventBinding(node) {
   return isEventHandlerFor(node, 'reset');
+}
+
+function isOnErrorEventBinding(node) {
+  return isEventHandlerFor(node, 'error');
+}
+
+function isOnLoadEventBinding(node) {
+  return isEventHandlerFor(node, 'load');
 }

--- a/test/unit/rules/lint-no-invalid-interactive-test.js
+++ b/test/unit/rules/lint-no-invalid-interactive-test.js
@@ -39,6 +39,7 @@ generateRuleTests({
       config: { additionalInteractiveTags: ['img'] },
       template: '<img onerror={{action "foo"}}>',
     },
+    '<img {{on "load" this.onLoad}} {{on "error" this.onError}}>',
   ],
 
   bad: [


### PR DESCRIPTION
ref: https://github.com/ember-template-lint/ember-template-lint/issues/940