### PR TITLE
Ignoring existing pending modules that have no linting errors

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -116,7 +116,13 @@ function run() {
 
     if (printPending) {
       let failingRules = Array.from(
-        fileErrors.reduce((memo, error) => memo.add(error.rule), new Set())
+        fileErrors.reduce((memo, error) => {
+          if (error.rule) {
+            memo.add(error.rule);
+          }
+
+          return memo;
+        }, new Set())
       );
 
       if (failingRules.length > 0) {

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -117,7 +117,7 @@ function run() {
     if (printPending) {
       let failingRules = Array.from(
         fileErrors.reduce((memo, error) => {
-          if (error.rule) {
+          if (error.rule !== 'invalid-pending-module') {
             memo.add(error.rule);
           }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -180,6 +180,7 @@ class Linter {
 
     if (pendingStatus && messages.length === 0) {
       messages.push({
+        rule: 'invalid-pending-module',
         message: `Pending module (\`${options.moduleId}\`) passes all rules. Please remove \`${options.moduleId}\` from pending list.`,
         moduleId: options.moduleId,
         severity: 2,

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -277,6 +277,7 @@ describe('public api', function() {
       });
 
       let expected = {
+        rule: 'invalid-pending-module',
         message:
           'Pending module (`some/path/here`) passes all rules. Please remove `some/path/here` from pending list.',
         moduleId: 'some/path/here',
@@ -302,6 +303,7 @@ describe('public api', function() {
       });
 
       let expected = {
+        rule: 'invalid-pending-module',
         message:
           'Pending module (`some/path/here`) passes all rules. Please remove `some/path/here` from pending list.',
         moduleId: 'some/path/here',

--- a/test/fixtures/with-passing-pending-modules/.template-lintrc.js
+++ b/test/fixtures/with-passing-pending-modules/.template-lintrc.js
@@ -1,0 +1,13 @@
+module.exports = {
+  rules: {
+    'no-html-comments': false
+  },
+  pending: [
+    {
+      'moduleId': 'app/templates/application',
+      'only': [
+        'no-html-comments'
+      ]
+    }
+  ]
+};

--- a/test/fixtures/with-passing-pending-modules/app/templates/application.hbs
+++ b/test/fixtures/with-passing-pending-modules/app/templates/application.hbs
@@ -1,0 +1,3 @@
+<h2>Here too!!</h2>
+<div>Bare strings are bad...</div>
+<!-- bad html comment! -->

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -362,6 +362,25 @@ describe('ember-template-lint executable', function() {
         expect(result.stdout).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
+
+      it('should ignore existing pending modules have no lint errors', function(done) {
+        execFile(
+          'node',
+          ['../../../bin/ember-template-lint.js', '.', '--print-pending'],
+          {
+            cwd: './test/fixtures/with-passing-pending-modules',
+          },
+          function(err, stdout, stderr) {
+            let expectedOutputData =
+              'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: []\n';
+
+            expect(err).to.be.ok;
+            expect(stdout).to.equal(expectedOutputData);
+            expect(stderr).to.be.empty;
+            done();
+          }
+        );
+      });
     });
 
     describe('with --print-pending and --json params', function() {

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -363,23 +363,17 @@ describe('ember-template-lint executable', function() {
         expect(result.stderr).toBeFalsy();
       });
 
-      it('should ignore existing pending modules have no lint errors', function(done) {
-        execFile(
-          'node',
-          ['../../../bin/ember-template-lint.js', '.', '--print-pending'],
-          {
-            cwd: './test/fixtures/with-passing-pending-modules',
-          },
-          function(err, stdout, stderr) {
-            let expectedOutputData =
-              'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: []\n';
+      it('should ignore existing pending modules that have no lint errors', function() {
+        let result = run(['.', '--print-pending'], {
+          cwd: './test/fixtures/with-passing-pending-modules',
+        });
 
-            expect(err).to.be.ok;
-            expect(stdout).to.equal(expectedOutputData);
-            expect(stderr).to.be.empty;
-            done();
-          }
-        );
+        let expectedOutputData =
+          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: []\n';
+
+        expect(result.code).toEqual(1);
+        expect(result.stdout).toEqual(expectedOutputData);
+        expect(result.stderr).toBeFalsy();
       });
     });
 


### PR DESCRIPTION
Was changing my rule configuration and running `ember-template-lint . --print-pending` to generate an updated pending list of files and noticed that there were some entries that looked like this:

```
{
 "moduleId": "my/path/to/a/template",
 "only": [
    null
  ]
},
```

Debugging led me to realize these were being added to the output for `--print-pending` due to an error being thrown during linting saying `Pending module ('my/path/to/a/template') passes all rules. Please remove 'my/path/to/a/template' from pending list.`

This PR adds a check when building the output for `--print-pending` to make sure that the error thrown by the linter has a rule.

Thanks for this great tool!