### PR TITLE
test/bin: Use `execa` to run CLI for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.0.1",
+    "execa": "^1.0.0",
     "lerna-changelog": "^0.8.2",
     "mocha": "^6.0.0",
     "mocha-only-detector": "^1.0.0",

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -14,8 +14,8 @@ describe('ember-template-lint executable', function() {
     describe('given path to non-existing file', function() {
       it('should exit without error and any console output', function() {
         let result = execa.sync(
-          'node',
-          ['../../../bin/ember-template-lint.js', 'app/templates/application-1.hbs'],
+          '../../../bin/ember-template-lint.js',
+          ['app/templates/application-1.hbs'],
           {
             cwd: './test/fixtures/with-errors',
             reject: false,
@@ -31,8 +31,8 @@ describe('ember-template-lint executable', function() {
     describe('given path to single file with errors', function() {
       it('should print errors', function() {
         let result = execa.sync(
-          'node',
-          ['../../../bin/ember-template-lint.js', 'app/templates/application.hbs'],
+          '../../../bin/ember-template-lint.js',
+          ['app/templates/application.hbs'],
           {
             cwd: './test/fixtures/with-errors',
             reject: false,
@@ -47,14 +47,10 @@ describe('ember-template-lint executable', function() {
 
     describe('given wildcard path resolving to single file', function() {
       it('should print errors', function() {
-        let result = execa.sync(
-          'node',
-          ['../../../bin/ember-template-lint.js', 'app/templates/*'],
-          {
-            cwd: './test/fixtures/with-errors',
-            reject: false,
-          }
-        );
+        let result = execa.sync('../../../bin/ember-template-lint.js', ['app/templates/*'], {
+          cwd: './test/fixtures/with-errors',
+          reject: false,
+        });
 
         expect(result.code).to.equal(1);
         expect(result.stdout).to.be.ok;
@@ -64,7 +60,7 @@ describe('ember-template-lint executable', function() {
 
     describe('given directory path', function() {
       it('should print errors', function() {
-        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', 'app'], {
+        let result = execa.sync('../../../bin/ember-template-lint.js', ['app'], {
           cwd: './test/fixtures/with-errors',
           reject: false,
         });
@@ -78,8 +74,8 @@ describe('ember-template-lint executable', function() {
     describe('given no path', function() {
       it('should print errors', function() {
         let result = execa.sync(
-          'node',
-          ['../../../bin/ember-template-lint.js', '<', 'app/templates/application.hbs'],
+          '../../../bin/ember-template-lint.js',
+          ['<', 'app/templates/application.hbs'],
           {
             cwd: './test/fixtures/with-errors',
             reject: false,
@@ -96,14 +92,8 @@ describe('ember-template-lint executable', function() {
     describe('given no path with --filename', function() {
       it('should print errors', function() {
         let result = execa.sync(
-          'node',
-          [
-            '../../../bin/ember-template-lint.js',
-            '--filename',
-            'app/templates/application.hbs',
-            '<',
-            'app/templates/application.hbs',
-          ],
+          '../../../bin/ember-template-lint.js',
+          ['--filename', 'app/templates/application.hbs', '<', 'app/templates/application.hbs'],
           {
             cwd: './test/fixtures/with-errors',
             reject: false,
@@ -120,8 +110,8 @@ describe('ember-template-lint executable', function() {
     describe('given - (stdin) path', function() {
       it('should print errors', function() {
         let result = execa.sync(
-          'node',
-          ['../../../bin/ember-template-lint.js', '-', '<', 'app/templates/application.hbs'],
+          '../../../bin/ember-template-lint.js',
+          ['-', '<', 'app/templates/application.hbs'],
           {
             cwd: './test/fixtures/stdin-with-errors',
             reject: false,
@@ -138,13 +128,8 @@ describe('ember-template-lint executable', function() {
     describe('given /dev/stdin path', function() {
       it('should print errors', function() {
         let result = execa.sync(
-          'node',
-          [
-            '../../../bin/ember-template-lint.js',
-            '/dev/stdin',
-            '<',
-            'app/templates/application.hbs',
-          ],
+          '../../../bin/ember-template-lint.js',
+          ['/dev/stdin', '<', 'app/templates/application.hbs'],
           {
             cwd: './test/fixtures/stdin-with-errors',
             reject: false,
@@ -161,8 +146,8 @@ describe('ember-template-lint executable', function() {
     describe('given path to single file without errors', function() {
       it('should exit without error and any console output', function() {
         let result = execa.sync(
-          'node',
-          ['../../../bin/ember-template-lint.js', 'app/templates/application.hbs'],
+          '../../../bin/ember-template-lint.js',
+          ['app/templates/application.hbs'],
           {
             cwd: './test/fixtures/without-errors',
             reject: false,
@@ -179,7 +164,7 @@ describe('ember-template-lint executable', function() {
   describe('errors and warnings formatting', function() {
     describe('without --json param', function() {
       it('should print properly formatted error messages', function() {
-        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', '.'], {
+        let result = execa.sync('../../../bin/ember-template-lint.js', ['.'], {
           cwd: './test/fixtures/with-errors',
           reject: false,
         });
@@ -197,7 +182,7 @@ describe('ember-template-lint executable', function() {
       });
 
       it('should print properly formatted error and warning messages', function() {
-        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', '.'], {
+        let result = execa.sync('../../../bin/ember-template-lint.js', ['.'], {
           cwd: './test/fixtures/with-errors-and-warnings',
           reject: false,
         });
@@ -218,7 +203,7 @@ describe('ember-template-lint executable', function() {
 
     describe('with --quiet param', function() {
       it('should print properly formatted error messages, omitting any warnings', function() {
-        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', '.', '--quiet'], {
+        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--quiet'], {
           cwd: './test/fixtures/with-errors-and-warnings',
           reject: false,
         });
@@ -236,7 +221,7 @@ describe('ember-template-lint executable', function() {
       });
 
       it('should exit without error and any console output', function() {
-        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', '.', '--quiet'], {
+        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--quiet'], {
           cwd: './test/fixtures/with-warnings',
           reject: false,
         });
@@ -249,7 +234,7 @@ describe('ember-template-lint executable', function() {
 
     describe('with --json param', function() {
       it('should print valid JSON string with errors', function() {
-        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', '.', '--json'], {
+        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--json'], {
           cwd: './test/fixtures/with-errors',
           reject: false,
         });
@@ -287,14 +272,10 @@ describe('ember-template-lint executable', function() {
 
     describe('with --json param and --quiet', function() {
       it('should print valid JSON string with errors, omitting warnings', function() {
-        let result = execa.sync(
-          'node',
-          ['../../../bin/ember-template-lint.js', '.', '--json', '--quiet'],
-          {
-            cwd: './test/fixtures/with-errors-and-warnings',
-            reject: false,
-          }
-        );
+        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--json', '--quiet'], {
+          cwd: './test/fixtures/with-errors-and-warnings',
+          reject: false,
+        });
 
         let fullTemplateFilePath = path.resolve(
           './test/fixtures/with-errors-and-warnings/app/templates/application.hbs'
@@ -327,14 +308,10 @@ describe('ember-template-lint executable', function() {
       });
 
       it('should exit without error and empty errors array', function() {
-        let result = execa.sync(
-          'node',
-          ['../../../bin/ember-template-lint.js', '.', '--json', '--quiet'],
-          {
-            cwd: './test/fixtures/with-warnings',
-            reject: false,
-          }
-        );
+        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--json', '--quiet'], {
+          cwd: './test/fixtures/with-warnings',
+          reject: false,
+        });
 
         let fullTemplateFilePath = path.resolve(
           './test/fixtures/with-warnings/app/templates/application.hbs'
@@ -352,13 +329,8 @@ describe('ember-template-lint executable', function() {
       describe('able to run only limited subset of rules', function() {
         it('should skip disabled rules from subset', function() {
           let result = execa.sync(
-            'node',
-            [
-              '../../../bin/ember-template-lint.js',
-              '.',
-              '--config-path',
-              '../rules-subset-disabled/temp-templatelint-rc.js',
-            ],
+            '../../../bin/ember-template-lint.js',
+            ['.', '--config-path', '../rules-subset-disabled/temp-templatelint-rc.js'],
             {
               cwd: './test/fixtures/rules-subset-disabled',
               reject: false,
@@ -372,13 +344,8 @@ describe('ember-template-lint executable', function() {
 
         it('should load only one rule and print error message', function() {
           let result = execa.sync(
-            'node',
-            [
-              '../../../bin/ember-template-lint.js',
-              '.',
-              '--config-path',
-              '../rules-subset/temp-templatelint-rc.js',
-            ],
+            '../../../bin/ember-template-lint.js',
+            ['.', '--config-path', '../rules-subset/temp-templatelint-rc.js'],
             {
               cwd: './test/fixtures/rules-subset',
               reject: false,
@@ -400,13 +367,8 @@ describe('ember-template-lint executable', function() {
       describe('given a directory with errors and a lintrc with rules', function() {
         it('should print properly formatted error messages', function() {
           let result = execa.sync(
-            'node',
-            [
-              '../../../bin/ember-template-lint.js',
-              '.',
-              '--config-path',
-              '../with-errors/.template-lintrc',
-            ],
+            '../../../bin/ember-template-lint.js',
+            ['.', '--config-path', '../with-errors/.template-lintrc'],
             {
               cwd: './test/fixtures/without-errors',
               reject: false,
@@ -429,13 +391,8 @@ describe('ember-template-lint executable', function() {
       describe('given a directory with errors but a lintrc without any rules', function() {
         it('should exit without error and any console output', function() {
           let result = execa.sync(
-            'node',
-            [
-              '../../../bin/ember-template-lint.js',
-              '.',
-              '--config-path',
-              '../without-errors/.template-lintrc',
-            ],
+            '../../../bin/ember-template-lint.js',
+            ['.', '--config-path', '../without-errors/.template-lintrc'],
             {
               cwd: './test/fixtures/with-errors',
               reject: false,
@@ -451,14 +408,10 @@ describe('ember-template-lint executable', function() {
 
     describe('with --print-pending param', function() {
       it('should print a list of pending modules', function() {
-        let result = execa.sync(
-          'node',
-          ['../../../bin/ember-template-lint.js', '.', '--print-pending'],
-          {
-            cwd: './test/fixtures/with-errors-and-warnings',
-            reject: false,
-          }
-        );
+        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--print-pending'], {
+          cwd: './test/fixtures/with-errors-and-warnings',
+          reject: false,
+        });
 
         let expectedOutputData =
           'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings",\n      "no-html-comments"\n    ]\n  }\n]\n';
@@ -472,8 +425,8 @@ describe('ember-template-lint executable', function() {
     describe('with --print-pending and --json params', function() {
       it('should print json of pending modules', function() {
         let result = execa.sync(
-          'node',
-          ['../../../bin/ember-template-lint.js', '.', '--print-pending', '--json'],
+          '../../../bin/ember-template-lint.js',
+          ['.', '--print-pending', '--json'],
           {
             cwd: './test/fixtures/with-errors-and-warnings',
             reject: false,

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -13,14 +13,9 @@ describe('ember-template-lint executable', function() {
 
     describe('given path to non-existing file', function() {
       it('should exit without error and any console output', function() {
-        let result = execa.sync(
-          '../../../bin/ember-template-lint.js',
-          ['app/templates/application-1.hbs'],
-          {
-            cwd: './test/fixtures/with-errors',
-            reject: false,
-          }
-        );
+        let result = run(['app/templates/application-1.hbs'], {
+          cwd: './test/fixtures/with-errors',
+        });
 
         expect(result.code).to.equal(0, 'exits without error');
         expect(result.stdout).to.be.empty;
@@ -30,14 +25,9 @@ describe('ember-template-lint executable', function() {
 
     describe('given path to single file with errors', function() {
       it('should print errors', function() {
-        let result = execa.sync(
-          '../../../bin/ember-template-lint.js',
-          ['app/templates/application.hbs'],
-          {
-            cwd: './test/fixtures/with-errors',
-            reject: false,
-          }
-        );
+        let result = run(['app/templates/application.hbs'], {
+          cwd: './test/fixtures/with-errors',
+        });
 
         expect(result.code).to.equal(1);
         expect(result.stdout).to.be.ok;
@@ -47,9 +37,8 @@ describe('ember-template-lint executable', function() {
 
     describe('given wildcard path resolving to single file', function() {
       it('should print errors', function() {
-        let result = execa.sync('../../../bin/ember-template-lint.js', ['app/templates/*'], {
+        let result = run(['app/templates/*'], {
           cwd: './test/fixtures/with-errors',
-          reject: false,
         });
 
         expect(result.code).to.equal(1);
@@ -60,9 +49,8 @@ describe('ember-template-lint executable', function() {
 
     describe('given directory path', function() {
       it('should print errors', function() {
-        let result = execa.sync('../../../bin/ember-template-lint.js', ['app'], {
+        let result = run(['app'], {
           cwd: './test/fixtures/with-errors',
-          reject: false,
         });
 
         expect(result.code).to.equal(1);
@@ -73,15 +61,10 @@ describe('ember-template-lint executable', function() {
 
     describe('given no path', function() {
       it('should print errors', function() {
-        let result = execa.sync(
-          '../../../bin/ember-template-lint.js',
-          ['<', 'app/templates/application.hbs'],
-          {
-            cwd: './test/fixtures/with-errors',
-            reject: false,
-            shell: true,
-          }
-        );
+        let result = run(['<', 'app/templates/application.hbs'], {
+          cwd: './test/fixtures/with-errors',
+          shell: true,
+        });
 
         expect(result.code).to.equal(1);
         expect(result.stdout).to.be.ok;
@@ -91,12 +74,10 @@ describe('ember-template-lint executable', function() {
 
     describe('given no path with --filename', function() {
       it('should print errors', function() {
-        let result = execa.sync(
-          '../../../bin/ember-template-lint.js',
+        let result = run(
           ['--filename', 'app/templates/application.hbs', '<', 'app/templates/application.hbs'],
           {
             cwd: './test/fixtures/with-errors',
-            reject: false,
             shell: true,
           }
         );
@@ -109,15 +90,10 @@ describe('ember-template-lint executable', function() {
 
     describe('given - (stdin) path', function() {
       it('should print errors', function() {
-        let result = execa.sync(
-          '../../../bin/ember-template-lint.js',
-          ['-', '<', 'app/templates/application.hbs'],
-          {
-            cwd: './test/fixtures/stdin-with-errors',
-            reject: false,
-            shell: true,
-          }
-        );
+        let result = run(['-', '<', 'app/templates/application.hbs'], {
+          cwd: './test/fixtures/stdin-with-errors',
+          shell: true,
+        });
 
         expect(result.code).to.equal(1);
         expect(result.stdout).to.be.ok;
@@ -127,15 +103,10 @@ describe('ember-template-lint executable', function() {
 
     describe('given /dev/stdin path', function() {
       it('should print errors', function() {
-        let result = execa.sync(
-          '../../../bin/ember-template-lint.js',
-          ['/dev/stdin', '<', 'app/templates/application.hbs'],
-          {
-            cwd: './test/fixtures/stdin-with-errors',
-            reject: false,
-            shell: true,
-          }
-        );
+        let result = run(['/dev/stdin', '<', 'app/templates/application.hbs'], {
+          cwd: './test/fixtures/stdin-with-errors',
+          shell: true,
+        });
 
         expect(result.code).to.equal(1);
         expect(result.stdout).to.be.ok;
@@ -145,14 +116,9 @@ describe('ember-template-lint executable', function() {
 
     describe('given path to single file without errors', function() {
       it('should exit without error and any console output', function() {
-        let result = execa.sync(
-          '../../../bin/ember-template-lint.js',
-          ['app/templates/application.hbs'],
-          {
-            cwd: './test/fixtures/without-errors',
-            reject: false,
-          }
-        );
+        let result = run(['app/templates/application.hbs'], {
+          cwd: './test/fixtures/without-errors',
+        });
 
         expect(result.code).to.equal(0);
         expect(result.stdout).to.be.empty;
@@ -164,9 +130,8 @@ describe('ember-template-lint executable', function() {
   describe('errors and warnings formatting', function() {
     describe('without --json param', function() {
       it('should print properly formatted error messages', function() {
-        let result = execa.sync('../../../bin/ember-template-lint.js', ['.'], {
+        let result = run(['.'], {
           cwd: './test/fixtures/with-errors',
-          reject: false,
         });
 
         expect(result.code).to.equal(1);
@@ -182,9 +147,8 @@ describe('ember-template-lint executable', function() {
       });
 
       it('should print properly formatted error and warning messages', function() {
-        let result = execa.sync('../../../bin/ember-template-lint.js', ['.'], {
+        let result = run(['.'], {
           cwd: './test/fixtures/with-errors-and-warnings',
-          reject: false,
         });
 
         expect(result.code).to.equal(1);
@@ -203,9 +167,8 @@ describe('ember-template-lint executable', function() {
 
     describe('with --quiet param', function() {
       it('should print properly formatted error messages, omitting any warnings', function() {
-        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--quiet'], {
+        let result = run(['.', '--quiet'], {
           cwd: './test/fixtures/with-errors-and-warnings',
-          reject: false,
         });
 
         expect(result.code).to.equal(1);
@@ -221,9 +184,8 @@ describe('ember-template-lint executable', function() {
       });
 
       it('should exit without error and any console output', function() {
-        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--quiet'], {
+        let result = run(['.', '--quiet'], {
           cwd: './test/fixtures/with-warnings',
-          reject: false,
         });
 
         expect(result.code).to.equal(0);
@@ -234,9 +196,8 @@ describe('ember-template-lint executable', function() {
 
     describe('with --json param', function() {
       it('should print valid JSON string with errors', function() {
-        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--json'], {
+        let result = run(['.', '--json'], {
           cwd: './test/fixtures/with-errors',
-          reject: false,
         });
 
         let fullTemplateFilePath = path.resolve(
@@ -272,9 +233,8 @@ describe('ember-template-lint executable', function() {
 
     describe('with --json param and --quiet', function() {
       it('should print valid JSON string with errors, omitting warnings', function() {
-        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--json', '--quiet'], {
+        let result = run(['.', '--json', '--quiet'], {
           cwd: './test/fixtures/with-errors-and-warnings',
-          reject: false,
         });
 
         let fullTemplateFilePath = path.resolve(
@@ -308,9 +268,8 @@ describe('ember-template-lint executable', function() {
       });
 
       it('should exit without error and empty errors array', function() {
-        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--json', '--quiet'], {
+        let result = run(['.', '--json', '--quiet'], {
           cwd: './test/fixtures/with-warnings',
-          reject: false,
         });
 
         let fullTemplateFilePath = path.resolve(
@@ -328,12 +287,10 @@ describe('ember-template-lint executable', function() {
     describe('with --config-path param', function() {
       describe('able to run only limited subset of rules', function() {
         it('should skip disabled rules from subset', function() {
-          let result = execa.sync(
-            '../../../bin/ember-template-lint.js',
+          let result = run(
             ['.', '--config-path', '../rules-subset-disabled/temp-templatelint-rc.js'],
             {
               cwd: './test/fixtures/rules-subset-disabled',
-              reject: false,
             }
           );
 
@@ -343,14 +300,9 @@ describe('ember-template-lint executable', function() {
         });
 
         it('should load only one rule and print error message', function() {
-          let result = execa.sync(
-            '../../../bin/ember-template-lint.js',
-            ['.', '--config-path', '../rules-subset/temp-templatelint-rc.js'],
-            {
-              cwd: './test/fixtures/rules-subset',
-              reject: false,
-            }
-          );
+          let result = run(['.', '--config-path', '../rules-subset/temp-templatelint-rc.js'], {
+            cwd: './test/fixtures/rules-subset',
+          });
 
           expect(result.code).to.equal(1);
           expect(result.stdout.split('\n')).to.deep.equal([
@@ -366,14 +318,9 @@ describe('ember-template-lint executable', function() {
 
       describe('given a directory with errors and a lintrc with rules', function() {
         it('should print properly formatted error messages', function() {
-          let result = execa.sync(
-            '../../../bin/ember-template-lint.js',
-            ['.', '--config-path', '../with-errors/.template-lintrc'],
-            {
-              cwd: './test/fixtures/without-errors',
-              reject: false,
-            }
-          );
+          let result = run(['.', '--config-path', '../with-errors/.template-lintrc'], {
+            cwd: './test/fixtures/without-errors',
+          });
 
           expect(result.code).to.equal(1);
           expect(result.stdout.split('\n')).to.deep.equal([
@@ -390,14 +337,9 @@ describe('ember-template-lint executable', function() {
 
       describe('given a directory with errors but a lintrc without any rules', function() {
         it('should exit without error and any console output', function() {
-          let result = execa.sync(
-            '../../../bin/ember-template-lint.js',
-            ['.', '--config-path', '../without-errors/.template-lintrc'],
-            {
-              cwd: './test/fixtures/with-errors',
-              reject: false,
-            }
-          );
+          let result = run(['.', '--config-path', '../without-errors/.template-lintrc'], {
+            cwd: './test/fixtures/with-errors',
+          });
 
           expect(result.code).to.equal(0);
           expect(result.stdout).to.be.empty;
@@ -408,9 +350,8 @@ describe('ember-template-lint executable', function() {
 
     describe('with --print-pending param', function() {
       it('should print a list of pending modules', function() {
-        let result = execa.sync('../../../bin/ember-template-lint.js', ['.', '--print-pending'], {
+        let result = run(['.', '--print-pending'], {
           cwd: './test/fixtures/with-errors-and-warnings',
-          reject: false,
         });
 
         let expectedOutputData =
@@ -424,14 +365,9 @@ describe('ember-template-lint executable', function() {
 
     describe('with --print-pending and --json params', function() {
       it('should print json of pending modules', function() {
-        let result = execa.sync(
-          '../../../bin/ember-template-lint.js',
-          ['.', '--print-pending', '--json'],
-          {
-            cwd: './test/fixtures/with-errors-and-warnings',
-            reject: false,
-          }
-        );
+        let result = run(['.', '--print-pending', '--json'], {
+          cwd: './test/fixtures/with-errors-and-warnings',
+        });
 
         let expectedOutputData = [
           {
@@ -592,3 +528,8 @@ describe('ember-template-lint executable', function() {
     });
   });
 });
+
+function run(args, options) {
+  options.reject = false;
+  return execa.sync('../../../bin/ember-template-lint.js', args, options);
+}

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const execFile = require('child_process').execFile;
+const execa = require('execa');
 const expect = require('chai').expect;
 const path = require('path');
 const BinScript = require('../../../bin/ember-template-lint');
@@ -12,99 +12,90 @@ describe('ember-template-lint executable', function() {
     });
 
     describe('given path to non-existing file', function() {
-      it('should exit without error and any console output', function(done) {
-        execFile(
+      it('should exit without error and any console output', function() {
+        let result = execa.sync(
           'node',
           ['../../../bin/ember-template-lint.js', 'app/templates/application-1.hbs'],
           {
             cwd: './test/fixtures/with-errors',
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.equal(null, 'exits without error');
-            expect(stdout).to.be.empty;
-            expect(stderr).to.be.empty;
-            done();
+            reject: false,
           }
         );
+
+        expect(result.code).to.equal(0, 'exits without error');
+        expect(result.stdout).to.be.empty;
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('given path to single file with errors', function() {
-      it('should print errors', function(done) {
-        execFile(
+      it('should print errors', function() {
+        let result = execa.sync(
           'node',
           ['../../../bin/ember-template-lint.js', 'app/templates/application.hbs'],
           {
             cwd: './test/fixtures/with-errors',
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.ok;
-            expect(stdout).to.be.ok;
-            expect(stderr).to.be.empty;
-            done();
+            reject: false,
           }
         );
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout).to.be.ok;
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('given wildcard path resolving to single file', function() {
-      it('should print errors', function(done) {
-        execFile(
+      it('should print errors', function() {
+        let result = execa.sync(
           'node',
           ['../../../bin/ember-template-lint.js', 'app/templates/*'],
           {
             cwd: './test/fixtures/with-errors',
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.ok;
-            expect(stdout).to.be.ok;
-            expect(stderr).to.be.empty;
-            done();
+            reject: false,
           }
         );
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout).to.be.ok;
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('given directory path', function() {
-      it('should print errors', function(done) {
-        execFile(
-          'node',
-          ['../../../bin/ember-template-lint.js', 'app'],
-          {
-            cwd: './test/fixtures/with-errors',
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.ok;
-            expect(stdout).to.be.ok;
-            expect(stderr).to.be.empty;
-            done();
-          }
-        );
+      it('should print errors', function() {
+        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', 'app'], {
+          cwd: './test/fixtures/with-errors',
+          reject: false,
+        });
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout).to.be.ok;
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('given no path', function() {
-      it('should print errors', function(done) {
-        execFile(
+      it('should print errors', function() {
+        let result = execa.sync(
           'node',
           ['../../../bin/ember-template-lint.js', '<', 'app/templates/application.hbs'],
           {
             cwd: './test/fixtures/with-errors',
+            reject: false,
             shell: true,
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.ok;
-            expect(stdout).to.be.ok;
-            expect(stderr).to.be.empty;
-            done();
           }
         );
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout).to.be.ok;
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('given no path with --filename', function() {
-      it('should print errors', function(done) {
-        execFile(
+      it('should print errors', function() {
+        let result = execa.sync(
           'node',
           [
             '../../../bin/ember-template-lint.js',
@@ -115,40 +106,38 @@ describe('ember-template-lint executable', function() {
           ],
           {
             cwd: './test/fixtures/with-errors',
+            reject: false,
             shell: true,
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.ok;
-            expect(stdout).to.be.ok;
-            expect(stderr).to.be.empty;
-            done();
           }
         );
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout).to.be.ok;
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('given - (stdin) path', function() {
-      it('should print errors', function(done) {
-        execFile(
+      it('should print errors', function() {
+        let result = execa.sync(
           'node',
           ['../../../bin/ember-template-lint.js', '-', '<', 'app/templates/application.hbs'],
           {
             cwd: './test/fixtures/stdin-with-errors',
+            reject: false,
             shell: true,
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.ok;
-            expect(stdout).to.be.ok;
-            expect(stderr).to.be.empty;
-            done();
           }
         );
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout).to.be.ok;
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('given /dev/stdin path', function() {
-      it('should print errors', function(done) {
-        execFile(
+      it('should print errors', function() {
+        let result = execa.sync(
           'node',
           [
             '../../../bin/ember-template-lint.js',
@@ -158,244 +147,211 @@ describe('ember-template-lint executable', function() {
           ],
           {
             cwd: './test/fixtures/stdin-with-errors',
+            reject: false,
             shell: true,
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.ok;
-            expect(stdout).to.be.ok;
-            expect(stderr).to.be.empty;
-            done();
           }
         );
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout).to.be.ok;
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('given path to single file without errors', function() {
-      it('should exit without error and any console output', function(done) {
-        execFile(
+      it('should exit without error and any console output', function() {
+        let result = execa.sync(
           'node',
           ['../../../bin/ember-template-lint.js', 'app/templates/application.hbs'],
           {
             cwd: './test/fixtures/without-errors',
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.null;
-            expect(stdout).to.be.empty;
-            expect(stderr).to.be.empty;
-            done();
+            reject: false,
           }
         );
+
+        expect(result.code).to.equal(0);
+        expect(result.stdout).to.be.empty;
+        expect(result.stderr).to.be.empty;
       });
     });
   });
 
   describe('errors and warnings formatting', function() {
     describe('without --json param', function() {
-      it('should print properly formatted error messages', function(done) {
-        execFile(
-          'node',
-          ['../../../bin/ember-template-lint.js', '.'],
-          {
-            cwd: './test/fixtures/with-errors',
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.ok;
-            expect(stdout.split('\n')).to.deep.equal([
-              path.resolve('./test/fixtures/with-errors/app/templates/application.hbs'),
-              '  1:4  error  Non-translated string used  no-bare-strings',
-              '  2:5  error  Non-translated string used  no-bare-strings',
-              '',
-              '✖ 2 problems (2 errors, 0 warnings)',
-              '',
-            ]);
-            expect(stderr).to.be.empty;
-            done();
-          }
-        );
+      it('should print properly formatted error messages', function() {
+        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', '.'], {
+          cwd: './test/fixtures/with-errors',
+          reject: false,
+        });
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout.split('\n')).to.deep.equal([
+          path.resolve('./test/fixtures/with-errors/app/templates/application.hbs'),
+          '  1:4  error  Non-translated string used  no-bare-strings',
+          '  2:5  error  Non-translated string used  no-bare-strings',
+          '',
+          '✖ 2 problems (2 errors, 0 warnings)',
+          '',
+        ]);
+        expect(result.stderr).to.be.empty;
       });
 
-      it('should print properly formatted error and warning messages', function(done) {
-        execFile(
-          'node',
-          ['../../../bin/ember-template-lint.js', '.'],
-          {
-            cwd: './test/fixtures/with-errors-and-warnings',
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.ok;
-            expect(stdout.split('\n')).to.deep.equal([
-              path.resolve(
-                './test/fixtures/with-errors-and-warnings/app/templates/application.hbs'
-              ),
-              '  1:4  error  Non-translated string used  no-bare-strings',
-              '  2:5  error  Non-translated string used  no-bare-strings',
-              '  3:0  warning  HTML comment detected  no-html-comments',
-              '',
-              '✖ 3 problems (2 errors, 1 warnings)',
-              '',
-            ]);
-            expect(stderr).to.be.empty;
-            done();
-          }
-        );
+      it('should print properly formatted error and warning messages', function() {
+        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', '.'], {
+          cwd: './test/fixtures/with-errors-and-warnings',
+          reject: false,
+        });
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout.split('\n')).to.deep.equal([
+          path.resolve('./test/fixtures/with-errors-and-warnings/app/templates/application.hbs'),
+          '  1:4  error  Non-translated string used  no-bare-strings',
+          '  2:5  error  Non-translated string used  no-bare-strings',
+          '  3:0  warning  HTML comment detected  no-html-comments',
+          '',
+          '✖ 3 problems (2 errors, 1 warnings)',
+          '',
+        ]);
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('with --quiet param', function() {
-      it('should print properly formatted error messages, omitting any warnings', function(done) {
-        execFile(
-          'node',
-          ['../../../bin/ember-template-lint.js', '.', '--quiet'],
-          {
-            cwd: './test/fixtures/with-errors-and-warnings',
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.ok;
-            expect(stdout.split('\n')).to.deep.equal([
-              path.resolve(
-                './test/fixtures/with-errors-and-warnings/app/templates/application.hbs'
-              ),
-              '  1:4  error  Non-translated string used  no-bare-strings',
-              '  2:5  error  Non-translated string used  no-bare-strings',
-              '',
-              '✖ 2 problems (2 errors, 0 warnings)',
-              '',
-            ]);
-            expect(stderr).to.be.empty;
-            done();
-          }
-        );
+      it('should print properly formatted error messages, omitting any warnings', function() {
+        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', '.', '--quiet'], {
+          cwd: './test/fixtures/with-errors-and-warnings',
+          reject: false,
+        });
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout.split('\n')).to.deep.equal([
+          path.resolve('./test/fixtures/with-errors-and-warnings/app/templates/application.hbs'),
+          '  1:4  error  Non-translated string used  no-bare-strings',
+          '  2:5  error  Non-translated string used  no-bare-strings',
+          '',
+          '✖ 2 problems (2 errors, 0 warnings)',
+          '',
+        ]);
+        expect(result.stderr).to.be.empty;
       });
 
-      it('should exit without error and any console output', function(done) {
-        execFile(
-          'node',
-          ['../../../bin/ember-template-lint.js', '.', '--quiet'],
-          {
-            cwd: './test/fixtures/with-warnings',
-          },
-          function(err, stdout, stderr) {
-            expect(err).to.be.null;
-            expect(stdout).to.be.empty;
-            expect(stderr).to.be.empty;
-            done();
-          }
-        );
+      it('should exit without error and any console output', function() {
+        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', '.', '--quiet'], {
+          cwd: './test/fixtures/with-warnings',
+          reject: false,
+        });
+
+        expect(result.code).to.equal(0);
+        expect(result.stdout).to.be.empty;
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('with --json param', function() {
-      it('should print valid JSON string with errors', function(done) {
-        execFile(
-          'node',
-          ['../../../bin/ember-template-lint.js', '.', '--json'],
-          {
-            cwd: './test/fixtures/with-errors',
-          },
-          function(err, stdout, stderr) {
-            let fullTemplateFilePath = path.resolve(
-              './test/fixtures/with-errors/app/templates/application.hbs'
-            );
-            let expectedOutputData = {};
-            expectedOutputData[fullTemplateFilePath] = [
-              {
-                column: 4,
-                line: 1,
-                message: 'Non-translated string used',
-                moduleId: 'app/templates/application',
-                rule: 'no-bare-strings',
-                severity: 2,
-                source: 'Here too!!',
-              },
-              {
-                column: 5,
-                line: 2,
-                message: 'Non-translated string used',
-                moduleId: 'app/templates/application',
-                rule: 'no-bare-strings',
-                severity: 2,
-                source: 'Bare strings are bad...',
-              },
-            ];
+      it('should print valid JSON string with errors', function() {
+        let result = execa.sync('node', ['../../../bin/ember-template-lint.js', '.', '--json'], {
+          cwd: './test/fixtures/with-errors',
+          reject: false,
+        });
 
-            expect(err).to.be.ok;
-            expect(JSON.parse(stdout)).to.deep.equal(expectedOutputData);
-            expect(stderr).to.be.empty;
-            done();
-          }
+        let fullTemplateFilePath = path.resolve(
+          './test/fixtures/with-errors/app/templates/application.hbs'
         );
+        let expectedOutputData = {};
+        expectedOutputData[fullTemplateFilePath] = [
+          {
+            column: 4,
+            line: 1,
+            message: 'Non-translated string used',
+            moduleId: 'app/templates/application',
+            rule: 'no-bare-strings',
+            severity: 2,
+            source: 'Here too!!',
+          },
+          {
+            column: 5,
+            line: 2,
+            message: 'Non-translated string used',
+            moduleId: 'app/templates/application',
+            rule: 'no-bare-strings',
+            severity: 2,
+            source: 'Bare strings are bad...',
+          },
+        ];
+
+        expect(result.code).to.equal(1);
+        expect(JSON.parse(result.stdout)).to.deep.equal(expectedOutputData);
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('with --json param and --quiet', function() {
-      it('should print valid JSON string with errors, omitting warnings', function(done) {
-        execFile(
+      it('should print valid JSON string with errors, omitting warnings', function() {
+        let result = execa.sync(
           'node',
           ['../../../bin/ember-template-lint.js', '.', '--json', '--quiet'],
           {
             cwd: './test/fixtures/with-errors-and-warnings',
-          },
-          function(err, stdout, stderr) {
-            let fullTemplateFilePath = path.resolve(
-              './test/fixtures/with-errors-and-warnings/app/templates/application.hbs'
-            );
-            let expectedOutputData = {};
-            expectedOutputData[fullTemplateFilePath] = [
-              {
-                column: 4,
-                line: 1,
-                message: 'Non-translated string used',
-                moduleId: 'app/templates/application',
-                rule: 'no-bare-strings',
-                severity: 2,
-                source: 'Here too!!',
-              },
-              {
-                column: 5,
-                line: 2,
-                message: 'Non-translated string used',
-                moduleId: 'app/templates/application',
-                rule: 'no-bare-strings',
-                severity: 2,
-                source: 'Bare strings are bad...',
-              },
-            ];
-
-            expect(err).to.be.ok;
-            expect(JSON.parse(stdout)).to.deep.equal(expectedOutputData);
-            expect(stderr).to.be.empty;
-            done();
+            reject: false,
           }
         );
+
+        let fullTemplateFilePath = path.resolve(
+          './test/fixtures/with-errors-and-warnings/app/templates/application.hbs'
+        );
+        let expectedOutputData = {};
+        expectedOutputData[fullTemplateFilePath] = [
+          {
+            column: 4,
+            line: 1,
+            message: 'Non-translated string used',
+            moduleId: 'app/templates/application',
+            rule: 'no-bare-strings',
+            severity: 2,
+            source: 'Here too!!',
+          },
+          {
+            column: 5,
+            line: 2,
+            message: 'Non-translated string used',
+            moduleId: 'app/templates/application',
+            rule: 'no-bare-strings',
+            severity: 2,
+            source: 'Bare strings are bad...',
+          },
+        ];
+
+        expect(result.code).to.equal(1);
+        expect(JSON.parse(result.stdout)).to.deep.equal(expectedOutputData);
+        expect(result.stderr).to.be.empty;
       });
 
-      it('should exit without error and empty errors array', function(done) {
-        execFile(
+      it('should exit without error and empty errors array', function() {
+        let result = execa.sync(
           'node',
           ['../../../bin/ember-template-lint.js', '.', '--json', '--quiet'],
           {
             cwd: './test/fixtures/with-warnings',
-          },
-          function(err, stdout, stderr) {
-            let fullTemplateFilePath = path.resolve(
-              './test/fixtures/with-warnings/app/templates/application.hbs'
-            );
-            let expectedOutputData = {};
-            expectedOutputData[fullTemplateFilePath] = [];
-
-            expect(err).to.be.null;
-            expect(JSON.parse(stdout)).to.deep.equal(expectedOutputData);
-            expect(stderr).to.be.empty;
-            done();
+            reject: false,
           }
         );
+
+        let fullTemplateFilePath = path.resolve(
+          './test/fixtures/with-warnings/app/templates/application.hbs'
+        );
+        let expectedOutputData = {};
+        expectedOutputData[fullTemplateFilePath] = [];
+
+        expect(result.code).to.equal(0);
+        expect(JSON.parse(result.stdout)).to.deep.equal(expectedOutputData);
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('with --config-path param', function() {
       describe('able to run only limited subset of rules', function() {
-        it('should skip disabled rules from subset', function(done) {
-          execFile(
+        it('should skip disabled rules from subset', function() {
+          let result = execa.sync(
             'node',
             [
               '../../../bin/ember-template-lint.js',
@@ -405,17 +361,17 @@ describe('ember-template-lint executable', function() {
             ],
             {
               cwd: './test/fixtures/rules-subset-disabled',
-            },
-            function(err, stdout, stderr) {
-              expect(err).to.be.null;
-              expect(stdout).to.be.empty;
-              expect(stderr).to.be.empty;
-              done();
+              reject: false,
             }
           );
+
+          expect(result.code).to.equal(0);
+          expect(result.stdout).to.be.empty;
+          expect(result.stderr).to.be.empty;
         });
-        it('should load only one rule and print error message', function(done) {
-          execFile(
+
+        it('should load only one rule and print error message', function() {
+          let result = execa.sync(
             'node',
             [
               '../../../bin/ember-template-lint.js',
@@ -425,25 +381,25 @@ describe('ember-template-lint executable', function() {
             ],
             {
               cwd: './test/fixtures/rules-subset',
-            },
-            function(err, stdout, stderr) {
-              expect(err).to.be.ok;
-              expect(stdout.split('\n')).to.deep.equal([
-                path.resolve('./test/fixtures/rules-subset/template.hbs'),
-                '  2:4  error  Ambiguous element used (`div`)  no-shadowed-elements',
-                '',
-                '✖ 1 problems (1 errors, 0 warnings)',
-                '',
-              ]);
-              expect(stderr).to.be.empty;
-              done();
+              reject: false,
             }
           );
+
+          expect(result.code).to.equal(1);
+          expect(result.stdout.split('\n')).to.deep.equal([
+            path.resolve('./test/fixtures/rules-subset/template.hbs'),
+            '  2:4  error  Ambiguous element used (`div`)  no-shadowed-elements',
+            '',
+            '✖ 1 problems (1 errors, 0 warnings)',
+            '',
+          ]);
+          expect(result.stderr).to.be.empty;
         });
       });
+
       describe('given a directory with errors and a lintrc with rules', function() {
-        it('should print properly formatted error messages', function(done) {
-          execFile(
+        it('should print properly formatted error messages', function() {
+          let result = execa.sync(
             'node',
             [
               '../../../bin/ember-template-lint.js',
@@ -453,27 +409,26 @@ describe('ember-template-lint executable', function() {
             ],
             {
               cwd: './test/fixtures/without-errors',
-            },
-            function(err, stdout, stderr) {
-              expect(err).to.be.ok;
-              expect(stdout.split('\n')).to.deep.equal([
-                path.resolve('./test/fixtures/without-errors/app/templates/application.hbs'),
-                '  1:4  error  Non-translated string used  no-bare-strings',
-                '  2:5  error  Non-translated string used  no-bare-strings',
-                '',
-                '✖ 2 problems (2 errors, 0 warnings)',
-                '',
-              ]);
-              expect(stderr).to.be.empty;
-              done();
+              reject: false,
             }
           );
+
+          expect(result.code).to.equal(1);
+          expect(result.stdout.split('\n')).to.deep.equal([
+            path.resolve('./test/fixtures/without-errors/app/templates/application.hbs'),
+            '  1:4  error  Non-translated string used  no-bare-strings',
+            '  2:5  error  Non-translated string used  no-bare-strings',
+            '',
+            '✖ 2 problems (2 errors, 0 warnings)',
+            '',
+          ]);
+          expect(result.stderr).to.be.empty;
         });
       });
 
       describe('given a directory with errors but a lintrc without any rules', function() {
-        it('should exit without error and any console output', function(done) {
-          execFile(
+        it('should exit without error and any console output', function() {
+          let result = execa.sync(
             'node',
             [
               '../../../bin/ember-template-lint.js',
@@ -483,61 +438,58 @@ describe('ember-template-lint executable', function() {
             ],
             {
               cwd: './test/fixtures/with-errors',
-            },
-            function(err, stdout, stderr) {
-              expect(err).to.be.null;
-              expect(stdout).to.be.empty;
-              expect(stderr).to.be.empty;
-              done();
+              reject: false,
             }
           );
+
+          expect(result.code).to.equal(0);
+          expect(result.stdout).to.be.empty;
+          expect(result.stderr).to.be.empty;
         });
       });
     });
 
     describe('with --print-pending param', function() {
-      it('should print a list of pending modules', function(done) {
-        execFile(
+      it('should print a list of pending modules', function() {
+        let result = execa.sync(
           'node',
           ['../../../bin/ember-template-lint.js', '.', '--print-pending'],
           {
             cwd: './test/fixtures/with-errors-and-warnings',
-          },
-          function(err, stdout, stderr) {
-            let expectedOutputData =
-              'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings",\n      "no-html-comments"\n    ]\n  }\n]\n';
-
-            expect(err).to.be.ok;
-            expect(stdout).to.equal(expectedOutputData);
-            expect(stderr).to.be.empty;
-            done();
+            reject: false,
           }
         );
+
+        let expectedOutputData =
+          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings",\n      "no-html-comments"\n    ]\n  }\n]\n';
+
+        expect(result.code).to.equal(1);
+        expect(result.stdout).to.equal(expectedOutputData);
+        expect(result.stderr).to.be.empty;
       });
     });
 
     describe('with --print-pending and --json params', function() {
-      it('should print json of pending modules', function(done) {
-        execFile(
+      it('should print json of pending modules', function() {
+        let result = execa.sync(
           'node',
           ['../../../bin/ember-template-lint.js', '.', '--print-pending', '--json'],
           {
             cwd: './test/fixtures/with-errors-and-warnings',
-          },
-          function(err, stdout, stderr) {
-            let expectedOutputData = [
-              {
-                moduleId: 'app/templates/application',
-                only: ['no-bare-strings', 'no-html-comments'],
-              },
-            ];
-
-            expect(err).to.be.ok;
-            expect(JSON.parse(stdout)).to.deep.equal(expectedOutputData);
-            expect(stderr).to.be.empty;
-            done();
+            reject: false,
           }
         );
+
+        let expectedOutputData = [
+          {
+            moduleId: 'app/templates/application',
+            only: ['no-bare-strings', 'no-html-comments'],
+          },
+        ];
+
+        expect(result.code).to.equal(1);
+        expect(JSON.parse(result.stdout)).to.deep.equal(expectedOutputData);
+        expect(result.stderr).to.be.empty;
       });
     });
   });


### PR DESCRIPTION
This simplifies the test suite because we no longer have to rely on calling `done()` and running the assertions in the callback function.