### PR TITLE
Add `no-invalid-role` rule

### DIFF
--- a/docs/rule/no-invalid-role.md
+++ b/docs/rule/no-invalid-role.md
@@ -1,0 +1,41 @@
+## no-invalid-role
+
+This rule checks for invalid element/role combinations.
+
+Current list of checks:
+
+1. Use of the presentation role for content which should convey semantic information may prevent the user from understanding that content. This rule checks semantic HTML elements for the presence of `role="none"` or `role="presentation"`. Elements that are permitted to explicitly have these role values are `<div>`, `<img>`, `<span>` and `<svg>`.
+
+### Examples
+
+This rule **forbids** the following:
+
+```hbs
+<table role="presentation">
+</table>
+```
+
+```hbs
+<ul role="none">
+</ul>
+```
+
+This rule **allows** the following:
+
+```hbs
+<img role="presentation">
+```
+
+```hbs
+<span role="none"></span>
+```
+
+### Migration
+
+* If violations are found, remediation should be planned to replace the semantic HTML with the `div` element. Additional CSS will likely be required.
+
+### References
+
+* [HTML elements reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)
+* [WAI-ARIA presentation(role)](https://www.w3.org/TR/wai-aria/#presentation)
+* [Failure of Success Criterion 1.3.1 due to the use of role presentation on content which conveys semantic information](https://www.w3.org/WAI/WCAG21/Techniques/failures/F92)

--- a/docs/rule/no-invalid-role.md
+++ b/docs/rule/no-invalid-role.md
@@ -4,7 +4,7 @@ This rule checks for invalid element/role combinations.
 
 Current list of checks:
 
-1. Use of the presentation role for content which should convey semantic information may prevent the user from understanding that content. This rule checks semantic HTML elements for the presence of `role="none"` or `role="presentation"`. Elements that are permitted to explicitly have these role values are `<div>`, `<img>`, `<span>` and `<svg>`.
+1. Use of the presentation role for content which should convey semantic information may prevent the user from understanding that content. This rule checks semantic HTML elements for the presence of `role="none"` or `role="presentation"` and compares it to the list of disallowed elements. It should not effect custom elements.
 
 ### Examples
 

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -26,6 +26,7 @@
 * [no-input-block](rule/no-input-block.md)
 * [no-input-tagname](rule/no-input-tagname.md)
 * [no-invalid-interactive](rule/no-invalid-interactive.md)
+* [no-invalid-role](rule/no-invalid-role.md)
 * [no-log](rule/no-log.md)
 * [no-meta-redirect-with-time-limit](rule/no-meta-redirect-with-time-limit.md)
 * [no-multiple-empty-lines](rule/no-multiple-empty-lines.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -30,6 +30,7 @@ module.exports = {
   'no-input-block': require('./no-input-block'),
   'no-input-tagname': require('./no-input-tagname'),
   'no-invalid-interactive': require('./no-invalid-interactive'),
+  'no-invalid-role': require('./no-invalid-role'),
   'no-log': require('./no-log'),
   'no-meta-redirect-with-time-limit': require('./no-meta-redirect-with-time-limit'),
   'no-multiple-empty-lines': require('./no-multiple-empty-lines'),

--- a/lib/rules/no-invalid-role.js
+++ b/lib/rules/no-invalid-role.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
+
+function ERROR_MESSAGE_INVALID_ROLE(element) {
+  return `Use of presentation role on <${element}> detected. Semantic elements should not be used for presentation.`;
+}
+
+// None of these elements can be marked with `role="presentation"` or `role="none"`.
+// List from https://developer.mozilla.org/en-US/docs/Web/HTML/Element.
+const DISALLOWED_ELEMENTS = [
+  'a',
+  'abbr',
+  'applet',
+  'area',
+  'audio',
+  'b',
+  'bdi',
+  'bdo',
+  'blockquote',
+  'br',
+  'button',
+  'caption',
+  'cite',
+  'code',
+  'col',
+  'colgroup',
+  'data',
+  'datalist',
+  'dd',
+  'del',
+  'details',
+  'dfn',
+  'dialog',
+  'dir',
+  'dl',
+  'dt',
+  'em',
+  'embed',
+  'fieldset',
+  'figcaption',
+  'figure',
+  'form',
+  'hr',
+  'i',
+  'iframe',
+  'input',
+  'ins',
+  'kbd',
+  'label',
+  'legend',
+  'li',
+  'main',
+  'map',
+  'mark',
+  'menu',
+  'menuitem',
+  'meter',
+  'noembed',
+  'object',
+  'ol',
+  'optgroup',
+  'option',
+  'output',
+  'p',
+  'param',
+  'pre',
+  'progress',
+  'q',
+  'rb',
+  'rp',
+  'rt',
+  'rtc',
+  'ruby',
+  's',
+  'samp',
+  'select',
+  'small',
+  'source',
+  'strong',
+  'sub',
+  'summary',
+  'sup',
+  'table',
+  'tbody',
+  'td',
+  'textarea',
+  'tfoot',
+  'th',
+  'thead',
+  'time',
+  'tr',
+  'track',
+  'tt',
+  'u',
+  'ul',
+  'var',
+  'video',
+  'wbr',
+];
+
+module.exports = class NoInvalidRole extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        const hasRoleAttribute = AstNodeInfo.hasAttribute(node, 'role');
+        const roleValue = AstNodeInfo.elementAttributeValue(node, 'role');
+        if (hasRoleAttribute) {
+          if (['presentation', 'none'].includes(roleValue)) {
+            if (DISALLOWED_ELEMENTS.includes(node.tag)) {
+              this.log({
+                message: ERROR_MESSAGE_INVALID_ROLE(node.tag),
+                line: node.loc && node.loc.start.line,
+                column: node.loc && node.loc.start.column,
+                source: this.sourceForNode(node),
+              });
+            }
+          }
+        }
+      },
+    };
+  }
+};
+
+module.exports.ERROR_MESSAGE_INVALID_ROLE = ERROR_MESSAGE_INVALID_ROLE;

--- a/lib/rules/no-invalid-role.js
+++ b/lib/rules/no-invalid-role.js
@@ -105,18 +105,24 @@ module.exports = class NoInvalidRole extends Rule {
     return {
       ElementNode(node) {
         const hasRoleAttribute = AstNodeInfo.hasAttribute(node, 'role');
+
+        if (!hasRoleAttribute) {
+          return;
+        }
+
         const roleValue = AstNodeInfo.elementAttributeValue(node, 'role');
-        if (hasRoleAttribute) {
-          if (['presentation', 'none'].includes(roleValue)) {
-            if (DISALLOWED_ELEMENTS.includes(node.tag)) {
-              this.log({
-                message: ERROR_MESSAGE_INVALID_ROLE(node.tag),
-                line: node.loc && node.loc.start.line,
-                column: node.loc && node.loc.start.column,
-                source: this.sourceForNode(node),
-              });
-            }
-          }
+
+        if (!['presentation', 'none'].includes(roleValue)) {
+          return;
+        }
+
+        if (DISALLOWED_ELEMENTS.includes(node.tag)) {
+          this.log({
+            message: ERROR_MESSAGE_INVALID_ROLE(node.tag),
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
         }
       },
     };

--- a/lib/rules/no-invalid-role.js
+++ b/lib/rules/no-invalid-role.js
@@ -3,7 +3,7 @@
 const AstNodeInfo = require('../helpers/ast-node-info');
 const Rule = require('./base');
 
-function ERROR_MESSAGE_INVALID_ROLE(element) {
+function createErrorMessage(element) {
   return `Use of presentation role on <${element}> detected. Semantic elements should not be used for presentation.`;
 }
 
@@ -118,7 +118,7 @@ module.exports = class NoInvalidRole extends Rule {
 
         if (DISALLOWED_ELEMENTS.includes(node.tag)) {
           this.log({
-            message: ERROR_MESSAGE_INVALID_ROLE(node.tag),
+            message: createErrorMessage(node.tag),
             line: node.loc && node.loc.start.line,
             column: node.loc && node.loc.start.column,
             source: this.sourceForNode(node),
@@ -129,4 +129,4 @@ module.exports = class NoInvalidRole extends Rule {
   }
 };
 
-module.exports.ERROR_MESSAGE_INVALID_ROLE = ERROR_MESSAGE_INVALID_ROLE;
+module.exports.createErrorMessage = createErrorMessage;

--- a/test/unit/rules/no-invalid-role-test.js
+++ b/test/unit/rules/no-invalid-role-test.js
@@ -22,6 +22,7 @@ generateRuleTests({
     '<span role="presentation"></span>',
     '<svg role="none"></svg>',
     '<svg role="presentation"></svg>',
+    '<custom-component role="none"></custom-component>',
   ],
 
   bad: [

--- a/test/unit/rules/no-invalid-role-test.js
+++ b/test/unit/rules/no-invalid-role-test.js
@@ -3,7 +3,7 @@
 const generateRuleTests = require('../../helpers/rule-test-harness');
 const rule = require('../../../lib/rules/no-invalid-role');
 
-const ERROR_MESSAGE_INVALID_ROLE = rule.ERROR_MESSAGE_INVALID_ROLE;
+const { createErrorMessage } = rule;
 
 generateRuleTests({
   name: 'no-invalid-role',
@@ -29,7 +29,7 @@ generateRuleTests({
     {
       template: '<ul role="presentation"></ul>',
       result: {
-        message: ERROR_MESSAGE_INVALID_ROLE('ul'),
+        message: createErrorMessage('ul'),
         moduleId: 'layout.hbs',
         source: '<ul role="presentation"></ul>',
         line: 1,
@@ -39,7 +39,7 @@ generateRuleTests({
     {
       template: '<table role="presentation"></table>',
       result: {
-        message: ERROR_MESSAGE_INVALID_ROLE('table'),
+        message: createErrorMessage('table'),
         moduleId: 'layout.hbs',
         source: '<table role="presentation"></table>',
         line: 1,
@@ -49,7 +49,7 @@ generateRuleTests({
     {
       template: '<table role="none"></table>',
       result: {
-        message: ERROR_MESSAGE_INVALID_ROLE('table'),
+        message: createErrorMessage('table'),
         moduleId: 'layout.hbs',
         source: '<table role="none"></table>',
         line: 1,

--- a/test/unit/rules/no-invalid-role-test.js
+++ b/test/unit/rules/no-invalid-role-test.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+const rule = require('../../../lib/rules/no-invalid-role');
+
+const ERROR_MESSAGE_INVALID_ROLE = rule.ERROR_MESSAGE_INVALID_ROLE;
+
+generateRuleTests({
+  name: 'no-invalid-role',
+
+  config: true,
+
+  good: [
+    '<div></div>',
+    '<div role="none"></div>',
+    '<div role="presentation"></div>',
+    '<img alt="" role="none">',
+    '<img role="none">',
+    '<img alt="" role="presentation">',
+    '<img role="presentation">',
+    '<span role="none"></span>',
+    '<span role="presentation"></span>',
+    '<svg role="none"></svg>',
+    '<svg role="presentation"></svg>',
+  ],
+
+  bad: [
+    {
+      template: '<ul role="presentation"></ul>',
+      result: {
+        message: ERROR_MESSAGE_INVALID_ROLE('ul'),
+        moduleId: 'layout.hbs',
+        source: '<ul role="presentation"></ul>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<table role="presentation"></table>',
+      result: {
+        message: ERROR_MESSAGE_INVALID_ROLE('table'),
+        moduleId: 'layout.hbs',
+        source: '<table role="presentation"></table>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<table role="none"></table>',
+      result: {
+        message: ERROR_MESSAGE_INVALID_ROLE('table'),
+        moduleId: 'layout.hbs',
+        source: '<table role="none"></table>',
+        line: 1,
+        column: 0,
+      },
+    },
+  ],
+});

--- a/test/unit/rules/no-invalid-role-test.js
+++ b/test/unit/rules/no-invalid-role-test.js
@@ -23,6 +23,8 @@ generateRuleTests({
     '<svg role="none"></svg>',
     '<svg role="presentation"></svg>',
     '<custom-component role="none"></custom-component>',
+    '<AwesomeThing role="none"></AwesomeThing>',
+    '<AwesomeThing role="presentation"></AwesomeThing>',
   ],
 
   bad: [


### PR DESCRIPTION
If merged, this adds a new rule called `no-invalid-role`. It checks for `role="presentation"` or `role="none"` on a list of HTML elements that should not have this role.

It should not effect custom components. 