### PR TITLE
no-multiple-empty-lines: Fix `parseConfig()` implementation

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -2,6 +2,8 @@
 
 const Rule = require('./base');
 
+const CONFIG_ERROR_MESSAGE = 'Invalid rule configuration for `no-multiple-empty-lines` found';
+
 module.exports = class NoMultipleEmptyLines extends Rule {
   parseConfig(config) {
     return parseConfig(config);
@@ -65,7 +67,21 @@ module.exports = class NoMultipleEmptyLines extends Rule {
 };
 
 function parseConfig(config) {
-  return config || {};
+  if (config === true) {
+    return { max: 1 };
+  }
+
+  if (typeof config !== 'object' || config === null) {
+    throw new Error(CONFIG_ERROR_MESSAGE);
+  }
+
+  let max = config.max;
+  if (typeof max !== 'number') {
+    throw new Error(CONFIG_ERROR_MESSAGE);
+  }
+
+  return { max };
 }
 
 module.exports.parseConfig = parseConfig;
+module.exports.CONFIG_ERROR_MESSAGE = CONFIG_ERROR_MESSAGE;

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -4,7 +4,7 @@ const Rule = require('./base');
 
 module.exports = class NoMultipleEmptyLines extends Rule {
   parseConfig(config) {
-    return config || {};
+    return parseConfig(config);
   }
 
   visitor() {
@@ -63,3 +63,9 @@ module.exports = class NoMultipleEmptyLines extends Rule {
     };
   }
 };
+
+function parseConfig(config) {
+  return config || {};
+}
+
+module.exports.parseConfig = parseConfig;

--- a/test/unit/rules/no-multiple-empty-lines-test.js
+++ b/test/unit/rules/no-multiple-empty-lines-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const generateRuleTests = require('../../helpers/rule-test-harness');
+const { parseConfig } = require('../../../lib/rules/no-multiple-empty-lines');
 
 generateRuleTests({
   name: 'no-multiple-empty-lines',
@@ -60,4 +61,20 @@ generateRuleTests({
       },
     },
   ],
+});
+
+describe('no-multiple-empty-lines', () => {
+  describe('parseConfig', () => {
+    const TESTS = [
+      [undefined, {}],
+      [{ max: 1 }, { max: 1 }],
+      [{ max: 2 }, { max: 2 }],
+    ];
+
+    for (let [input, expected] of TESTS) {
+      test(`${input} -> ${expected}`, () => {
+        expect(parseConfig(input)).toEqual(expected);
+      });
+    }
+  });
 });

--- a/test/unit/rules/no-multiple-empty-lines-test.js
+++ b/test/unit/rules/no-multiple-empty-lines-test.js
@@ -1,10 +1,12 @@
 'use strict';
 
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const { parseConfig } = require('../../../lib/rules/no-multiple-empty-lines');
+const { parseConfig, CONFIG_ERROR_MESSAGE } = require('../../../lib/rules/no-multiple-empty-lines');
 
 generateRuleTests({
   name: 'no-multiple-empty-lines',
+
+  config: true,
 
   good: [
     '<div>foo</div><div>bar</div>',
@@ -66,14 +68,23 @@ generateRuleTests({
 describe('no-multiple-empty-lines', () => {
   describe('parseConfig', () => {
     const TESTS = [
-      [undefined, {}],
+      [true, { max: 1 }],
       [{ max: 1 }, { max: 1 }],
       [{ max: 2 }, { max: 2 }],
+      [{ max: 42, foo: 'bar' }, { max: 42 }],
     ];
 
     for (let [input, expected] of TESTS) {
-      test(`${input} -> ${expected}`, () => {
+      test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
         expect(parseConfig(input)).toEqual(expected);
+      });
+    }
+
+    const FAILURE_TESTS = [undefined, false, {}, { foo: 'bar' }, { max: 'foo' }];
+
+    for (let input of FAILURE_TESTS) {
+      test(`${JSON.stringify(input)} -> Error`, () => {
+        expect(() => parseConfig(input)).toThrow(CONFIG_ERROR_MESSAGE);
       });
     }
   });


### PR DESCRIPTION
Resolves #983