### PR TITLE
Add rule `no-invalid-link-text`

### DIFF
--- a/docs/rule/no-invalid-link-text.md
+++ b/docs/rule/no-invalid-link-text.md
@@ -2,7 +2,7 @@
 
 Screen readers call up a dialog box that has a list of links from the page, which users refer to decide where they will go. But if many of the links in that list simply say "click here" or "more" they will be unable to use this feature in their screen reader, which is a core navigation strategy.
 
-This rule checks links containing a few default words("click here" and "more"), and is configurable so additional words can be added as appropriate for your project.
+This rule checks links containing a few default words("click here" and "more"), and is configurable so additional words can be added as appropriate for your project. Disallowed list: click here, more info, read more, more. 
 
 ### Examples
 

--- a/docs/rule/no-invalid-link-text.md
+++ b/docs/rule/no-invalid-link-text.md
@@ -13,24 +13,18 @@ This rule **forbids** the following:
 ```
 
 ```hbs
-{{link-to}}more{{/link-to}}
+<a href={{link}}>more</a>
 ```
 
 This rule **allows** the following:
 
 ```hbs
-<LinkTo>Click here to read more about plastics in the ocean</LinkTo>
+<LinkTo>Click here to read more about common accessibility failures</LinkTo>
 ```
 
 ```hbs
-{{link-to}}Read more about semantic html{{/link-to}}
+<a href={{link}}>Read more about semantic html</a>
 ```
-
-### Configuration
-
-* object -- containing the following properties:
-  * string -- `parameterName1` -- description of parameter including the possible values and default value
-  * boolean -- `parameterName2` -- description of parameter including the possible values and default value
 
 ### References
 

--- a/docs/rule/no-invalid-link-text.md
+++ b/docs/rule/no-invalid-link-text.md
@@ -1,0 +1,37 @@
+## no-invalid-link-text
+
+Screen readers call up a dialog box that has a list of links from the page, which users refer to decide where they will go. But if many of the links in that list simply say "click here" or "more" they will be unable to use this feature in their screen reader, which is a core navigation strategy.
+
+This rule checks links containing a few default words("click here" and "more"), and is configurable so additional words can be added as appropriate for your project.
+
+### Examples
+
+This rule **forbids** the following:
+
+```hbs
+<LinkTo>click here</LinkTo>
+```
+
+```hbs
+{{link-to}}more{{/link-to}}
+```
+
+This rule **allows** the following:
+
+```hbs
+<LinkTo>Click here to read more about plastics in the ocean</LinkTo>
+```
+
+```hbs
+{{link-to}}Read more about semantic html{{/link-to}}
+```
+
+### Configuration
+
+* object -- containing the following properties:
+  * string -- `parameterName1` -- description of parameter including the possible values and default value
+  * boolean -- `parameterName2` -- description of parameter including the possible values and default value
+
+### References
+
+* [Failure of Success Criterion 2.4.9 due to using a non-specific link such as "click here" or "more" without a mechanism to change the link text to specific text.](https://www.w3.org/WAI/WCAG21/Techniques/failures/F84)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -26,6 +26,7 @@
 * [no-input-block](rule/no-input-block.md)
 * [no-input-tagname](rule/no-input-tagname.md)
 * [no-invalid-interactive](rule/no-invalid-interactive.md)
+* [no-invalid-link-text](rule/no-invalid-link-text.md)
 * [no-invalid-role](rule/no-invalid-role.md)
 * [no-log](rule/no-log.md)
 * [no-meta-redirect-with-time-limit](rule/no-meta-redirect-with-time-limit.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -30,6 +30,7 @@ module.exports = {
   'no-input-block': require('./no-input-block'),
   'no-input-tagname': require('./no-input-tagname'),
   'no-invalid-interactive': require('./no-invalid-interactive'),
+  'no-invalid-link-text': require('./no-invalid-link-text'),
   'no-invalid-role': require('./no-invalid-role'),
   'no-log': require('./no-log'),
   'no-meta-redirect-with-time-limit': require('./no-meta-redirect-with-time-limit'),

--- a/lib/rules/no-invalid-link-text.js
+++ b/lib/rules/no-invalid-link-text.js
@@ -15,6 +15,11 @@ function hasInvalidLinkText(node) {
   // Extract the text content(s) from the TextNode child(ren)
   const nodeChildren = AstNodeInfo.childrenFor(node);
   const textChildren = nodeChildren.filter(child => AstNodeInfo.isTextNode(child));
+
+  if (nodeChildren.length !== textChildren.length) {
+    // do not flag an error when the link contains additional dynamic (non-text) children
+    return;
+  }
   const linkTexts = textChildren.map(linkText => linkText['chars'].toLowerCase().trim());
 
   // Check to see if the text content is too `generic` by checking it against

--- a/lib/rules/no-invalid-link-text.js
+++ b/lib/rules/no-invalid-link-text.js
@@ -3,7 +3,7 @@
 const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
 
-const disallowedGenericLinkTextList = [
+const DISALLOWED_LINK_TEXT = [
   // WCAG F84-Provided Examples
   'click here',
   'more info',
@@ -14,6 +14,9 @@ module.exports = class NoInvalidLinkText extends Rule {
   visitor() {
     return {
       ElementNode(node) {
+        if (node.tag !== 'a') {
+          return;
+        }
         if (AstNodeInfo.isLinkElement(node)) {
           // Extract the text content(s) from the TextNode child(ren)
           const nodeChildren = AstNodeInfo.childrenFor(node);
@@ -23,14 +26,12 @@ module.exports = class NoInvalidLinkText extends Rule {
           // Check to see if the text content is too `generic` by checking it against
           // the reference list (array, above) of `disallowed` link text Strings/phrases
           const genericLinkTexts = linkTexts.filter(linkText =>
-            disallowedGenericLinkTextList.includes(linkText)
+            DISALLOWED_LINK_TEXT.includes(linkText)
           );
-          const hasGenericLinkTexts = genericLinkTexts.length > 0;
-
-          // Report if one or more child TextNode element(s) is `disallowed`
-          if (hasGenericLinkTexts) {
+          // Report if one or more child TextNode element(s) is on the disallowed list
+          if (genericLinkTexts.length > 0) {
             this.log({
-              message: 'Anchor Elements should have descriptive link text',
+              message: 'Links should have descriptive text',
               line: node.loc && node.loc.start.line,
               column: node.loc && node.loc.start.column,
               source: this.sourceForNode(node),

--- a/lib/rules/no-invalid-link-text.js
+++ b/lib/rules/no-invalid-link-text.js
@@ -10,26 +10,39 @@ const DISALLOWED_LINK_TEXT = [
   'read more',
   'more',
 ];
+
+function hasInvalidLinkText(node) {
+  // Extract the text content(s) from the TextNode child(ren)
+  const nodeChildren = AstNodeInfo.childrenFor(node);
+  const textChildren = nodeChildren.filter(child => AstNodeInfo.isTextNode(child));
+  const linkTexts = textChildren.map(linkText => linkText['chars'].toLowerCase().trim());
+
+  // Check to see if the text content is too `generic` by checking it against
+  // the reference list (array, above) of `disallowed` link text Strings/phrases
+  const hasGenericLinkTexts = linkTexts.some(linkText => DISALLOWED_LINK_TEXT.includes(linkText));
+  return hasGenericLinkTexts;
+}
+
 module.exports = class NoInvalidLinkText extends Rule {
   visitor() {
     return {
       ElementNode(node) {
-        if (node.tag !== 'a') {
-          return;
-        }
-        if (AstNodeInfo.isLinkElement(node)) {
-          // Extract the text content(s) from the TextNode child(ren)
-          const nodeChildren = AstNodeInfo.childrenFor(node);
-          const textChildren = nodeChildren.filter(child => AstNodeInfo.isTextNode(child));
-          const linkTexts = textChildren.map(linkText => linkText['chars'].toLowerCase().trim());
-
-          // Check to see if the text content is too `generic` by checking it against
-          // the reference list (array, above) of `disallowed` link text Strings/phrases
-          const genericLinkTexts = linkTexts.filter(linkText =>
-            DISALLOWED_LINK_TEXT.includes(linkText)
-          );
+        if (node.tag === 'a' || node.tag === 'LinkTo') {
           // Report if one or more child TextNode element(s) is on the disallowed list
-          if (genericLinkTexts.length > 0) {
+          if (hasInvalidLinkText(node)) {
+            this.log({
+              message: 'Links should have descriptive text',
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(node),
+            });
+          }
+        }
+      },
+      BlockStatement(node) {
+        if (node.path.original === 'link-to') {
+          // Report if one or more child TextNode element(s) is on the disallowed list
+          if (hasInvalidLinkText(node)) {
             this.log({
               message: 'Links should have descriptive text',
               line: node.loc && node.loc.start.line,

--- a/lib/rules/no-invalid-link-text.js
+++ b/lib/rules/no-invalid-link-text.js
@@ -3,22 +3,41 @@
 const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
 
+const disallowedGenericLinkTextList = [
+  // WCAG F84-Provided Examples
+  'click here',
+  'more info',
+  'read more',
+  'more',
+];
 module.exports = class NoInvalidLinkText extends Rule {
   visitor() {
     return {
-        TargetNodeType(node)  {
+      ElementNode(node) {
+        if (AstNodeInfo.isLinkElement(node)) {
+          // Extract the text content(s) from the TextNode child(ren)
+          const nodeChildren = AstNodeInfo.childrenFor(node);
+          const textChildren = nodeChildren.filter(child => AstNodeInfo.isTextNode(child));
+          const linkTexts = textChildren.map(linkText => linkText['chars'].toLowerCase().trim());
 
-          // Conditions for rule detection go here
+          // Check to see if the text content is too `generic` by checking it against
+          // the reference list (array, above) of `disallowed` link text Strings/phrases
+          const genericLinkTexts = linkTexts.filter(linkText =>
+            disallowedGenericLinkTextList.includes(linkText)
+          );
+          const hasGenericLinkTexts = genericLinkTexts.length > 0;
 
-        {
-          this.log({
-            message: 'Error Message to Report',
-            line: node.loc && node.loc.start.line,
-            column: node.loc && node.loc.start.column,
-            source: this.sourceForNode(node)
-          });
+          // Report if one or more child TextNode element(s) is `disallowed`
+          if (hasGenericLinkTexts) {
+            this.log({
+              message: 'Anchor Elements should have descriptive link text',
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(node),
+            });
+          }
         }
-      }
+      },
     };
   }
 };

--- a/lib/rules/no-invalid-link-text.js
+++ b/lib/rules/no-invalid-link-text.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const Rule = require('./base');
+const AstNodeInfo = require('../helpers/ast-node-info');
+
+module.exports = class NoInvalidLinkText extends Rule {
+  visitor() {
+    return {
+        TargetNodeType(node)  {
+
+          // Conditions for rule detection go here
+
+        {
+          this.log({
+            message: 'Error Message to Report',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node)
+          });
+        }
+      }
+    };
+  }
+};

--- a/test/unit/rules/no-invalid-link-text-test.js
+++ b/test/unit/rules/no-invalid-link-text-test.js
@@ -3,7 +3,7 @@
 const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
-  name: 'new-rule-name',
+  name: 'no-invalid-link-text',
 
   config: true,
 
@@ -11,11 +11,11 @@ generateRuleTests({
 
   bad: [
     {
-      template: '<a href="https://myurl.com>click here</a>',
+      template: '<a href="https://myurl.com">click here</a>',
       result: {
-        message: 'Anchor Elements should have descriptive link text',
+        message: 'Links should have descriptive text',
         moduleId: 'layout.hbs',
-        source: '<a href="https://myurl.com>click here</a>',
+        source: '<a href="https://myurl.com">click here</a>',
         line: 1,
         column: 0,
       },

--- a/test/unit/rules/no-invalid-link-text-test.js
+++ b/test/unit/rules/no-invalid-link-text-test.js
@@ -3,30 +3,22 @@
 const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
-
   name: 'new-rule-name',
 
   config: true,
 
-  good: [
-    'passingTest00',
-    'passing Test01'
-  ],
-
+  good: ['<a href="https://myurl.com">Click here to read more about this amazing adventure</a>'],
 
   bad: [
-  
     {
-      template: 'FailingTest00',
+      template: '<a href="https://myurl.com>click here</a>',
       result: {
+        message: 'Anchor Elements should have descriptive link text',
         moduleId: 'layout.hbs',
-        message: 'Error Message to Report',
+        source: '<a href="https://myurl.com>click here</a>',
         line: 1,
         column: 0,
-        source: 'FailingTest00',
       },
     },
-
-  ]
-  
+  ],
 });

--- a/test/unit/rules/no-invalid-link-text-test.js
+++ b/test/unit/rules/no-invalid-link-text-test.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+
+  name: 'new-rule-name',
+
+  config: true,
+
+  good: [
+    'passingTest00',
+    'passing Test01'
+  ],
+
+
+  bad: [
+  
+    {
+      template: 'FailingTest00',
+      result: {
+        moduleId: 'layout.hbs',
+        message: 'Error Message to Report',
+        line: 1,
+        column: 0,
+        source: 'FailingTest00',
+      },
+    },
+
+  ]
+  
+});

--- a/test/unit/rules/no-invalid-link-text-test.js
+++ b/test/unit/rules/no-invalid-link-text-test.js
@@ -11,6 +11,7 @@ generateRuleTests({
     '<a href="https://myurl.com">Click here to read more about this amazing adventure</a>',
     '{{#link-to}} click here to read more about our company{{/link-to}}',
     '<LinkTo>Read more about ways semantic HTML can make your code more accessible.</LinkTo>',
+    '<LinkTo>{{foo}} more</LinkTo>',
   ],
 
   bad: [

--- a/test/unit/rules/no-invalid-link-text-test.js
+++ b/test/unit/rules/no-invalid-link-text-test.js
@@ -7,7 +7,11 @@ generateRuleTests({
 
   config: true,
 
-  good: ['<a href="https://myurl.com">Click here to read more about this amazing adventure</a>'],
+  good: [
+    '<a href="https://myurl.com">Click here to read more about this amazing adventure</a>',
+    '{{#link-to}} click here to read more about our company{{/link-to}}',
+    '<LinkTo>Read more about ways semantic HTML can make your code more accessible.</LinkTo>',
+  ],
 
   bad: [
     {
@@ -16,6 +20,26 @@ generateRuleTests({
         message: 'Links should have descriptive text',
         moduleId: 'layout.hbs',
         source: '<a href="https://myurl.com">click here</a>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<LinkTo>click here</LinkTo>',
+      result: {
+        message: 'Links should have descriptive text',
+        moduleId: 'layout.hbs',
+        source: '<LinkTo>click here</LinkTo>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '{{#link-to}}click here{{/link-to}}',
+      result: {
+        message: 'Links should have descriptive text',
+        moduleId: 'layout.hbs',
+        source: '{{#link-to}}click here{{/link-to}}',
         line: 1,
         column: 0,
       },


### PR DESCRIPTION
If merged, this rule will check link text to prevent common accessibility failure 84- Failure of Success Criterion 2.4.9 due to using a non-specific link such as "click here" or "more". 

