### PR TITLE
updated rule to cover orientation lock failure

### DIFF
--- a/docs/rule/no-invalid-meta.md
+++ b/docs/rule/no-invalid-meta.md
@@ -6,8 +6,10 @@ This rule checks for these meta tag issues:
 - a meta with a timed refresh- the timed delay should be greater than 72,000 seconds.
 - a meta that locks orientation to landscape or portrait view
 
+### Redirects & Refresh
 Sometimes a page automatically redirects to a different page. When this happens after a timed delay, it is an unexpected change of context that may interrupt the user. Redirects without timed delays are okay, but please consider a server-side method for redirecting instead (method will vary based on your server type).
 
+### Orientation Lock
 When content is presented with a restriction to a specific orientation, users must orient their devices to view the content in the orientation that the author imposed. Some users have their devices mounted in a fixed orientation (e.g. on the arm of a power wheelchair), and if the content cannot be viewed in that orientation it creates problems for the user.
 
 ### Examples

--- a/docs/rule/no-invalid-meta.md
+++ b/docs/rule/no-invalid-meta.md
@@ -1,11 +1,14 @@
 ## no-invalid-meta
 
-Sometimes a page automatically redirects to a different page. When this happens after a timed delay, it is an unexpected change of context that may interrupt the user. Redirects without timed delays are okay, but please consider a server-side method for redirecting instead (method will vary based on your server type).
-
 This rule checks for these meta tag issues:
 
 - a meta with a redirect- if it exists, it checks for a timed delay greater than 0.
 - a meta with a timed refresh- the timed delay should be greater than 72,000 seconds.
+- a meta that locks orientation to landscape or portrait view
+
+Sometimes a page automatically redirects to a different page. When this happens after a timed delay, it is an unexpected change of context that may interrupt the user. Redirects without timed delays are okay, but please consider a server-side method for redirecting instead (method will vary based on your server type).
+
+When content is presented with a restriction to a specific orientation, users must orient their devices to view the content in the orientation that the author imposed. Some users have their devices mounted in a fixed orientation (e.g. on the arm of a power wheelchair), and if the content cannot be viewed in that orientation it creates problems for the user.
 
 ### Examples
 
@@ -15,15 +18,28 @@ This rule **forbids** the following:
 <meta http-equiv="refresh" content="5; url=http://www.example.com" />
 ```
 
+```hbs
+<meta name="viewport" content="user-scalable=no">
+```
+
+```hbs
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+```
+
 This rule **allows** the following:
 
 ```hbs
 <meta http-equiv="refresh" content="0; url=http://www.example.com" />
 ```
 
+```hbs
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+```
+
 ### Migration
 
 * To fix, reduce the timed delay to zero, or use the appropriate server-side redirect method for your server type.
+* To fix orientation issues, remove references to `maximum-scale=1.0` and change `user-scalable=no` to `user-scalable=yes`.
 
 ### References
 
@@ -32,3 +48,4 @@ This rule **allows** the following:
 * [Success Criterion 2.2.1: Timing Adjustable](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable)
 * [Success Criterion 2.2.4: Interruptions](https://www.w3.org/WAI/WCAG21/Understanding/interruptions)
 * [Success Criterion 3.2.5: Change on Request](https://www.w3.org/WAI/WCAG21/Understanding/change-on-request)
+* [Failure due to locking the orientation to landscape or portrait view](https://www.w3.org/WAI/WCAG21/Techniques/failures/F97)

--- a/lib/rules/no-invalid-meta.js
+++ b/lib/rules/no-invalid-meta.js
@@ -17,10 +17,9 @@ module.exports = class NoInvalidMeta extends Rule {
       ElementNode(node) {
         const isMeta = node.tag === 'meta';
         const hasMetaRedirect = AstNodeInfo.hasAttribute(node, 'http-equiv');
-
+        const contentAttr = AstNodeInfo.hasAttribute(node, 'content');
+        const contentAttrValue = AstNodeInfo.elementAttributeValue(node, 'content');
         if (isMeta && hasMetaRedirect) {
-          const contentAttr = AstNodeInfo.hasAttribute(node, 'content');
-          const contentAttrValue = AstNodeInfo.elementAttributeValue(node, 'content');
           if (contentAttr) {
             // if there is a semicolon, it is a REDIRECT and should not have a delay value greater than zero
             if (contentAttrValue.includes(';')) {
@@ -33,7 +32,6 @@ module.exports = class NoInvalidMeta extends Rule {
                 });
               }
             } else {
-              // if there is not a semicolon, it is a REFRESH and should have a delay greater than 72000 seconds
               // eslint-disable-next-line radix
               if (parseInt(contentAttrValue) <= 72000) {
                 this.log({
@@ -45,6 +43,22 @@ module.exports = class NoInvalidMeta extends Rule {
               }
             }
           }
+        }
+        if (contentAttrValue.includes('user-scalable=no')) {
+          this.log({
+            message: 'a meta viewport should not restrict user-scalable',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
+        }
+        if (contentAttrValue.includes('maximum-scale')) {
+          this.log({
+            message: 'a meta viewport should not set a maximum scale on content',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
         }
       },
     };

--- a/test/unit/rules/no-invalid-meta-test.js
+++ b/test/unit/rules/no-invalid-meta-test.js
@@ -10,6 +10,7 @@ generateRuleTests({
   good: [
     '<meta http-equiv="refresh" content="0; url=http://www.example.com">',
     '<meta http-equiv="refresh" content="72001">',
+    '<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">',
   ],
 
   bad: [
@@ -33,6 +34,30 @@ generateRuleTests({
         line: 1,
         column: 0,
         source: '<meta http-equiv="refresh" content="71999">',
+      },
+    },
+    {
+      template: '<meta name="viewport" content="user-scalable=no">',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message: 'a meta viewport should not restrict user-scalable',
+        line: 1,
+        column: 0,
+        source: '<meta name="viewport" content="user-scalable=no">',
+      },
+    },
+    {
+      template:
+        '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message: 'a meta viewport should not set a maximum scale on content',
+        line: 1,
+        column: 0,
+        source:
+          '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">',
       },
     },
   ],


### PR DESCRIPTION
If merged, this PR updates the `no-invalid-meta` to cover common failure 97- failure due to locking orientation. 