### PR TITLE
Use `Template` and `Block` nodes instead of `Program` fallback

### DIFF
--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -98,7 +98,11 @@ module.exports = class BaseRule {
     // according to whether they will be called before/after the rule's AST
     // event handlers.
     let astHandlers = {
-      Program: {
+      Template: {
+        enter: { before: [], after: [] },
+        exit: { before: [], after: [] },
+      },
+      Block: {
         enter: { before: [], after: [] },
         exit: { before: [], after: [] },
       },
@@ -154,7 +158,8 @@ module.exports = class BaseRule {
       visitor[key] = this._wrapVisitor(ruleVisitor[key], astHandlers[key]);
     }
 
-    visitor.Program = visitor.Program || this._wrapVisitor(null, astHandlers.Program);
+    visitor.Template = visitor.Template || this._wrapVisitor(null, astHandlers.Template);
+    visitor.Block = visitor.Block || this._wrapVisitor(null, astHandlers.Block);
     visitor.CommentStatement =
       visitor.CommentStatement || this._wrapVisitor(null, astHandlers.CommentStatement);
     visitor.MustacheCommentStatement =
@@ -177,8 +182,11 @@ module.exports = class BaseRule {
       scope.popFrame();
     }
 
-    astHandlers.Program.enter.before.push(pushFrame);
-    astHandlers.Program.exit.after.push(popFrame);
+    astHandlers.Template.enter.before.push(pushFrame);
+    astHandlers.Template.exit.after.push(popFrame);
+
+    astHandlers.Block.enter.before.push(pushFrame);
+    astHandlers.Block.exit.after.push(popFrame);
 
     astHandlers.ElementNode.keys.children.enter.before.push(pushFrame);
     astHandlers.ElementNode.keys.children.exit.after.push(popFrame);

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -36,31 +36,11 @@ module.exports = class EolLast extends Rule {
 
   visitor() {
     return {
-      Program: {
+      Template: {
         // implementation goes here in exit(): in the exit handler, the rule will not
         // be called if it has been disabled by any inline comments within the file.
 
         exit(node) {
-          let line = node.loc.start.line;
-          let column = node.loc.start.column;
-
-          // yielded content makes it in here too
-          //
-          // `{{#my-component}}
-          //   test
-          // {{/my-component}}`
-          //
-          // becomes
-          //
-          // `
-          //   test
-          // `
-          //
-          // check for that case
-          if (line !== 1 || column !== 0) {
-            return;
-          }
-
           let bodyLength = node.body.length;
           // if there is a block component invocation without a body
           // it will make it here too
@@ -87,6 +67,9 @@ module.exports = class EolLast extends Rule {
           }
 
           if (message) {
+            let line = node.loc.start.line;
+            let column = node.loc.start.column;
+
             this.log({
               message,
               line,

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -14,15 +14,9 @@ module.exports = class NoMultipleEmptyLines extends Rule {
     let allLines =
       this.source[this.source.length - 1] === '' ? this.source.slice(0, -1) : this.source;
 
-    let first = true;
-
     return {
-      Program: {
+      Template: {
         exit() {
-          if (!first) {
-            return;
-          }
-
           let max = 'max' in this.config ? this.config.max : 1;
 
           allLines
@@ -58,8 +52,6 @@ module.exports = class NoMultipleEmptyLines extends Rule {
 
               return lineNumber;
             }, 0);
-
-          first = false;
         },
       },
     };

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -5,31 +5,11 @@ const Rule = require('./base');
 module.exports = class NoTrailingSpaces extends Rule {
   visitor() {
     return {
-      Program: {
+      Template: {
         // implementation goes here in exit(): in the exit handler, the rule will not
         // be called if it has been disabled by any inline comments within the file.
 
         exit(node) {
-          let line = node.loc.start.line;
-          let column = node.loc.start.column;
-
-          // yielded content makes it in here too
-          //
-          // `{{#my-component}}
-          //   test
-          // {{/my-component}}`
-          //
-          // becomes
-          //
-          // `
-          //   test
-          // `
-          //
-          // check for that case
-          if (line !== 1 || column !== 0) {
-            return;
-          }
-
           let source = this.sourceForNode(node);
 
           source.split('\n').forEach((line, i) => {

--- a/lib/rules/no-unused-block-params.js
+++ b/lib/rules/no-unused-block-params.js
@@ -45,7 +45,7 @@ const Rule = require('./base');
 module.exports = class UnusedBlockParams extends Rule {
   visitor() {
     return {
-      Program: {
+      Block: {
         exit(node) {
           let unusedLocal = this.scope.frameHasUnusedBlockParams();
           if (unusedLocal) {

--- a/lib/rules/template-length.js
+++ b/lib/rules/template-length.js
@@ -70,16 +70,12 @@ module.exports = class LengthValidation extends Rule {
   }
 
   visitor() {
-    let seenOuterProgram = false;
     return {
-      Program: {
+      Template: {
         // implementation goes here in exit(): in the exit handler, the rule will not
         // be called if it has been disabled by any inline comments within the file.
 
         exit(node) {
-          if (seenOuterProgram === true) {
-            return;
-          }
           if (this.config.max && this.source.length > this.config.max) {
             this.log({
               message: `Template length of ${this.source.length} exceeds ${this.config.max}`,
@@ -93,7 +89,6 @@ module.exports = class LengthValidation extends Rule {
               column: node.loc.start.column,
             });
           }
-          seenOuterProgram = true;
         },
       },
     };

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -197,12 +197,12 @@ describe('base plugin', function() {
     let wasCalled;
 
     let visitor = {
-      Program() {
+      Template() {
         wasCalled = true;
       },
     };
 
-    it('calls the "Program" node type', function() {
+    it('calls the "Template" node type', function() {
       runRules('<div>Foo</div>', [plugin(buildPlugin(visitor), 'fake', config)]);
 
       expect(wasCalled).toBe(true);


### PR DESCRIPTION
The Glimmer AST is using `Template` and `Block` nodes now instead of `Program`, and our rules have been running the visitor function in "compatibility mode".

This PR changes the rule implementations to use `Template` and `Block` callbacks instead, which simplifies the internal implementations in several cases.

Since we rely on a specific version of the Glimmer parser we can do this without any backward compatibility concerns. 🎉 