### PR TITLE
Add `no-invalid-link-text` and `no-invalid-meta` to octane configuration.

### DIFF
--- a/lib/config/octane.js
+++ b/lib/config/octane.js
@@ -21,6 +21,8 @@ module.exports = {
     'no-input-block': true,
     'no-input-tagname': true,
     'no-invalid-interactive': true,
+    'no-invalid-link-text': true,
+    'no-invalid-meta': true,
     'no-log': true,
     'no-nested-interactive': true,
     'no-obsolete-elements': true,


### PR DESCRIPTION
adds in two rules we just merged