### PR TITLE
no-curly-component-invocation: Ignore block invocations with inverse blocks

### DIFF
--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -88,6 +88,11 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
       return;
     }
 
+    // ignore BlockStatements with `{{else}}` blocks
+    if (node.inverse) {
+      return;
+    }
+
     let name = node.path.original;
     if (node.path.type !== 'PathExpression' || this.isAmbiguousLocalInvocation(node)) {
       return '';

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -29,6 +29,7 @@ generateRuleTests({
      {{/each}}`,
     '{{#-in-element}}Hello{{/-in-element}}',
     '{{#in-element}}Hello{{/in-element}}',
+    '{{#some-component foo="bar"}}foo{{else}}bar{{/some-component}}',
     '<MyComponent @arg={{my-helper this.foobar}} />',
     '<MyComponent @arg="{{my-helper this.foobar}}" />',
     '<MyComponent {{my-modifier this.foobar}} />',


### PR DESCRIPTION


Resolves https://github.com/ember-template-lint/ember-template-lint/issues/1003