### PR TITLE
no-curly-component-invocation: Ignore *all* curly invocations with positional arguments

### DIFF
--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -84,7 +84,7 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
   }
 
   getCurlyInvocationSyntaxError(node) {
-    if (node.type === 'MustacheStatement' && node.params.length !== 0) {
+    if (node.params.length !== 0) {
       return;
     }
 

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -36,6 +36,7 @@ generateRuleTests({
     '{{t "some.translation.key"}}',
     '{{model.selectedTransfersCount}}',
     '{{request.note}}',
+    '{{#animated-if condition}}foo{{/animated-if}}',
   ],
 
   bad: [
@@ -70,10 +71,6 @@ generateRuleTests({
           '{{#heading size="1"}}Disallowed heading component{{/heading}}'
         ),
       ],
-    },
-    {
-      template: '{{#foo bar}}baz{{/foo}}',
-      results: [getErrorResult(generateError('foo'), '{{#foo bar}}baz{{/foo}}')],
     },
   ],
 });


### PR DESCRIPTION
Resolves #1004 

as originally intended in https://github.com/ember-template-lint/ember-template-lint/issues/925#issuecomment-554481335 🤦‍♂️