### PR TITLE
Extract `Printer` classes

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -6,58 +6,8 @@ const fs = require('fs');
 const path = require('path');
 const globby = require('globby');
 const Linter = require('../lib/index');
-const chalk = require('chalk');
 
 const STDIN = '/dev/stdin';
-
-function printErrors(errors, invocationOptions) {
-  let { quiet, json, verbose } = invocationOptions.named;
-
-  let errorCount = 0;
-  let warningCount = 0;
-
-  Object.keys(errors).forEach(filePath => {
-    let fileErrors = errors[filePath] || [];
-
-    let errorsFiltered = fileErrors.filter(error => error.severity === Linter.ERROR_SEVERITY);
-    let warnings = quiet
-      ? []
-      : fileErrors.filter(error => error.severity === Linter.WARNING_SEVERITY);
-
-    errorCount += errorsFiltered.length;
-    warningCount += warnings.length;
-
-    errors[filePath] = errorsFiltered.concat(warnings);
-  });
-
-  if (json) {
-    console.log(JSON.stringify(errors, null, 2));
-  } else {
-    Object.keys(errors).forEach(filePath => {
-      let options = {};
-      let fileErrors = errors[filePath] || [];
-
-      if (verbose) {
-        options.verbose = true;
-      }
-
-      const messages = Linter.errorsToMessages(filePath, fileErrors, options);
-      if (messages !== '') {
-        console.log(messages);
-      }
-    });
-
-    const count = errorCount + warningCount;
-
-    if (count > 0) {
-      console.log(
-        chalk.red(
-          chalk.bold(`✖ ${count} problems (${errorCount} errors, ${warningCount} warnings)`)
-        )
-      );
-    }
-  }
-}
 
 function lintFile(linter, filePath, moduleId) {
   let toRead = filePath === STDIN ? process.stdin.fd : filePath;
@@ -203,18 +153,29 @@ function run() {
     return;
   }
 
-  if (Object.keys(errors).length) {
-    printErrors(errors, options);
-  }
+  let filePaths = Object.keys(errors);
+  if (filePaths.length) {
+    for (let filePath of filePaths) {
+      let fileErrors = errors[filePath] || [];
 
-  linter.reportGitHubActionAnnotations(errors);
+      let errorsFiltered = fileErrors.filter(error => error.severity === Linter.ERROR_SEVERITY);
+      let warnings = options.named.quiet
+        ? []
+        : fileErrors.filter(error => error.severity === Linter.WARNING_SEVERITY);
+
+      errors[filePath] = errorsFiltered.concat(warnings);
+    }
+
+    let Printer = require('../lib/printers/default');
+    let printer = new Printer(options.named);
+    printer.print(errors);
+  }
 }
 
 // exports are for easier unit testing
 module.exports = {
   _parseArgv: parseArgv,
   _expandFileGlobs: expandFileGlobs,
-  _printErrors: printErrors,
 };
 
 if (require.main === module) {

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -153,19 +153,7 @@ function run() {
     return;
   }
 
-  let filePaths = Object.keys(errors);
-  if (filePaths.length) {
-    for (let filePath of filePaths) {
-      let fileErrors = errors[filePath] || [];
-
-      let errorsFiltered = fileErrors.filter(error => error.severity === Linter.ERROR_SEVERITY);
-      let warnings = options.named.quiet
-        ? []
-        : fileErrors.filter(error => error.severity === Linter.WARNING_SEVERITY);
-
-      errors[filePath] = errorsFiltered.concat(warnings);
-    }
-
+  if (Object.keys(errors).length) {
     let Printer = require('../lib/printers/default');
     let printer = new Printer(options.named);
     printer.print(errors);

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@ const { preprocess, traverse } = require('@glimmer/syntax');
 const Minimatch = require('minimatch').Minimatch;
 const getConfig = require('./get-config');
 const stripBom = require('strip-bom');
-const chalk = require('chalk');
 let path = require('path');
 
 function buildErrorMessage(moduleId, error) {
@@ -189,100 +188,6 @@ class Linter {
 
     return messages;
   }
-
-  logLintingError(name, moduleName, message) {
-    this._messages.push({
-      rule: name,
-      moduleId: moduleName,
-      message,
-    });
-
-    this.console.log(message);
-  }
-
-  static errorsToMessages(filePath, errors, options) {
-    errors = errors || [];
-    options = options || {
-      verbose: false,
-    };
-
-    if (errors.length === 0) {
-      return '';
-    }
-
-    let errorsMessages = errors.map(error => this._formatError(error, options)).join('\n');
-
-    return `${chalk.underline(filePath)}\n${errorsMessages}\n`;
-  }
-
-  static _formatError(error, options) {
-    let message = '';
-
-    let line = error.line === undefined ? '-' : error.line;
-    let column = error.column === undefined ? '-' : error.column;
-
-    message += chalk.dim(`  ${line}:${column}`);
-
-    if (error.severity === WARNING_SEVERITY) {
-      message += `  ${chalk.yellow('warning')}`;
-    } else {
-      message += `  ${chalk.red('error')}`;
-    }
-
-    message += `  ${error.message}  ${chalk.dim(error.rule)}`;
-
-    if (options.verbose) {
-      message += `\n${error.source}`;
-    }
-
-    return message;
-  }
-
-  reportGitHubActionAnnotations(errors) {
-    if (!process.env.GITHUB_ACTIONS || process.env.DISABLE_GITHUB_ACTIONS_ANNOTATIONS) {
-      return;
-    }
-
-    let files = Object.keys(errors);
-    for (let file of files) {
-      let fileErrors = errors[file];
-      for (let error of fileErrors) {
-        let line = error.line;
-        let col = error.column;
-
-        let annotation = Linter._formatGitHubActionAnnotation(error.message, { file, line, col });
-        this.console.log(annotation);
-      }
-    }
-  }
-
-  static _formatGitHubActionAnnotation(message, options = {}) {
-    message = message || '';
-
-    let output = '::error';
-
-    let outputOptions = Object.keys(options)
-      .map(key => `${key}=${escape(String(options[key]))}`)
-      .join(',');
-
-    if (outputOptions) {
-      output += ` ${outputOptions}`;
-    }
-
-    return `${output}::${escapeData(message)}`;
-  }
-}
-
-function escapeData(s) {
-  return s.replace(/\r/g, '%0D').replace(/\n/g, '%0A');
-}
-
-function escape(s) {
-  return s
-    .replace(/\r/g, '%0D')
-    .replace(/\n/g, '%0A')
-    .replace(/]/g, '%5D')
-    .replace(/;/g, '%3B');
 }
 
 module.exports = Linter;

--- a/lib/printers/default.js
+++ b/lib/printers/default.js
@@ -1,0 +1,28 @@
+'use strict';
+
+class DefaultPrinter {
+  constructor(options = {}) {
+    this.delegates = [];
+
+    if (options.json) {
+      let JsonPrinter = require('./json');
+      this.delegates.push(new JsonPrinter(options));
+    } else {
+      let PrettyPrinter = require('./pretty');
+      this.delegates.push(new PrettyPrinter(options));
+    }
+
+    if (process.env.GITHUB_ACTIONS && !process.env.DISABLE_GITHUB_ACTIONS_ANNOTATIONS) {
+      let GitHubActionsPrinter = require('./github-actions');
+      this.delegates.push(new GitHubActionsPrinter(options));
+    }
+  }
+
+  print(errors) {
+    for (let delegate of this.delegates) {
+      delegate.print(errors);
+    }
+  }
+}
+
+module.exports = DefaultPrinter;

--- a/lib/printers/github-actions.js
+++ b/lib/printers/github-actions.js
@@ -1,0 +1,49 @@
+class GitHubActionsPrinter {
+  constructor(options = {}) {
+    this.console = options.console || console;
+  }
+
+  print(errors) {
+    let files = Object.keys(errors);
+    for (let file of files) {
+      let fileErrors = errors[file];
+      for (let error of fileErrors) {
+        let line = error.line;
+        let col = error.column;
+
+        let annotation = this._formatAnnotation(error.message, { file, line, col });
+        this.console.log(annotation);
+      }
+    }
+  }
+
+  _formatAnnotation(message, options = {}) {
+    message = message || '';
+
+    let output = '::error';
+
+    let outputOptions = Object.keys(options)
+      .map(key => `${key}=${escape(String(options[key]))}`)
+      .join(',');
+
+    if (outputOptions) {
+      output += ` ${outputOptions}`;
+    }
+
+    return `${output}::${escapeData(message)}`;
+  }
+}
+
+function escapeData(s) {
+  return s.replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+}
+
+function escape(s) {
+  return s
+    .replace(/\r/g, '%0D')
+    .replace(/\n/g, '%0A')
+    .replace(/]/g, '%5D')
+    .replace(/;/g, '%3B');
+}
+
+module.exports = GitHubActionsPrinter;

--- a/lib/printers/github-actions.js
+++ b/lib/printers/github-actions.js
@@ -1,3 +1,5 @@
+const Linter = require('../index');
+
 class GitHubActionsPrinter {
   constructor(options = {}) {
     this.console = options.console || console;
@@ -8,11 +10,16 @@ class GitHubActionsPrinter {
     for (let file of files) {
       let fileErrors = errors[file];
       for (let error of fileErrors) {
-        let line = error.line;
-        let col = error.column;
+        if (
+          error.severity === Linter.ERROR_SEVERITY ||
+          error.severity === Linter.WARNING_SEVERITY
+        ) {
+          let line = error.line;
+          let col = error.column;
 
-        let annotation = this._formatAnnotation(error.message, { file, line, col });
-        this.console.log(annotation);
+          let annotation = this._formatAnnotation(error.message, { file, line, col });
+          this.console.log(annotation);
+        }
       }
     }
   }

--- a/lib/printers/json.js
+++ b/lib/printers/json.js
@@ -1,10 +1,25 @@
+const Linter = require('../index');
+
 class JsonPrinter {
   constructor(options = {}) {
+    this.options = options;
     this.console = options.console || console;
   }
 
   print(errors) {
-    this.console.log(JSON.stringify(errors, null, 2));
+    let filteredErrors = {};
+    for (let filePath of Object.keys(errors)) {
+      let fileErrors = errors[filePath] || [];
+
+      let errorsFiltered = fileErrors.filter(error => error.severity === Linter.ERROR_SEVERITY);
+      let warnings = this.options.quiet
+        ? []
+        : fileErrors.filter(error => error.severity === Linter.WARNING_SEVERITY);
+
+      filteredErrors[filePath] = errorsFiltered.concat(warnings);
+    }
+
+    this.console.log(JSON.stringify(filteredErrors, null, 2));
   }
 }
 

--- a/lib/printers/json.js
+++ b/lib/printers/json.js
@@ -1,0 +1,11 @@
+class JsonPrinter {
+  constructor(options = {}) {
+    this.console = options.console || console;
+  }
+
+  print(errors) {
+    this.console.log(JSON.stringify(errors, null, 2));
+  }
+}
+
+module.exports = JsonPrinter;

--- a/lib/printers/pretty.js
+++ b/lib/printers/pretty.js
@@ -12,14 +12,19 @@ class PrettyPrinter {
     let warningCount = 0;
 
     for (const filePath of Object.keys(errors)) {
-      let fileErrors = errors[filePath];
+      let fileErrors = errors[filePath] || [];
 
-      let warnings = fileErrors.filter(error => error.severity === Linter.WARNING_SEVERITY);
+      let errorsFiltered = fileErrors.filter(error => error.severity === Linter.ERROR_SEVERITY);
+      let warnings = this.options.quiet
+        ? []
+        : fileErrors.filter(error => error.severity === Linter.WARNING_SEVERITY);
 
-      errorCount += fileErrors.length - warnings.length;
+      errorCount += errorsFiltered.length;
       warningCount += warnings.length;
 
-      let messages = this.errorsToMessages(filePath, fileErrors, this.options);
+      let allIssues = errorsFiltered.concat(warnings);
+
+      let messages = this.errorsToMessages(filePath, allIssues, this.options);
       if (messages !== '') {
         this.console.log(messages);
       }

--- a/lib/printers/pretty.js
+++ b/lib/printers/pretty.js
@@ -1,0 +1,75 @@
+const chalk = require('chalk');
+const Linter = require('../index');
+
+class PrettyPrinter {
+  constructor(options = {}) {
+    this.options = options;
+    this.console = options.console || console;
+  }
+
+  print(errors) {
+    let errorCount = 0;
+    let warningCount = 0;
+
+    for (const filePath of Object.keys(errors)) {
+      let fileErrors = errors[filePath];
+
+      let warnings = fileErrors.filter(error => error.severity === Linter.WARNING_SEVERITY);
+
+      errorCount += fileErrors.length - warnings.length;
+      warningCount += warnings.length;
+
+      let messages = this.errorsToMessages(filePath, fileErrors, this.options);
+      if (messages !== '') {
+        this.console.log(messages);
+      }
+    }
+
+    let count = errorCount + warningCount;
+
+    if (count > 0) {
+      this.console.log(
+        chalk.red(
+          chalk.bold(`✖ ${count} problems (${errorCount} errors, ${warningCount} warnings)`)
+        )
+      );
+    }
+  }
+
+  errorsToMessages(filePath, errors) {
+    errors = errors || [];
+
+    if (errors.length === 0) {
+      return '';
+    }
+
+    let errorsMessages = errors.map(error => this._formatError(error)).join('\n');
+
+    return `${chalk.underline(filePath)}\n${errorsMessages}\n`;
+  }
+
+  _formatError(error) {
+    let message = '';
+
+    let line = error.line === undefined ? '-' : error.line;
+    let column = error.column === undefined ? '-' : error.column;
+
+    message += chalk.dim(`  ${line}:${column}`);
+
+    if (error.severity === Linter.WARNING_SEVERITY) {
+      message += `  ${chalk.yellow('warning')}`;
+    } else {
+      message += `  ${chalk.red('error')}`;
+    }
+
+    message += `  ${error.message}  ${chalk.dim(error.rule)}`;
+
+    if (this.options.verbose) {
+      message += `\n${error.source}`;
+    }
+
+    return message;
+  }
+}
+
+module.exports = PrettyPrinter;

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -4,7 +4,6 @@ const path = require('path');
 const fs = require('fs');
 const Linter = require('../lib/index');
 const buildFakeConsole = require('./helpers/console');
-const chalk = require('chalk');
 
 const fixturePath = path.join(__dirname, 'fixtures');
 const initialCWD = process.cwd();
@@ -581,72 +580,6 @@ describe('public api', function() {
 
       expect(linter.statusForModule('pending', `${process.cwd()}/some/path/here`)).toBeTruthy();
       expect(linter.statusForModule('pending', `${process.cwd()}/foo/bar/baz`)).toBeTruthy();
-    });
-  });
-
-  describe('Linter.errorsToMessages', function() {
-    beforeEach(() => {
-      chalk.enabled = false;
-    });
-
-    it('formats error with rule, message and moduleId', function() {
-      let result = Linter.errorsToMessages('file/path', [
-        { rule: 'some rule', message: 'some message' },
-      ]);
-
-      expect(result).toEqual('file/path\n' + '  -:-  error  some message  some rule\n');
-    });
-
-    it('formats error with rule, message, line and column numbers even when they are "falsey"', function() {
-      let result = Linter.errorsToMessages('file/path', [
-        { rule: 'some rule', message: 'some message', line: 1, column: 0 },
-      ]);
-
-      expect(result).toEqual('file/path\n' + '  1:0  error  some message  some rule\n');
-    });
-
-    it('formats error with rule, message, line and column numbers', function() {
-      let result = Linter.errorsToMessages('file/path', [
-        { rule: 'some rule', message: 'some message', line: 11, column: 12 },
-      ]);
-
-      expect(result).toEqual('file/path\n' + '  11:12  error  some message  some rule\n');
-    });
-
-    it('formats error with rule, message, source', function() {
-      let result = Linter.errorsToMessages(
-        'file/path',
-        [{ rule: 'some rule', message: 'some message', source: 'some source' }],
-        { verbose: true }
-      );
-
-      expect(result).toEqual(
-        'file/path\n' + '  -:-  error  some message  some rule\n' + 'some source\n'
-      );
-    });
-
-    it('formats more than one error', function() {
-      let result = Linter.errorsToMessages('file/path', [
-        { rule: 'some rule', message: 'some message', line: 11, column: 12 },
-        {
-          rule: 'some rule2',
-          message: 'some message2',
-          moduleId: 'some moduleId2',
-          source: 'some source2',
-        },
-      ]);
-
-      expect(result).toEqual(
-        'file/path\n' +
-          '  11:12  error  some message  some rule\n' +
-          '  -:-  error  some message2  some rule2\n'
-      );
-    });
-
-    it('formats empty errors', function() {
-      let result = Linter.errorsToMessages('file/path', []);
-
-      expect(result).toEqual('');
     });
   });
 });

--- a/test/printers/pretty-test.js
+++ b/test/printers/pretty-test.js
@@ -1,0 +1,66 @@
+const chalk = require('chalk');
+const Printer = require('../../lib/printers/pretty');
+
+describe('Linter.errorsToMessages', function() {
+  beforeEach(() => {
+    chalk.enabled = false;
+  });
+
+  it('formats error with rule, message and moduleId', function() {
+    let result = new Printer().errorsToMessages('file/path', [
+      { rule: 'some rule', message: 'some message' },
+    ]);
+
+    expect(result).toEqual('file/path\n' + '  -:-  error  some message  some rule\n');
+  });
+
+  it('formats error with rule, message, line and column numbers even when they are "falsey"', function() {
+    let result = new Printer().errorsToMessages('file/path', [
+      { rule: 'some rule', message: 'some message', line: 1, column: 0 },
+    ]);
+
+    expect(result).toEqual('file/path\n' + '  1:0  error  some message  some rule\n');
+  });
+
+  it('formats error with rule, message, line and column numbers', function() {
+    let result = new Printer().errorsToMessages('file/path', [
+      { rule: 'some rule', message: 'some message', line: 11, column: 12 },
+    ]);
+
+    expect(result).toEqual('file/path\n' + '  11:12  error  some message  some rule\n');
+  });
+
+  it('formats error with rule, message, source', function() {
+    let result = new Printer({ verbose: true }).errorsToMessages('file/path', [
+      { rule: 'some rule', message: 'some message', source: 'some source' },
+    ]);
+
+    expect(result).toEqual(
+      'file/path\n' + '  -:-  error  some message  some rule\n' + 'some source\n'
+    );
+  });
+
+  it('formats more than one error', function() {
+    let result = new Printer().errorsToMessages('file/path', [
+      { rule: 'some rule', message: 'some message', line: 11, column: 12 },
+      {
+        rule: 'some rule2',
+        message: 'some message2',
+        moduleId: 'some moduleId2',
+        source: 'some source2',
+      },
+    ]);
+
+    expect(result).toEqual(
+      'file/path\n' +
+        '  11:12  error  some message  some rule\n' +
+        '  -:-  error  some message2  some rule2\n'
+    );
+  });
+
+  it('formats empty errors', function() {
+    let result = new Printer().errorsToMessages('file/path', []);
+
+    expect(result).toEqual('');
+  });
+});

--- a/test/unit/github-actions-test.js
+++ b/test/unit/github-actions-test.js
@@ -1,18 +1,21 @@
 'use strict';
 
-const Linter = require('../../lib/index');
-
-const format = Linter._formatGitHubActionAnnotation;
+const Printer = require('../../lib/printers/github-actions');
 
 describe('GitHub Actions Annotations', function() {
   describe('_formatGitHubActionAnnotation', () => {
+    let printer;
+    beforeEach(() => {
+      printer = new Printer();
+    });
+
     test('formats error annotations', () => {
-      let output = format('foo', { file: 'bar.hbs', line: 4, col: 5 });
+      let output = printer._formatAnnotation('foo', { file: 'bar.hbs', line: 4, col: 5 });
       expect(output).toEqual('::error file=bar.hbs,line=4,col=5::foo');
     });
 
     test('escapes correctly', () => {
-      let output = format('wow!\r\nthis is a multiline\nmessage!!', {
+      let output = printer._formatAnnotation('wow!\r\nthis is a multiline\nmessage!!', {
         file: 'semi;colon.hbs',
         line: 4,
         col: 5,


### PR DESCRIPTION
This PR extracts several `Printer` classes from the code to simplify the console output logic.

This prepares to implement a `JUnitPrinter` class (see https://github.com/ember-template-lint/ember-template-lint/issues/616) in a later PR.