### PR TITLE
Implement JUnit XML printer

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -59,6 +59,9 @@ function parseArgv(_argv) {
         case '--json':
           options.named.json = true;
           break;
+        case '--junit':
+          options.named.junit = true;
+          break;
         case '--verbose':
           options.named.verbose = true;
           break;

--- a/lib/printers/default.js
+++ b/lib/printers/default.js
@@ -12,6 +12,11 @@ class DefaultPrinter {
       this.delegates.push(new PrettyPrinter(options));
     }
 
+    if (options.junit) {
+      let JUnitPrinter = require('./junit');
+      this.delegates.push(new JUnitPrinter(options));
+    }
+
     if (process.env.GITHUB_ACTIONS && !process.env.DISABLE_GITHUB_ACTIONS_ANNOTATIONS) {
       let GitHubActionsPrinter = require('./github-actions');
       this.delegates.push(new GitHubActionsPrinter(options));

--- a/lib/printers/junit.js
+++ b/lib/printers/junit.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const builder = require('xmlbuilder');
+const Linter = require('../index');
+
+class JsonPrinter {
+  constructor(options = {}) {
+    this.options = options;
+    this.console = options.console || console;
+  }
+
+  print(result) {
+    fs.writeFileSync('junit-template-lint.xml', this.format(result), 'utf8');
+  }
+
+  format(result) {
+    let root = builder.create('testsuite');
+
+    let filePaths = Object.keys(result);
+
+    let tests = filePaths.length;
+    let failures = 0;
+
+    for (let filePath of filePaths) {
+      let fileResult = result[filePath] || [];
+
+      let el = root.element('testcase');
+      el.attribute('name', filePath);
+
+      let errors = fileResult.filter(it => it.severity !== Linter.WARNING_SEVERITY);
+      if (errors.length !== 0) {
+        let failure = el.element('failure');
+        failure.text(errors.map(it => this.formatFailure(it)).join('\n'));
+
+        failures += 1;
+      }
+    }
+
+    root.attribute('tests', tests);
+    root.attribute('failures', failures);
+
+    return root.end({ pretty: true });
+  }
+
+  formatFailure(error) {
+    let line = error.line === undefined ? '-' : error.line;
+    let column = error.column === undefined ? '-' : error.column;
+
+    return `${line}:${column}  ${error.message}  ${error.rule}`;
+  }
+}
+
+module.exports = JsonPrinter;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "globby": "^9.0.0",
     "minimatch": "^3.0.4",
     "resolve": "^1.1.3",
-    "strip-bom": "^3.0.0"
+    "strip-bom": "^3.0.0",
+    "xmlbuilder": "^13.0.2"
   },
   "devDependencies": {
     "common-tags": "^1.8.0",

--- a/test/printers/junit-test.js
+++ b/test/printers/junit-test.js
@@ -1,0 +1,96 @@
+const Printer = require('../../lib/printers/junit');
+
+describe('JUnit printer', function() {
+  it('formats error with rule, message and moduleId', function() {
+    let printer = new Printer();
+    let result = printer.format({
+      'file/path': [{ rule: 'some rule', message: 'some message' }],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+"<?xml version=\\"1.0\\"?>
+<testsuite tests=\\"1\\" failures=\\"1\\">
+  <testcase name=\\"file/path\\">
+    <failure>-:-  some message  some rule</failure>
+  </testcase>
+</testsuite>"
+`);
+  });
+
+  it('formats error with rule, message, line and column numbers even when they are "falsey"', function() {
+    let printer = new Printer();
+    let result = printer.format({
+      'file/path': [{ rule: 'some rule', message: 'some message', line: 1, column: 0 }],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+"<?xml version=\\"1.0\\"?>
+<testsuite tests=\\"1\\" failures=\\"1\\">
+  <testcase name=\\"file/path\\">
+    <failure>1:0  some message  some rule</failure>
+  </testcase>
+</testsuite>"
+`);
+  });
+
+  it('formats error with rule, message, line and column numbers', function() {
+    let printer = new Printer();
+    let result = printer.format({
+      'file/path': [{ rule: 'some rule', message: 'some message', line: 11, column: 12 }],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+"<?xml version=\\"1.0\\"?>
+<testsuite tests=\\"1\\" failures=\\"1\\">
+  <testcase name=\\"file/path\\">
+    <failure>11:12  some message  some rule</failure>
+  </testcase>
+</testsuite>"
+`);
+  });
+
+  it('formats more than one error', function() {
+    let printer = new Printer();
+    let result = printer.format({
+      'file/path': [
+        { rule: 'some rule', message: 'some message', line: 11, column: 12 },
+        {
+          rule: 'some rule2',
+          message: 'some message2',
+          moduleId: 'some moduleId2',
+          source: 'some source2',
+        },
+      ],
+      'file/other/path': [{ rule: 'some rule', message: 'some message', line: 11, column: 12 }],
+      'foo/bar.hbs': false,
+      'foo/baz.hbs': [],
+    });
+
+    expect(result).toMatchInlineSnapshot(`
+"<?xml version=\\"1.0\\"?>
+<testsuite tests=\\"4\\" failures=\\"2\\">
+  <testcase name=\\"file/path\\">
+    <failure>11:12  some message  some rule
+-:-  some message2  some rule2</failure>
+  </testcase>
+  <testcase name=\\"file/other/path\\">
+    <failure>11:12  some message  some rule</failure>
+  </testcase>
+  <testcase name=\\"foo/bar.hbs\\"/>
+  <testcase name=\\"foo/baz.hbs\\"/>
+</testsuite>"
+`);
+  });
+
+  it('formats empty errors', function() {
+    let printer = new Printer();
+    let result = printer.format({ 'file/path': [] });
+
+    expect(result).toMatchInlineSnapshot(`
+"<?xml version=\\"1.0\\"?>
+<testsuite tests=\\"1\\" failures=\\"0\\">
+  <testcase name=\\"file/path\\"/>
+</testsuite>"
+`);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5982,6 +5982,11 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
+xmlbuilder@^13.0.2:
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-13.0.2.tgz#02ae33614b6a047d1c32b5389c1fdacb2bce47a7"
+  integrity sha512-Eux0i2QdDYKbdbA6AM6xE4m6ZTZr4G4xF9kahI2ukSEMCzwce2eX9WlTI5J3s+NU7hpasFsr8hWIONae7LluAQ==
+
 xtend@~4.0.1:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"


### PR DESCRIPTION
Resolves https://github.com/ember-template-lint/ember-template-lint/issues/616

This implements a basic JUnit XML reporter that writes its output to the `junit-template-lint.xml` file if the `--junit` option is used. Unlike `--json`, this is not mutually exclusive with the regular pretty text reporter.

Ideally, we would have more CLI options to control the output but I figured this would probably be good enough for now.