### PR TITLE
Fix missing `Linter.errorsToMessages()` API for ember-cli-template-lint

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -188,6 +188,17 @@ class Linter {
 
     return messages;
   }
+
+  // this should eventually be removed but is currently still used by ember-cli-template-lint
+  static errorsToMessages(filePath, errors, options) {
+    errors = errors || [];
+    options = options || {
+      verbose: false,
+    };
+
+    let PrettyPrinter = require('./printers/pretty');
+    return PrettyPrinter.errorsToMessages(filePath, errors, options);
+  }
 }
 
 module.exports = Linter;

--- a/lib/printers/pretty.js
+++ b/lib/printers/pretty.js
@@ -24,7 +24,7 @@ class PrettyPrinter {
 
       let allIssues = errorsFiltered.concat(warnings);
 
-      let messages = this.errorsToMessages(filePath, allIssues, this.options);
+      let messages = PrettyPrinter.errorsToMessages(filePath, allIssues, this.options);
       if (messages !== '') {
         this.console.log(messages);
       }
@@ -41,19 +41,19 @@ class PrettyPrinter {
     }
   }
 
-  errorsToMessages(filePath, errors) {
+  static errorsToMessages(filePath, errors, options = {}) {
     errors = errors || [];
 
     if (errors.length === 0) {
       return '';
     }
 
-    let errorsMessages = errors.map(error => this._formatError(error)).join('\n');
+    let errorsMessages = errors.map(error => PrettyPrinter._formatError(error, options)).join('\n');
 
     return `${chalk.underline(filePath)}\n${errorsMessages}\n`;
   }
 
-  _formatError(error) {
+  static _formatError(error, options = {}) {
     let message = '';
 
     let line = error.line === undefined ? '-' : error.line;
@@ -69,7 +69,7 @@ class PrettyPrinter {
 
     message += `  ${error.message}  ${chalk.dim(error.rule)}`;
 
-    if (this.options.verbose) {
+    if (options.verbose) {
       message += `\n${error.source}`;
     }
 

--- a/test/acceptance-test.js
+++ b/test/acceptance-test.js
@@ -4,6 +4,7 @@ const path = require('path');
 const fs = require('fs');
 const Linter = require('../lib/index');
 const buildFakeConsole = require('./helpers/console');
+const chalk = require('chalk');
 
 const fixturePath = path.join(__dirname, 'fixtures');
 const initialCWD = process.cwd();
@@ -580,6 +581,72 @@ describe('public api', function() {
 
       expect(linter.statusForModule('pending', `${process.cwd()}/some/path/here`)).toBeTruthy();
       expect(linter.statusForModule('pending', `${process.cwd()}/foo/bar/baz`)).toBeTruthy();
+    });
+  });
+
+  describe('Linter.errorsToMessages', function() {
+    beforeEach(() => {
+      chalk.enabled = false;
+    });
+
+    it('formats error with rule, message and moduleId', function() {
+      let result = Linter.errorsToMessages('file/path', [
+        { rule: 'some rule', message: 'some message' },
+      ]);
+
+      expect(result).toEqual('file/path\n' + '  -:-  error  some message  some rule\n');
+    });
+
+    it('formats error with rule, message, line and column numbers even when they are "falsey"', function() {
+      let result = Linter.errorsToMessages('file/path', [
+        { rule: 'some rule', message: 'some message', line: 1, column: 0 },
+      ]);
+
+      expect(result).toEqual('file/path\n' + '  1:0  error  some message  some rule\n');
+    });
+
+    it('formats error with rule, message, line and column numbers', function() {
+      let result = Linter.errorsToMessages('file/path', [
+        { rule: 'some rule', message: 'some message', line: 11, column: 12 },
+      ]);
+
+      expect(result).toEqual('file/path\n' + '  11:12  error  some message  some rule\n');
+    });
+
+    it('formats error with rule, message, source', function() {
+      let result = Linter.errorsToMessages(
+        'file/path',
+        [{ rule: 'some rule', message: 'some message', source: 'some source' }],
+        { verbose: true }
+      );
+
+      expect(result).toEqual(
+        'file/path\n' + '  -:-  error  some message  some rule\n' + 'some source\n'
+      );
+    });
+
+    it('formats more than one error', function() {
+      let result = Linter.errorsToMessages('file/path', [
+        { rule: 'some rule', message: 'some message', line: 11, column: 12 },
+        {
+          rule: 'some rule2',
+          message: 'some message2',
+          moduleId: 'some moduleId2',
+          source: 'some source2',
+        },
+      ]);
+
+      expect(result).toEqual(
+        'file/path\n' +
+          '  11:12  error  some message  some rule\n' +
+          '  -:-  error  some message2  some rule2\n'
+      );
+    });
+
+    it('formats empty errors', function() {
+      let result = Linter.errorsToMessages('file/path', []);
+
+      expect(result).toEqual('');
     });
   });
 });

--- a/test/printers/pretty-test.js
+++ b/test/printers/pretty-test.js
@@ -7,7 +7,7 @@ describe('Linter.errorsToMessages', function() {
   });
 
   it('formats error with rule, message and moduleId', function() {
-    let result = new Printer().errorsToMessages('file/path', [
+    let result = Printer.errorsToMessages('file/path', [
       { rule: 'some rule', message: 'some message' },
     ]);
 
@@ -15,7 +15,7 @@ describe('Linter.errorsToMessages', function() {
   });
 
   it('formats error with rule, message, line and column numbers even when they are "falsey"', function() {
-    let result = new Printer().errorsToMessages('file/path', [
+    let result = Printer.errorsToMessages('file/path', [
       { rule: 'some rule', message: 'some message', line: 1, column: 0 },
     ]);
 
@@ -23,7 +23,7 @@ describe('Linter.errorsToMessages', function() {
   });
 
   it('formats error with rule, message, line and column numbers', function() {
-    let result = new Printer().errorsToMessages('file/path', [
+    let result = Printer.errorsToMessages('file/path', [
       { rule: 'some rule', message: 'some message', line: 11, column: 12 },
     ]);
 
@@ -31,9 +31,11 @@ describe('Linter.errorsToMessages', function() {
   });
 
   it('formats error with rule, message, source', function() {
-    let result = new Printer({ verbose: true }).errorsToMessages('file/path', [
-      { rule: 'some rule', message: 'some message', source: 'some source' },
-    ]);
+    let result = Printer.errorsToMessages(
+      'file/path',
+      [{ rule: 'some rule', message: 'some message', source: 'some source' }],
+      { verbose: true }
+    );
 
     expect(result).toEqual(
       'file/path\n' + '  -:-  error  some message  some rule\n' + 'some source\n'
@@ -41,7 +43,7 @@ describe('Linter.errorsToMessages', function() {
   });
 
   it('formats more than one error', function() {
-    let result = new Printer().errorsToMessages('file/path', [
+    let result = Printer.errorsToMessages('file/path', [
       { rule: 'some rule', message: 'some message', line: 11, column: 12 },
       {
         rule: 'some rule2',
@@ -59,7 +61,7 @@ describe('Linter.errorsToMessages', function() {
   });
 
   it('formats empty errors', function() {
-    let result = new Printer().errorsToMessages('file/path', []);
+    let result = Printer.errorsToMessages('file/path', []);
 
     expect(result).toEqual('');
   });


### PR DESCRIPTION
turns out that `ember-cli-template-lint` was relying on that method to exist... 😩 

/cc @rwjblue 