### PR TITLE
Adding error when individual pending rules are passing

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -115,9 +115,10 @@ function run() {
     let fileErrors = lintFile(linter, filePath, moduleId);
 
     if (printPending) {
+      const ignoredPendingRules = ['invalid-pending-module', 'invalid-pending-module-rule'];
       let failingRules = Array.from(
         fileErrors.reduce((memo, error) => {
-          if (error.rule !== 'invalid-pending-module') {
+          if (!ignoredPendingRules.includes(error.rule)) {
             memo.add(error.rule);
           }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -178,13 +178,30 @@ class Linter {
       }
     }
 
-    if (pendingStatus && messages.length === 0) {
-      messages.push({
-        rule: 'invalid-pending-module',
-        message: `Pending module (\`${options.moduleId}\`) passes all rules. Please remove \`${options.moduleId}\` from pending list.`,
-        moduleId: options.moduleId,
-        severity: 2,
-      });
+    if (pendingStatus) {
+      if (messages.length === 0) {
+        messages.push({
+          rule: 'invalid-pending-module',
+          message: `Pending module (\`${options.moduleId}\`) passes all rules. Please remove \`${options.moduleId}\` from pending list.`,
+          moduleId: options.moduleId,
+          severity: 2,
+        });
+      } else {
+        if (pendingStatus.only) {
+          let failedRules = messages.reduce((rules, message) => rules.add(message.rule), new Set());
+
+          pendingStatus.only.forEach(pendingRule => {
+            if (!failedRules.has(pendingRule)) {
+              messages.push({
+                rule: 'invalid-pending-module-rule',
+                message: `Pending module (\`${options.moduleId}\`) passes \`${pendingRule}\` rule. Please remove \`${pendingRule}\` from pending rules list.`,
+                moduleId: options.moduleId,
+                severity: 2,
+              });
+            }
+          });
+        }
+      }
     }
 
     return messages;

--- a/test/fixtures/with-partially-passing-pending-modules/.template-lintrc.js
+++ b/test/fixtures/with-partially-passing-pending-modules/.template-lintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  rules: {
+    'no-html-comments': true,
+    'no-bare-strings': true
+  },
+  pending: [
+    {
+      'moduleId': 'app/templates/application',
+      'only': [
+        'no-html-comments', 'no-bare-strings'
+      ]
+    }
+  ]
+};

--- a/test/fixtures/with-partially-passing-pending-modules/app/templates/application.hbs
+++ b/test/fixtures/with-partially-passing-pending-modules/app/templates/application.hbs
@@ -1,0 +1,2 @@
+<h2>Here too!!</h2>
+<div>Bare strings are bad...</div>

--- a/test/unit/bin/ember-template-lint-test.js
+++ b/test/unit/bin/ember-template-lint-test.js
@@ -375,6 +375,19 @@ describe('ember-template-lint executable', function() {
         expect(result.stdout).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
+
+      it('should ignore existing pending modules that have partially passing rules', function() {
+        let result = run(['.', '--print-pending'], {
+          cwd: './test/fixtures/with-partially-passing-pending-modules',
+        });
+
+        let expectedOutputData =
+          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings"\n    ]\n  }\n]\n';
+
+        expect(result.code).toEqual(1);
+        expect(result.stdout).toEqual(expectedOutputData);
+        expect(result.stderr).toBeFalsy();
+      });
     });
 
     describe('with --print-pending and --json params', function() {


### PR DESCRIPTION
This hopefully fixes the following scenario:

1. We have the following `pending` config:
        ```
{
  moduleId: 'some/path/here',
  only: ['no-bare-strings', 'quotes']
}
        ```
1. Someone "accidentally" fixes all the `quote` issues in `some/path/here` but doesn't update the `pending` config
1. `ember-template-lint` continues happily chugging along
1. Someone reintroduces `quote` issues  in `some/path/here` and `ember-template-lint` doesn't catch them
1. Repeat

The changes in this PR would catch the passing pending rule in step 2, prompting the dev to remove the rule from pending rules.

This new "meta" rule should be incorporated to the work done in #954 after it's merged.