### PR TITLE
--fix: Implement fix algorithm (part 2/2)

### DIFF
--- a/lib/apply-fixes.js
+++ b/lib/apply-fixes.js
@@ -1,3 +1,26 @@
+const { print, transform } = require('ember-template-recast');
+
+/**
+ * Compares the locations of two objects in a source file
+ * @param {line: number, column: number} itemA The first object
+ * @param {line: number, column: number} itemB The second object
+ * @returns {number} A value less than 1 if itemA appears before itemB in the source file, greater than 1 if
+ * itemA appears after itemB in the source file, or 0 if itemA and itemB have the same location.
+ */
+function compareLocations(itemA, itemB) {
+  return itemA.line - itemB.line || itemA.column - itemB.column;
+}
+
+/**
+ * @param {string} source - The source code to fix.
+ * @param {Object} fixer - A visitor that will fix the template
+ * @returns {Object} result - The fixed source
+ */
+function applyFix(source, fixer) {
+  let { ast } = transform(source, fixer);
+  return print(ast);
+}
+
 /**
  * @param {Object} options
  * @param {string} options.source - The source code to fix.
@@ -5,19 +28,16 @@
  * @returns {string} output - The fixed source.
  */
 function applyFixes(options, messages) {
-  let output = options.source;
+  // here sort the messages by position
+  let fixers = messages.filter(message => Boolean(message.fixer));
 
-  let fixes = messages.filter(message => Boolean(message.fix));
-
-  if (!fixes.length) {
-    return output;
+  if (!fixers.length) {
+    return options.source;
   }
 
-  for (const fix of fixes) {
-    output = applyFix(source, fix);
-  }
+  let [message] = fixers.sort(compareLocations);
 
-  return output;
+  return applyFix(options.source, message.fixer);
 }
 
 module.exports = applyFixes;

--- a/lib/apply-fixes.js
+++ b/lib/apply-fixes.js
@@ -1,0 +1,11 @@
+/**
+ * @param {Object} options
+ * @param {string} options.source - The source code to fix.
+ * @param {Object[]} messages - The lint messages.
+ * @returns {string} output - The fixed source.
+ */
+function applyFixes(options /* messages */) {
+  return options.source;
+}
+
+module.exports = applyFixes;

--- a/lib/apply-fixes.js
+++ b/lib/apply-fixes.js
@@ -4,8 +4,20 @@
  * @param {Object[]} messages - The lint messages.
  * @returns {string} output - The fixed source.
  */
-function applyFixes(options /* messages */) {
-  return options.source;
+function applyFixes(options, messages) {
+  let output = options.source;
+
+  let fixes = messages.filter(message => Boolean(message.fix));
+
+  if (!fixes.length) {
+    return output;
+  }
+
+  for (const fix of fixes) {
+    output = applyFix(source, fix);
+  }
+
+  return output;
 }
 
 module.exports = applyFixes;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -9,15 +9,7 @@ const MAX_AUTOFIX_PASSES = 10;
 const WARNING_SEVERITY = 1;
 const ERROR_SEVERITY = 2;
 
-/**
- * @param {Object} options
- * @param {string} options.source - The source code to fix.
- * @param {Object[]} messages - The lint messages.
- * @returns {string} output - The fixed source.
- */
-function applyFixes(options /* messages */) {
-  return options.source;
-}
+const applyFixes = require('./apply-fixes');
 
 function buildErrorMessage(moduleId, error) {
   let message = {


### PR DESCRIPTION
Should be reviewed after https://github.com/ember-template-lint/ember-template-lint/pull/935

In follow-ups (that are ready but no PR opened yet), I have:
- implemented the fs write operation
- implemented the --fix option for `require-button-type`
- setup Jest snapshots to test the above mentioned rule

## Caveheats
- it removes a potential BOM. But is should be easy to preserve it in a follow-up.
- ~~more important: the notion of range is not available yet in the AST, I'll have to add it in template-recast~~

## TODO
- ~~implement the range in template-recast (probably?)~~
- ~~document the fixer API, taken from eslint~~
- implement a few examples
- add more tests
- create a meta issue to implement fix option on fixable rules
- we will need documentation for: how to write a fixer?, how to use builders?, API doc for builders, ...?