### PR TITLE
no-curly-component-invocation: Fix false positives

### DIFF
--- a/docs/rule/no-curly-component-invocation.md
+++ b/docs/rule/no-curly-component-invocation.md
@@ -12,37 +12,49 @@ look like they could be component invocations.
 
 ### Examples
 
-This rule **forbids** the following:
+- `{{foo}}` ✅
+  (simple mustache without `-` in the path is likely to be a property; unless in `disallow` list and not a scoped variable)
 
-```hbs
-{{bad-code}}
-{{#bad-code}}{{/bad-code}}
-{{nested/bad-code}}
-{{#nested/bad-code}}{{/nested/bad-code}}
-```
+- `{{foo.bar}}` ✅
+  (simple mustache with nested path is likely to be a nested property)
 
-This rule **allows** the following:
+- `{{foo-bar}}` ❌ (angle brackets: `<FooBar />`)
+  (simple mustache with `-` in the path is more likely a component than a property or helper; unless in `allow` list)
 
-```hbs
-<GoodCode />
-<GoodCode></GoodCode>
-<Nested::GoodCode />
-<Nested::GoodCode></Nested::GoodCode>
-```
+- `{{nested/component}}` ❌ (angle brackets: `<Nested::Component />`)
+  (simple mustache with `/` in the path is more likely a component than a property or helper; unless in `allow` list)
 
-```hbs
-{{! whitelisted helpers}}
-{{some-valid-helper param}}
-{{some/some-valid-helper param}}
-```
+- `{{42}}` ✅
+  (literal value mustaches)
 
-```hbs
-{{! in-built helpers}}
-{{if someProperty "yay"}}
-{{#each items as |item|}}
-  {{item}}
-{{/each}}
-```
+- `{{foo bar}}` ✅
+  (mustache with positional parameters can't be converted to angle brackets syntax)
+
+- `{{foo bar=baz}}` ❌ (angle brackets: `<Foo @bar={{baz}} />`)
+  (mustache with only named parameters is likely a component; unless in `allow` list)
+
+  Setting `requireDash: true` lets `{{foo bar=baz}}` pass, but `{{foo-bar bar=baz}}` fails
+
+- `<div {{foo}} />` ✅
+  (mustache is a modifier)
+
+- `<Foo @bar={{baz}} />` ✅
+  (mustache is an argument or attribute)
+
+- `{{#foo}}{{/foo}}` ❌ (angle brackets: `<Foo></Foo>`)
+  (block mustache is considered a component unless it has positional parameters, an inverse block, or is in `allow` list)
+
+- `{{#foo bar}}{{/foo}}` ✅
+  (block mustache with positional parameters can't be converted to angle brackets syntax)
+
+- `{{#foo}}bar{{else}}baz{{/foo}}` ✅
+  (block mustache with inverse block can't be converted to angle brackets syntax)
+
+- `{{link-to "bar" "foo"}}` ❌ (angle brackets: `<LinkTo @route="foo">bar</LinkTo>`)
+  (inline form of the built-in `link-to` component)
+
+- `{{#link-to "foo"}}bar{{/link-to}}` ❌ (angle brackets: `<LinkTo @route="foo">bar</LinkTo>`)
+  (block form of the built-in `link-to` component)
 
 ### Migration
 

--- a/docs/rule/no-curly-component-invocation.md
+++ b/docs/rule/no-curly-component-invocation.md
@@ -13,27 +13,34 @@ look like they could be component invocations.
 ### Examples
 
 - `{{foo}}` ✅
-  (simple mustache without `-` in the path is likely to be a property; unless in `disallow` list and not a scoped variable)
+  (simple mustache without `-` in the path is likely to be a property; unless
+  `noImplicitThis` is set or in `disallow` list and not a scoped variable)
 
 - `{{foo.bar}}` ✅
-  (simple mustache with nested path is likely to be a nested property)
+  (simple mustache with nested path is likely to be a nested property; unless
+  `noImplicitThis` is set)
 
 - `{{foo-bar}}` ❌ (angle brackets: `<FooBar />`)
-  (simple mustache with `-` in the path is more likely a component than a property or helper; unless in `allow` list)
+  (simple mustache with `-` in the path is more likely a component than a
+  property or helper; unless in `allow` list)
 
 - `{{nested/component}}` ❌ (angle brackets: `<Nested::Component />`)
-  (simple mustache with `/` in the path is more likely a component than a property or helper; unless in `allow` list)
+  (simple mustache with `/` in the path is more likely a component than a
+  property or helper; unless in `allow` list)
 
 - `{{42}}` ✅
   (literal value mustaches)
 
 - `{{foo bar}}` ✅
-  (mustache with positional parameters can't be converted to angle brackets syntax)
+  (mustache with positional parameters can't be converted to angle brackets
+  syntax)
 
 - `{{foo bar=baz}}` ❌ (angle brackets: `<Foo @bar={{baz}} />`)
-  (mustache with only named parameters is likely a component; unless in `allow` list)
+  (mustache with only named parameters is likely a component; unless in
+  `allow` list)
 
-  Setting `requireDash: true` lets `{{foo bar=baz}}` pass, but `{{foo-bar bar=baz}}` fails
+  Setting `requireDash: true` lets `{{foo bar=baz}}` pass, but
+  `{{foo-bar bar=baz}}` fails
 
 - `<div {{foo}} />` ✅
   (mustache is a modifier)
@@ -42,13 +49,16 @@ look like they could be component invocations.
   (mustache is an argument or attribute)
 
 - `{{#foo}}{{/foo}}` ❌ (angle brackets: `<Foo></Foo>`)
-  (block mustache is considered a component unless it has positional parameters, an inverse block, or is in `allow` list)
+  (block mustache is considered a component unless it has positional
+  parameters, an inverse block, or is in `allow` list)
 
 - `{{#foo bar}}{{/foo}}` ✅
-  (block mustache with positional parameters can't be converted to angle brackets syntax)
+  (block mustache with positional parameters can't be converted to angle
+  brackets syntax)
 
 - `{{#foo}}bar{{else}}baz{{/foo}}` ✅
-  (block mustache with inverse block can't be converted to angle brackets syntax)
+  (block mustache with inverse block can't be converted to angle
+  brackets syntax)
 
 - `{{link-to "bar" "foo"}}` ❌ (angle brackets: `<LinkTo @route="foo">bar</LinkTo>`)
   (inline form of the built-in `link-to` component)
@@ -63,6 +73,10 @@ look like they could be component invocations.
 ### Configuration
 
 - object -- containing the following properties:
+  - boolean -- `noImplicitThis` -- if `true`, the rule considers all simple
+    curly invocations without positional or named arguments as components unless
+    they are prefixed with `this.` or `@` 
+    (default: `false`)
   - boolean -- `requireDash` -- if `true`, the rule only considers curly
     invocations with a `-` character as potential component invocations
     (default: `true`)

--- a/docs/rule/no-curly-component-invocation.md
+++ b/docs/rule/no-curly-component-invocation.md
@@ -2,7 +2,12 @@
 
 ### Rule name: `no-curly-component-invocation`
 
-There are two ways to invoke a component in a template: curly compoment syntax (`{{my-component}}`), and angle bracket syntax (`<MyComponent />`). The difference between them is syntactical. You should favour angle bracket syntax as it improves readability of templates, i.e. disambiguates components from helpers, and is also the future direction Ember is going with the Octane Edition.
+There are two ways to invoke a component in a template: curly compoment syntax
+(`{{my-component}}`), and angle bracket syntax (`<MyComponent />`). The
+difference between them is syntactical. You should favour angle bracket syntax
+as it improves readability of templates, i.e. disambiguates components from
+helpers, and is also the future direction Ember is going with the Octane
+Edition.
 
 #### Bad
 
@@ -33,8 +38,13 @@ There are two ways to invoke a component in a template: curly compoment syntax (
 ```
 
 ## Configuration
+
 ### Whitelisting helpers
-To be able to differentiate between components and helpers used within curlies, e.g. `{{my-helper}}`, you can add a whitelist of all your known helpers to this rule's configuration. To do this add the following to your `.template-lintrc.js` which enables your rule.
+
+To be able to differentiate between components and helpers used within curlies,
+e.g. `{{my-helper}}`, you can add a whitelist of all your known helpers to this
+rule's configuration. To do this add the following to your `.template-lintrc.js`
+which enables your rule.
 
 ```js
 module.exports = {
@@ -49,7 +59,8 @@ module.exports = {
 };
 ```
 
-To get a list of of all the helpers in your app run the following code in your browser's Developer Tools Console when your app has loaded:
+To get a list of of all the helpers in your app run the following code in your
+browser's Developer Tools Console when your app has loaded:
 
 ``` js
 var componentLikeHelpers = Object.keys(require.entries)
@@ -67,7 +78,12 @@ copy(JSON.stringify(componentLikeHelpers));
 Hat tip to @lifeart for [this code](https://github.com/lifeart/ember-ast-hot-load#how-to-use-this-addon).
 
 ### Blacklisting components without dashes
-Since Ember 3.10 components have not required dashes in their name, e.g. `{{datepicker}}`. To help the linter throw an error on these curly component invocations, which it would otherwise have thought to be a helper or property, you can explicitly add it to the `disallow` section of the rule's config. Any curly statements matching an entry in `disallow` will throw a lint error.
+
+Since Ember 3.10 components have not required dashes in their name, e.g.
+`{{datepicker}}`. To help the linter throw an error on these curly component
+invocations, which it would otherwise have thought to be a helper or property,
+you can explicitly add it to the `disallow` section of the rule's config. Any
+curly statements matching an entry in `disallow` will throw a lint error.
 
 ```js
 module.exports = {
@@ -82,7 +98,9 @@ module.exports = {
 };
 ```
 
-To get a list of of all the components in your app which don't have dashes in their name run the following code in your browser's Developer Tools Console when your app has loaded:
+To get a list of of all the components in your app which don't have dashes in
+their name run the following code in your browser's Developer Tools Console when
+your app has loaded:
 
 ``` js
 var componentsWithoutDashes = Object.keys(require.entries)
@@ -98,7 +116,11 @@ copy(JSON.stringify(componentsWithoutDashes));
 ```
 
 ### Matching on components without dashes in their name
-Before Ember 3.10 components were required to have at least one dash, `-`, in their name. By default this rule assumes that all components have `-` in their name. If you'd like to change this behaviour to match all curly invocations, even those without dashes then set the `requireDash` option to `false`.
+
+Before Ember 3.10 components were required to have at least one dash, `-`, in
+their name. By default this rule assumes that all components have `-` in their
+name. If you'd like to change this behaviour to match all curly invocations,
+even those without dashes then set the `requireDash` option to `false`.
 
 ```js
 module.exports = {

--- a/docs/rule/no-curly-component-invocation.md
+++ b/docs/rule/no-curly-component-invocation.md
@@ -1,6 +1,4 @@
-## Use angle bracket syntax for components
-
-### Rule name: `no-curly-component-invocation`
+## no-curly-component-invocation
 
 There are two ways to invoke a component in a template: curly compoment syntax
 (`{{my-component}}`), and angle bracket syntax (`<MyComponent />`). The
@@ -9,7 +7,12 @@ as it improves readability of templates, i.e. disambiguates components from
 helpers, and is also the future direction Ember is going with the Octane
 Edition.
 
-#### Bad
+This rule checks all the curly braces in your app and warns about those that
+look like they could be component invocations.
+
+### Examples
+
+This rule **forbids** the following:
 
 ```hbs
 {{bad-code}}
@@ -18,18 +21,22 @@ Edition.
 {{#nested/bad-code}}{{/nested/bad-code}}
 ```
 
-#### Good
+This rule **allows** the following:
 
 ```hbs
 <GoodCode />
 <GoodCode></GoodCode>
 <Nested::GoodCode />
 <Nested::GoodCode></Nested::GoodCode>
+```
 
+```hbs
 {{! whitelisted helpers}}
 {{some-valid-helper param}}
 {{some/some-valid-helper param}}
+```
 
+```hbs
 {{! in-built helpers}}
 {{if someProperty "yay"}}
 {{#each items as |item|}}
@@ -37,101 +44,23 @@ Edition.
 {{/each}}
 ```
 
-## Configuration
+### Migration
 
-### Whitelisting helpers
+- use https://github.com/ember-codemods/ember-angle-brackets-codemod
 
-To be able to differentiate between components and helpers used within curlies,
-e.g. `{{my-helper}}`, you can add a whitelist of all your known helpers to this
-rule's configuration. To do this add the following to your `.template-lintrc.js`
-which enables your rule.
+### Configuration
 
-```js
-module.exports = {
-  rules: {
-    'no-curly-component-invocation': {
-        allow: [
-        'some-random-helper',
-        'another-helper',
-      ],
-    },
-  },
-};
-```
+- object -- containing the following properties:
+  - boolean -- `requireDash` -- if `true`, the rule only considers curly
+    invocations with a `-` character as potential component invocations
+    (default: `true`)
+  - array -- `allow` -- a list of curly invocation paths that are known to
+    **not** be component invocations
+  - array -- `disallow` -- a list of curly invocation paths that are known to
+    be component invocations
 
-To get a list of of all the helpers in your app run the following code in your
-browser's Developer Tools Console when your app has loaded:
+### References
 
-``` js
-var componentLikeHelpers = Object.keys(require.entries)
-  .filter(name => name.includes('/helpers/'))
-  .map(name => {
-    let path = name.split('/helpers/');
-    return path.pop();
-  })
-  .filter(name => !name.includes('/'))
-  .uniq();
-
-copy(JSON.stringify(componentLikeHelpers));
-```
-
-Hat tip to @lifeart for [this code](https://github.com/lifeart/ember-ast-hot-load#how-to-use-this-addon).
-
-### Blacklisting components without dashes
-
-Since Ember 3.10 components have not required dashes in their name, e.g.
-`{{datepicker}}`. To help the linter throw an error on these curly component
-invocations, which it would otherwise have thought to be a helper or property,
-you can explicitly add it to the `disallow` section of the rule's config. Any
-curly statements matching an entry in `disallow` will throw a lint error.
-
-```js
-module.exports = {
-  rules: {
-    'no-curly-component-invocation': {
-        disallow: [
-        'heading',
-        'datepicker',
-      ],
-    },
-  },
-};
-```
-
-To get a list of of all the components in your app which don't have dashes in
-their name run the following code in your browser's Developer Tools Console when
-your app has loaded:
-
-``` js
-var componentsWithoutDashes = Object.keys(require.entries)
-  .filter(name => name.includes('/components/'))
-  .filter(name => !name.includes('-'))
-  .map(name => {
-    let path = name.split('/components/');
-    return path.pop();
-  })
-  .uniq();
-
-copy(JSON.stringify(componentsWithoutDashes));
-```
-
-### Matching on components without dashes in their name
-
-Before Ember 3.10 components were required to have at least one dash, `-`, in
-their name. By default this rule assumes that all components have `-` in their
-name. If you'd like to change this behaviour to match all curly invocations,
-even those without dashes then set the `requireDash` option to `false`.
-
-```js
-module.exports = {
-  rules: {
-    'no-curly-component-invocation': {
-        requireDash: false,
-    },
-  },
-};
-```
-
-### Related Rules
-
-* [no-args-paths](no-args-paths.md)
+- [RFC #311](https://github.com/emberjs/rfcs/pull/311) (Angle Bracket Syntax)
+- [RFC #457](https://github.com/emberjs/rfcs/pull/457) (Nested Components)
+- [RFC #459](https://github.com/emberjs/rfcs/pull/459) (Angle Bracket Syntax for built-in components)

--- a/lib/config/octane.js
+++ b/lib/config/octane.js
@@ -10,6 +10,7 @@ module.exports = {
     'no-args-paths': true,
     'no-attrs-in-components': true,
     'no-curly-component-invocation': {
+      noImplicitThis: true,
       requireDash: false,
     },
     'no-debugger': true,

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -68,7 +68,32 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
         let name = path.original;
 
         let hasNamedArguments = node.hash.pairs.length !== 0;
-        if (!hasNamedArguments) {
+        if (hasNamedArguments) {
+          if (path.parts.length > 1) {
+            // {{foo.bar bar=baz}}
+            this.logNode({ message: this.generateError(name), node });
+            return;
+          }
+
+          if (this.config.allow.includes(name)) {
+            return;
+          }
+
+          if (['input', 'textarea'].includes(name)) {
+            // {{input type="text" value=this.model.name}}
+            // {{textarea value=this.model.body}}
+            this.logNode({ message: this.generateError(name), node });
+            return;
+          }
+
+          if (this.config.requireDash && !name.includes('-')) {
+            // {{foo bar=baz}}
+            return;
+          }
+
+          // {{foo-bar bar=baz}}
+          this.logNode({ message: this.generateError(name), node });
+        } else {
           if (path.parts.length > 1) {
             // {{foo.bar}}
             return;
@@ -87,36 +112,10 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
             // {{foo-bar}}
             // {{nested/component}}
             this.logNode({ message: this.generateError(name), node });
-            return;
           }
 
-          return;
+          // {{foo}}
         }
-
-        if (path.parts.length > 1) {
-          // {{foo.bar bar=baz}}
-          this.logNode({ message: this.generateError(name), node });
-          return;
-        }
-
-        if (this.config.allow.includes(name)) {
-          return;
-        }
-
-        if (['input', 'textarea'].includes(name)) {
-          // {{input type="text" value=this.model.name}}
-          // {{textarea value=this.model.body}}
-          this.logNode({ message: this.generateError(name), node });
-          return;
-        }
-
-        if (this.config.requireDash && !name.includes('-')) {
-          // {{foo bar=baz}}
-          return;
-        }
-
-        // {{foo-bar bar=baz}}
-        this.logNode({ message: this.generateError(name), node });
       },
 
       BlockStatement(node) {

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -97,6 +97,12 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
     if (node.path.type !== 'PathExpression' || this.isAmbiguousLocalInvocation(node)) {
       return '';
     }
+
+    // skip multi-part paths like `{{request.note}}`
+    if (node.path.parts.length > 1) {
+      return;
+    }
+
     if (
       node.type === 'BlockStatement' &&
       !BUILT_IN_HELPERS.includes(name) &&

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -2,39 +2,6 @@ const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
 const { transformTagName } = require('../helpers/curly-component-invocation');
 
-const BUILT_IN_HELPERS = [
-  'action',
-  'array',
-  'component',
-  'concat',
-  'debugger',
-  'each',
-  'each-in',
-  'fn',
-  'get',
-  'hasBlock',
-  'hasBlockParams',
-  'hash',
-  'if',
-  'input',
-  'let',
-  'link-to',
-  'loc',
-  'log',
-  'mount',
-  'mut',
-  'on',
-  'outlet',
-  'partial',
-  'query-params',
-  'textarea',
-  'unbound',
-  'unless',
-  'with',
-  'yield',
-  '-in-element',
-  'in-element',
-];
 const DEFAULT_CONFIG = {
   allow: [],
   disallow: [],
@@ -69,6 +36,7 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
 
     throw new Error(errorMessage);
   }
+
   logNode({ message, node }) {
     this.log({
       message,
@@ -78,95 +46,132 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
     });
   }
 
-  isAmbiguousLocalInvocation(node) {
-    let hasArguments = node.params.length > 0 || node.hash.pairs.length > 0;
-    return this.isLocal(node) && !hasArguments;
-  }
-
-  getCurlyInvocationSyntaxError(node) {
-    if (node.params.length !== 0) {
-      return;
-    }
-
-    // ignore BlockStatements with `{{else}}` blocks
-    if (node.inverse) {
-      return;
-    }
-
-    let name = node.path.original;
-    if (node.path.type !== 'PathExpression' || this.isAmbiguousLocalInvocation(node)) {
-      return '';
-    }
-
-    // skip multi-part paths like `{{request.note}}`
-    if (node.path.parts.length > 1) {
-      return;
-    }
-
-    if (
-      node.type === 'BlockStatement' &&
-      !BUILT_IN_HELPERS.includes(name) &&
-      !this.isAllowed(name)
-    ) {
-      return this.generateError(name);
-    }
-    if (name.startsWith('this.') || name.startsWith('@') || this.isAllowed(name)) {
-      return '';
-    }
-    if (this.isDisallowed(name) || !this.config.requireDash) {
-      return this.generateError(name);
-    }
-    return /\w+-\w+/g.test(name) ? this.generateError(name) : '';
-  }
-
-  isDisallowed(name) {
-    return this.config.disallow && this.config.disallow.includes(name);
-  }
-
-  isAllowed(name) {
-    return (
-      BUILT_IN_HELPERS.includes(name) || (this.config.allow && this.config.allow.includes(name))
-    );
-  }
-
   generateError(name) {
     let angleBracketName = transformTagName(name);
     return `You are using the component {{${name}}} with curly component syntax. You should use <${angleBracketName}> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['${name}'] }\`.`;
   }
+
   visitor() {
-    let inSafeNamespace = false;
+    let inAttrNode = false;
+
     return {
-      ElementModifierStatement: {
-        enter() {
-          inSafeNamespace = true;
-        },
-        exit() {
-          inSafeNamespace = false;
-        },
-      },
       AttrNode: {
         enter() {
-          inSafeNamespace = true;
+          inAttrNode = true;
         },
         exit() {
-          inSafeNamespace = false;
+          inAttrNode = false;
         },
       },
+
       MustacheStatement(node) {
-        if (inSafeNamespace) {
+        if (inAttrNode) {
+          // <Foo @bar={{baz}} />
           return;
         }
-        let message = this.getCurlyInvocationSyntaxError(node);
-        if (message) {
-          this.logNode({ message, node });
+
+        let { path } = node;
+        if (path.type !== 'PathExpression') {
+          // {{42}}
+          // {{true}}
+          // {{"foo-bar"}}
+          return;
         }
+
+        if (path.original === 'link-to') {
+          // {{link-to "bar" "foo"}}
+          this.logNode({ message: this.generateError('link-to'), node });
+          return;
+        }
+
+        if (node.params.length !== 0) {
+          // {{foo bar}}
+          return;
+        }
+
+        let hasNamedArguments = node.hash.pairs.length !== 0;
+        if (!hasNamedArguments) {
+          if (path.parts.length > 1) {
+            // {{foo.bar}}
+            return;
+          }
+
+          let name = path.original;
+          if (this.config.allow && this.config.allow.includes(name)) {
+            return;
+          }
+
+          if (this.config.disallow && this.config.disallow.includes(name) && !this.isLocal(path)) {
+            this.logNode({ message: this.generateError(name), node });
+            return;
+          }
+
+          if (name.includes('-') || name.includes('/')) {
+            // {{foo-bar}}
+            // {{nested/component}}
+            this.logNode({ message: this.generateError(name), node });
+            return;
+          }
+
+          return;
+        }
+
+        let name = path.original;
+        if (path.parts.length > 1) {
+          // {{foo.bar bar=baz}}
+          this.logNode({ message: this.generateError(name), node });
+          return;
+        }
+
+        if (this.config.allow && this.config.allow.includes(name)) {
+          return;
+        }
+
+        if (['input', 'textarea'].includes(name)) {
+          // {{input type="text" value=this.model.name}}
+          // {{textarea value=this.model.body}}
+          this.logNode({ message: this.generateError(name), node });
+          return;
+        }
+
+        if (this.config.requireDash && !name.includes('-')) {
+          // {{foo bar=baz}}
+          return;
+        }
+
+        // {{foo-bar bar=baz}}
+        this.logNode({ message: this.generateError(name), node });
       },
 
       BlockStatement(node) {
-        let message = this.getCurlyInvocationSyntaxError(node);
-        if (message) {
-          this.logNode({ message, node });
+        if (node.inverse) {
+          // {{#foo}}bar{{else}}baz{{/foo}}
+          return;
         }
+
+        let { path } = node;
+        if (path.type !== 'PathExpression') {
+          return;
+        }
+
+        if (path.original === 'link-to') {
+          // {{#link-to "foo"}}bar{{/link-to}}
+          this.logNode({ message: this.generateError('link-to'), node });
+          return;
+        }
+
+        if (node.params.length !== 0) {
+          // {{#foo bar}}{{/foo}}
+          return;
+        }
+
+        if (this.config.allow && this.config.allow.includes(path.original)) {
+          return;
+        }
+
+        // {{#foo}}{{/foo}}
+        // {{#foo bar=baz}}{{/foo}}
+        this.logNode({ message: this.generateError(path.original), node });
       },
     };
   }

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -10,31 +10,7 @@ const DEFAULT_CONFIG = {
 
 module.exports = class NoCurlyComponentInvocation extends Rule {
   parseConfig(config) {
-    let configType = typeof config;
-
-    switch (configType) {
-      case 'boolean':
-        // if `true` use `DEFAULT_CONFIG`
-        return config ? DEFAULT_CONFIG : false;
-      case 'object':
-        return Object.assign({}, DEFAULT_CONFIG, config);
-      case 'undefined':
-        return false;
-    }
-
-    let errorMessage = createErrorMessage(
-      this.ruleName,
-      [
-        '  * boolean - `true` to enable / `false` to disable',
-        '  * object -- An object with the following keys:',
-        '    * `allow` -- array: A list of whitelisted helpers to be allowed used with curly component syntax',
-        '    * `disallow` -- array: A list of component names to not allow use with curly component syntax',
-        '    * `requireDash` -- boolean: The codemod assumes that all components have a dash in their name. `true` to enable (default) / `false` to disable',
-      ],
-      config
-    );
-
-    throw new Error(errorMessage);
+    return parseConfig(config);
   }
 
   logNode({ message, node }) {
@@ -97,11 +73,11 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
           }
 
           let name = path.original;
-          if (this.config.allow && this.config.allow.includes(name)) {
+          if (this.config.allow.includes(name)) {
             return;
           }
 
-          if (this.config.disallow && this.config.disallow.includes(name) && !this.isLocal(path)) {
+          if (this.config.disallow.includes(name) && !this.isLocal(path)) {
             this.logNode({ message: this.generateError(name), node });
             return;
           }
@@ -123,7 +99,7 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
           return;
         }
 
-        if (this.config.allow && this.config.allow.includes(name)) {
+        if (this.config.allow.includes(name)) {
           return;
         }
 
@@ -165,7 +141,7 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
           return;
         }
 
-        if (this.config.allow && this.config.allow.includes(path.original)) {
+        if (this.config.allow.includes(path.original)) {
           return;
         }
 
@@ -176,3 +152,33 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
     };
   }
 };
+
+function parseConfig(config) {
+  if (config === true) {
+    return DEFAULT_CONFIG;
+  }
+
+  if (config && typeof config === 'object') {
+    return {
+      allow: 'allow' in config ? config.allow : DEFAULT_CONFIG.allow,
+      disallow: 'disallow' in config ? config.disallow : DEFAULT_CONFIG.disallow,
+      requireDash: 'requireDash' in config ? config.requireDash : DEFAULT_CONFIG.requireDash,
+    };
+  }
+
+  let errorMessage = createErrorMessage(
+    'no-curly-component-invocation',
+    [
+      '  * boolean - `true` to enable / `false` to disable',
+      '  * object -- An object with the following keys:',
+      '    * `allow` -- array: A list of whitelisted helpers to be allowed used with curly component syntax',
+      '    * `disallow` -- array: A list of component names to not allow use with curly component syntax',
+      '    * `requireDash` -- boolean: The codemod assumes that all components have a dash in their name. `true` to enable (default) / `false` to disable',
+    ],
+    config
+  );
+
+  throw new Error(errorMessage);
+}
+
+module.exports.parseConfig = parseConfig;

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -65,6 +65,8 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
           return;
         }
 
+        let name = path.original;
+
         let hasNamedArguments = node.hash.pairs.length !== 0;
         if (!hasNamedArguments) {
           if (path.parts.length > 1) {
@@ -72,7 +74,6 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
             return;
           }
 
-          let name = path.original;
           if (this.config.allow.includes(name)) {
             return;
           }
@@ -92,7 +93,6 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
           return;
         }
 
-        let name = path.original;
         if (path.parts.length > 1) {
           // {{foo.bar bar=baz}}
           this.logNode({ message: this.generateError(name), node });

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -6,6 +6,7 @@ const DEFAULT_CONFIG = {
   allow: [],
   disallow: [],
   requireDash: true,
+  noImplicitThis: false,
 };
 
 module.exports = class NoCurlyComponentInvocation extends Rule {
@@ -40,6 +41,7 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
         },
       },
 
+      // eslint-disable-next-line complexity
       MustacheStatement(node) {
         if (inAttrNode) {
           // <Foo @bar={{baz}} />
@@ -94,8 +96,14 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
           // {{foo-bar bar=baz}}
           this.logNode({ message: this.generateError(name), node });
         } else {
+          let isExplicitThis = path.this || path.data;
+
           if (path.parts.length > 1) {
             // {{foo.bar}}
+            if (this.config.noImplicitThis && !isExplicitThis) {
+              this.logNode({ message: this.generateError(name), node });
+            }
+
             return;
           }
 
@@ -103,7 +111,8 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
             return;
           }
 
-          if (this.config.disallow.includes(name) && !this.isLocal(path)) {
+          let isLocal = this.isLocal(path);
+          if (this.config.disallow.includes(name) && !isLocal) {
             this.logNode({ message: this.generateError(name), node });
             return;
           }
@@ -112,9 +121,13 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
             // {{foo-bar}}
             // {{nested/component}}
             this.logNode({ message: this.generateError(name), node });
+            return;
           }
 
           // {{foo}}
+          if (this.config.noImplicitThis && !isExplicitThis && !isLocal) {
+            this.logNode({ message: this.generateError(name), node });
+          }
         }
       },
 
@@ -162,6 +175,8 @@ function parseConfig(config) {
       allow: 'allow' in config ? config.allow : DEFAULT_CONFIG.allow,
       disallow: 'disallow' in config ? config.disallow : DEFAULT_CONFIG.disallow,
       requireDash: 'requireDash' in config ? config.requireDash : DEFAULT_CONFIG.requireDash,
+      noImplicitThis:
+        'noImplicitThis' in config ? config.noImplicitThis : DEFAULT_CONFIG.noImplicitThis,
     };
   }
 

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -19,6 +19,15 @@ const SHARED_GOOD = [
   `{{#each items as |item|}}
      {{item}}
    {{/each}}`,
+  '{{#-in-element}}Hello{{/-in-element}}',
+  '{{#in-element}}Hello{{/in-element}}',
+  '{{#some-component foo="bar"}}foo{{else}}bar{{/some-component}}',
+  '<MyComponent @arg={{my-helper this.foobar}} />',
+  '<MyComponent @arg="{{my-helper this.foobar}}" />',
+  '<MyComponent {{my-modifier this.foobar}} />',
+  '{{svg-jar "status"}}',
+  '{{t "some.translation.key"}}',
+  '{{#animated-if condition}}foo{{/animated-if}}',
 ];
 
 const SHARED_BAD = [
@@ -54,20 +63,7 @@ generateRuleTests({
     disallow: ['heading'],
   },
 
-  good: [
-    ...SHARED_GOOD,
-    '{{#-in-element}}Hello{{/-in-element}}',
-    '{{#in-element}}Hello{{/in-element}}',
-    '{{#some-component foo="bar"}}foo{{else}}bar{{/some-component}}',
-    '<MyComponent @arg={{my-helper this.foobar}} />',
-    '<MyComponent @arg="{{my-helper this.foobar}}" />',
-    '<MyComponent {{my-modifier this.foobar}} />',
-    '{{svg-jar "status"}}',
-    '{{t "some.translation.key"}}',
-    '{{model.selectedTransfersCount}}',
-    '{{request.note}}',
-    '{{#animated-if condition}}foo{{/animated-if}}',
-  ],
+  good: [...SHARED_GOOD, '{{model.selectedTransfersCount}}', '{{request.note}}'],
 
   bad: [
     ...SHARED_BAD,

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -6,6 +6,46 @@ function generateError(name) {
   return `You are using the component {{${name}}} with curly component syntax. You should use <${angleBracketName}> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. \`'no-curly-component-invocation': { allow: ['${name}'] }\`.`;
 }
 
+const SHARED_GOOD = [
+  '<GoodCode />',
+  '<GoodCode></GoodCode>',
+  '{{if someProperty "yay"}}',
+  '<Nested::GoodCode />',
+  '<Nested::GoodCode @someProperty={{-50}} @someProperty={{"-50"}} @someProperty={{true}} />',
+  '{{some-valid-helper param}}',
+  '{{some/valid-nested-helper param}}',
+  '{{@someArg}}',
+  '{{this.someProperty}}',
+  `{{#each items as |item|}}
+     {{item}}
+   {{/each}}`,
+];
+
+const SHARED_BAD = [
+  {
+    template: '{{nested/bad-code}}',
+    results: [getErrorResult(generateError('nested/bad-code'), '{{nested/bad-code}}')],
+  },
+  {
+    template: '{{heading size="1" text="Disallowed heading component"}}',
+    results: [
+      getErrorResult(
+        generateError('heading'),
+        '{{heading size="1" text="Disallowed heading component"}}'
+      ),
+    ],
+  },
+  {
+    template: '{{#heading size="1"}}Disallowed heading component{{/heading}}',
+    results: [
+      getErrorResult(
+        generateError('heading'),
+        '{{#heading size="1"}}Disallowed heading component{{/heading}}'
+      ),
+    ],
+  },
+];
+
 generateRuleTests({
   name: 'no-curly-component-invocation',
 
@@ -15,18 +55,7 @@ generateRuleTests({
   },
 
   good: [
-    '<GoodCode />',
-    '<GoodCode></GoodCode>',
-    '{{if someProperty "yay"}}',
-    '<Nested::GoodCode />',
-    '<Nested::GoodCode @someProperty={{-50}} @someProperty={{"-50"}} @someProperty={{true}} />',
-    '{{some-valid-helper param}}',
-    '{{some/valid-nested-helper param}}',
-    '{{@someArg}}',
-    '{{this.someProperty}}',
-    `{{#each items as |item|}}
-        {{item}}
-     {{/each}}`,
+    ...SHARED_GOOD,
     '{{#-in-element}}Hello{{/-in-element}}',
     '{{#in-element}}Hello{{/in-element}}',
     '{{#some-component foo="bar"}}foo{{else}}bar{{/some-component}}',
@@ -41,36 +70,15 @@ generateRuleTests({
   ],
 
   bad: [
-    {
-      template: '<div>{{bad-code}}</div>',
-      results: [
-        Object.assign(getErrorResult(generateError('bad-code'), '{{bad-code}}'), { column: 5 }),
-      ],
-    },
+    ...SHARED_BAD,
     {
       template: '{{bad-code}}',
       results: [getErrorResult(generateError('bad-code'), '{{bad-code}}')],
     },
     {
-      template: '{{nested/bad-code}}',
-      results: [getErrorResult(generateError('nested/bad-code'), '{{nested/bad-code}}')],
-    },
-    {
-      template: '{{heading size="1" text="Disallowed heading component"}}',
+      template: '<div>{{bad-code}}</div>',
       results: [
-        getErrorResult(
-          generateError('heading'),
-          '{{heading size="1" text="Disallowed heading component"}}'
-        ),
-      ],
-    },
-    {
-      template: '{{#heading size="1"}}Disallowed heading component{{/heading}}',
-      results: [
-        getErrorResult(
-          generateError('heading'),
-          '{{#heading size="1"}}Disallowed heading component{{/heading}}'
-        ),
+        Object.assign(getErrorResult(generateError('bad-code'), '{{bad-code}}'), { column: 5 }),
       ],
     },
   ],
@@ -85,48 +93,13 @@ generateRuleTests({
     requireDash: false,
   },
 
-  good: [
-    '<GoodCode />',
-    '<GoodCode></GoodCode>',
-    '{{if someProperty "yay"}}',
-    '<Nested::GoodCode />',
-    '<Nested::GoodCode @someProperty={{-50}} @someProperty={{"-50"}}/ />',
-    '{{some-valid-helper param}}',
-    '{{some/valid-nested-helper param}}',
-    '{{@someArg}}',
-    '{{this.someProperty}}',
-    `{{#each items as |item|}}
-       {{item}}
-     {{/each}}`,
-    '{{#each items as |item|}}{{item value}}{{/each}}',
-  ],
+  good: [...SHARED_GOOD, '{{#each items as |item|}}{{item value}}{{/each}}'],
 
   bad: [
+    ...SHARED_BAD,
     {
       template: '{{box}}',
       results: [getErrorResult(generateError('box'), '{{box}}')],
-    },
-    {
-      template: '{{nested/bad-code}}',
-      results: [getErrorResult(generateError('nested/bad-code'), '{{nested/bad-code}}')],
-    },
-    {
-      template: '{{heading size="1" text="Disallowed heading component"}}',
-      results: [
-        getErrorResult(
-          generateError('heading'),
-          '{{heading size="1" text="Disallowed heading component"}}'
-        ),
-      ],
-    },
-    {
-      template: '{{#heading size="1"}}Disallowed heading component{{/heading}}',
-      results: [
-        getErrorResult(
-          generateError('heading'),
-          '{{#heading size="1"}}Disallowed heading component{{/heading}}'
-        ),
-      ],
     },
     {
       template: '{{#each items as |item|}} {{item some=args}} {{/each}}',

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -80,6 +80,17 @@ const SHARED_BAD = [
     ],
   },
   {
+    template: '{{foo.bar bar=baz}}',
+    results: [
+      {
+        message: generateError('foo.bar'),
+        line: 1,
+        column: 0,
+        source: '{{foo.bar bar=baz}}',
+      },
+    ],
+  },
+  {
     template: '{{link-to "bar" "foo"}}',
     results: [
       {
@@ -191,7 +202,13 @@ generateRuleTests({
     requireDash: false,
   },
 
-  good: [...SHARED_GOOD, '{{aaa-bbb}}', '{{aaa/bbb}}', '{{aaa-bbb bar=baz}}'],
+  good: [
+    ...SHARED_GOOD,
+    '{{aaa-bbb}}',
+    '{{aaa/bbb}}',
+    '{{aaa-bbb bar=baz}}',
+    '{{#aaa-bbb bar=baz}}{{/aaa-bbb}}',
+  ],
   bad: [...SHARED_BAD],
 });
 

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -28,6 +28,9 @@ const SHARED_GOOD = [
   '{{svg-jar "status"}}',
   '{{t "some.translation.key"}}',
   '{{#animated-if condition}}foo{{/animated-if}}',
+  '{{model.selectedTransfersCount}}',
+  '{{request.note}}',
+  '{{42}}',
 ];
 
 const SHARED_BAD = [
@@ -63,7 +66,7 @@ generateRuleTests({
     disallow: ['heading'],
   },
 
-  good: [...SHARED_GOOD, '{{model.selectedTransfersCount}}', '{{request.note}}'],
+  good: [...SHARED_GOOD],
 
   bad: [
     ...SHARED_BAD,

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -1,5 +1,6 @@
 const generateRuleTests = require('../../helpers/rule-test-harness');
 const { transformTagName } = require('../../../lib/helpers/curly-component-invocation');
+const { parseConfig } = require('../../../lib/rules/no-curly-component-invocation');
 
 function generateError(name) {
   let angleBracketName = transformTagName(name);
@@ -203,4 +204,32 @@ generateRuleTests({
 
   good: [...SHARED_GOOD, '{{foo bar=baz}}'],
   bad: [...SHARED_BAD],
+});
+
+describe('no-curly-component-invocation', () => {
+  describe('parseConfig', () => {
+    const TESTS = [
+      [true, { allow: [], disallow: [], requireDash: true }],
+      [{ allow: ['foo'] }, { allow: ['foo'], disallow: [], requireDash: true }],
+      [{ requireDash: false }, { allow: [], disallow: [], requireDash: false }],
+      [
+        { allow: ['foo'], disallow: ['bar', 'baz'], requireDash: false },
+        { allow: ['foo'], disallow: ['bar', 'baz'], requireDash: false },
+      ],
+    ];
+
+    for (let [input, expected] of TESTS) {
+      test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
+        expect(parseConfig(input)).toEqual(expected);
+      });
+    }
+
+    const FAILURE_TESTS = [undefined, null, false, 'error'];
+
+    for (let input of FAILURE_TESTS) {
+      test(`${JSON.stringify(input)} -> Error`, () => {
+        expect(() => parseConfig(input)).toThrow();
+      });
+    }
+  });
 });


### PR DESCRIPTION
This PR resolves https://github.com/ember-template-lint/ember-template-lint/issues/1026 by basically rewriting the rule 🙈 

I've documented the assumptions that the rule now makes in the rule documentation.

I would personally consider this a bugfix since it clarifies some edge cases and should result in less false positive warnings.