### PR TITLE
no-passed-in-event-handlers: Ignore built-in `input` and `textarea` components

### DIFF
--- a/lib/rules/no-passed-in-event-handlers.js
+++ b/lib/rules/no-passed-in-event-handlers.js
@@ -43,20 +43,23 @@ const EVENT_HANDLER_METHODS = [
 module.exports = class NoPassedInEventHandlers extends Rule {
   visitor() {
     return {
-      AttrNode(node) {
-        let { name } = node;
-        if (!name.startsWith('@')) {
-          return;
-        }
-        name = name.slice(1);
+      ElementNode(node) {
+        let { attributes } = node;
+        for (let attribute of attributes) {
+          let { name } = attribute;
+          if (!name.startsWith('@')) {
+            continue;
+          }
+          name = name.slice(1);
 
-        if (EVENT_HANDLER_METHODS.includes(name)) {
-          this.log({
-            message: makeErrorMessage(name),
-            line: node.loc && node.loc.start.line,
-            column: node.loc && node.loc.start.column,
-            source: this.sourceForNode(node),
-          });
+          if (EVENT_HANDLER_METHODS.includes(name)) {
+            this.log({
+              message: makeErrorMessage(name),
+              line: attribute.loc && attribute.loc.start.line,
+              column: attribute.loc && attribute.loc.start.column,
+              source: this.sourceForNode(attribute),
+            });
+          }
         }
       },
 

--- a/lib/rules/no-passed-in-event-handlers.js
+++ b/lib/rules/no-passed-in-event-handlers.js
@@ -44,7 +44,12 @@ module.exports = class NoPassedInEventHandlers extends Rule {
   visitor() {
     return {
       ElementNode(node) {
-        let { attributes } = node;
+        let { tag, attributes } = node;
+
+        if (['Input', 'Textarea'].includes(tag)) {
+          return;
+        }
+
         for (let attribute of attributes) {
           let { name } = attribute;
           if (!name.startsWith('@')) {
@@ -64,7 +69,13 @@ module.exports = class NoPassedInEventHandlers extends Rule {
       },
 
       MustacheStatement(node) {
-        let { pairs } = node.hash;
+        let { path, hash } = node;
+        let { pairs } = hash;
+
+        if (path.type === 'PathExpression' && ['input', 'textarea'].includes(path.original)) {
+          return;
+        }
+
         for (let pair of pairs) {
           let { key } = pair;
 

--- a/test/unit/rules/no-passed-in-event-handlers-test.js
+++ b/test/unit/rules/no-passed-in-event-handlers-test.js
@@ -15,6 +15,8 @@ generateRuleTests({
     '<Foo @touch={{this.handleClick}} />',
     '<Foo @random="foo" />',
     '<Foo @random={{true}} />',
+    '<Input @click={{this.handleClick}} />',
+    '<Textarea @click={{this.handleClick}} />',
 
     '{{foo}}',
     '{{foo onClick=this.handleClick}}',
@@ -23,6 +25,8 @@ generateRuleTests({
     '{{foo touch=this.handleClick}}',
     '{{foo random="foo"}}',
     '{{foo random=true}}',
+    '{{input click=this.handleClick}}',
+    '{{textarea click=this.handleClick}}',
   ],
   bad: [
     {


### PR DESCRIPTION
Resolves https://github.com/ember-template-lint/ember-template-lint/issues/1030

/cc @boris-petrov @lifeart 