### PR TITLE
no-curly-component-invocation: Ignore built-ins and fix nested key scoped variable scenario

### DIFF
--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -97,10 +97,11 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
           this.logNode({ message: this.generateError(name), node });
         } else {
           let isExplicitThis = path.this || path.data;
+          let isLocal = this.isLocal(path);
 
           if (path.parts.length > 1) {
             // {{foo.bar}}
-            if (this.config.noImplicitThis && !isExplicitThis) {
+            if (this.config.noImplicitThis && !isExplicitThis && !isLocal) {
               this.logNode({ message: this.generateError(name), node });
             }
 
@@ -111,7 +112,6 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
             return;
           }
 
-          let isLocal = this.isLocal(path);
           if (this.config.disallow.includes(name) && !isLocal) {
             this.logNode({ message: this.generateError(name), node });
             return;

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -9,6 +9,41 @@ const DEFAULT_CONFIG = {
   noImplicitThis: false,
 };
 
+const BUILT_INS = [
+  'action',
+  'array',
+  'component',
+  'concat',
+  'debugger',
+  'each',
+  'each-in',
+  'fn',
+  'get',
+  'hasBlock',
+  'has-block',
+  'has-block-params',
+  'hash',
+  'if',
+  'input',
+  'let',
+  'link-to',
+  'loc',
+  'log',
+  'mount',
+  'mut',
+  'on',
+  'outlet',
+  'partial',
+  'query-params',
+  'textarea',
+  'unbound',
+  'unless',
+  'with',
+  'yield',
+  '-in-element',
+  'in-element',
+];
+
 module.exports = class NoCurlyComponentInvocation extends Rule {
   parseConfig(config) {
     return parseConfig(config);
@@ -114,6 +149,13 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
 
           if (this.config.disallow.includes(name) && !isLocal) {
             this.logNode({ message: this.generateError(name), node });
+            return;
+          }
+
+          if (BUILT_INS.includes(name)) {
+            // {{debugger}}
+            // {{outlet}}
+            // {{yield}}
             return;
           }
 

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -16,6 +16,7 @@ const SHARED_MOSTLY_GOOD = [
 
 const SHARED_GOOD = [
   '{{#each items as |item|}}{{item}}{{/each}}',
+  '{{#each items as |item|}}{{item.foo}}{{/each}}',
   '{{42}}',
   '{{true}}',
   '{{undefined}}',

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -27,6 +27,17 @@ const SHARED_GOOD = [
   '{{#foo bar}}{{/foo}}',
   '{{#foo}}bar{{else}}baz{{/foo}}',
 
+  // single-word no-arguments built-ins
+  '{{array}}',
+  '{{concat}}',
+  '{{debugger}}',
+  '{{has-block}}',
+  '{{has-block-params}}',
+  '{{hasBlock}}',
+  '{{hash}}',
+  '{{outlet}}',
+  '{{yield}}',
+
   // real world examples
   '<GoodCode />',
   '<GoodCode></GoodCode>',


### PR DESCRIPTION
This PR addresses https://github.com/ember-template-lint/ember-template-lint/pull/1027#discussion_r361016133 and https://github.com/ember-template-lint/ember-template-lint/pull/1027#issuecomment-568596607.

Sorry about that... 😔 

/cc @chancancode 