### PR TITLE
Refactor test-harness

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -91,10 +91,9 @@ module.exports = function generateRuleTests({
       linter.config.rules[name] = localConfig;
     }
 
-    function verify(template, localConfig) {
+    function prepare(template, localConfig) {
       updateLinterConfig(localConfig);
-      let options = getVerifyOptions(template, meta);
-      return linter.verify(options);
+      return getVerifyOptions(template, meta);
     }
 
     groupMethodBefore(function() {
@@ -137,7 +136,8 @@ module.exports = function generateRuleTests({
 
         meta = parseMeta(badItem);
 
-        let actual = verify(template, badItem.config);
+        let options = prepare(template, badItem.config);
+        let actual = linter.verify(options);
 
         if (badItem.fatal) {
           assert.strictEqual(actual.length, 1); // can't have more than one fatal error
@@ -155,7 +155,8 @@ module.exports = function generateRuleTests({
           meta = parseMeta(badItem);
 
           let config = false;
-          let actual = verify(template, config);
+          let options = prepare(template, config);
+          let actual = linter.verify(options);
 
           assert.deepStrictEqual(actual, []);
         });
@@ -164,7 +165,8 @@ module.exports = function generateRuleTests({
           `passes with \`${template}\` when disabled via inline comment - single rule`,
           function() {
             meta = parseMeta(badItem);
-            let actual = verify(`${DISABLE_ONE}\n${template}`);
+            let options = prepare(`${DISABLE_ONE}\n${template}`);
+            let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
           }
@@ -174,7 +176,8 @@ module.exports = function generateRuleTests({
           `passes with \`${template}\` when disabled via long-form inline comment - single rule`,
           function() {
             meta = parseMeta(badItem);
-            let actual = verify(`${DISABLE_ONE_LONG}\n${template}`);
+            let options = prepare(`${DISABLE_ONE_LONG}\n${template}`);
+            let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
           }
@@ -184,7 +187,8 @@ module.exports = function generateRuleTests({
           `passes with \`${template}\` when disabled via inline comment - all rules`,
           function() {
             meta = parseMeta(badItem);
-            let actual = verify(`${DISABLE_ALL}\n${template}`);
+            let options = prepare(`${DISABLE_ALL}\n${template}`);
+            let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
           }
@@ -197,13 +201,9 @@ module.exports = function generateRuleTests({
 
       testMethod(`passes when given \`${template}\``, function() {
         meta = parseMeta(goodItem);
-        let actual;
 
-        if (typeof goodItem === 'string') {
-          actual = verify(goodItem);
-        } else {
-          actual = verify(template, goodItem.config);
-        }
+        let options = prepare(template, goodItem.config);
+        let actual = linter.verify(options);
 
         assert.deepStrictEqual(actual, []);
       });
@@ -219,7 +219,8 @@ module.exports = function generateRuleTests({
         meta = parseMeta(item);
         expectedResults = expectedResults.map(parseResult);
 
-        let actual = verify(template, config);
+        let options = prepare(template, config);
+        let actual = linter.verify(options);
 
         for (let i = 0; i < actual.length; i++) {
           if (actual[i].fatal) {

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -91,6 +91,16 @@ module.exports = function generateRuleTests({
       linter.config.rules[name] = localConfig;
     }
 
+    /**
+     * Prepare an invidividual snippet to be linted in a test:
+     * - update linter config with the config passed along the snippet (optional)
+     * - return options, to be provided to linter
+     *
+     * @param {string|Object} item - a snippet to lint
+     * @param {string} [item.template] - if item was an object, the snippet
+     * @param {boolean|Object} localConfig - the config passed along the snippet
+     * @returns {Object} options - options to pass to the linter instance
+     */
     function prepare(item, localConfig) {
       let template = typeof item === 'string' ? item : item.template;
       let meta = parseMeta(item);

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -81,7 +81,7 @@ module.exports = function generateRuleTests({
     let DISABLE_ONE = `{{! template-lint-disable ${name} }}`;
     let DISABLE_ONE_LONG = `{{!-- template-lint-disable ${name} --}}`;
 
-    let linter, meta;
+    let linter;
 
     function updateLinterConfig(localConfig) {
       if (localConfig === undefined) {
@@ -91,7 +91,7 @@ module.exports = function generateRuleTests({
       linter.config.rules[name] = localConfig;
     }
 
-    function prepare(template, localConfig) {
+    function prepare(template, localConfig, meta) {
       updateLinterConfig(localConfig);
       return getVerifyOptions(template, meta);
     }
@@ -102,8 +102,6 @@ module.exports = function generateRuleTests({
         rules: {},
       };
       initialConfig.rules[name] = passedConfig;
-
-      meta = null;
 
       linter = new Linter({
         config: initialConfig,
@@ -134,9 +132,8 @@ module.exports = function generateRuleTests({
       testMethod(`logs a message in the console when given \`${template}\``, function() {
         let expectedResults = badItem.results || [badItem.result];
 
-        meta = parseMeta(badItem);
-
-        let options = prepare(template, badItem.config);
+        let meta = parseMeta(badItem);
+        let options = prepare(template, badItem.config, meta);
         let actual = linter.verify(options);
 
         if (badItem.fatal) {
@@ -152,10 +149,9 @@ module.exports = function generateRuleTests({
 
       if (!skipDisabledTests) {
         testMethod(`passes with \`${template}\` when rule is disabled`, function() {
-          meta = parseMeta(badItem);
-
           let config = false;
-          let options = prepare(template, config);
+          let meta = parseMeta(badItem);
+          let options = prepare(template, config, meta);
           let actual = linter.verify(options);
 
           assert.deepStrictEqual(actual, []);
@@ -164,8 +160,8 @@ module.exports = function generateRuleTests({
         testMethod(
           `passes with \`${template}\` when disabled via inline comment - single rule`,
           function() {
-            meta = parseMeta(badItem);
-            let options = prepare(`${DISABLE_ONE}\n${template}`);
+            let meta = parseMeta(badItem);
+            let options = prepare(`${DISABLE_ONE}\n${template}`, undefined, meta);
             let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
@@ -175,8 +171,8 @@ module.exports = function generateRuleTests({
         testMethod(
           `passes with \`${template}\` when disabled via long-form inline comment - single rule`,
           function() {
-            meta = parseMeta(badItem);
-            let options = prepare(`${DISABLE_ONE_LONG}\n${template}`);
+            let meta = parseMeta(badItem);
+            let options = prepare(`${DISABLE_ONE_LONG}\n${template}`, undefined, meta);
             let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
@@ -186,8 +182,8 @@ module.exports = function generateRuleTests({
         testMethod(
           `passes with \`${template}\` when disabled via inline comment - all rules`,
           function() {
-            meta = parseMeta(badItem);
-            let options = prepare(`${DISABLE_ALL}\n${template}`);
+            let meta = parseMeta(badItem);
+            let options = prepare(`${DISABLE_ALL}\n${template}`, undefined, meta);
             let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
@@ -200,9 +196,8 @@ module.exports = function generateRuleTests({
       let template = typeof goodItem === 'string' ? goodItem : goodItem.template;
 
       testMethod(`passes when given \`${template}\``, function() {
-        meta = parseMeta(goodItem);
-
-        let options = prepare(template, goodItem.config);
+        let meta = parseMeta(goodItem);
+        let options = prepare(template, goodItem.config, meta);
         let actual = linter.verify(options);
 
         assert.deepStrictEqual(actual, []);
@@ -216,10 +211,10 @@ module.exports = function generateRuleTests({
 
       testMethod(`errors when given \`${template}\` with config \`${friendlyConfig}\``, function() {
         let expectedResults = item.results || [item.result];
-        meta = parseMeta(item);
         expectedResults = expectedResults.map(parseResult);
 
-        let options = prepare(template, config);
+        let meta = parseMeta(item);
+        let options = prepare(template, config, meta);
         let actual = linter.verify(options);
 
         for (let i = 0; i < actual.length; i++) {

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -73,24 +73,41 @@ module.exports = function generateRuleTests({
     let DISABLE_ONE = `{{! template-lint-disable ${name} }}`;
     let DISABLE_ONE_LONG = `{{!-- template-lint-disable ${name} --}}`;
 
-    let linter, config, meta;
+    let linter, meta;
 
-    function verify(template) {
-      linter.config.rules[name] = config;
-      return linter.verify({ source: template, moduleId: meta.moduleId });
+    function updateLinterConfig(localConfig) {
+      if (localConfig === undefined) {
+        return;
+      }
+
+      linter.config.rules[name] = localConfig;
+    }
+
+    function getVerifyOptions(template) {
+      const options = { source: template, moduleId: meta.moduleId };
+      if ('configResolver' in meta) {
+        options.configResolver = meta.configResolver;
+      }
+      return options;
+    }
+
+    function verify(template, localConfig) {
+      updateLinterConfig(localConfig);
+      let options = getVerifyOptions(template);
+      return linter.verify(options);
     }
 
     groupMethodBefore(function() {
-      let fullConfig = {
+      let initialConfig = {
         plugins,
         rules: {},
       };
-      fullConfig.rules[name] = config = passedConfig;
+      initialConfig.rules[name] = passedConfig;
 
       meta = null;
 
       linter = new Linter({
-        config: fullConfig,
+        config: initialConfig,
       });
     });
 
@@ -120,11 +137,7 @@ module.exports = function generateRuleTests({
 
         meta = parseMeta(badItem);
 
-        if (badItem.config) {
-          config = badItem.config;
-        }
-
-        let actual = verify(template);
+        let actual = verify(template, badItem.config);
 
         if (badItem.fatal) {
           assert.strictEqual(actual.length, 1); // can't have more than one fatal error
@@ -139,9 +152,10 @@ module.exports = function generateRuleTests({
 
       if (!skipDisabledTests) {
         testMethod(`passes with \`${template}\` when rule is disabled`, function() {
-          config = false;
           meta = parseMeta(badItem);
-          let actual = verify(template);
+
+          let config = false;
+          let actual = verify(template, config);
 
           assert.deepStrictEqual(actual, []);
         });
@@ -188,11 +202,7 @@ module.exports = function generateRuleTests({
         if (typeof goodItem === 'string') {
           actual = verify(goodItem);
         } else {
-          if (goodItem.config !== undefined) {
-            config = goodItem.config;
-          }
-
-          actual = verify(template);
+          actual = verify(template, goodItem.config);
         }
 
         assert.deepStrictEqual(actual, []);
@@ -200,24 +210,16 @@ module.exports = function generateRuleTests({
     });
 
     error.forEach(item => {
-      let template = item.template;
-
-      if (item.config !== undefined) {
-        config = item.config;
-      }
+      let { config, template } = item;
 
       let friendlyConfig = JSON.stringify(config);
-
-      let _config = config;
 
       testMethod(`errors when given \`${template}\` with config \`${friendlyConfig}\``, function() {
         let expectedResults = item.results || [item.result];
         meta = parseMeta(item);
         expectedResults = expectedResults.map(parseResult);
 
-        config = _config;
-
-        let actual = verify(template);
+        let actual = verify(template, config);
 
         for (let i = 0; i < actual.length; i++) {
           if (actual[i].fatal) {

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -11,6 +11,14 @@ function parseMeta(item) {
   return meta;
 }
 
+function getVerifyOptions(template, meta) {
+  const options = { source: template, moduleId: meta.moduleId };
+  if ('configResolver' in meta) {
+    options.configResolver = meta.configResolver;
+  }
+  return options;
+}
+
 /**
  * allows tests to be defined without needing to setup test infastructure everytime
  * @param  {Array}  [bad=[]]            - an array of items that describe the use case that should fail
@@ -83,17 +91,9 @@ module.exports = function generateRuleTests({
       linter.config.rules[name] = localConfig;
     }
 
-    function getVerifyOptions(template) {
-      const options = { source: template, moduleId: meta.moduleId };
-      if ('configResolver' in meta) {
-        options.configResolver = meta.configResolver;
-      }
-      return options;
-    }
-
     function verify(template, localConfig) {
       updateLinterConfig(localConfig);
-      let options = getVerifyOptions(template);
+      let options = getVerifyOptions(template, meta);
       return linter.verify(options);
     }
 

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -91,8 +91,12 @@ module.exports = function generateRuleTests({
       linter.config.rules[name] = localConfig;
     }
 
-    function prepare(template, localConfig, meta) {
+    function prepare(item, localConfig) {
+      let template = typeof item === 'string' ? item : item.template;
+      let meta = parseMeta(item);
+
       updateLinterConfig(localConfig);
+
       return getVerifyOptions(template, meta);
     }
 
@@ -132,8 +136,7 @@ module.exports = function generateRuleTests({
       testMethod(`logs a message in the console when given \`${template}\``, function() {
         let expectedResults = badItem.results || [badItem.result];
 
-        let meta = parseMeta(badItem);
-        let options = prepare(template, badItem.config, meta);
+        let options = prepare(badItem, badItem.config);
         let actual = linter.verify(options);
 
         if (badItem.fatal) {
@@ -150,8 +153,7 @@ module.exports = function generateRuleTests({
       if (!skipDisabledTests) {
         testMethod(`passes with \`${template}\` when rule is disabled`, function() {
           let config = false;
-          let meta = parseMeta(badItem);
-          let options = prepare(template, config, meta);
+          let options = prepare(badItem, config);
           let actual = linter.verify(options);
 
           assert.deepStrictEqual(actual, []);
@@ -160,8 +162,7 @@ module.exports = function generateRuleTests({
         testMethod(
           `passes with \`${template}\` when disabled via inline comment - single rule`,
           function() {
-            let meta = parseMeta(badItem);
-            let options = prepare(`${DISABLE_ONE}\n${template}`, undefined, meta);
+            let options = prepare(`${DISABLE_ONE}\n${template}`);
             let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
@@ -171,8 +172,7 @@ module.exports = function generateRuleTests({
         testMethod(
           `passes with \`${template}\` when disabled via long-form inline comment - single rule`,
           function() {
-            let meta = parseMeta(badItem);
-            let options = prepare(`${DISABLE_ONE_LONG}\n${template}`, undefined, meta);
+            let options = prepare(`${DISABLE_ONE_LONG}\n${template}`);
             let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
@@ -182,8 +182,7 @@ module.exports = function generateRuleTests({
         testMethod(
           `passes with \`${template}\` when disabled via inline comment - all rules`,
           function() {
-            let meta = parseMeta(badItem);
-            let options = prepare(`${DISABLE_ALL}\n${template}`, undefined, meta);
+            let options = prepare(`${DISABLE_ALL}\n${template}`);
             let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
@@ -196,8 +195,7 @@ module.exports = function generateRuleTests({
       let template = typeof goodItem === 'string' ? goodItem : goodItem.template;
 
       testMethod(`passes when given \`${template}\``, function() {
-        let meta = parseMeta(goodItem);
-        let options = prepare(template, goodItem.config, meta);
+        let options = prepare(goodItem, goodItem.config);
         let actual = linter.verify(options);
 
         assert.deepStrictEqual(actual, []);
@@ -213,8 +211,7 @@ module.exports = function generateRuleTests({
         let expectedResults = item.results || [item.result];
         expectedResults = expectedResults.map(parseResult);
 
-        let meta = parseMeta(item);
-        let options = prepare(template, config, meta);
+        let options = prepare(item, item.config);
         let actual = linter.verify(options);
 
         for (let i = 0; i < actual.length; i++) {


### PR DESCRIPTION
My goal is to make some space to test individual rules with both `verify` and `verifyAndFix`. (see https://github.com/ember-template-lint/ember-template-lint/pull/935)

To do so, this PR proposes to harmonize how tests are prepared.