### PR TITLE
Remove no-implicit-this from `recommended` config.

### DIFF
--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -11,7 +11,6 @@ module.exports = {
     'no-duplicate-attributes': true,
     'no-extra-mut-helper-argument': true,
     'no-html-comments': true,
-    'no-implicit-this': true,
     'no-inline-styles': true,
     'no-input-block': true,
     'no-input-tagname': true,


### PR DESCRIPTION
This is included in `octane` configuration already, and `octane` will eventually become `recommended` (in a future major version).