### PR TITLE
Add `stylistic` configuration

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -5,4 +5,5 @@ module.exports = {
   '1-x-recommended': require('./1-x-recommended'),
   octane: require('./octane'),
   recommended: require('./recommended'),
+  stylistic: require('./stylistic'),
 };

--- a/lib/config/stylistic.js
+++ b/lib/config/stylistic.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'block-indentation': true,
+    'linebreak-style': true,
+    'no-unnecessary-concat': true,
+    quotes: true,
+    'self-closing-void-elements': true,
+  },
+};


### PR DESCRIPTION
These rules were removed from the `recommended` configuration in v2 (https://github.com/ember-template-lint/ember-template-lint/pull/899) but we are providing a separate configuration for those who want to continue to use them (as an easier migration path vs. adopting prettier https://github.com/ember-template-lint/ember-template-lint/issues/953).