### PR TITLE
Fix configuration of `quotes` rule in `stylistic` preset

### DIFF
--- a/lib/config/stylistic.js
+++ b/lib/config/stylistic.js
@@ -5,7 +5,7 @@ module.exports = {
     'block-indentation': true,
     'linebreak-style': true,
     'no-unnecessary-concat': true,
-    quotes: true,
+    quotes: 'double',
     'self-closing-void-elements': true,
   },
 };


### PR DESCRIPTION
Fix for the new preset I just added in https://github.com/ember-template-lint/ember-template-lint/pull/1048