### PR TITLE
Remove deprecated array config for `no-nested-interactive` rule

### DIFF
--- a/lib/rules/no-nested-interactive.js
+++ b/lib/rules/no-nested-interactive.js
@@ -20,55 +20,9 @@ const Rule = require('./base');
 const isInteractiveElement = require('../helpers/is-interactive-element');
 const parseConfig = require('../helpers/parse-interactive-element-config');
 
-const ARRAY_DEPRECATION_MESSAGE =
-  'Specifying an array as the configurate for the `no-nested-interactive` rule is deprecated and will be removed in future versions.  Please update `.template-lintrc.js` to use the newer object format.';
-
-function convertConfigArrayToObject(config) {
-  let base = {
-    ignoredTags: [],
-    ignoreTabindex: false,
-    ignoreUsemapAttribute: false,
-  };
-
-  for (let i = 0; i < config.length; i++) {
-    let value = config[i];
-
-    switch (value) {
-      case 'tabindex':
-        base.ignoreTabindex = true;
-        break;
-      case 'usemap':
-        base.ignoreUsemapAttribute = true;
-        break;
-      default:
-        base.ignoredTags.push(value);
-    }
-  }
-
-  return base;
-}
-
 module.exports = class LogNestedInteractive extends Rule {
   parseConfig(config) {
-    if (Array.isArray(config)) {
-      this.log({
-        message: ARRAY_DEPRECATION_MESSAGE,
-        source: JSON.stringify(config),
-        severity: 1,
-      });
-
-      return convertConfigArrayToObject(config);
-    }
-
     return parseConfig(this.ruleName, config);
-  }
-
-  getConfigWhiteList() {
-    if (Array.isArray(this.config)) {
-      return this.config;
-    } else {
-      return [];
-    }
   }
 
   visitor() {
@@ -193,5 +147,3 @@ module.exports = class LogNestedInteractive extends Rule {
     return `Do not use ${childReason} inside ${parentReason}`;
   }
 };
-
-module.exports.ARRAY_DEPRECATION_MESSAGE = ARRAY_DEPRECATION_MESSAGE;

--- a/test/unit/rules/no-nested-interactive-test.js
+++ b/test/unit/rules/no-nested-interactive-test.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ARRAY_DEPRECATION_MESSAGE = require('../../../lib/rules/no-nested-interactive')
-  .ARRAY_DEPRECATION_MESSAGE;
 
 generateRuleTests({
   name: 'no-nested-interactive',
@@ -228,41 +226,6 @@ generateRuleTests({
         source: '<label for="foo">\n  <div id="foo" tabindex=-1></div>\n  <input>\n</label>',
         line: 3,
         column: 2,
-      },
-    },
-
-    // deprecated
-    {
-      config: ['button'],
-      template: '<button><input></button>',
-
-      result: {
-        message: ARRAY_DEPRECATION_MESSAGE,
-        source: '["button"]',
-        moduleId: null,
-        severity: 1,
-      },
-    },
-    {
-      config: ['tabindex'],
-      template: '<button><div tabindex=-1></div></button>',
-
-      result: {
-        message: ARRAY_DEPRECATION_MESSAGE,
-        source: '["tabindex"]',
-        moduleId: null,
-        severity: 1,
-      },
-    },
-    {
-      config: ['usemap'],
-      template: '<button><img usemap=""></button>',
-
-      result: {
-        message: ARRAY_DEPRECATION_MESSAGE,
-        source: '["usemap"]',
-        moduleId: null,
-        severity: 1,
       },
     },
   ],


### PR DESCRIPTION
It looks like this has been deprecated for years.