### PR TITLE
Add more rules to `stylistic` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Name   | Description |
 |:-----|:------------|
 | [recommended](https://github.com/ember-template-lint/ember-template-lint/blob/next/lib/config/recommended.js) | enables the recommended rules |
 | [octane](https://github.com/ember-template-lint/ember-template-lint/blob/next/lib/config/octane.js) | extends the `recommended` preset by enabling Ember Octane rules |
-| [stylistic](https://github.com/ember-template-lint/ember-template-lint/blob/next/lib/config/stylistic.js) | enables stylistic rules for those who aren't ready to adopt [ember-template-lint-plugin-prettier](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier) (these stylistic rules were previously in the `recommended` preset in ember-template-lint v1) |
+| [stylistic](https://github.com/ember-template-lint/ember-template-lint/blob/next/lib/config/stylistic.js) | enables stylistic rules for those who aren't ready to adopt [ember-template-lint-plugin-prettier](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier) (including stylistic rules that were previously in the `recommended` preset in ember-template-lint v1) |
 
 ### Project Wide
 

--- a/lib/config/stylistic.js
+++ b/lib/config/stylistic.js
@@ -4,6 +4,8 @@ module.exports = {
   rules: {
     'block-indentation': true,
     'linebreak-style': true,
+    'no-multiple-empty-lines': true,
+    'no-trailing-spaces': true,
     'no-unnecessary-concat': true,
     quotes: 'double',
     'self-closing-void-elements': true,

--- a/lib/config/stylistic.js
+++ b/lib/config/stylistic.js
@@ -3,6 +3,7 @@
 module.exports = {
   rules: {
     'block-indentation': true,
+    'eol-last': 'editorconfig',
     'linebreak-style': true,
     'no-multiple-empty-lines': true,
     'no-trailing-spaces': true,


### PR DESCRIPTION
Since we're adding this new preset in v2 (originally added in https://github.com/ember-template-lint/ember-template-lint/pull/1048), we might as well include all of the stylistic rules in it, especially since these additional rules are trivial to adopt, and can be disabled as needed.

* [eol-last](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/eol-last.md)
* [no-multiple-empty-lines](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-multiple-empty-lines.md)
* [no-trailing-spaces](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-trailing-spaces.md)