### PR TITLE
CI: Remove next branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - next
       - 'v*'
   pull_request: {}
   schedule:


### PR DESCRIPTION
This is a very small cleanup to prepare v2 release. As `next` branch is going to disappear.