### PR TITLE
Remove deprecated rules

### DIFF
--- a/lib/helpers/deprecated-rules.js
+++ b/lib/helpers/deprecated-rules.js
@@ -1,15 +1,7 @@
 'use strict';
 
 let DEPRECATED_RULES = new Map([
-  // deprecated in the 0.8.x cycle, can be removed just before 0.9.0
-  ['inline-styles', 'no-inline-styles'],
-  ['bare-strings', 'no-bare-strings'],
-  ['html-comments', 'no-html-comments'],
-  ['invalid-interactive', 'no-invalid-interactive'],
-  ['nested-interactive', 'no-nested-interactive'],
-  ['triple-curlies', 'no-triple-curlies'],
-  ['unused-block-params', 'no-unused-block-params'],
-  ['no-attr-in-components', 'no-attrs-in-components'],
+  // deprecated in the 1.x cycle, can be removed in 3.x
   ['img-alt-attributes', 'require-valid-alt-text'],
   ['no-meta-redirect-with-time-limit', 'no-invalid-meta'],
 ]);

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -129,7 +129,7 @@ describe('public api', function() {
     it('with deprecated rule config', function() {
       let expected = {
         rules: {
-          'bare-strings': true,
+          'no-bare-strings': true,
         },
       };
       project.write({
@@ -172,7 +172,7 @@ describe('public api', function() {
     let linter;
     let expected = {
       rules: {
-        'bare-strings': true,
+        'no-bare-strings': true,
       },
     };
 

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -101,11 +101,11 @@ generateRuleTests({
       template: '<input placeholder="{{foo}}X">',
     },
 
-    '{{! template-lint-disable bare-strings}}LOL{{! template-lint-enable bare-strings}}',
+    '{{! template-lint-disable no-bare-strings}}LOL{{! template-lint-enable no-bare-strings}}',
 
-    `{{!-- template-lint-disable bare-strings --}}
+    `{{!-- template-lint-disable no-bare-strings --}}
 <i class="material-icons">folder_open</i>
-{{!-- template-lint-enable bare-strings --}}`,
+{{!-- template-lint-enable no-bare-strings --}}`,
     '<div data-test-foo-bar></div>',
   ],
 

--- a/test/unit/rules/no-html-comments-test.js
+++ b/test/unit/rules/no-html-comments-test.js
@@ -12,7 +12,7 @@ generateRuleTests({
     '{{!--comment here--}}',
     '{{! template-lint-disable no-bare-strings }}',
     '{{! template-lint-disable }}',
-    '{{! template-lint-disable html-comments }}<!-- lol -->',
+    '{{! template-lint-disable no-html-comments }}<!-- lol -->',
   ],
 
   bad: [

--- a/test/unit/rules/no-triple-curlies-test.js
+++ b/test/unit/rules/no-triple-curlies-test.js
@@ -11,7 +11,7 @@ generateRuleTests({
     '{{foo}}',
     '{{! template-lint-disable no-bare-strings }}',
     '{{! template-lint-disable }}',
-    '{{! template-lint-disable triple-curlies}}{{{lol}}}',
+    '{{! template-lint-disable no-triple-curlies}}{{{lol}}}',
   ],
 
   bad: [

--- a/test/unit/rules/no-unused-block-params-test.js
+++ b/test/unit/rules/no-unused-block-params-test.js
@@ -20,7 +20,7 @@ generateRuleTests({
       '{{/each}}' +
       '{{/each}}',
     '{{#each cats as |cat|}}{{#meow-meow cat as |cat|}}{{cat}}{{/meow-meow}}{{/each}}',
-    '{{! template-lint-disable unused-block-params}}{{#each cats as |cat|}}Dogs{{/each}}',
+    '{{! template-lint-disable no-unused-block-params}}{{#each cats as |cat|}}Dogs{{/each}}',
     '{{#with (component "foo-bar") as |FooBar|}}<FooBar />{{/with}}',
     '<BurgerMenu as |menu|><header>Something</header><menu.item>Text</menu.item></BurgerMenu>',
     '{{#burger-menu as |menu|}}<header>Something</header>{{#menu.item}}Text{{/menu.item}}{{/burger-menu}}',


### PR DESCRIPTION
I'm not entirely sure on this one.

An alternative might be to empty the deprecated rules Map.