### PR TITLE
Update `no-invalid-interactive` to allow `change` event with `<form>` elements

### DIFF
--- a/lib/rules/no-invalid-interactive.js
+++ b/lib/rules/no-invalid-interactive.js
@@ -80,7 +80,11 @@ module.exports = class InvalidInteractive extends Rule {
           // Allow {{action "foo" on="reset"}} on form tags
           // Allow {{action "foo" on="submit"}} on form tags
           if (this._element.tag === 'form') {
-            if (isSubmitEventBinding(node) || isResetEventBinding(node)) {
+            if (
+              isSubmitEventBinding(node) ||
+              isResetEventBinding(node) ||
+              isChangeEventBinding(node)
+            ) {
               return;
             }
           }
@@ -104,13 +108,8 @@ module.exports = class InvalidInteractive extends Rule {
 
         let helperName = node.value.path.original;
 
-        // Allow onsubmit={{action "foo"}} on form tags
-        if (this._element.tag === 'form' && node.name === 'onsubmit') {
-          return;
-        }
-
-        // Allow onreset={{action "foo"}} on form tags
-        if (this._element.tag === 'form' && node.name === 'onreset') {
+        //  Allow onreset={{action "foo"}}, onsubmit={{action "foo"}} on form tags
+        if (this._element.tag === 'form' && ['onchange', 'onreset', 'onsubmit']) {
           return;
         }
 
@@ -177,6 +176,9 @@ function isEventHandlerFor(node, name) {
   }
 }
 
+function isChangeEventBinding(node) {
+  return isEventHandlerFor(node, 'change');
+}
 function isSubmitEventBinding(node) {
   return isEventHandlerFor(node, 'submit');
 }

--- a/lib/rules/no-invalid-interactive.js
+++ b/lib/rules/no-invalid-interactive.js
@@ -70,9 +70,9 @@ module.exports = class InvalidInteractive extends Rule {
 
         let modifierName = node.path.original;
 
-        if (modifierName === 'action' || modifierName === 'on') {
+        if (['action', 'on'].includes(modifierName)) {
           if (this._element.tag === 'img') {
-            if (isOnLoadEventBinding(node) || isOnErrorEventBinding(node)) {
+            if (isSomeEventHandlersFor(node, ['error', 'load'])) {
               return;
             }
           }
@@ -80,11 +80,7 @@ module.exports = class InvalidInteractive extends Rule {
           // Allow {{action "foo" on="reset"}} on form tags
           // Allow {{action "foo" on="submit"}} on form tags
           if (this._element.tag === 'form') {
-            if (
-              isSubmitEventBinding(node) ||
-              isResetEventBinding(node) ||
-              isChangeEventBinding(node)
-            ) {
+            if (isSomeEventHandlersFor(node, ['submit', 'reset', 'change'])) {
               return;
             }
           }
@@ -171,29 +167,13 @@ function actionModifierHasAction(node, name) {
   return false;
 }
 
+function isSomeEventHandlersFor(node, names = []) {
+  return names.some(name => isEventHandlerFor(node, name));
+}
 function isEventHandlerFor(node, name) {
   if (node.path.original === 'on') {
     return onModifierHasAction(node, name);
   } else {
     return actionModifierHasAction(node, name);
   }
-}
-
-function isChangeEventBinding(node) {
-  return isEventHandlerFor(node, 'change');
-}
-function isSubmitEventBinding(node) {
-  return isEventHandlerFor(node, 'submit');
-}
-
-function isResetEventBinding(node) {
-  return isEventHandlerFor(node, 'reset');
-}
-
-function isOnErrorEventBinding(node) {
-  return isEventHandlerFor(node, 'error');
-}
-
-function isOnLoadEventBinding(node) {
-  return isEventHandlerFor(node, 'load');
 }

--- a/lib/rules/no-invalid-interactive.js
+++ b/lib/rules/no-invalid-interactive.js
@@ -109,7 +109,10 @@ module.exports = class InvalidInteractive extends Rule {
         let helperName = node.value.path.original;
 
         //  Allow onreset={{action "foo"}}, onsubmit={{action "foo"}} on form tags
-        if (this._element.tag === 'form' && ['onchange', 'onreset', 'onsubmit']) {
+        if (
+          this._element.tag === 'form' &&
+          ['onchange', 'onreset', 'onsubmit'].includes(node.name)
+        ) {
           return;
         }
 

--- a/test/unit/rules/no-invalid-interactive-test.js
+++ b/test/unit/rules/no-invalid-interactive-test.js
@@ -14,7 +14,9 @@ generateRuleTests({
     '<li><button {{action "foo"}}></button></li>',
     '<form {{action "foo" on="submit"}}></form>',
     '<form onsubmit={{action "foo"}}></form>',
+    '<form onchange={{action "foo"}}></form>',
     '<form {{action "foo" on="reset"}}></form>',
+    '<form {{action "foo" on="change"}}></form>',
     '<form onreset={{action "foo"}}></form>',
     '<img onerror={{action "foo"}}>',
     '<img onload={{action "foo"}}>',
@@ -23,6 +25,7 @@ generateRuleTests({
     '{{#with (hash bar=(component "foo")) as |foo|}}<foo.bar @onInput={{action "foo"}}></foo.bar>{{/with}}',
     '<form {{on "submit" this.send}}></form>',
     '<form {{on "reset" this.reset}}></form>',
+    '<form {{on "change" this.change}}></form>',
     {
       config: { additionalInteractiveTags: ['div'] },
       template: '<div {{on "click" this.onClick}}></div>',


### PR DESCRIPTION
ref:

![image](https://user-images.githubusercontent.com/1360552/72179337-c1d22400-33f5-11ea-90b3-e5190e54572a.png)

usecase example:
https://codepen.io/lifeart/pen/XWJqMbV