### PR TITLE
Add `modifier-name-case` rule

### DIFF
--- a/docs/rule/modifier-name-case.md
+++ b/docs/rule/modifier-name-case.md
@@ -1,0 +1,23 @@
+## modifier-name-case
+
+It is currently possible to invoke a modifier with multiple words in its name
+using camelCase: `{{didInsert}}` or using dasherized-case: `{{did-insert}}`.
+This means that you can potentially have a lot of inconsistency throughout your
+codebase.
+
+This rule enforces that you will always use the dasherized-case form of the
+modifier invocation.
+
+### Examples
+
+This rule **forbids** the following:
+
+```hbs
+<div {{didInsert}}></div>
+```
+
+This rule **allows** the following:
+
+```hbs
+<div {{did-insert}}></div>
+```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -9,6 +9,7 @@
 * [linebreak-style](rule/linebreak-style.md)
 * [link-href-attributes](rule/link-href-attributes.md)
 * [link-rel-noopener](rule/link-rel-noopener.md)
+* [modifier-name-case](rule/modifier-name-case.md)
 * [no-abstract-roles](rule/no-abstract-roles.md)
 * [no-action](rule/no-action.md)
 * [no-action-modifiers](rule/no-action-modifiers.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -13,6 +13,7 @@ module.exports = {
   'linebreak-style': require('./linebreak-style'),
   'link-href-attributes': require('./link-href-attributes'),
   'link-rel-noopener': require('./link-rel-noopener'),
+  'modifier-name-case': require('./modifier-name-case'),
   'no-abstract-roles': require('./no-abstract-roles'),
   'no-action-modifiers': require('./no-action-modifiers'),
   'no-attrs-in-components': require('./no-attrs-in-components'),

--- a/lib/rules/modifier-name-case.js
+++ b/lib/rules/modifier-name-case.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const Rule = require('./base');
+const dasherize = require('../helpers/dasherize-component-name');
+
+function generateErrorMessage(modifierName) {
+  let dasherizeModifierName = dasherize(modifierName);
+  return `Use dasherized names for modifier invocation. Please replace \`${modifierName}\` with \`${dasherizeModifierName}\`.`;
+}
+
+module.exports = class ModifierNameCase extends Rule {
+  visitor() {
+    return {
+      ElementModifierStatement(node) {
+        let modifierName = node.path.original;
+
+        if (modifierName === dasherize(modifierName)) {
+          return;
+        }
+
+        this.log({
+          message: generateErrorMessage(modifierName),
+          line: node.path.loc && node.path.loc.start.line,
+          column: node.path.loc && node.path.loc.start.column,
+          source: this.sourceForNode(node.path),
+        });
+      },
+    };
+  }
+};
+
+module.exports.generateErrorMessage = generateErrorMessage;

--- a/test/unit/rules/modifier-name-case-test.js
+++ b/test/unit/rules/modifier-name-case-test.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'modifier-name-case',
+
+  config: true,
+
+  good: [
+    '<div {{did-insert}}></div>',
+    '<div {{did-insert "something"}}></div>',
+    '<div {{did-insert action=something}}></div>',
+    '<button {{on "click" somethingAmazing}}></button>',
+    '<button onclick={{do-a-thing "foo"}}></button>',
+    '<button onclick={{doAThing "foo"}}></button>',
+    '<a href="#" onclick={{amazingActionThing "foo"}} {{did-insert}}></a>',
+    '<div didInsert></div>',
+  ],
+
+  bad: [
+    {
+      template: '<div {{didInsert}}></div>',
+      result: {
+        message:
+          'Use dasherized names for modifier invocation. Please replace `didInsert` with `did-insert`.',
+        source: 'didInsert',
+        line: 1,
+        column: 7,
+      },
+    },
+    {
+      template: '<div class="monkey" {{didInsert "something" with="somethingElse"}}></div>',
+      result: {
+        message:
+          'Use dasherized names for modifier invocation. Please replace `didInsert` with `did-insert`.',
+        source: 'didInsert',
+        line: 1,
+        column: 22,
+      },
+    },
+    {
+      template: '<a href="#" onclick={{amazingActionThing "foo"}} {{doSomething}}></a>',
+      result: {
+        message:
+          'Use dasherized names for modifier invocation. Please replace `doSomething` with `do-something`.',
+        source: 'doSomething',
+        line: 1,
+        column: 51,
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Adding a rule that makes sure you always use the dasherized-case form for modifier invocations.