### PR TITLE
Fix crash from missing `content` attribute in `no-invalid-meta` rule

### DIFF
--- a/docs/rule/no-invalid-meta.md
+++ b/docs/rule/no-invalid-meta.md
@@ -45,6 +45,7 @@ This rule **allows** the following:
 
 ### References
 
+* [HTML meta tag doc](https://www.w3schools.com/tags/tag_meta.asp)
 * [F40: Failure due to using meta redirect with a time limit](https://www.w3.org/WAI/WCAG21/Techniques/failures/F40)
 * [F41: Failure due to using meta refresh to reload the page](https://www.w3.org/WAI/WCAG21/Techniques/failures/F41)
 * [Success Criterion 2.2.1: Timing Adjustable](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable)

--- a/lib/rules/no-invalid-meta.js
+++ b/lib/rules/no-invalid-meta.js
@@ -19,12 +19,13 @@ module.exports = class NoInvalidMeta extends Rule {
           return;
         }
 
-        const hasMetaRedirect = AstNodeInfo.hasAttribute(node, 'http-equiv');
-        const contentAttr = AstNodeInfo.hasAttribute(node, 'content');
+        const hasHttpEquiv = AstNodeInfo.hasAttribute(node, 'http-equiv');
+        const hasContent = AstNodeInfo.hasAttribute(node, 'content');
+
         const contentAttrValue = AstNodeInfo.elementAttributeValue(node, 'content');
 
-        if (hasMetaRedirect) {
-          if (contentAttr) {
+        if (hasContent && typeof contentAttrValue === 'string') {
+          if (hasHttpEquiv) {
             // if there is a semicolon, it is a REDIRECT and should not have a delay value greater than zero
             if (contentAttrValue.includes(';')) {
               if (contentAttrValue.charAt(0) !== '0') {
@@ -47,24 +48,26 @@ module.exports = class NoInvalidMeta extends Rule {
               }
             }
           }
-        }
-        // Looks for spaces because Apple allowed spaces in their spec.
-        let userScalableRegExp = /user-scalable(\s*?)=(\s*?)no/gim;
-        if (contentAttrValue.match(userScalableRegExp)) {
-          this.log({
-            message: 'a meta viewport should not restrict user-scalable',
-            line: node.loc && node.loc.start.line,
-            column: node.loc && node.loc.start.column,
-            source: this.sourceForNode(node),
-          });
-        }
-        if (contentAttrValue.includes('maximum-scale')) {
-          this.log({
-            message: 'a meta viewport should not set a maximum scale on content',
-            line: node.loc && node.loc.start.line,
-            column: node.loc && node.loc.start.column,
-            source: this.sourceForNode(node),
-          });
+
+          // Looks for spaces because Apple allowed spaces in their spec.
+          let userScalableRegExp = /user-scalable(\s*?)=(\s*?)no/gim;
+          if (contentAttrValue.match(userScalableRegExp)) {
+            this.log({
+              message: 'a meta viewport should not restrict user-scalable',
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(node),
+            });
+          }
+
+          if (contentAttrValue.includes('maximum-scale')) {
+            this.log({
+              message: 'a meta viewport should not set a maximum scale on content',
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(node),
+            });
+          }
         }
       },
     };

--- a/test/unit/rules/no-invalid-meta-test.js
+++ b/test/unit/rules/no-invalid-meta-test.js
@@ -8,11 +8,15 @@ generateRuleTests({
   config: true,
 
   good: [
+    '<meta>',
+    '<meta charset="UTF-8">',
     '<meta http-equiv="refresh" content="0; url=http://www.example.com">',
     '<meta http-equiv="refresh" content="72001">',
+    '<meta http-equiv={{httpEquiv}} content={{content}}>',
     '<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">',
     '<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable = yes">',
     '<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable= yes">',
+    '<meta name={{name}} content={{content}}>',
 
     // doesn't error on unrelated elements
     '<div></div>',


### PR DESCRIPTION
Fixes crashes by checking for `content` attribute presence and value type before analyzing it.

Fixes #1080.