### PR TITLE
Update `no-invalid-meta` rule to catch incorrect meta attribute combinations

### DIFF
--- a/docs/rule/no-invalid-meta.md
+++ b/docs/rule/no-invalid-meta.md
@@ -5,6 +5,8 @@ This rule checks for these meta tag issues:
 - a meta with a redirect- if it exists, it checks for a timed delay greater than 0.
 - a meta with a timed refresh- the timed delay should be greater than 72,000 seconds.
 - a meta that locks orientation to landscape or portrait view
+- a meta with a content attribute when neither the name nor http-equiv attributes are present
+- a meta without a content attribute when either the name or http-equiv attributes are present
 
 ### Redirects & Refresh
 Sometimes a page automatically redirects to a different page. When this happens after a timed delay, it is an unexpected change of context that may interrupt the user. Redirects without timed delays are okay, but please consider a server-side method for redirecting instead (method will vary based on your server type).

--- a/lib/rules/no-invalid-meta.js
+++ b/lib/rules/no-invalid-meta.js
@@ -14,6 +14,7 @@ module.exports = class NoInvalidMeta extends Rule {
   }
   visitor() {
     return {
+      // eslint-disable-next-line complexity
       ElementNode(node) {
         if (node.tag !== 'meta') {
           return;
@@ -21,8 +22,27 @@ module.exports = class NoInvalidMeta extends Rule {
 
         const hasHttpEquiv = AstNodeInfo.hasAttribute(node, 'http-equiv');
         const hasContent = AstNodeInfo.hasAttribute(node, 'content');
+        const hasName = AstNodeInfo.hasAttribute(node, 'name');
 
         const contentAttrValue = AstNodeInfo.elementAttributeValue(node, 'content');
+
+        if ((hasName || hasHttpEquiv) && !hasContent) {
+          this.log({
+            message:
+              'a meta content attribute must be defined if the name or the http-equiv attribute is defined',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
+        } else if (hasContent && !hasName && !hasHttpEquiv) {
+          this.log({
+            message:
+              'a meta content attribute cannot be defined if neither the name nor the http-equiv attributes are defined',
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
+        }
 
         if (hasContent && typeof contentAttrValue === 'string') {
           if (hasHttpEquiv) {

--- a/test/unit/rules/no-invalid-meta-test.js
+++ b/test/unit/rules/no-invalid-meta-test.js
@@ -91,5 +91,43 @@ generateRuleTests({
           '<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">',
       },
     },
+
+    {
+      template: '<meta name="viewport">',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message:
+          'a meta content attribute must be defined if the name or the http-equiv attribute is defined',
+        line: 1,
+        column: 0,
+        source: '<meta name="viewport">',
+      },
+    },
+    {
+      template: '<meta http-equiv="refresh">',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message:
+          'a meta content attribute must be defined if the name or the http-equiv attribute is defined',
+        line: 1,
+        column: 0,
+        source: '<meta http-equiv="refresh">',
+      },
+    },
+
+    {
+      template: '<meta content="72001">',
+
+      result: {
+        moduleId: 'layout.hbs',
+        message:
+          'a meta content attribute cannot be defined if neither the name nor the http-equiv attributes are defined',
+        line: 1,
+        column: 0,
+        source: '<meta content="72001">',
+      },
+    },
   ],
 });


### PR DESCRIPTION
Targeting the v2 release for this since it updates the rule to report new violations.

Enforces this part of the [spec](https://www.w3schools.com/tags/tag_meta.asp):

> The content attribute MUST be defined if the name or the http-equiv attribute is defined. If none of these are defined, the content attribute CANNOT be defined.

Related to #1087.