### PR TITLE
Update `no-curly-component-invocation` rule to ignore all usages of the `yield` helper

### DIFF
--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -39,10 +39,11 @@ const BUILT_INS = [
   'unbound',
   'unless',
   'with',
-  'yield',
   '-in-element',
   'in-element',
 ];
+
+const ALWAYS_CURLY = ['yield'];
 
 module.exports = class NoCurlyComponentInvocation extends Rule {
   parseConfig(config) {
@@ -103,6 +104,11 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
         }
 
         let name = path.original;
+
+        if (ALWAYS_CURLY.includes(name)) {
+          // {{yield}}
+          return;
+        }
 
         let hasNamedArguments = node.hash.pairs.length !== 0;
         if (hasNamedArguments) {

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -37,6 +37,7 @@ const SHARED_GOOD = [
   '{{hash}}',
   '{{outlet}}',
   '{{yield}}',
+  '{{yield to="inverse"}}',
 
   // real world examples
   '<GoodCode />',


### PR DESCRIPTION
Fixes #1089.