### PR TITLE
Update `no-bare-strings` rule to allow `&ndash;`

### DIFF
--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -75,6 +75,7 @@ const DEFAULT_CONFIG = {
     '&bull;', // •
     '&bullet;', // •
     '&mdash;', // —
+    '&ndash;', // –
     '&nbsp;', // non-breaking space
     '&Tab;',
     '&NewLine;',

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -46,6 +46,7 @@ generateRuleTests({
     '{{t "foo"}}, {{t "bar"}} ({{length}})',
     '(),.&+-=*/#%!?:[]{}',
     '&lpar;&rpar;&comma;&period;&amp;&nbsp;',
+    '&mdash;&ndash;',
     '{{! template-lint-disable no-bare-strings }}',
     '{{! template-lint-disable }}',
     '<script> fdff sf sf f </script>',


### PR DESCRIPTION
The en dash is a slightly smaller typeset version of em dash (mdash).