### PR TITLE
no-invalid-interactive: add support for the tablist role

### DIFF
--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -29,6 +29,7 @@ const ARIA_WIDGET_ROLES = [
   'slider',
   'spinbutton',
   'tab',
+  'tablist',
   'textbox',
   'tooltip',
   'treeitem',

--- a/test/unit/helpers/is-interactive-element-test.js
+++ b/test/unit/helpers/is-interactive-element-test.js
@@ -40,6 +40,7 @@ describe('isInteractiveElement', function() {
     '<div tabindex=1></div>': 'an element with the `tabindex` attribute',
     '<label></label>': '<label>',
     '<div role="button"></div>': 'an element with `role="button"`',
+    '<div role="tablist"></div>': 'an element with `role="tablist"`',
     '<div role="textbox"></div>': 'an element with `role="textbox"`',
     '<video controls></video>': 'an <video> element with the `controls` attribute',
     '<audio controls></audio>': 'an <audio> element with the `controls` attribute',


### PR DESCRIPTION
This makes it possible to add keydown event handlers to elements with
the `tablist` role which is a requirement if you want to create a fully
keyboard accessible tab component.

reference: https://www.w3.org/TR/wai-aria-practices/#tabpanel