### PR TITLE
Add new rule `no-invalid-link-title`

### DIFF
--- a/docs/rule/no-invalid-link-title.md
+++ b/docs/rule/no-invalid-link-title.md
@@ -1,10 +1,10 @@
-## no-invalid-link-title
+# no-invalid-link-title
 
-The `title` attribute is a useful way to give users extra context for a link. However, this content should be complementary content and should not be the exact same value as the link text. 
+The `title` attribute is a useful way to give users extra context for a link. However, this content should be complementary content and should not be the exact same value as the link text.
 
 This rule checks links for the presence of a `title` attribute and ensures that it is not the same as the link text.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -15,17 +15,14 @@ This rule **forbids** the following:
 This rule **allows** the following:
 
 ```hbs
-'<a href="https://mytutorial.com" title="New to Ember? Read the full tutorial for the best experience">Read the Tutorial</a>',
+<a href="https://mytutorial.com" title="New to Ember? Read the full tutorial for the best experience">Read the Tutorial</a>,
 ```
 
-
-### Migration
-
-(suggest any fast/automated techniques for fixing violations in a large codebase)
+## Migration
 
 * If the `title` attribute value is the same as the link text, it's better to leave it out.
 
-### References
+## References
 
-* (https://www.w3.org/TR/WCAG20-TECHS/H33.html)
+* [Supplementing link text with the title attribute](<https://www.w3.org/TR/WCAG20-TECHS/H33.html)>
 * [Understanding Link Purpose](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html)

--- a/docs/rule/no-invalid-link-title.md
+++ b/docs/rule/no-invalid-link-title.md
@@ -1,53 +1,31 @@
-## No Invalid Link Title
+## no-invalid-link-title
 
-(context about the problem goes here)
+The `title` attribute is a useful way to give users extra context for a link. However, this content should be complementary content and should not be the exact same value as the link text. 
 
-(what the rule does goes here)
+This rule checks links for the presence of a `title` attribute and ensures that it is not the same as the link text.
 
 ### Examples
 
 This rule **forbids** the following:
 
 ```hbs
-{{!-- Example 1  --}}
-```
-
-```hbs
-{{!-- Example 2  --}}
+<a href="https://mytutorial.com" title="read the tutorial">Read the Tutorial</a>
 ```
 
 This rule **allows** the following:
 
 ```hbs
-{{!-- Example 1  --}}
+'<a href="https://mytutorial.com" title="New to Ember? Read the full tutorial for the best experience">Read the Tutorial</a>',
 ```
 
-```hbs
-{{!-- Example 2  --}}
-```
 
 ### Migration
 
 (suggest any fast/automated techniques for fixing violations in a large codebase)
 
-* suggestion on how to fix violations using find-and-replace / regexp
-* suggestion on how to fix violations using a codemod
-
-### Configuration
-
-(exclude this section if the rule has no extra configuration)
-
-* object -- containing the following properties:
-  * string -- `parameterName1` -- description of parameter including the possible values and default value
-  * boolean -- `parameterName2` -- description of parameter including the possible values and default value
-
-### Related Rules
-
-* [related-rule-name1](related-rule-name1.md)
-* [related-rule-name2](related-rule-name2.md)
+* If the `title` attribute value is the same as the link text, it's better to leave it out.
 
 ### References
 
-* (link to relevant documentation goes here)
-* (link to relevant function spec goes here)
-* (link to relevant guide goes here)
+* (https://www.w3.org/TR/WCAG20-TECHS/H33.html)
+* [Understanding Link Purpose](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html)

--- a/docs/rule/no-invalid-link-title.md
+++ b/docs/rule/no-invalid-link-title.md
@@ -1,0 +1,53 @@
+## No Invalid Link Title
+
+(context about the problem goes here)
+
+(what the rule does goes here)
+
+### Examples
+
+This rule **forbids** the following:
+
+```hbs
+{{!-- Example 1  --}}
+```
+
+```hbs
+{{!-- Example 2  --}}
+```
+
+This rule **allows** the following:
+
+```hbs
+{{!-- Example 1  --}}
+```
+
+```hbs
+{{!-- Example 2  --}}
+```
+
+### Migration
+
+(suggest any fast/automated techniques for fixing violations in a large codebase)
+
+* suggestion on how to fix violations using find-and-replace / regexp
+* suggestion on how to fix violations using a codemod
+
+### Configuration
+
+(exclude this section if the rule has no extra configuration)
+
+* object -- containing the following properties:
+  * string -- `parameterName1` -- description of parameter including the possible values and default value
+  * boolean -- `parameterName2` -- description of parameter including the possible values and default value
+
+### Related Rules
+
+* [related-rule-name1](related-rule-name1.md)
+* [related-rule-name2](related-rule-name2.md)
+
+### References
+
+* (link to relevant documentation goes here)
+* (link to relevant function spec goes here)
+* (link to relevant guide goes here)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -29,6 +29,7 @@
 * [no-invalid-block-param-definition](rule/no-invalid-block-param-definition.md)
 * [no-invalid-interactive](rule/no-invalid-interactive.md)
 * [no-invalid-link-text](rule/no-invalid-link-text.md)
+* [no-invalid-link-title](rule/no-invalid-link-title.md)
 * [no-invalid-meta](rule/no-invalid-meta.md)
 * [no-invalid-role](rule/no-invalid-role.md)
 * [no-log](rule/no-log.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -33,6 +33,7 @@ module.exports = {
   'no-invalid-block-param-definition': require('./no-invalid-block-param-definition'),
   'no-invalid-interactive': require('./no-invalid-interactive'),
   'no-invalid-link-text': require('./no-invalid-link-text'),
+  'no-invalid-link-title': require('./no-invalid-link-title'),
   'no-invalid-meta': require('./no-invalid-meta'),
   'no-invalid-role': require('./no-invalid-role'),
   'no-log': require('./no-log'),

--- a/lib/rules/no-invalid-link-title.js
+++ b/lib/rules/no-invalid-link-title.js
@@ -4,19 +4,21 @@ const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
 
 function hasInvalidLinkTitle(node) {
-  const hasTitleAttribute = AstNodeInfo.hasAttribute(node, 'title');
+  let hasTitleAttribute = AstNodeInfo.hasAttribute(node, 'title');
   // If it doesn't have a title attribute then don't even worry about it
   if (!hasTitleAttribute) {
-    return;
+    return false;
   }
   // Extract the text content(s) from the TextNode child(ren)
   const nodeChildren = AstNodeInfo.childrenFor(node);
   const textChildren = nodeChildren.filter(child => AstNodeInfo.isTextNode(child));
   const linkTexts = textChildren.map(linkText => linkText['chars'].toLowerCase().trim());
 
-  const titleAttributeValue = AstNodeInfo.elementAttributeValue(node, 'title')
+  // Extract the value from the title attribute
+  let titleAttributeValue = AstNodeInfo.elementAttributeValue(node, 'title')
     .toLowerCase()
     .trim();
+
   // Check to see if the text content is the same as the title attribute value
   const hasMatchingLinkAndTitleText = linkTexts.some(linkText =>
     titleAttributeValue.includes(linkText)

--- a/lib/rules/no-invalid-link-title.js
+++ b/lib/rules/no-invalid-link-title.js
@@ -1,0 +1,34 @@
+'use strict';
+
+const Rule = require('./base');
+const AstNodeInfo = require('../helpers/ast-node-info');
+
+module.exports = class NoInvalidLinkTitle extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        if (node.tag === 'a' || node.tag === 'LinkTo') {
+          // Extract the text content(s) from the TextNode child(ren)
+          let nodeChildren = AstNodeInfo.childrenFor(node);
+          let textChildren = nodeChildren.filter(child => AstNodeInfo.isTextNode(child));
+          let linkTexts = textChildren.map(linkText => linkText['chars'].toLowerCase().trim());
+          let hasTitleAttribute = AstNodeInfo.hasAttribute(node, 'title');
+          if (!hasTitleAttribute) {
+            return;
+          }
+          let titleAttributeValue = AstNodeInfo.elementAttributeValue(node, 'title')
+            .toLowerCase()
+            .trim();
+          if (linkTexts.includes(titleAttributeValue)) {
+            this.log({
+              message: 'Title attribute values should not be the same as the link text.',
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(node),
+            });
+          }
+        }
+      },
+    };
+  }
+};

--- a/lib/rules/no-invalid-link-title.js
+++ b/lib/rules/no-invalid-link-title.js
@@ -3,23 +3,45 @@
 const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
 
+function hasInvalidLinkTitle(node) {
+  const hasTitleAttribute = AstNodeInfo.hasAttribute(node, 'title');
+  // If it doesn't have a title attribute then don't even worry about it
+  if (!hasTitleAttribute) {
+    return;
+  }
+  // Extract the text content(s) from the TextNode child(ren)
+  const nodeChildren = AstNodeInfo.childrenFor(node);
+  const textChildren = nodeChildren.filter(child => AstNodeInfo.isTextNode(child));
+  const linkTexts = textChildren.map(linkText => linkText['chars'].toLowerCase().trim());
+
+  const titleAttributeValue = AstNodeInfo.elementAttributeValue(node, 'title')
+    .toLowerCase()
+    .trim();
+  // Check to see if the text content is the same as the title attribute value
+  const hasMatchingLinkAndTitleText = linkTexts.some(linkText =>
+    titleAttributeValue.includes(linkText)
+  );
+  return hasMatchingLinkAndTitleText;
+}
+
 module.exports = class NoInvalidLinkTitle extends Rule {
   visitor() {
     return {
       ElementNode(node) {
         if (node.tag === 'a' || node.tag === 'LinkTo') {
-          // Extract the text content(s) from the TextNode child(ren)
-          let nodeChildren = AstNodeInfo.childrenFor(node);
-          let textChildren = nodeChildren.filter(child => AstNodeInfo.isTextNode(child));
-          let linkTexts = textChildren.map(linkText => linkText['chars'].toLowerCase().trim());
-          let hasTitleAttribute = AstNodeInfo.hasAttribute(node, 'title');
-          if (!hasTitleAttribute) {
-            return;
+          if (hasInvalidLinkTitle(node)) {
+            this.log({
+              message: 'Title attribute values should not be the same as the link text.',
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(node),
+            });
           }
-          let titleAttributeValue = AstNodeInfo.elementAttributeValue(node, 'title')
-            .toLowerCase()
-            .trim();
-          if (linkTexts.includes(titleAttributeValue)) {
+        }
+      },
+      BlockStatement(node) {
+        if (node.path.original === 'link-to') {
+          if (hasInvalidLinkTitle(node)) {
             this.log({
               message: 'Title attribute values should not be the same as the link text.',
               line: node.loc && node.loc.start.line,

--- a/lib/rules/no-invalid-link-title.js
+++ b/lib/rules/no-invalid-link-title.js
@@ -3,26 +3,17 @@
 const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
 
-function hasInvalidLinkTitle(node) {
-  let hasTitleAttribute = AstNodeInfo.hasAttribute(node, 'title');
-  // If it doesn't have a title attribute then don't even worry about it
-  if (!hasTitleAttribute) {
-    return false;
-  }
+function hasInvalidLinkTitle(node, titleAttributeValues) {
   // Extract the text content(s) from the TextNode child(ren)
   const nodeChildren = AstNodeInfo.childrenFor(node);
   const textChildren = nodeChildren.filter(child => AstNodeInfo.isTextNode(child));
-  const linkTexts = textChildren.map(linkText => linkText['chars'].toLowerCase().trim());
-
-  // Extract the value from the title attribute
-  let titleAttributeValue = AstNodeInfo.elementAttributeValue(node, 'title')
-    .toLowerCase()
-    .trim();
+  const linkTexts = textChildren.map(linkText => linkText.chars.toLowerCase().trim());
 
   // Check to see if the text content is the same as the title attribute value
   const hasMatchingLinkAndTitleText = linkTexts.some(linkText =>
-    titleAttributeValue.includes(linkText)
+    titleAttributeValues.some(titleValue => titleValue.includes(linkText))
   );
+
   return hasMatchingLinkAndTitleText;
 }
 
@@ -31,7 +22,24 @@ module.exports = class NoInvalidLinkTitle extends Rule {
     return {
       ElementNode(node) {
         if (node.tag === 'a' || node.tag === 'LinkTo') {
-          if (hasInvalidLinkTitle(node)) {
+          let titleValues = [
+            AstNodeInfo.elementAttributeValue(node, 'title'),
+            node.tag === 'LinkTo' && AstNodeInfo.elementAttributeValue(node, '@title'),
+          ]
+            .filter(possibleValue => typeof possibleValue === 'string')
+            .map(value => value.toLowerCase().trim());
+
+          if (titleValues.length > 1) {
+            this.log({
+              message:
+                'Specifying title as both an attribute and an argument to <LinkTo /> is invalid.',
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(node),
+            });
+          }
+
+          if (hasInvalidLinkTitle(node, titleValues)) {
             this.log({
               message: 'Title attribute values should not be the same as the link text.',
               line: node.loc && node.loc.start.line,
@@ -43,13 +51,18 @@ module.exports = class NoInvalidLinkTitle extends Rule {
       },
       BlockStatement(node) {
         if (node.path.original === 'link-to') {
-          if (hasInvalidLinkTitle(node)) {
-            this.log({
-              message: 'Title attribute values should not be the same as the link text.',
-              line: node.loc && node.loc.start.line,
-              column: node.loc && node.loc.start.column,
-              source: this.sourceForNode(node),
-            });
+          let titleHashArg = node.hash.pairs.find(pair => pair.key === 'title');
+          if (titleHashArg && titleHashArg.value.type === 'StringLiteral') {
+            let titleValue = titleHashArg.value.value.toLowerCase().trim();
+
+            if (hasInvalidLinkTitle(node, [titleValue])) {
+              this.log({
+                message: 'Title attribute values should not be the same as the link text.',
+                line: node.loc && node.loc.start.line,
+                column: node.loc && node.loc.start.column,
+                source: this.sourceForNode(node),
+              });
+            }
           }
         }
       },

--- a/test/unit/rules/no-invalid-link-title-test.js
+++ b/test/unit/rules/no-invalid-link-title-test.js
@@ -20,7 +20,6 @@ generateRuleTests({
       template: '<a href="https://myurl.com" title="read the tutorial">Read the Tutorial</a>',
       result: {
         message: 'Title attribute values should not be the same as the link text.',
-        moduleId: 'layout.hbs',
         source: '<a href="https://myurl.com" title="read the tutorial">Read the Tutorial</a>',
         line: 1,
         column: 0,
@@ -30,7 +29,6 @@ generateRuleTests({
       template: '<LinkTo title="quickstart">Quickstart</LinkTo>',
       result: {
         message: 'Title attribute values should not be the same as the link text.',
-        moduleId: 'layout.hbs',
         source: '<LinkTo title="quickstart">Quickstart</LinkTo>',
         line: 1,
         column: 0,

--- a/test/unit/rules/no-invalid-link-title-test.js
+++ b/test/unit/rules/no-invalid-link-title-test.js
@@ -34,23 +34,5 @@ generateRuleTests({
         column: 0,
       },
     },
-    {
-      template: '{{#link-to title="Do the things"}}Do the things{{/link-to}}',
-      result: {
-        message: 'Title attribute values should not be the same as the link text.',
-        source: '{{#link-to title="Do the things"}}Do the things{{/link-to}}',
-        line: 1,
-        column: 0,
-      },
-    },
-    {
-      template: '<LinkTo @route="some.route" @title="Do the things">Do the things</LinkTo>',
-      result: {
-        message: 'Title attribute values should not be the same as the link text.',
-        source: '<LinkTo @route="some.route" @title="Do the things">Do the things</LinkTo>',
-        line: 1,
-        column: 0,
-      },
-    },
   ],
 });

--- a/test/unit/rules/no-invalid-link-title-test.js
+++ b/test/unit/rules/no-invalid-link-title-test.js
@@ -34,5 +34,23 @@ generateRuleTests({
         column: 0,
       },
     },
+    {
+      template: '{{#link-to title="Do the things"}}Do the things{{/link-to}}',
+      result: {
+        message: 'Title attribute values should not be the same as the link text.',
+        source: '{{#link-to title="Do the things"}}Do the things{{/link-to}}',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<LinkTo @route="some.route" @title="Do the things">Do the things</LinkTo>',
+      result: {
+        message: 'Title attribute values should not be the same as the link text.',
+        source: '<LinkTo @route="some.route" @title="Do the things">Do the things</LinkTo>',
+        line: 1,
+        column: 0,
+      },
+    },
   ],
 });

--- a/test/unit/rules/no-invalid-link-title-test.js
+++ b/test/unit/rules/no-invalid-link-title-test.js
@@ -12,7 +12,11 @@ generateRuleTests({
     '{{#link-to}} click here to read more about our company{{/link-to}}',
     '<LinkTo>Read more about ways semantic HTML can make your code more accessible.</LinkTo>',
     '<LinkTo>{{foo}} more</LinkTo>',
+    '<LinkTo @title="nice title">Something else</LinkTo>',
+    '<LinkTo title="great titles!">Whatever, don\'t judge me</LinkTo>',
     '<a href="https://myurl.com" title="New to Ember? Read the full tutorial for the best experience">Read the Tutorial</a>',
+    '<a href="./whatever" title={{foo}}>Hello!</a>',
+    '{{#link-to "blah.route.here" title="awesome title"}}Some thing else here{{/link-to}}',
   ],
 
   bad: [
@@ -30,6 +34,33 @@ generateRuleTests({
       result: {
         message: 'Title attribute values should not be the same as the link text.',
         source: '<LinkTo title="quickstart">Quickstart</LinkTo>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<LinkTo @title="foo" title="blah">derp</LinkTo>',
+      result: {
+        message: 'Specifying title as both an attribute and an argument to <LinkTo /> is invalid.',
+        source: '<LinkTo @title="foo" title="blah">derp</LinkTo>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '{{#link-to title="Do the things"}}Do the things{{/link-to}}',
+      result: {
+        message: 'Title attribute values should not be the same as the link text.',
+        source: '{{#link-to title="Do the things"}}Do the things{{/link-to}}',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<LinkTo @route="some.route" @title="Do the things">Do the things</LinkTo>',
+      result: {
+        message: 'Title attribute values should not be the same as the link text.',
+        source: '<LinkTo @route="some.route" @title="Do the things">Do the things</LinkTo>',
         line: 1,
         column: 0,
       },

--- a/test/unit/rules/no-invalid-link-title-test.js
+++ b/test/unit/rules/no-invalid-link-title-test.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'no-invalid-link-title',
+
+  config: true,
+
+  good: [
+    '<a href="https://myurl.com">Click here to read more about this amazing adventure</a>',
+    '{{#link-to}} click here to read more about our company{{/link-to}}',
+    '<LinkTo>Read more about ways semantic HTML can make your code more accessible.</LinkTo>',
+    '<LinkTo>{{foo}} more</LinkTo>',
+    '<a href="https://myurl.com" title="New to Ember? Read the full tutorial for the best experience">Read the Tutorial</a>',
+  ],
+
+  bad: [
+    {
+      template: '<a href="https://myurl.com" title="read the tutorial">Read the Tutorial</a>',
+      result: {
+        message: 'Title attribute values should not be the same as the link text.',
+        moduleId: 'layout.hbs',
+        source: '<a href="https://myurl.com" title="read the tutorial">Read the Tutorial</a>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<LinkTo title="quickstart">Quickstart</LinkTo>',
+      result: {
+        message: 'Title attribute values should not be the same as the link text.',
+        moduleId: 'layout.hbs',
+        source: '<LinkTo title="quickstart">Quickstart</LinkTo>',
+        line: 1,
+        column: 0,
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Adds a new rule that provides a basic check to ensure that if a `title` attribute is present, it is not the same as the link text. 