### PR TITLE
Fix issues introduced by ember-template-recast@4.0.1.

### DIFF
--- a/lib/rules/no-quoteless-attributes.js
+++ b/lib/rules/no-quoteless-attributes.js
@@ -5,35 +5,28 @@ const Rule = require('./base');
 module.exports = class NoQuotelessAttributes extends Rule {
   visitor() {
     return {
-      ElementNode(node) {
-        node.attributes.forEach(attribute => {
-          let value = attribute.value;
+      TextNode(node, path) {
+        if (path.parentNode.type !== 'AttrNode') {
+          return;
+        }
 
-          if (value.type !== 'TextNode') {
-            return;
-          }
+        let attribute = path.parentNode;
+        let element = path.parent.parentNode;
 
-          let isValueless =
-            value.loc &&
-            value.loc.start.line === value.loc.end.line &&
-            value.loc.start.column === value.loc.end.column;
+        let { isValueless, quoteType } = attribute;
 
-          if (isValueless) {
-            return;
-          }
+        if (isValueless) {
+          return;
+        }
 
-          let source = this.sourceForNode(attribute.value);
-          let isQuoted = source[0] === '"' || source[0] === "'";
-
-          if (!isQuoted) {
-            this.log({
-              message: `Attribute ${attribute.name} should be either quoted or wrapped in mustaches`,
-              line: value.loc && value.loc.start.line,
-              column: value.loc && value.loc.start.column,
-              source: this.sourceForNode(node),
-            });
-          }
-        });
+        if (quoteType === null) {
+          this.log({
+            message: `Attribute ${attribute.name} should be either quoted or wrapped in mustaches`,
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(element),
+          });
+        }
       },
     };
   }

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -48,24 +48,32 @@ module.exports = class Quotes extends Rule {
         break;
     }
 
-    let checkForQuotes = node => {
-      let source = this.sourceForNode(node);
-      if (source[0] === badChar) {
-        return this.log({
-          message,
-          line: node.loc.start.line,
-          column: node.loc.start.column,
-          source,
-        });
-      }
-    };
-
     return {
       AttrNode(node) {
-        checkForQuotes(node.value);
+        let source = this.sourceForNode(node);
+
+        if (!node.isValueless && node.quoteType === badChar) {
+          return this.log({
+            message,
+            line: node.loc.start.line,
+            column: node.loc.start.column,
+            source,
+          });
+        }
       },
-      StringLiteral(node) {
-        checkForQuotes(node);
+
+      StringLiteral(node, path) {
+        let source = this.sourceForNode(node);
+        let errorSource = this.sourceForNode(path.parentNode);
+
+        if (source[0] === badChar) {
+          return this.log({
+            message,
+            line: node.loc.start.line,
+            column: node.loc.start.column,
+            source: errorSource,
+          });
+        }
       },
     };
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "chalk": "^2.4.2",
-    "ember-template-recast": "^4.0.1",
+    "ember-template-recast": "^4.1.0",
     "globby": "^11.0.0",
     "micromatch": "^4.0.2",
     "minimatch": "^3.0.4",

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -186,7 +186,7 @@ describe('base plugin', function() {
         '<div>\n  <div data-foo="blerp">\n    Wheee!\n  </div>\n</div>',
         '\n  ',
         '<div data-foo="blerp">\n    Wheee!\n  </div>',
-        '"blerp"',
+        'blerp',
         '\n    Wheee!\n  ',
         '\n',
       ],

--- a/test/unit/rules/quotes-test.js
+++ b/test/unit/rules/quotes-test.js
@@ -42,7 +42,7 @@ generateRuleTests({
         message: 'you must use double quotes in templates',
         line: 1,
         column: 12,
-        source: "'test'",
+        source: "{{component 'test'}}",
       },
     },
     {
@@ -54,7 +54,7 @@ generateRuleTests({
         message: 'you must use double quotes in templates',
         line: 1,
         column: 10,
-        source: "'test'",
+        source: "x='test'",
       },
     },
     {
@@ -65,8 +65,8 @@ generateRuleTests({
         moduleId: 'layout.hbs',
         message: 'you must use double quotes in templates',
         line: 1,
-        column: 12,
-        source: "'checkbox'",
+        column: 7,
+        source: "type='checkbox'",
       },
     },
     {
@@ -78,7 +78,7 @@ generateRuleTests({
         message: 'you must use single quotes in templates',
         line: 1,
         column: 12,
-        source: '"test"',
+        source: '{{component "test"}}',
       },
     },
     {
@@ -90,7 +90,7 @@ generateRuleTests({
         message: 'you must use single quotes in templates',
         line: 1,
         column: 10,
-        source: '"test"',
+        source: 'x="test"',
       },
     },
     {
@@ -101,8 +101,8 @@ generateRuleTests({
         moduleId: 'layout.hbs',
         message: 'you must use single quotes in templates',
         line: 1,
-        column: 12,
-        source: '"checkbox"',
+        column: 7,
+        source: 'type="checkbox"',
       },
     },
   ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1575,10 +1575,10 @@ ee-first@1.1.1:
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
-ember-template-recast@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/ember-template-recast/-/ember-template-recast-4.0.1.tgz#20f86106bc990a505f5993f434a8d386abdb3175"
-  integrity sha512-0ZdNL2CotrwBf3kW8etxurupxiUPtwnwp8bIADEHmPRSd729SIb5qiw6p1aCgEtsj64Fa9kNNQUePCdgZDWAJQ==
+ember-template-recast@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ember-template-recast/-/ember-template-recast-4.1.0.tgz#7d72fc40c56d7d0f3fa34b50a67608ff7e595faa"
+  integrity sha512-BSusv6T9N+toxTzzTQgRpKn4OFce8AFsuJ6tf6N9/YSAAJ63nSBKtXkAoFKSHBET6DgzFEjSe3F0ChCDtYMHWg==
   dependencies:
     "@glimmer/syntax" "^0.47.9"
     async-promise-queue "^1.0.5"


### PR DESCRIPTION
The fixes introduced into the `next` branch (while merging master into the branch) which uses ember-template-recast as its parser). The underlying reason for the issue is that ember-template-lint was
_basically_ relying on the bug fixed (e.g. it was looking at `AttrNode`'s `.value` and doing sourceForLoc` on that node, then checking if it starts with a quote).

In order for these rules to function (`quotes` and `no-quoteless-attribute`) they need to know if a given attribute had a value (aka was it `<div data-test-blah></div>` vs `<div data-test-blah="thing"></div>`) and what type of quotes were used (single, double, none, etc).

This updates ember-template-recast to 4.1.0 (which adds some additional properties to `AttrNode`'s) and tweaks the implementation of the rules to leverage that functionality.

Additionally, I updated the `quotes` rule to emit a bit more "source" information (which I found a bit more helpful to have more context).