### PR TITLE
Add `modifier-name-case` rule to `recommended` configuration

### DIFF
--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -5,6 +5,7 @@ module.exports = {
     'deprecated-render-helper': true,
     'link-rel-noopener': 'strict',
     'link-href-attributes': true,
+    'modifier-name-case': true,
     'no-abstract-roles': true,
     'no-args-paths': true,
     'no-attrs-in-components': true,


### PR DESCRIPTION
The rule was added recently in #1078.

[Rule doc](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/modifier-name-case.md).

CC: @mansona