### PR TITLE
Add `ignoredTags` option to `no-invalid-interactive` rule

### DIFF
--- a/lib/rules/no-invalid-interactive.js
+++ b/lib/rules/no-invalid-interactive.js
@@ -46,6 +46,8 @@ module.exports = class InvalidInteractive extends Rule {
   visitor() {
     this._element = null;
 
+    const ignoredTags = this.config.ignoredTags || [];
+
     let visitor = {
       enter(node) {
         let isInteractive =
@@ -65,6 +67,10 @@ module.exports = class InvalidInteractive extends Rule {
     return {
       ElementModifierStatement(node) {
         if (!this._element) {
+          return;
+        }
+
+        if (ignoredTags.includes(this._element.tag)) {
           return;
         }
 
@@ -95,6 +101,10 @@ module.exports = class InvalidInteractive extends Rule {
 
       AttrNode(node) {
         if (!this._element) {
+          return;
+        }
+
+        if (ignoredTags.includes(this._element.tag)) {
           return;
         }
 

--- a/test/unit/rules/no-invalid-interactive-test.js
+++ b/test/unit/rules/no-invalid-interactive-test.js
@@ -42,6 +42,14 @@ generateRuleTests({
       config: { additionalInteractiveTags: ['img'] },
       template: '<img onerror={{action "foo"}}>',
     },
+    {
+      config: { ignoredTags: ['div'] },
+      template: '<div {{on "click" this.actionName}}>...</div>',
+    },
+    {
+      config: { ignoredTags: ['div'] },
+      template: '<div onclick={{action "foo"}}></div>',
+    },
     '<img {{on "load" this.onLoad}} {{on "error" this.onError}}>',
   ],
 


### PR DESCRIPTION
This option was in the [documentation](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-invalid-interactive.md) for this rule but not actually implemented. Note that this option is the same as the one from the [no-nested-interactive](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-nested-interactive.md) rule.

Fixes #148.