### PR TITLE
Update `no-curly-component-invocation` rule to ignore ember-cli-app-version usage

### DIFF
--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -129,9 +129,7 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
           }
 
           if (BUILT_INS.includes(name)) {
-            // {{debugger}}
-            // {{outlet}}
-            // {{yield}}
+            // {{app-version versionOnly=true}}
             return;
           }
 

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -43,7 +43,7 @@ const BUILT_INS = new Set([
   'in-element',
 ]);
 
-const ALWAYS_CURLY = new Set(['yield']);
+const ALWAYS_CURLY = new Set(['yield', 'app-version' /* from ember-cli-app-version */]);
 
 module.exports = class NoCurlyComponentInvocation extends Rule {
   parseConfig(config) {

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -128,7 +128,7 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
             return;
           }
 
-          if (BUILT_INS.includes(name)) {
+          if (BUILT_INS.has(name)) {
             // {{app-version versionOnly=true}}
             return;
           }

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -41,9 +41,11 @@ const BUILT_INS = new Set([
   'with',
   '-in-element',
   'in-element',
+  /* from ember-cli-app-version */
+  'app-version',
 ]);
 
-const ALWAYS_CURLY = new Set(['yield', 'app-version' /* from ember-cli-app-version */]);
+const ALWAYS_CURLY = new Set(['yield']);
 
 module.exports = class NoCurlyComponentInvocation extends Rule {
   parseConfig(config) {
@@ -123,6 +125,13 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
 
           if (this.config.requireDash && !name.includes('-')) {
             // {{foo bar=baz}}
+            return;
+          }
+
+          if (BUILT_INS.includes(name)) {
+            // {{debugger}}
+            // {{outlet}}
+            // {{yield}}
             return;
           }
 

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -39,6 +39,10 @@ const SHARED_GOOD = [
   '{{yield}}',
   '{{yield to="inverse"}}',
 
+  // ember-cli related addon
+  '{{app-version}}',
+  '{{app-version versionOnly=true}}',
+
   // real world examples
   '<GoodCode />',
   '<GoodCode></GoodCode>',


### PR DESCRIPTION
ref: https://github.com/ember-template-lint/ember-template-lint/issues/1043