### PR TITLE
Automatically discover `.template-lintrc.js` when running linter from a project subdirectory (e.g. a monorepo's package, with linting configuration in the project root).

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -20,43 +20,46 @@ const ALLOWED_ERROR_CODES = [
   'QUALIFIED_PATH_RESOLUTION_FAILED',
 ];
 
-function resolveConfigPath(configPath, pluginPath) {
-  let usedPath = configPath
-    ? path.resolve(process.cwd(), configPath)
-    : findUp.sync(CONFIG_FILE_NAME);
+function resolvePlugin(pluginName, fromConfigPath) {
+  // throws exception if not found
+  let pluginPath = resolve.sync(pluginName, { basedir: path.dirname(fromConfigPath) });
 
-  if (pluginPath) {
-    // throws exception if not found
-    pluginPath = resolve.sync(pluginPath, { basedir: path.dirname(usedPath) });
-  }
+  return require(pluginPath); // eslint-disable-line import/no-dynamic-require
+}
 
-  let filePath = pluginPath || usedPath;
-  // Making sure that the filePath exists
-  try {
-    require.resolve(filePath);
-  } catch (e) {
-    // nodejs don't have error code for it and throw:
-    // "The first argument to require.resolve must be a string. Recived null or undefined."
-    if (!filePath) {
-      // tests:
-      // uses an empty set of rules if no .template-lintrc is present
-      // should be able to instantiate without options
-      return {};
-    }
-    let isModuleMissingError = ALLOWED_ERROR_CODES.includes(e.code);
-    if (!isModuleMissingError) {
-      throw e;
-    }
+function resolveProjectConfig(specifiedConfigPath) {
+  let configPath;
 
-    if (configPath) {
+  if (specifiedConfigPath) {
+    configPath = path.resolve(process.cwd(), specifiedConfigPath);
+
+    try {
+      // Making sure that the filePath exists, before requiring it directly this is
+      // needed in order to ensure that we only squelch module missing errors for
+      // the config path itself (and not other files that the config path may
+      // require itself)
+      require.resolve(configPath);
+    } catch (e) {
+      let isModuleMissingError = ALLOWED_ERROR_CODES.includes(e.code);
+      if (!isModuleMissingError) {
+        throw e;
+      }
+
       throw new Error(
-        `The configuration file specified (${configPath}) could not be found. Aborting.`
+        `The configuration file specified (${specifiedConfigPath}) could not be found. Aborting.`
       );
-    } else {
+    }
+  } else {
+    configPath = findUp.sync(CONFIG_FILE_NAME);
+
+    if (configPath === undefined) {
+      // we weren't given an explicit --config-path argument, and we couldn't
+      // find a relative .template-lintrc.js file, just use the default "empty" config
       return {};
     }
   }
-  return require(filePath); // eslint-disable-line import/no-dynamic-require
+
+  return require(configPath); // eslint-disable-line import/no-dynamic-require
 }
 
 function forEachPluginConfiguration(plugins, callback) {
@@ -141,7 +144,10 @@ function processPlugins(config, options, checkForCircularReference) {
 
       if (typeof plugin === 'string') {
         pluginName = plugin;
-        plugin = resolveConfigPath(options.configPath, pluginName);
+        // the second argument here should actually be the config file path for
+        // the _currently being processed_ config file (not neccesarily the one
+        // specified to the bin script)
+        plugin = resolvePlugin(pluginName, options.configPath);
       }
 
       let errorMessage;
@@ -296,7 +302,7 @@ function validateRules(config, options) {
 }
 
 module.exports = function(options) {
-  let source = options.config || resolveConfigPath(options.configPath);
+  let source = options.config || resolveProjectConfig(options.configPath);
   let config;
 
   if (source._processed) {

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -4,12 +4,14 @@ const path = require('path');
 const resolve = require('resolve');
 const chalk = require('chalk');
 const Minimatch = require('minimatch').Minimatch;
+const findUp = require('find-up');
 const defaultRules = require('./rules');
 const defaultConfigurations = require('./config/index');
 const DEPRECATED_RULES = require('./helpers/deprecated-rules');
 
 const KNOWN_ROOT_PROPERTIES = ['extends', 'rules', 'pending', 'ignore', 'plugins'];
 
+const CONFIG_FILE_NAME = '.template-lintrc.js';
 const ALLOWED_ERROR_CODES = [
   // resolve package error codes
   'MODULE_NOT_FOUND',
@@ -19,7 +21,9 @@ const ALLOWED_ERROR_CODES = [
 ];
 
 function resolveConfigPath(configPath, pluginPath) {
-  let usedPath = path.resolve(process.cwd(), configPath || '.template-lintrc');
+  let usedPath = configPath
+    ? path.resolve(process.cwd(), configPath)
+    : findUp.sync(CONFIG_FILE_NAME);
 
   if (pluginPath) {
     // throws exception if not found
@@ -31,6 +35,14 @@ function resolveConfigPath(configPath, pluginPath) {
   try {
     require.resolve(filePath);
   } catch (e) {
+    // nodejs don't have error code for it and throw:
+    // "The first argument to require.resolve must be a string. Recived null or undefined."
+    if (!filePath) {
+      // tests:
+      // uses an empty set of rules if no .template-lintrc is present
+      // should be able to instantiate without options
+      return {};
+    }
     let isModuleMissingError = ALLOWED_ERROR_CODES.includes(e.code);
     if (!isModuleMissingError) {
       throw e;
@@ -105,12 +117,12 @@ function migrateRulesFromRoot(config, source, options) {
   if (invalidKeysFound.length > 0) {
     logger.log(
       chalk.yellow(
-        [
-          'Rule configuration has been moved into a `rules` property.',
-          'Please update your `.template-lintrc.js` file.',
-          'The following rules have been migrated to the `rules`',
-          `property: ${invalidKeysFound}.`,
-        ].join(' ')
+        `
+        Rule configuration has been moved into a \`rules\` property.
+        Please update your \`${CONFIG_FILE_NAME}\` file.
+        The following rules have been migrated to the \`rules\`
+        property: ${invalidKeysFound}.
+        `
       )
     );
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "chalk": "^2.4.2",
     "ember-template-recast": "^4.1.0",
+    "find-up": "^4.1.0",
     "globby": "^11.0.0",
     "micromatch": "^4.0.2",
     "minimatch": "^3.0.4",

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -117,6 +117,55 @@ describe('public api', function() {
       expect(linter.config.rules).toEqual(expected.rules);
     });
 
+    it('uses .template-lintrc from upper folder structure if file does not exists in cwd', function() {
+      let expected = {
+        rules: {
+          foo: 'bar',
+          baz: 'derp',
+        },
+      };
+      project.write({
+        '.template-lintrc.js': `module.exports = ${JSON.stringify(expected)};`,
+        app: {
+          templates: {
+            'application.hbs': '',
+          },
+        },
+      });
+
+      process.chdir(path.join(process.cwd(), 'app', 'templates'));
+      let linter = new Linter({
+        console: mockConsole,
+      });
+
+      expect(linter.config.rules).toEqual(expected.rules);
+    });
+
+    it('uses first .template-lintrc from upper folder structure if file does not exists in cwd', function() {
+      let expected = {
+        rules: {
+          foo: 'bar',
+          baz: 'derp',
+        },
+      };
+      project.write({
+        '.template-lintrc.js': `module.exports = ${JSON.stringify({ rules: { boo: 'baz' } })};`,
+        app: {
+          '.template-lintrc.js': `module.exports = ${JSON.stringify(expected)};`,
+          templates: {
+            'application.hbs': '',
+          },
+        },
+      });
+
+      process.chdir(path.join(process.cwd(), 'app', 'templates'));
+      let linter = new Linter({
+        console: mockConsole,
+      });
+
+      expect(linter.config.rules).toEqual(expected.rules);
+    });
+
     it('breaks if the specified configPath does not exist', function() {
       expect(() => {
         new Linter({


### PR DESCRIPTION
ref: https://github.com/ember-template-lint/ember-template-lint/issues/813