### PR TITLE
Add markdownlint and fix violations

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,3 @@
+{
+  "line-length": false
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -836,7 +836,7 @@ You can read more about the rule [in the documentation](https://github.com/ember
 
 - Add new `attribute-indentation` rule.  Examples:
 
-``` hbs
+```hbs
 {{! good }}
 
 {{foo-bar baz="bat" derp="qux"}}
@@ -858,7 +858,7 @@ as |foo|}}
 {{/foo-bar}}
 ```
 
-``` hbs
+```hbs
 {{! bad }}
 
 {{foo-bar baz="bat"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the `no-bare-strings` rule found an error.
 
 To install ember-template-lint
 
-```
+```shell
 npm install --save-dev ember-template-lint
 ```
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,6 @@ Releases are mostly automated using
 [release-it](https://github.com/release-it/release-it/) and
 [lerna-changelog](https://github.com/lerna/lerna-changelog/).
 
-
 ## Preparation
 
 Since the majority of the actual release process is automated, the primary
@@ -25,12 +24,11 @@ When reviewing merged PR's the labels to be used are:
 * internal - Used for internal changes that still require a mention in the
   changelog/release notes.
 
-
-## Release
+## Commands
 
 Once the prep work is completed, the actual release is straight forward:
 
-```
+```shell
 yarn install
 yarn release
 ```

--- a/dev/versioning.md
+++ b/dev/versioning.md
@@ -2,9 +2,9 @@
 
 `ember-template-lint` follows [semantic versioning](http://semver.org/) and [ESLint's Semantic Versioning Policy](https://github.com/eslint/eslint#semantic-versioning-policy).
 
-For clarity, we define semver policy for this addon in two parts- as related to **rules** and as related to **config** files. 
+For clarity, we define semver policy for this addon in two parts- as related to **rules** and as related to **config** files.
 
-## Related to Rules 
+## Related to Rules
 
 ### Patch Release
 
@@ -35,14 +35,14 @@ A major release is likely to break your lint build.
 
 ## Config Files
 
-
 ### Patch or Minor Release
+
 A patch or minor release should not break your lint build.
 
 * Removing a rule
 * Making a rule less restrictive
 
-### Major Release
+### Major Releases
 
 A major release is likely to break your lint build.
 

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -1,4 +1,4 @@
-## Ignore support
+# Ignore support
 
 You can tell the linter to ignore individual files or entire directories with the `ignore` option.
 
@@ -7,7 +7,7 @@ The ignore option takes an array of strings that either match exact modules or g
 * **module** -- `'app/templates/exceptional-page'`
 * **glob** -- `'app/templates/components/odd-ones/**'`
 
-### Sample configuration
+## Sample configuration
 
 ```javascript
 module.exports = {
@@ -22,7 +22,7 @@ module.exports = {
 };
 ```
 
-### Why are patterns duplicated?
+## Why patterns are duplicated
 
 You may have noticed in the sample configuration that the four patterns are actually two patterns repeated with different prefixes.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,10 +1,10 @@
-## Plugin Support
+# Plugin Support
 
 You can customize the linter with rules that are more specific to your use case with the `ember-template-lint` plugin system.
 
 Plugins can define new rules and set up default configurations that can be extended.
 
-### Defining plugin objects
+## Defining plugin objects
 
 Each plugin object can include these properties.
 
@@ -48,7 +48,7 @@ Sample plugin object:
 }
 ```
 
-### Adding Plugins to Your Configuration
+## Adding Plugins to Your Configuration
 
 In order to enable a plugin, you must add it to the `plugins` key in your configuration file.
 
@@ -89,11 +89,11 @@ module.exports = {
 }
 ```
 
-### Rule APIs
+## Rule APIs
 
 Every rule defined by a plugin can use these public APIs defined by `ember-template-lint`.
 
-#### Building a rule object
+### Building a rule object
 
 Each file that defines a rule should export a class that extends from the base rule object.
 
@@ -133,16 +133,16 @@ The base rule also has a few helper functions that can be useful in defining rul
 * `function log(options)`
 
   Report a lint error. The `log` function accepts an Object as its only argument, which can contain the following parameters:
-    - `message` -- `string`
-      The error message to display.
-    - `line` -- `number`
-      The line number of the error in the source string.
-    - `column` -- `number`
-      The column number of the error in the source string.
-    - `source` -- `string`
-      The source string that caused the error.
-    - `fix` -- `string`
-      An optional string to display with the recommended fix.
+  * `message` -- `string`
+    The error message to display.
+  * `line` -- `number`
+    The line number of the error in the source string.
+  * `column` -- `number`
+    The column number of the error in the source string.
+  * `source` -- `string`
+    The source string that caused the error.
+  * `fix` -- `string`
+    An optional string to display with the recommended fix.
 
 * `function sourceForNode(node): string`
 
@@ -152,7 +152,7 @@ The base rule also has a few helper functions that can be useful in defining rul
 
   Given an AST node, check if it is derived from a local / block param.
 
-#### AST Node Helpers
+### AST Node Helpers
 
 There are a number of helper functions exported by [`ember-template-lint`](../lib/helpers/ast-node-info.js) that can be used with AST nodes in your rule's visitor handlers.
 

--- a/docs/rule/_TEMPLATE_.md
+++ b/docs/rule/_TEMPLATE_.md
@@ -1,10 +1,10 @@
-## (rule name goes here)
+# (rule name goes here)
 
 (context about the problem goes here)
 
 (what the rule does goes here)
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -26,14 +26,14 @@ This rule **allows** the following:
 {{!-- Example 2  --}}
 ```
 
-### Migration
+## Migration
 
 (suggest any fast/automated techniques for fixing violations in a large codebase)
 
 * suggestion on how to fix violations using find-and-replace / regexp
 * suggestion on how to fix violations using a codemod
 
-### Configuration
+## Configuration
 
 (exclude this section if the rule has no extra configuration)
 
@@ -41,12 +41,12 @@ This rule **allows** the following:
   * string -- `parameterName1` -- description of parameter including the possible values and default value
   * boolean -- `parameterName2` -- description of parameter including the possible values and default value
 
-### Related Rules
+## Related Rules
 
 * [related-rule-name1](related-rule-name1.md)
 * [related-rule-name2](related-rule-name2.md)
 
-### References
+## References
 
 * (link to relevant documentation goes here)
 * (link to relevant function spec goes here)

--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -1,130 +1,133 @@
-## attribute-indentation
+# attribute-indentation
 
 This rule requires the positional params, attributes, and block params of the helper/component to be indented by moving them to multiple lines when the open invocation has more than 80 characters (configurable).
 
-### Forbidden
+## Forbidden
 
 Non-Block form
-``` hbs
 
-  {{employee-details firstName=firstName lastName=lastName age=age avatarUrl=avatarUrl}}
+```hbs
+{{employee-details firstName=firstName lastName=lastName age=age avatarUrl=avatarUrl}}
 ```
 
 Block form
-``` hbs
 
-  {{#employee-details firstName=firstName lastName=lastName age=age avatarUrl=avatarUrl as |employee|}}
-    {{employee.fullName}}
-  {{/employee-details}}
+```hbs
+{{#employee-details firstName=firstName lastName=lastName age=age avatarUrl=avatarUrl as |employee|}}
+  {{employee.fullName}}
+{{/employee-details}}
 ```
 
 Non-Block form (HTML)
-``` hbs
 
-  <input disabled id="firstName" value={{firstName}} class="input-field first-name" type="text">
+```hbs
+<input disabled id="firstName" value={{firstName}} class="input-field first-name" type="text">
 ```
 
 Block form (HTML)
-``` hbs
 
-  <a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>
+```hbs
+<a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>
 ```
 
-### Allowed
+## Allowed
 
 Non-Block form
-``` hbs
 
-  {{employee-details
-    firstName=firstName
-    lastName=lastName
-    age=age
-    avatarUrl=avatarUrl
-  }}
+```hbs
+{{employee-details
+  firstName=firstName
+  lastName=lastName
+  age=age
+  avatarUrl=avatarUrl
+}}
 ```
 
 Non-Block form (open invocation < 80 characters)
-``` hbs
 
-  {{employee-details firstName=firstName lastName=lastName}}
+```hbs
+{{employee-details firstName=firstName lastName=lastName}}
 ```
 
 Non-Block form with Helper
+
 ```hbs
-  {{if
-    (or logout.isRunning (not session.isAuthenticated))
-    "Logging Out..."
-    "Log Out"
-  }}
+{{if
+  (or logout.isRunning (not session.isAuthenticated))
+  "Logging Out..."
+  "Log Out"
+}}
 ```
 
 Non-Block form with Helper unfolded
+
 ```hbs
-  {{if
-    (or
-      logout.isRunning
-      (not session.isAuthenticated)
-    )
-    "Logging Out..."
-    "Log Out"
-  }}
+{{if
+  (or
+    logout.isRunning
+    (not session.isAuthenticated)
+  )
+  "Logging Out..."
+  "Log Out"
+}}
 ```
 
 Non-Block form (HTML)
-``` hbs
 
-  <input
-    disabled
-    id="firstName"
-    value={{firstName}}
-    class="input-field first-name"
-    type="text"
-  >
+```hbs
+<input
+  disabled
+  id="firstName"
+  value={{firstName}}
+  class="input-field first-name"
+  type="text"
+>
 ```
 
 Block form
-``` hbs
 
-  {{#employee-details
-    firstName=firstName
-    lastName=lastName
-    age=age
-    avatarUrl=avatarUrl
-  as |employee|
-  }}
-    {{employee.fullName}}
-  {{/employee-details}}
+```hbs
+{{#employee-details
+  firstName=firstName
+  lastName=lastName
+  age=age
+  avatarUrl=avatarUrl
+as |employee|
+}}
+  {{employee.fullName}}
+{{/employee-details}}
 ```
 
 Block form (open invocation < 80 characters)
-``` hbs
 
-  {{#employee-details firstName=firstName lastName=lastName as |employee|}}
-    {{employee.fullName}}
-  {{/employee-details}}
+```hbs
+{{#employee-details firstName=firstName lastName=lastName as |employee|}}
+  {{employee.fullName}}
+{{/employee-details}}
 ```
 
 Block form (HTML)
-``` html
 
-  <a
-    href="https://www.emberjs.com"
-    class="emberjs-home link"
-    rel="noopener"
-    target="_blank"
-  >
-    Ember JS
-  </a>
+```html
+<a
+  href="https://www.emberjs.com"
+  class="emberjs-home link"
+  rel="noopener"
+  target="_blank"
+>
+  Ember JS
+</a>
 ```
 
-### Configuration
-  * boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines.
-  * object - { 'indentation': n spaces } - Indentation length for attributes (defaults to `2`).
-  * object - { 'open-invocation-max-len': n characters } - Maximum length of the opening invocation.
-  * object - { 'process-elements': `true` } - Also validate the indentation of HTML/SVG elements.
-  * object - { 'element-open-end': `new-line`|`last-attribute` } - Enforce the position of the closing brace `>` to be on a new line or next to the last attribute (defaults to `new-line`).
-  * object - { 'mustache-open-end': `new-line`|`last-attribute` } - Enforce the position of the closing braces `}}` to be on a new line or next to the last attribute (defaults to `new-line`).
+## Configuration
 
-### Related Rules
+* boolean - `true` - Enables the rule to be enforced when the opening invocation has more than 80 characters or when it spans multiple lines.
+* object - { 'indentation': n spaces } - Indentation length for attributes (defaults to `2`).
+* object - { 'open-invocation-max-len': n characters } - Maximum length of the opening invocation.
+* object - { 'process-elements': `true` } - Also validate the indentation of HTML/SVG elements.
+* object - { 'element-open-end': `new-line`|`last-attribute` } - Enforce the position of the closing brace `>` to be on a new line or next to the last attribute (defaults to `new-line`).
+* object - { 'mustache-open-end': `new-line`|`last-attribute` } - Enforce the position of the closing braces `}}` to be on a new line or next to the last attribute (defaults to `new-line`).
+
+## Related Rules
 
 * [block-indentation](block-indentation.md)

--- a/docs/rule/block-indentation.md
+++ b/docs/rule/block-indentation.md
@@ -1,6 +1,8 @@
-## block-indentation
+# block-indentation
 
 Good indentation is crucial for long-term maintenance of templates. For example, having blocks misaligned is a common cause of logic errors.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -31,17 +33,17 @@ This rule **allows** the following:
 {{/my-component}}
 ```
 
-### Configuration
+## Configuration
 
 The following values are valid configuration:
 
-  * boolean -- `true` indicates a 2 space indent, `false` indicates that the rule is disabled.
-  * numeric -- the number of spaces to require for indentation
-  * "tab" -- To indicate tab style indentation (1 char)
-  * object -- An object with the following keys:
-     * `indentation: <numeric>` - number of spaces to indent (defaults to 2)
-     * `ignoreComments: <boolean>` - skip indentation for comments (defaults to `false`)
+* boolean -- `true` indicates a 2 space indent, `false` indicates that the rule is disabled.
+* numeric -- the number of spaces to require for indentation
+* "tab" -- To indicate tab style indentation (1 char)
+* object -- An object with the following keys:
+  * `indentation: <numeric>` - number of spaces to indent (defaults to 2)
+  * `ignoreComments: <boolean>` - skip indentation for comments (defaults to `false`)
 
-### Related Rules
+## Related Rules
 
-  * [attribute-indentation](attribute-indentation.md)
+* [attribute-indentation](attribute-indentation.md)

--- a/docs/rule/deprecations/deprecated-each-syntax.md
+++ b/docs/rule/deprecations/deprecated-each-syntax.md
@@ -1,7 +1,9 @@
-## deprecated-each-syntax
+# deprecated-each-syntax
 
 In Ember 2.0, support for using the `in` form of the `{{#each}}` helper
 has been removed.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -19,6 +21,6 @@ This rule **allows** the following:
 {{/each}}
 ```
 
-### References
+## References
 
 * More information is available at the [Deprecation Guide](http://emberjs.com/deprecations/v1.x/#toc_code-in-code-syntax-for-code-each-code).

--- a/docs/rule/deprecations/deprecated-inline-view-helper.md
+++ b/docs/rule/deprecations/deprecated-inline-view-helper.md
@@ -1,6 +1,8 @@
-## deprecated-inline-view-helper
+# deprecated-inline-view-helper
 
 In Ember 1.12, support for invoking the inline View helper was deprecated.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -28,6 +30,6 @@ This rule **allows** the following:
 <div foo={{bar}}></div>
 ```
 
-### References
+## References
 
 * More information is available at the [Deprecation Guide](http://emberjs.com/deprecations/v1.x/#toc_ember-view).

--- a/docs/rule/deprecations/deprecated-render-helper.md
+++ b/docs/rule/deprecations/deprecated-render-helper.md
@@ -1,6 +1,8 @@
-## deprecated-render-helper
+# deprecated-render-helper
 
 In Ember 2.6 and newer, support for using the `{{render}}` helper has been deprecated.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -18,6 +20,6 @@ This rule **allows** the following:
 {{saul-goodman model=model}}
 ```
 
-### References
+## References
 
 * More information is available at the [Deprecation Guide](https://emberjs.com/deprecations/v2.x/#toc_code-render-code-helper).

--- a/docs/rule/eol-last.md
+++ b/docs/rule/eol-last.md
@@ -1,4 +1,4 @@
-## eol-last
+# eol-last
 
 Require or disallow newline at the end of files.
 
@@ -15,12 +15,12 @@ or this (with newline at end):
 {{!-- newline would be here  --}}
 ```
 
-### Configuration
+## Configuration
 
 The following values are valid configuration:
 
-  * string -- "always" enforces that files end with a newline, "never" enforces that files do not end with a newline
+* string -- "always" enforces that files end with a newline, "never" enforces that files do not end with a newline
 
-### Related Rules
+## Related Rules
 
 * [eol-last](https://eslint.org/docs/rules/eol-last) from eslint

--- a/docs/rule/img-alt-attributes.md
+++ b/docs/rule/img-alt-attributes.md
@@ -1,10 +1,12 @@
-## img-alt-attributes
+# img-alt-attributes
 
 **NOTE**: This rule is deprecated in favor of the more comprehensive rule [require-valid-alt-text](./require-valid-alt-text.md).
 
 An `<img>` without an `alt` attribute is essentially invisible to assistive/accessibility technology (i.e. screen readers).
 In order to ensure that screen readers can provide useful information, we need to ensure that all `<img>` elements
 have an `alt` attribute specified.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -18,6 +20,6 @@ This rule **allows** the following:
 <img src="rwjblue.png" alt="picture of Robert Jackson">
 ```
 
-### References
+## References
 
 * See [WCAG Suggestion H37](https://www.w3.org/TR/WCAG20-TECHS/H37.html)

--- a/docs/rule/inline-link-to.md
+++ b/docs/rule/inline-link-to.md
@@ -1,6 +1,8 @@
-## inline-link-to
+# inline-link-to
 
 Ember's `link-to` component has both an inline form and a block form. This rule forbids the inline form.
+
+## Examples
 
 This rule **forbids** the following (inline form):
 

--- a/docs/rule/invocable-blacklist.md
+++ b/docs/rule/invocable-blacklist.md
@@ -1,6 +1,8 @@
-## invocable-blacklist
+# invocable-blacklist
 
 Disallow certain components or helpers from being used. Use case is you bring in some addon like ember-composable-helpers, but your team deems one or many of the helpers not suitable and wants to guard against their usage.
+
+## Examples
 
 Given a config of:
 
@@ -18,6 +20,6 @@ This rule **forbids** the following:
 {{#foo}}{{/foo}}
 ```
 
-### Configuration
+## Configuration
 
-  * array of strings - helpers or components to blacklist
+* array of strings - helpers or components to blacklist

--- a/docs/rule/linebreak-style.md
+++ b/docs/rule/linebreak-style.md
@@ -1,8 +1,8 @@
-## linebreak-style
+# linebreak-style
 
 Having consistent linebreaks is important to make sure that the source code is rendered correctly in editors.
 
-### Configuration
+## Configuration
 
 This rule is configured with a boolean, or a string value:
 

--- a/docs/rule/link-href-attributes.md
+++ b/docs/rule/link-href-attributes.md
@@ -1,6 +1,8 @@
-## link-href-attributes
+# link-href-attributes
 
 It's common to treat anchor tags as buttons. However, this is typically considered bad practice, as an anchor tag without an `href` is unfocusable which breaks accessibility.
+
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/link-rel-noopener.md
+++ b/docs/rule/link-rel-noopener.md
@@ -1,4 +1,4 @@
-## link-rel-noopener
+# link-rel-noopener
 
 When you want to link to an external page from your app, it is very common to use `<a href="url" target="_blank"></a>`
 to make the browser open this link in a new tab.
@@ -9,6 +9,8 @@ to a malicious clone to perform phishing on your users.
 
 Adding `rel="noopener noreferrer"` closes that door and avoids javascript in the opened tab to block the main
 thread in the opener. Also note that Firefox versions prior 52 do not implement `noopener`, so `rel="noreferrer"` should be used instead ([see Firefox issue](https://bugzilla.mozilla.org/show_bug.cgi?id=1222516)).
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -22,14 +24,15 @@ This rule **allows** the following:
 <a href="https://i.seem.secure.com" target="_blank" rel="noopener noreferrer">I'm a bait</a>
 ```
 
-### Configuration
+## Configuration
 
 The following values are valid configuration:
 
-  * string -- `strict` for enabled and validating both noopener `and` noreferrer
-  * boolean `true` to maintain backwards compatibility with previous versions of `ember-template-lint` that validate noopener `or` noreferrer
-  If you are supporting Firefox, you should use `strict`.
+* string -- `strict` for enabled and validating both noopener `and` noreferrer
+* boolean `true` to maintain backwards compatibility with previous versions of `ember-template-lint` that validate noopener `or` noreferrer
 
-### References
+If you are supporting Firefox, you should use `strict`.
+
+## References
 
 * [Link type "noreferrer"](https://html.spec.whatwg.org/multipage/semantics.html#link-type-noreferrer) spec

--- a/docs/rule/modifier-name-case.md
+++ b/docs/rule/modifier-name-case.md
@@ -1,4 +1,4 @@
-## modifier-name-case
+# modifier-name-case
 
 It is currently possible to invoke a modifier with multiple words in its name
 using camelCase: `{{didInsert}}` or using dasherized-case: `{{did-insert}}`.
@@ -8,7 +8,7 @@ codebase.
 This rule enforces that you will always use the dasherized-case form of the
 modifier invocation.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-abstract-roles.md
+++ b/docs/rule/no-abstract-roles.md
@@ -1,4 +1,4 @@
-## no-abstract-roles
+# no-abstract-roles
 
 The HTML attribute `role` must never have the following values:
 
@@ -15,7 +15,7 @@ The HTML attribute `role` must never have the following values:
 * `widget`
 * `window`
 
-### `<* role>`
+## `<* role>`
 
 This rule **forbids** the following:
 
@@ -29,5 +29,6 @@ This rule **allows** the following:
 <div role="button"> Push it </div>
 ```
 
-### References
+## References
+
 * See [https://www.w3.org/TR/wai-aria-1.0/roles#abstract_roles](https://www.w3.org/TR/wai-aria-1.0/roles#abstract_roles)

--- a/docs/rule/no-action-modifiers.md
+++ b/docs/rule/no-action-modifiers.md
@@ -1,8 +1,10 @@
-## no-action-modifiers
+# no-action-modifiers
 
 This rule forbids the use of `{{action}}` modifiers on elements.
 
 The recommended alternative is the `on` modifier. `on` is available in Ember 3.11+ and by [polyfill](https://github.com/buschtoens/ember-on-modifier) for earlier versions.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -16,21 +18,21 @@ This rule **allows** the following:
 <button {{on 'click' this.submit}}>Submit</button>
 ```
 
-### Configuration
+## Configuration
 
 The following values are valid configuration:
 
-  * boolean -- `true` for enabled / `false` for disabled
-  * array -- an array of whitelisted element tag names, which will accept action modifiers
+* boolean -- `true` for enabled / `false` for disabled
+* array -- an array of whitelisted element tag names, which will accept action modifiers
 
-### References
+## References
 
 * [Documentation](https://guides.emberjs.com/release/templates/actions/) for template actions
 * [Polyfill](https://github.com/buschtoens/ember-on-modifier) for the `on` modifier (needed below Ember 3.11)
 * [Spec](http://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/fn?anchor=on) for the `on` modifier
 * [Spec](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/action?anchor=action) for the `action` modifier
 
-### Related Rules
+## Related Rules
 
 * [no-action](no-action.md)
 * [no-element-event-actions](no-element-event-actions.md)

--- a/docs/rule/no-action.md
+++ b/docs/rule/no-action.md
@@ -1,10 +1,11 @@
-## no-action
+# no-action
 
 What's wrong with `{{action}}`?
 
 "Action" is an overloaded term in Ember parlance. Actions are:
 
 1.) Methods on the `actions` hash
+
 ```js
 actions: {
   helloWorld() {}
@@ -12,16 +13,19 @@ actions: {
 ```
 
 2.) But also element modifiers that setup event handlers?
+
 ```hbs
 <div {{action 'helloWorld'}}></div>
 ```
 
 3.) Oh, and they are partial applied functions too:
+
 ```hbs
 {{some-component onClick=(action 'addNumbers' 1 2 3)}}
 ```
 
 4.) Also, they usually receive strings, but can also receive functions?
+
 ```hbs
 <div {{action this.someMethod}}></div>
 ```
@@ -41,10 +45,9 @@ Actions have served many different purposes over the years, and this makes them 
 
 We wanted to separate out the different responsibilities here, and the `@action` decorator was the first part of the puzzle, and the other two pieces are the `{{fn}}` helper and `{{on}}` modifier.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
-
 
 ```hbs
 <button onclick={{action 'foo'}}></button>
@@ -76,7 +79,7 @@ This rule **allows** the following:
 <button {{on "submit" this.action}}>Click Me</button>
 ```
 
-### Migration
+## Migration
 
 ```hbs
 <select onchange={{action this.updateSelection this.options}}>
@@ -85,6 +88,7 @@ This rule **allows** the following:
   {{/each}}
 </select>
 ```
+
 to
 
 ```hbs
@@ -95,12 +99,12 @@ to
 </select>
 ```
 
-### Related Rules
+## Related Rules
 
 * [no-action-modifiers](no-action-modifiers.md)
 * [no-element-event-actions](no-element-event-actions.md)
 
-### References
+## References
 
 * [Ember Octane Update: What's up with `@action`?](https://www.pzuraq.com/ember-octane-update-action/)
 * [RFC-471 `on` modifier](https://github.com/emberjs/rfcs/blob/master/text/0471-on-modifier.md)

--- a/docs/rule/no-args-paths.md
+++ b/docs/rule/no-args-paths.md
@@ -1,4 +1,4 @@
-## no-args-paths
+# no-args-paths
 
 Arguments that are passed to components are prefixed with the `@` symbol in Angle bracket syntax.
 Ember Octane leverages this in the component's templates by allowing users to directly refer to an argument using the same prefix:
@@ -14,9 +14,9 @@ Ember Octane leverages this in the component's templates by allowing users to di
 </ul>
 ```
 
-We can immediately tell now by looking at this template that `@todos` is an argument that was passed to the component externally. This is in fact _always true_ - there is no way to modify the value referenced by `@todos` from the component class, it is the original, unmodified value. 
+We can immediately tell now by looking at this template that `@todos` is an argument that was passed to the component externally. This is in fact _always true_ - there is no way to modify the value referenced by `@todos` from the component class, it is the original, unmodified value.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -48,16 +48,15 @@ This rule **allows** the following:
 <div {{my-modifier @foo}}></div>
 ```
 
-
-### Migration
+## Migration
 
 * find in templates `this.args.` replace to `@`
 
-### Related Rules
+## Related Rules
 
 * [no-curly-component-invocation](no-curly-component-invocation.md)
 
-### References
+## References
 
 * [RFC #276](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md)
 * [Coming Soon in Ember Octane - Part 2: Named Argument Syntax](https://www.pzuraq.com/coming-soon-in-ember-octane-part-2-angle-brackets-and-named-arguments/#namedargumentsyntax)

--- a/docs/rule/no-attrs-in-components.md
+++ b/docs/rule/no-attrs-in-components.md
@@ -1,12 +1,15 @@
-## no-attrs-in-components
+# no-attrs-in-components
 
 This rule prevents the usage of `attrs` property to access values passed to the component since all the values can be accessed directly from the template.
+
+## Examples
 
 This rule **forbids** the following:
 
 ```hbs
 {{attr.foo}}
 ```
+
 This rule **allows** the following:
 
 ```hbs

--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -1,6 +1,8 @@
-## no-bare-strings
+# no-bare-strings
 
 In order to be able to internationalize your application, you will need to avoid using plain strings in your templates. Instead, you would need to use a template helper specializing in translation ([ember-intl](https://github.com/ember-intl/ember-intl) is the recommended project to use this for).
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -15,18 +17,19 @@ This rule **allows** the following:
 <h2>{{t 'photos.banner' numPhotos=model.photos.length}}</h2>
 ```
 
-### Configuration
+## Configuration
 
  The following values are valid configuration:
 
-   * boolean -- `true` for enabled / `false` for disabled
-   * array -- an array of whitelisted strings
-   * object -- An object with the following keys:
-     * `whitelist` -- An array of whitelisted strings
-     * `globalAttributes` -- An array of attributes to check on every element.
-     * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
+* boolean -- `true` for enabled / `false` for disabled
+* array -- an array of whitelisted strings
+* object -- An object with the following keys:
+  * `whitelist` -- An array of whitelisted strings
+  * `globalAttributes` -- An array of attributes to check on every element.
+  * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
 
 When the config value of `true` is used the following configuration is used:
- * `whitelist` - `(),.&+-=*/#%!?:[]{}`
- * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
- * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
+
+* `whitelist` - `(),.&+-=*/#%!?:[]{}`
+* `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
+* `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`

--- a/docs/rule/no-curly-component-invocation.md
+++ b/docs/rule/no-curly-component-invocation.md
@@ -1,4 +1,4 @@
-## no-curly-component-invocation
+# no-curly-component-invocation
 
 There are two ways to invoke a component in a template: curly component syntax
 (`{{my-component}}`), and angle bracket syntax (`<MyComponent />`). The
@@ -10,7 +10,7 @@ Edition.
 This rule checks all the curly braces in your app and warns about those that
 look like they could be component invocations.
 
-### Examples
+## Examples
 
 - `{{foo}}` ✅
   (simple mustache without `-` in the path is likely to be a property; unless
@@ -66,11 +66,11 @@ look like they could be component invocations.
 - `{{#link-to "foo"}}bar{{/link-to}}` ❌ (angle brackets: `<LinkTo @route="foo">bar</LinkTo>`)
   (block form of the built-in `link-to` component)
 
-### Migration
+## Migration
 
-- use https://github.com/ember-codemods/ember-angle-brackets-codemod
+- use <https://github.com/ember-codemods/ember-angle-brackets-codemod>
 
-### Configuration
+## Configuration
 
 - boolean -- if `true`, default configuration is applied
   (`noImplicitThis: false`, `requireDash: true`), see below for details
@@ -88,7 +88,7 @@ look like they could be component invocations.
   - array -- `disallow` -- a list of curly invocation paths that are known to
     be component invocations
 
-### References
+## References
 
 - [RFC #311](https://github.com/emberjs/rfcs/pull/311) (Angle Bracket Syntax)
 - [RFC #457](https://github.com/emberjs/rfcs/pull/457) (Nested Components)

--- a/docs/rule/no-debugger.md
+++ b/docs/rule/no-debugger.md
@@ -1,6 +1,8 @@
-## no-debugger
+# no-debugger
 
 The `{{debugger}}` helper is equivalent to a JavaScript `debugger` statement. This will halt execution if the browser developer tools are open. That is undesirable in a production environment.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -8,7 +10,7 @@ This rule **forbids** the following:
 {{debugger}}
 ```
 
-### References
+## References
 
 * Ember's template [Development Helpers](https://guides.emberjs.com/release/templates/development-helpers/) guide
 * Ember's template [debugger](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/if?anchor=debugger) helper documentation

--- a/docs/rule/no-duplicate-attributes.md
+++ b/docs/rule/no-duplicate-attributes.md
@@ -1,6 +1,8 @@
-## no-duplicate-attributes
+# no-duplicate-attributes
 
 This rule forbids multiple attributes passed to a Component, Helper, or an ElementNode with the same name.
+
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-element-event-actions.md
+++ b/docs/rule/no-element-event-actions.md
@@ -1,4 +1,4 @@
-## no-element-event-actions
+# no-element-event-actions
 
 Using HTML element event properties such as `onclick` for Ember actions is not recommended for the following reasons:
 
@@ -6,6 +6,8 @@ Using HTML element event properties such as `onclick` for Ember actions is not r
 * It can lead to confusing and unexpected behavior when mixed with normal action usage. For a comprehensive explanation of why, read [Deep Dive on Ember Events].
 
 The recommended alternative is the `on` modifier. `on` is available in Ember 3.11+ and by [polyfill](https://github.com/buschtoens/ember-on-modifier) for earlier versions.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -19,7 +21,7 @@ This rule **allows** the following:
 <button {{on 'click' this.submit}}>Submit</button>
 ```
 
-### References
+## References
 
 * [Documentation](https://guides.emberjs.com/release/templates/actions/) for template actions
 * [Polyfill](https://github.com/buschtoens/ember-on-modifier) for the `on` modifier (needed below Ember 3.11)
@@ -30,7 +32,7 @@ This rule **allows** the following:
 
 [Deep Dive on Ember Events]: https://medium.com/square-corner-blog/deep-dive-on-ember-events-cf684fd3b808
 
-### Related Rules
+## Related Rules
 
 * [no-action](no-action.md)
 * [no-action-modifiers](no-action-modifiers.md)

--- a/docs/rule/no-extra-mut-helper-argument.md
+++ b/docs/rule/no-extra-mut-helper-argument.md
@@ -1,6 +1,8 @@
-## no-extra-mut-helper-argument
+# no-extra-mut-helper-argument
 
 A common mistake when using the Ember handlebars template `mut(attr)` helper is to pass an extra `value` parameter to it when only `attr` should be passed. Instead, the `value` should be passed outside of `mut`.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -14,6 +16,6 @@ This rule **allows** the following:
 {{my-component click=(action (mut isClicked) true)}}
 ```
 
-### References
+## References
 
 * See the [documentation](https://emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/mut?anchor=mut) for the Ember handlebars template `mut` helper

--- a/docs/rule/no-html-comments.md
+++ b/docs/rule/no-html-comments.md
@@ -1,10 +1,12 @@
-## no-html-comments
+# no-html-comments
 
 HTML comments in your templates will get compiled and rendered into the DOM at runtime. This is undesirable in a production environment. Instead, you can annotate your templates using Handlebars comments, which will be stripped out when the template is compiled and have no effect at runtime.
 
+## Examples
+
 This rule **forbids** the following:
 
-``` hbs
+```hbs
 <!-- comment goes here -->
 ```
 

--- a/docs/rule/no-implicit-this.md
+++ b/docs/rule/no-implicit-this.md
@@ -1,8 +1,8 @@
-## no-implicit-this
+# no-implicit-this
 
 This rule aides in the migration path for [emberjs/rfcs#308](https://github.com/emberjs/rfcs/pull/308).
 
-### Motivation
+## Motivation
 
 Currently, the way to access properties on a components class is `{{greeting}}`
 from a template. This works because the component class is one of the objects
@@ -13,7 +13,7 @@ ambiguous, as it could be referring to a local variable (block param), a helper
 with no arguments, a closed over component, or a property on the component
 class.
 
-#### Exemplar
+## Exemplar
 
 Consider the following example where the ambiguity can cause issues:
 
@@ -88,11 +88,11 @@ know about fallback resolution rules. This makes common features like ["Go To
 Definition"](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)
 much easier to implement since we have semantics that mean "property on class".
 
-### Configuration
+## Configuration
 
  The following values are valid configuration:
 
-  * boolean - `true` to enable / `false` to disable
-  * object -- An object with the following keys:
-    * `allow` -- An array of component / helper names for that may be called
-      without arguments (string or regular expression)
+* boolean - `true` to enable / `false` to disable
+* object -- An object with the following keys:
+  * `allow` -- An array of component / helper names for that may be called
+    without arguments (string or regular expression)

--- a/docs/rule/no-index-component-invocation.md
+++ b/docs/rule/no-index-component-invocation.md
@@ -1,4 +1,4 @@
-## no-index-component-invocation
+# no-index-component-invocation
 
 Components and Component Templates can be structured as `app/components/foo-bar/index.js` and
 `app/components/foo-bar/index.hbs`. This allows additional files related to the
@@ -17,7 +17,7 @@ template with the same name that is made available with the resolver API.
 Instead of being resolved at runtime, a template in `app/components` will be
 associated with the component's JavaScript class at build time.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -47,11 +47,11 @@ This rule **allows** the following:
 {{foo}}
 ```
 
-### Migration
+## Migration
 
 * replace all `::Index>` to `>`
 * replace all `/index}}` to `}}`
 
-### References
+## References
 
 * [RFC #481](https://github.com/emberjs/rfcs/blob/master/text/0481-component-templates-co-location.md#high-level-design)

--- a/docs/rule/no-inline-styles.md
+++ b/docs/rule/no-inline-styles.md
@@ -1,6 +1,8 @@
-## no-inline-styles
+# no-inline-styles
 
 Inline styles are not the best practice because they are hard to maintain and usually make the overall size of the project bigger. This rule forbids inline styles. Use CSS classes instead.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -19,14 +21,14 @@ This rule **allows** the following:
 <div style={{html-safe (concat "background-image: url(" url ")")}}></div>
 ```
 
-### Configuration
+## Configuration
 
  The following values are valid configuration:
 
-  * boolean - `true` to enable / `false` to disable
-  * object -- An object with the following keys:
-    * `allowDynamicStyles` -- Whether dynamically-generated inline styles should be allowed (defaults to `false`)
+* boolean - `true` to enable / `false` to disable
+* object -- An object with the following keys:
+  * `allowDynamicStyles` -- Whether dynamically-generated inline styles should be allowed (defaults to `false`)
 
-### Related Rules
+## Related Rules
 
 * [style-concatenation](style-concatenation.md)

--- a/docs/rule/no-input-block.md
+++ b/docs/rule/no-input-block.md
@@ -1,6 +1,8 @@
-## no-input-block
+# no-input-block
 
 Use of the block form of the handlebars `input` helper will result in an error at runtime.
+
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-input-tagname.md
+++ b/docs/rule/no-input-tagname.md
@@ -1,6 +1,8 @@
-## no-input-tagname
+# no-input-tagname
 
 `{{input tagName=x}}` will result in obtuse errors. Typically, the input will simply fail to render, whether used in block form or inline. The only valid `tagName` for the input helper is `input`. For `textarea`, `button`, and other input-like elements, you should instead create a new component or better use the DOM!
+
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-invalid-interactive.md
+++ b/docs/rule/no-invalid-interactive.md
@@ -1,7 +1,9 @@
-## no-invalid-interactive
+# no-invalid-interactive
 
 Adding interactivity to an element that is not naturally interactive content leads to a very poor experience for
 users of assistive technology (i.e. screen readers). In order to ensure that screen readers can provide useful information to their users, we should add an appropriate `role` attribute when the underlying element would not have made that role obvious.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -15,13 +17,13 @@ This rule **allows** the following:
 <div role="button" {{action "foo"}}></div>
 ```
 
-### Configuration
+## Configuration
 
 The following values are valid configuration (same as the `no-nested-interactive` rule above):
 
-  * boolean -- `true` indicates all whitelist test will run, `false` indicates that the rule is disabled.
-  * object - Containing the following values:
-    * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.
-    * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
-    * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
-    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.
+* boolean -- `true` indicates all whitelist test will run, `false` indicates that the rule is disabled.
+* object - Containing the following values:
+  * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.
+  * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
+  * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
+  * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.

--- a/docs/rule/no-invalid-link-text.md
+++ b/docs/rule/no-invalid-link-text.md
@@ -1,10 +1,10 @@
-## no-invalid-link-text
+# no-invalid-link-text
 
 Screen readers call up a dialog box that has a list of links from the page, which users refer to decide where they will go. But if many of the links in that list simply say "click here" or "more" they will be unable to use this feature in their screen reader, which is a core navigation strategy.
 
-This rule checks links containing a few default words("click here" and "more"), and is configurable so additional words can be added as appropriate for your project. Disallowed list: click here, more info, read more, more. 
+This rule checks links containing a few default words("click here" and "more"), and is configurable so additional words can be added as appropriate for your project. Disallowed list: click here, more info, read more, more.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -26,6 +26,6 @@ This rule **allows** the following:
 <a href={{link}}>Read more about semantic html</a>
 ```
 
-### References
+## References
 
 * [Failure of Success Criterion 2.4.9 due to using a non-specific link such as "click here" or "more" without a mechanism to change the link text to specific text.](https://www.w3.org/WAI/WCAG21/Techniques/failures/F84)

--- a/docs/rule/no-invalid-meta.md
+++ b/docs/rule/no-invalid-meta.md
@@ -1,4 +1,4 @@
-## no-invalid-meta
+# no-invalid-meta
 
 This rule checks for these meta tag issues:
 
@@ -6,13 +6,15 @@ This rule checks for these meta tag issues:
 - a meta with a timed refresh- the timed delay should be greater than 72,000 seconds.
 - a meta that locks orientation to landscape or portrait view
 
-### Redirects & Refresh
+## Redirects & Refresh
+
 Sometimes a page automatically redirects to a different page. When this happens after a timed delay, it is an unexpected change of context that may interrupt the user. Redirects without timed delays are okay, but please consider a server-side method for redirecting instead (method will vary based on your server type).
 
-### Orientation Lock
+## Orientation Lock
+
 When content is presented with a restriction to a specific orientation, users must orient their devices to view the content in the orientation that the author imposed. Some users have their devices mounted in a fixed orientation (e.g. on the arm of a power wheelchair), and if the content cannot be viewed in that orientation it creates problems for the user.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -38,17 +40,17 @@ This rule **allows** the following:
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 ```
 
-### Migration
+## Migration
 
-* To fix, reduce the timed delay to zero, or use the appropriate server-side redirect method for your server type.
-* To fix orientation issues, remove references to `maximum-scale=1.0` and change `user-scalable=no` to `user-scalable=yes`.
+- To fix, reduce the timed delay to zero, or use the appropriate server-side redirect method for your server type.
+- To fix orientation issues, remove references to `maximum-scale=1.0` and change `user-scalable=no` to `user-scalable=yes`.
 
-### References
+## References
 
-* [HTML meta tag doc](https://www.w3schools.com/tags/tag_meta.asp)
-* [F40: Failure due to using meta redirect with a time limit](https://www.w3.org/WAI/WCAG21/Techniques/failures/F40)
-* [F41: Failure due to using meta refresh to reload the page](https://www.w3.org/WAI/WCAG21/Techniques/failures/F41)
-* [Success Criterion 2.2.1: Timing Adjustable](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable)
-* [Success Criterion 2.2.4: Interruptions](https://www.w3.org/WAI/WCAG21/Understanding/interruptions)
-* [Success Criterion 3.2.5: Change on Request](https://www.w3.org/WAI/WCAG21/Understanding/change-on-request)
-* [Failure due to locking the orientation to landscape or portrait view](https://www.w3.org/WAI/WCAG21/Techniques/failures/F97)
+- [HTML meta tag doc](https://www.w3schools.com/tags/tag_meta.asp)
+- [F40: Failure due to using meta redirect with a time limit](https://www.w3.org/WAI/WCAG21/Techniques/failures/F40)
+- [F41: Failure due to using meta refresh to reload the page](https://www.w3.org/WAI/WCAG21/Techniques/failures/F41)
+- [Success Criterion 2.2.1: Timing Adjustable](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable)
+- [Success Criterion 2.2.4: Interruptions](https://www.w3.org/WAI/WCAG21/Understanding/interruptions)
+- [Success Criterion 3.2.5: Change on Request](https://www.w3.org/WAI/WCAG21/Understanding/change-on-request)
+- [Failure due to locking the orientation to landscape or portrait view](https://www.w3.org/WAI/WCAG21/Techniques/failures/F97)

--- a/docs/rule/no-invalid-role.md
+++ b/docs/rule/no-invalid-role.md
@@ -1,4 +1,4 @@
-## no-invalid-role
+# no-invalid-role
 
 This rule checks for invalid element/role combinations.
 
@@ -6,7 +6,7 @@ Current list of checks:
 
 1. Use of the presentation role for content which should convey semantic information may prevent the user from understanding that content. This rule checks semantic HTML elements for the presence of `role="none"` or `role="presentation"` and compares it to the list of disallowed elements. It should not effect custom elements.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -30,11 +30,11 @@ This rule **allows** the following:
 <span role="none"></span>
 ```
 
-### Migration
+## Migration
 
 * If violations are found, remediation should be planned to replace the semantic HTML with the `div` element. Additional CSS will likely be required.
 
-### References
+## References
 
 * [HTML elements reference](https://developer.mozilla.org/en-US/docs/Web/HTML/Element)
 * [WAI-ARIA presentation(role)](https://www.w3.org/TR/wai-aria/#presentation)

--- a/docs/rule/no-log.md
+++ b/docs/rule/no-log.md
@@ -1,6 +1,8 @@
-## no-log
+# no-log
 
 `{{log}}` will produce messages in the browser console. That is undesirable in a production environment.
+
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-meta-redirect-with-time-limit.md
+++ b/docs/rule/no-meta-redirect-with-time-limit.md
@@ -1,4 +1,4 @@
-## (no-meta-redirect-with-time-limit)
+# no-meta-redirect-with-time-limit
 
 **NOTE**: This rule is deprecated in favor of the more comprehensive rule [no-invalid-meta](./no-invalid-meta.md).
 
@@ -6,7 +6,7 @@ Sometimes a page automatically redirects to a different page. When this happens 
 
 This rule checks for the meta tag with a redirect; if it exists, it checks for a timed delay greater than 0.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -20,11 +20,11 @@ This rule **allows** the following:
 <meta http-equiv="refresh" content="0; url=http://www.example.com" />
 ```
 
-### Migration
+## Migration
 
 * To fix, reduce the timed delay to zero, or use the appropriate server-side redirect method for your server type.
 
-### References
+## References
 
 * [F40: Failure due to using meta redirect with a time limit](https://www.w3.org/WAI/WCAG21/Techniques/failures/F40)
 * [Success Criterion 2.2.1: Timing Adjustable](https://www.w3.org/WAI/WCAG21/Understanding/timing-adjustable)

--- a/docs/rule/no-multiple-empty-lines.md
+++ b/docs/rule/no-multiple-empty-lines.md
@@ -1,4 +1,4 @@
-## no-multiple-empty-lines
+# no-multiple-empty-lines
 
 Some developers prefer to have multiple blank lines removed, while others feel
 that it helps improve readability. Whitespace is useful for separating logical
@@ -7,7 +7,7 @@ sections of code, but excess whitespace takes up more of the screen.
 This rule aims to reduce the scrolling required when reading through your code.
 It will warn when the maximum amount of empty lines has been exceeded.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -31,11 +31,11 @@ This rule **allows** the following:
 <div>bar</div>
 ```
 
-### Configuration
+## Configuration
 
 * object -- containing the following properties:
   * number -- `max` --  (default: `1`) enforces a maximum number of consecutive empty lines.
 
-### References
+## References
 
-* https://eslint.org/docs/rules/no-multiple-empty-lines
+* <https://eslint.org/docs/rules/no-multiple-empty-lines>

--- a/docs/rule/no-negated-condition.md
+++ b/docs/rule/no-negated-condition.md
@@ -1,4 +1,4 @@
-## no-negated-condition
+# no-negated-condition
 
 It can be hard to reason about negated conditions:
 
@@ -10,6 +10,8 @@ Negated conditions can often be avoided or simplified by:
 * Flipping `if (not condition) ... else ...` to `if .... else ...`
 * Replacing `if (not condition)` with `unless`
 * Replacing `unless (not condition)` with `if`
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -75,10 +77,10 @@ And similar examples with non-block forms like:
 {{input class=(if condition "some-class" "other-class")}}
 ```
 
-### Related Rules
+## Related Rules
 
 * [simple-unless](simple-unless.md)
 
-### References
+## References
 
 * [no-negated-condition](https://eslint.org/docs/rules/no-negated-condition) from eslint

--- a/docs/rule/no-nested-interactive.md
+++ b/docs/rule/no-nested-interactive.md
@@ -1,6 +1,8 @@
-## no-nested-interactive
+# no-nested-interactive
 
 Usage of nested, interactive content can lead to UX problems, accessibility problems, bugs, and in some cases DOM errors. You should not put interactive content elements nested inside other interactive content elements. Instead of using nested interactive content elements, you should separate them, or use styling on a single element.
+
+## Examples
 
 This rule **forbids** the following (button nested inside a link):
 
@@ -18,13 +20,13 @@ This rule **allows** the following (link with button styling):
 <a href="/contact-us" class="button">Contact Us</a>
 ```
 
-### Configuration
+## Configuration
 
 The following values are valid configuration:
 
-  * boolean -- `true` indicates all whitelist test will run, `false` indicates that the rule is disabled.
-  * object - Containing the following values:
-    * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.
-    * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
-    * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
-    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.
+* boolean -- `true` indicates all whitelist test will run, `false` indicates that the rule is disabled.
+* object - Containing the following values:
+  * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.
+  * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
+  * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
+  * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.

--- a/docs/rule/no-obsolete-elements.md
+++ b/docs/rule/no-obsolete-elements.md
@@ -1,10 +1,10 @@
-## no-obsolete-elements
+# no-obsolete-elements
 
-Some elements are entirely obsolete and must not be used by authors. 
+Some elements are entirely obsolete and must not be used by authors.
 
 This rule forbids the use of obsolete elements.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -41,11 +41,11 @@ This rule **forbids** the following:
 
 This rule **allows** anything that is not an obsolete element.
 
-### Migration
+## Migration
 
 * replace any use of these elements with the appropriate updated element or a `div` element.
 
-### References
+## References
 
 * [no-obsolete-elements](https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features)
 * [Failure of Success Criterion 2.2.2 due to using the blink element](https://www.w3.org/TR/WCAG20-TECHS/failures.html#F47)

--- a/docs/rule/no-outlet-outside-routes.md
+++ b/docs/rule/no-outlet-outside-routes.md
@@ -1,6 +1,8 @@
-## no-outlet-outside-routes
+# no-outlet-outside-routes
 
 The `{{outlet}}` helper is used to specify locations into which routes may be rendered. Typically, to keep routing clear, only route templates should make use of `{{outlet}}`. Using `{{outlet}}` outside of a route template, e.g. in a component or a partial, will often lead to unexpected rendering locations for child routes.
+
+## Examples
 
 This rule **forbids** the following (except in routes):
 

--- a/docs/rule/no-partial.md
+++ b/docs/rule/no-partial.md
@@ -1,4 +1,4 @@
-## no-partial
+# no-partial
 
 Partials are a legacy hold over from the days in which Ember had little to no mechanism for sharing "template snippets". Today, we can use "contextual components" (and soon "named blocks"), which serves the original need for partials.
 
@@ -6,6 +6,8 @@ In addition to having a better solution for the original problem, there are also
 
 * The `partial` helper is essentially an `eval`, which means that Ember's template rendering system can make little to no optimizations
 * The `partial` helper provides the partial template with unrestricted access to the local scope which leads to extreme confusion and "scope creep", as it's not clear what data/actions are coming in and out
+
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-passed-in-event-handlers.md
+++ b/docs/rule/no-passed-in-event-handlers.md
@@ -1,4 +1,4 @@
-## no-passed-in-event-handlers
+# no-passed-in-event-handlers
 
 It is possible to pass e.g. `@click` to an Ember component to override the
 default `click` event handler. For tagless components this will trigger an
@@ -8,7 +8,7 @@ components it will not work out of the box, like in Ember components, either.
 This rule scans potential component invocations for these patterns and flags
 them as issues.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -42,10 +42,10 @@ This rule **allows** the following:
 {{foo onClick=this.handleClick}}
 ```
 
-### Migration
+## Migration
 
 - create explicit component APIs for these events (e.g. `@click` -> `@onClick`)
 
-### References
+## References
 
-- https://api.emberjs.com/ember/release/classes/Component#event-handler-methods
+- <https://api.emberjs.com/ember/release/classes/Component#event-handler-methods>

--- a/docs/rule/no-positive-tabindex.md
+++ b/docs/rule/no-positive-tabindex.md
@@ -1,10 +1,12 @@
-## no-positive-tabindex
+# no-positive-tabindex
 
-### `<* tabindex>`
+## `<* tabindex>`
 
 Avoid positive tabIndex property values to synchronize the flow of the page with keyboard tab order.
 
 This rule takes no arguments.
+
+## Examples
 
 This rule **allows** the following:
 
@@ -24,7 +26,8 @@ This rule **forbids** the following:
 <span tabindex="2">never really sure what goes after baz</span>
 ```
 
-### References
+## References
+
 1. [AX_FOCUS_03](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_focus_03)
 1. [w3.org/TR/wai-aria-practices/#kbd_general_between](https://www.w3.org/TR/wai-aria-practices/#kbd_general_between)
 1. [w3.org/TR/2009/WD-wai-aria-practices-20090224/#focus_tabindex](https://www.w3.org/TR/2009/WD-wai-aria-practices-20090224/#focus_tabindex)

--- a/docs/rule/no-quoteless-attributes.md
+++ b/docs/rule/no-quoteless-attributes.md
@@ -1,4 +1,4 @@
-## no-quoteless-attributes
+# no-quoteless-attributes
 
 In HTML, all attribute values are considered strings, regardless of whether they are quoted or not.
 
@@ -20,6 +20,8 @@ In this case, the simple _presence_ of the `disabled` attribute means that the `
 This is just _one_ (of many) cases where the default "string" based parsing of attributes in HTML can trip folks up.
 
 This rule attempts to make this situation _slightly_ better by at least ensuring that all attribute values are quoted. This obviously doesn't fix the :troll:y nature of HTML here but it does ensure that you still **see** the quotes (which should hopefully help remind you that these are strings and not values).
+
+## Examples
 
 This rule **forbids** the following (note that `someValue` could have been intended either as a string or expression):
 

--- a/docs/rule/no-shadowed-elements.md
+++ b/docs/rule/no-shadowed-elements.md
@@ -1,7 +1,9 @@
-## no-shadowed-elements
+# no-shadowed-elements
 
 This rule prevents ambiguity in situations where a yielded block param which starts with a lower case letter is also
 used within the block itself as an element name.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -10,6 +12,7 @@ This rule **forbids** the following:
   <div></div>
 </FooBar>
 ```
+
 This rule **allows** the following:
 
 ```hbs

--- a/docs/rule/no-trailing-dot-in-path-expression.md
+++ b/docs/rule/no-trailing-dot-in-path-expression.md
@@ -1,4 +1,4 @@
-## no-trailing-dot-in-path-expression
+# no-trailing-dot-in-path-expression
 
 This rule doesn't allow trailing dot(s) on a path expression. Since the trailing dot is treated as a separate path expression which represents the context associated to the template.
 
@@ -23,6 +23,8 @@ hence results in
 ```html
 <span class="<my-app@controller:application::ember223>">John</span>
 ```
+
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-trailing-spaces.md
+++ b/docs/rule/no-trailing-spaces.md
@@ -1,6 +1,8 @@
-## no-trailing-spaces
+# no-trailing-spaces
 
 Disallow trailing whitespace at the end of lines.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -16,6 +18,6 @@ This rule **allows** the following:
 //
 ```
 
-### Related Rules
+## Related Rules
 
 * [no-trailing-spaces](https://eslint.org/docs/rules/no-trailing-spaces) from eslint

--- a/docs/rule/no-triple-curlies.md
+++ b/docs/rule/no-triple-curlies.md
@@ -1,19 +1,21 @@
-## no-triple-curlies
+# no-triple-curlies
 
 Usage of triple curly braces to allow raw HTML to be injected into the DOM is a large vector for exploits of your application (especially when the raw HTML is user-controllable). Instead of using `{{{foo}}}`, you should use appropriate helpers or computed properties that return a `SafeString` (via `Ember.String.htmlSafe` generally) and ensure that user-supplied data is properly escaped.
 
+## Examples
+
 This rule **forbids** the following:
 
-``` hbs
+```hbs
 {{{foo}}}
 ```
 
 This rule **allows** the following:
 
-``` hbs
+```hbs
 {{foo}}
 ```
 
-### References
+## References
 
 * See the [documentation](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe) for Ember's `htmlSafe` function

--- a/docs/rule/no-unbound.md
+++ b/docs/rule/no-unbound.md
@@ -1,9 +1,11 @@
-## no-unbound
+# no-unbound
 
 `{{unbound}}` is a legacy hold over from the days in which Ember's template engine was less performant. Its use today
 is vestigial, and it no longer offers performance benefits.
 
-It is also a poor practice to use it for rendering only the initial value of a property that may later change. 
+It is also a poor practice to use it for rendering only the initial value of a property that may later change.
+
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-unnecessary-component-helper.md
+++ b/docs/rule/no-unnecessary-component-helper.md
@@ -1,8 +1,8 @@
-## no-unnecessary-component-helper
+# no-unnecessary-component-helper
 
 The `component` template helper can be used to dynamically pick the component being rendered based on the provided property. But if the component name is passed as a string because it's already known, then the component should be invoked directly, instead of using the `component` helper.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -30,7 +30,7 @@ This rule **allows** the following:
 <MyComponent @close={{component "link-to" "index"}} />
 ```
 
-### References
+## References
 
 * [component helper guide](https://guides.emberjs.com/release/components/defining-a-component/#toc_dynamically-rendering-a-component)
 * [component helper spec](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/component?anchor=component)

--- a/docs/rule/no-unnecessary-concat.md
+++ b/docs/rule/no-unnecessary-concat.md
@@ -1,6 +1,8 @@
-## no-unnecessary-concat
+# no-unnecessary-concat
 
 This rule forbids unnecessary use of quotes (`""`) around expressions like `{{myValue}}`.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -11,6 +13,7 @@ This rule **forbids** the following:
 
 <label for="{{concat elementId "-date"}}">
 ```
+
 This rule **allows** the following:
 
 ```hbs
@@ -21,7 +24,7 @@ This rule **allows** the following:
 <label for={{concat elementId "-date"}}>
 ```
 
-### Migration
+## Migration
 
 Use regexp find-and-replace to fix existing violations of this rule:
 

--- a/docs/rule/no-unused-block-params.md
+++ b/docs/rule/no-unused-block-params.md
@@ -1,10 +1,12 @@
-## no-unused-block-params
+# no-unused-block-params
 
 This rule forbids unused block parameters except when they are needed to access a later parameter.
 
+## Examples
+
 This rule **forbids** the following (unused parameters):
 
-``` hbs
+```hbs
 {{#each users as |user index|}}
   {{user.name}}
 {{/each}}
@@ -14,13 +16,13 @@ This rule **allows** the following:
 
 Allowed (used parameters):
 
-``` hbs
+```hbs
 {{#each users as |user|}}
   {{user.name}}
 {{/each}}
 ```
 
-``` hbs
+```hbs
 {{#each users as |user index|}}
   {{index}} {{user.name}}
 {{/each}}
@@ -28,7 +30,7 @@ Allowed (used parameters):
 
 Allowed (later parameter used):
 
-``` hbs
+```hbs
 {{#each users as |user index|}}
   {{index}}
 {{/each}}

--- a/docs/rule/no-whitespace-within-word.md
+++ b/docs/rule/no-whitespace-within-word.md
@@ -1,4 +1,4 @@
-## no-whitespace-within-word
+# no-whitespace-within-word
 
 In practice, the predominant issue raised by inline whitespace styling is that the resultant text 'formatting' is entirely visual in nature; the ability to discern the correct manner in which to read the text, and therefore, to correctly comprehend its meaning, is restricted to sighted users.
 
@@ -6,7 +6,7 @@ Using in-line whitespace word formatting produces results that are explicitly me
 
 The `no-whitespace-within-word` rule operates on the assumption that artificially-spaced English words in rendered text content contain, at a minimum, two word characters fencepost-delimited by three whitespace characters  (`space-char-space-char-space`) so it should be avoided.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -44,11 +44,11 @@ This rule **allows** the following:
 
 This rule uses the heuristic of letter, whitespace character, letter, whitespace character, letter which makes it a good candidate for most use cases, but not ideal for some languages (such as Japanese).
 
-### Migration
+## Migration
 
 Use CSS to add letter-spacing to a word.
 
-### References
+## References
 
 * [F32: Using white space characters to create multiple columns in plain text content](https://www.w3.org/TR/WCAG20-TECHS/failures.html#F32)
 * [WCAG Success Criterion 1.3.2: Meaningful Sequence](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-sequence.html)

--- a/docs/rule/no-yield-only.md
+++ b/docs/rule/no-yield-only.md
@@ -1,4 +1,4 @@
-## no-yield-only
+# no-yield-only
 
 Templates that only contain a single `{{yield}}` instruction are not required
 and increase the total template payload size.
@@ -6,7 +6,7 @@ and increase the total template payload size.
 This rule warns about templates that only contain a single `{{yield}}`
 instruction.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 
@@ -15,7 +15,7 @@ This rule **forbids** the following:
 ```
 
 ```hbs
-  
+
    {{yield}}
 
 
@@ -31,10 +31,10 @@ This rule **allows** the following:
 <div>{{yield}}</div>
 ```
 
-### Migration
+## Migration
 
 * delete all files that are flagged by this rule
 
-### References
+## References
 
-* https://github.com/ember-template-lint/ember-template-lint/issues/29
+* <https://github.com/ember-template-lint/ember-template-lint/issues/29>

--- a/docs/rule/quotes.md
+++ b/docs/rule/quotes.md
@@ -1,4 +1,4 @@
-## quotes
+# quotes
 
 Enforce the consistent use of either double or single quotes.
 
@@ -16,12 +16,12 @@ or:
 {{my-helper 'hello there'}}
 ```
 
-### Configuration
+## Configuration
 
 The following values are valid configuration:
 
-  * string -- "double" requires the use of double quotes wherever possible, "single" requires the use of single quotes wherever possible
+* string -- "double" requires the use of double quotes wherever possible, "single" requires the use of single quotes wherever possible
 
-### Related Rules
+## Related Rules
 
 * [quotes](https://eslint.org/docs/rules/quotes) from eslint

--- a/docs/rule/require-button-type.md
+++ b/docs/rule/require-button-type.md
@@ -1,4 +1,4 @@
-## require-button-type
+# require-button-type
 
 This rule requires all `<button>` elements to have a valid `type` attribute.
 
@@ -6,6 +6,8 @@ By default, the `type` attribute of `<button>` elements is `submit`. This can
 be very confusing, when a button component is developed in isolation without
 `type="button"`, and when inside a `<form>` element it suddenly starts to
 submit the form.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -23,6 +25,6 @@ This rule **allows** the following:
 <button type="reset">Hello World!</button>
 ```
 
-### References
+## References
 
 * Red [HTML spec - the button element](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type)

--- a/docs/rule/require-iframe-title.md
+++ b/docs/rule/require-iframe-title.md
@@ -1,10 +1,12 @@
-## require-iframe-title
+# require-iframe-title
 
-### `<iframe>`
+## `<iframe>`
 
 `<iframe>` elements must have a unique title property to indicate its content to the user.
 
 This rule takes no arguments.
+
+## Examples
 
 This rule **allows** the following:
 
@@ -20,7 +22,7 @@ This rule **forbids** the following:
 <iframe title="" />
 ```
 
-### References
+## References
 
 - [Deque University](https://dequeuniversity.com/rules/axe/1.1/frame-title)
 - [Technique H65: Using the title attribute of the frame and iframe elements](https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H64)

--- a/docs/rule/require-valid-alt-text.md
+++ b/docs/rule/require-valid-alt-text.md
@@ -1,4 +1,4 @@
-## require-valid-alt-text
+# require-valid-alt-text
 
 Enforce that all elements that require alternative text have meaningful information to relay back to the end user. This is a critical component of accessibility for screenreader users in order for them to understand the content's purpose on the page. By default, this rule checks for alternative text on the following elements: `<img>`, `<area>`, `<input type="image">`, and `<object>`.
 
@@ -6,7 +6,7 @@ Enforce `img` alt attribute does not contain the word image, picture, or photo. 
 
 This rule **forbids** the following:
 
-### `<img>`
+## `<img>`
 
 An `<img>` must have the `alt` attribute. It must have either meaningful text, or be an empty string. If it is an empty string, the `<img>` element tag must also have `role="presentation"` or `role="none"`.
 
@@ -41,7 +41,7 @@ This rule **allows** the following:
 <img src="foo" alt="" role="presentation"> // This is valid because it has a role of presentation.
 ```
 
-### `<object>`
+## `<object>`
 
 Add alternative text to all embedded `<object>` elements using either inner text, setting the `title` prop, or using the `aria-label` or `aria-labelledby` props.
 
@@ -59,7 +59,7 @@ This rule **allows** the following:
 <object width="128" height="256" aria-labelledby="id-12345"></object>
 ```
 
-### `<input type="image">`
+## `<input type="image">`
 
 All `<input type="image">` elements must have a non-empty `alt` prop set with a meaningful description of the image or have the `aria-label` or `aria-labelledby` props set.
 
@@ -75,7 +75,7 @@ This rule **allows** the following:
 <input type="image" alt="Select image to upload">
 ```
 
-### `<area>`
+## `<area>`
 
 All clickable `<area>` elements within an image map have an `alt`, `aria-label` or `aria-labelledby` prop that describes the purpose of the link.
 
@@ -91,7 +91,7 @@ This rule **allows** the following:
 <area shape="poly" coords="113,24,211,0" href="inform.html" alt="Inform">
 ```
 
-### References
+## References
 
 * [WCAG Technique- using alt attributes on img elements](https://www.w3.org/TR/WCAG20-TECHS/H37.html)
 * [WCAG Criterion 1.1.1 - Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)

--- a/docs/rule/self-closing-void-elements.md
+++ b/docs/rule/self-closing-void-elements.md
@@ -1,7 +1,9 @@
-## self-closing-void-elements
+# self-closing-void-elements
 
 HTML has no self-closing tags. The HTML5 parser will ignore self-closing tag in the case of [void elements](https://www.w3.org/TR/html-markup/syntax.html#void-elements) (tags that shouldn't have a "closing tag"). Although the parser will ignore it, it's
 unnecessary and can lead to confusion with SVG/XML code.
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -19,9 +21,9 @@ This rule **allows** the following:
 
 There may be cases where a self-closing tag may be necessary for void elements. In such cases, a `require` string may be passed to log the missing closing tags.
 
-### Configuration
+## Configuration
 
 The following values are valid configuration:
 
-  * boolean -- `true` for enabled / `false` for disabled
-  * string -- `require` to mandate the use of self closing tags
+* boolean -- `true` for enabled / `false` for disabled
+* string -- `require` to mandate the use of self closing tags

--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -1,4 +1,4 @@
-## simple-unless
+# simple-unless
 
 This rule strongly advises against `{{unless}}` blocks in the following situations:
 
@@ -7,15 +7,17 @@ This rule strongly advises against `{{unless}}` blocks in the following situatio
 
 Common solutions are to use an `{{if}}` block, or refactor potentially confusing logic within the template.
 
+## Examples
+
 This rule **forbids** the following:
 
-``` hbs
+```hbs
 {{!-- `unless` condition has a template helper  --}}
 
 {{unless (if true) "This is not recommended"}}
 ```
 
-``` hbs
+```hbs
 {{!-- `unless` statement has an `else` block  --}}
 
 {{#unless bandwagoner}}
@@ -25,7 +27,7 @@ This rule **forbids** the following:
 {{/unless}}
 ```
 
-``` hbs
+```hbs
 {{!-- conditional statement has an `else unless` block  --}}
 
 {{#if condition}}
@@ -37,7 +39,7 @@ This rule **forbids** the following:
 
 This rule **allows** the following:
 
-``` hbs
+```hbs
 {{#if bandwagoner}}
   Go Blue Jays!
 {{else}}
@@ -45,22 +47,22 @@ This rule **allows** the following:
 {{/if}}
 ```
 
-``` hbs
+```hbs
 {{#unless condition}}
   Hello World
 {{/unless}}
 ```
 
-### Configuration
+## Configuration
 
 The following values are valid configuration:
 
-  * boolean -- `true` for enabled / `false` for disabled
-  * object --
-    * `whitelist` -- array - `['or']` for specific helpers / `[]` for wildcard
-    * `blacklist` -- array - `['or']` for specific helpers / `[]` for none
-    * `maxHelpers` -- number - use -1 for no limit
+* boolean -- `true` for enabled / `false` for disabled
+* object --
+  * `whitelist` -- array - `['or']` for specific helpers / `[]` for wildcard
+  * `blacklist` -- array - `['or']` for specific helpers / `[]` for none
+  * `maxHelpers` -- number - use -1 for no limit
 
-### Related Rules
+## Related Rules
 
-  * [no-negated-condition](no-negated-condition.md)
+* [no-negated-condition](no-negated-condition.md)

--- a/docs/rule/style-concatenation.md
+++ b/docs/rule/style-concatenation.md
@@ -1,4 +1,4 @@
-## style-concatenation
+# style-concatenation
 
 Ember has a runtime warning that says:
 
@@ -10,6 +10,8 @@ Common cases which do not propagate `htmlSafe` include:
 
 * Implied string concatenation using quotes
 * The `concat` helper
+
+## Examples
 
 This rule **forbids** the following:
 
@@ -41,13 +43,13 @@ This rule **allows** the following:
 <div style={{html-safe (concat knownSafeStyle1 ";" knownSafeStyle2)}}>
 ```
 
-### References
+## References
 
 * See the [Binding Style Attributes](https://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes) Ember deprecation documentation
 * See the [documentation](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe) for Ember's `htmlSafe` function
 * See the [documentation](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat) for Ember's `concat` handlebars template helper
 * See the [documentation](https://github.com/romulomachado/ember-cli-string-helpers#html-safe) for the `html-safe` handlebars template helper from the `ember-cli-string-helpers` addon
 
-### Related Rules
+## Related Rules
 
 * [no-inline-styles](no-inline-styles.md)

--- a/docs/rule/table-groups.md
+++ b/docs/rule/table-groups.md
@@ -1,4 +1,4 @@
-## table-groups
+# table-groups
 
 It is best practice to group table rows into one of:
 
@@ -7,6 +7,8 @@ It is best practice to group table rows into one of:
 * `tfoot`
 
 This helps avoid a very nuanced (and possibly deprecated in the future) feature of glimmer that auto-inserts these tags.
+
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/template-length.md
+++ b/docs/rule/template-length.md
@@ -1,4 +1,4 @@
-## template-length
+# template-length
 
 Some ember shops try to put some guard-rails on the length of templates for the following reasons:
 
@@ -14,13 +14,13 @@ Some ember shops try to put some guard-rails on the length of templates for the 
 - Templates that are extremely short might be better off inlined into the
   component itself rather than existing as a separate `.hbs` file.
 
-### Configuration
+## Configuration
 
 This rule is configured with a boolean, or a string value:
 
-* boolean -- `true` for enabled (defaults of max: 200 / min: 5) / `false` for disabling this rule
-* object --
-  * max {number} - the longest a template should be without failing a test (assuming the
+- boolean -- `true` for enabled (defaults of max: 200 / min: 5) / `false` for disabling this rule
+- object --
+  - max {number} - the longest a template should be without failing a test (assuming the
     right thing to do would be to split the template up into pieces).
-  * min {number} - the shortest a template should be without failing a test (assuming the
+  - min {number} - the shortest a template should be without failing a test (assuming the
     right thing to do would be to inline the template.

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "bin": "./bin/ember-template-lint.js",
   "scripts": {
     "changelog": "lerna-changelog",
-    "lint": "yarn lint:js",
+    "lint": "yarn lint:js && yarn lint:docs",
+    "lint:docs": "markdownlint '**/*.md' -i CHANGELOG.md -i LICENSE.md -i node_modules",
     "lint:js": "eslint . --cache",
     "release": "release-it",
     "test": "jest"
@@ -42,6 +43,7 @@
     "execa": "^1.0.0",
     "jest": "^23.6.0",
     "lerna-changelog": "^1.0.0",
+    "markdownlint-cli": "^0.22.0",
     "prettier": "^1.15.3",
     "release-it": "^12.2.1",
     "release-it-lerna-changelog": "^1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1153,6 +1153,13 @@ commander@~2.20.3:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
+commander@~2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  integrity sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
@@ -1352,6 +1359,11 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
+deep-extend@~0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.5.1.tgz#b894a9dd90d3023fbf1c55a394fb858eb2066f1f"
+  integrity sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==
+
 deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
@@ -1549,6 +1561,11 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
   dependencies:
     once "^1.4.0"
+
+entities@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
+  integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
 
 err-code@^1.0.0:
   version "1.1.2"
@@ -2259,6 +2276,11 @@ get-stdin@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
+get-stdin@~5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+  integrity sha1-Ei4WFZHiH/TFJTAwVpPyDmOTo5g=
+
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
@@ -2340,7 +2362,7 @@ glob-to-regexp@^0.3.0:
   resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
   integrity sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=
 
-glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.0, glob@^7.0.3, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@~7.1.2:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -2420,6 +2442,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.2
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+  integrity sha1-TK+tdrxi8C+gObL5Tpo906ORpyU=
 
 growly@^1.3.0:
   version "1.3.0"
@@ -2624,7 +2651,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.0.5, ignore@^5.1.1:
+ignore@^5.0.5, ignore@^5.1.1, ignore@~5.1.4:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
@@ -3491,7 +3518,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@^3.13.1, js-yaml@^3.7.0:
+js-yaml@^3.13.1, js-yaml@^3.7.0, js-yaml@~3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -3575,6 +3602,11 @@ json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
   integrity sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=
+
+jsonc-parser@~2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.2.1.tgz#db73cd59d78cce28723199466b2a03d1be1df2bc"
+  integrity sha512-o6/yDBYccGvTz1+QFevz6l6OBZ2+fMVu2JZ9CIhzsYRX4mjaK5IyX9eldUdCmga16zlgQxyrj5pt9kzuj2C02w==
 
 jsprim@^1.2.2:
   version "1.4.1"
@@ -3689,6 +3721,13 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+linkify-it@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
+  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+  dependencies:
+    uc.micro "^1.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -3738,10 +3777,20 @@ lodash.camelcase@4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
+lodash.differencewith@~4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.differencewith/-/lodash.differencewith-4.5.0.tgz#bafafbc918b55154e179176a00bb0aefaac854b7"
+  integrity sha1-uvr7yRi1UVTheRdqALsK76rIVLc=
+
 lodash.find@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.find/-/lodash.find-4.6.0.tgz#cb0704d47ab71789ffa0de8b97dd926fb88b13b1"
   integrity sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=
+
+lodash.flatten@~4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+  integrity sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=
 
 lodash.get@^4.4.2:
   version "4.4.2"
@@ -3897,10 +3946,57 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-10.0.0.tgz#abfc64f141b1722d663402044e43927f1f50a8dc"
+  integrity sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~2.0.0"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
+
+markdownlint-cli@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-cli/-/markdownlint-cli-0.22.0.tgz#e5e3251ae6207a41eeb01640363fe2aa0f663a51"
+  integrity sha512-qRg6tK5dXWqkaFvEstz9YSQal1ECMgofrSZgdBOaPWG8cD50pk8Hs0ZpBCJ6SCHPKF71pCdtuSL2u82sIx2XWA==
+  dependencies:
+    commander "~2.9.0"
+    deep-extend "~0.5.1"
+    get-stdin "~5.0.1"
+    glob "~7.1.2"
+    ignore "~5.1.4"
+    js-yaml "~3.13.1"
+    jsonc-parser "~2.2.0"
+    lodash.differencewith "~4.5.0"
+    lodash.flatten "~4.4.0"
+    markdownlint "~0.19.0"
+    markdownlint-rule-helpers "~0.7.0"
+    minimatch "~3.0.4"
+    rc "~1.2.7"
+
+markdownlint-rule-helpers@~0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/markdownlint-rule-helpers/-/markdownlint-rule-helpers-0.7.0.tgz#66476c373fcad6727ac5b64cb662e900cbe46bfe"
+  integrity sha512-xZByWJNBaCMHo7nYPv/5aO8Jt68YcMvyouFXhuXmJzbqCsQy8rfCj0kYcv22kdK5PwAgMdbHg0hyTdURbUZtJw==
+
+markdownlint@~0.19.0:
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/markdownlint/-/markdownlint-0.19.0.tgz#a692c7b5c077874d4ee8b74e188d6c464ccce81e"
+  integrity sha512-+MsWOnYVUH4klcKM7iRx5cno9FQMDAb6FC6mWlZkeXPwIaK6Z5Vd9VkXkykPidRqmLHU2wI+MNyfUMnUCBw3pQ==
+  dependencies:
+    markdown-it "10.0.0"
+
 math-random@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/math-random/-/math-random-1.0.4.tgz#5dd6943c938548267016d4e34f057583080c514c"
   integrity sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==
+
+mdurl@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
 
 mem@^1.1.0:
   version "1.1.0"
@@ -4008,7 +4104,7 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-minimatch@^3.0.3, minimatch@^3.0.4:
+minimatch@^3.0.3, minimatch@^3.0.4, minimatch@~3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -4941,7 +5037,7 @@ randomatic@^3.0.0:
     kind-of "^6.0.0"
     math-random "^1.0.1"
 
-rc@^1.2.7, rc@^1.2.8:
+rc@^1.2.7, rc@^1.2.8, rc@~1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
   integrity sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
@@ -5989,6 +6085,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+uc.micro@^1.0.1, uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^3.1.4:
   version "3.7.0"


### PR DESCRIPTION
Cleans up docs (especially regarding using consistent headers). Enforces markdownlint via linting/CI scripts.