### PR TITLE
Fix linting failures in  no-invalid-block-param-definition documentation.

### DIFF
--- a/docs/rule/no-invalid-block-param-definition.md
+++ b/docs/rule/no-invalid-block-param-definition.md
@@ -1,8 +1,8 @@
-## no-invalid-block-param-definition
+# no-invalid-block-param-definition
 
 There are a few common failure scenarios when using angle bracket components that use block parameters. This rule attempts to identify these pitfalls.
 
-### Examples
+## Examples
 
 This rule **forbids** the following:
 


### PR DESCRIPTION
#1126 landed right at the same time as #1140, this fixes master's CI...