### PR TITLE
Update execa from 1.x to 4.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-import": "^2.20.1",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
-    "execa": "^1.0.0",
+    "execa": "^4.0.0",
     "jest": "^25.1.0",
     "lerna-changelog": "^1.0.0",
     "markdownlint-cli": "^0.22.0",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -4,6 +4,8 @@ const execa = require('execa');
 const path = require('path');
 
 describe('ember-template-lint executable', function() {
+  setupEnvVar('FORCE_COLOR', '0');
+
   describe('basic usage', function() {
     describe('without any parameters', function() {
       it.skip('should emit help text', function() {});
@@ -15,7 +17,7 @@ describe('ember-template-lint executable', function() {
           cwd: './test/fixtures/with-errors',
         });
 
-        expect(result.code).toEqual(0, 'exits without error');
+        expect(result.exitCode).toEqual(0, 'exits without error');
         expect(result.stdout).toBeFalsy();
         expect(result.stderr).toBeFalsy();
       });
@@ -27,7 +29,7 @@ describe('ember-template-lint executable', function() {
           cwd: './test/fixtures/with-errors',
         });
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeTruthy();
         expect(result.stderr).toBeFalsy();
       });
@@ -39,7 +41,7 @@ describe('ember-template-lint executable', function() {
           cwd: './test/fixtures/with-errors',
         });
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeTruthy();
         expect(result.stderr).toBeFalsy();
       });
@@ -51,7 +53,7 @@ describe('ember-template-lint executable', function() {
           cwd: './test/fixtures/with-errors',
         });
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeTruthy();
         expect(result.stderr).toBeFalsy();
       });
@@ -64,7 +66,7 @@ describe('ember-template-lint executable', function() {
           shell: true,
         });
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeTruthy();
         expect(result.stderr).toBeFalsy();
       });
@@ -80,7 +82,7 @@ describe('ember-template-lint executable', function() {
           }
         );
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeTruthy();
         expect(result.stderr).toBeFalsy();
       });
@@ -93,7 +95,7 @@ describe('ember-template-lint executable', function() {
           shell: true,
         });
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeTruthy();
         expect(result.stderr).toBeFalsy();
       });
@@ -106,7 +108,7 @@ describe('ember-template-lint executable', function() {
           shell: true,
         });
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeTruthy();
         expect(result.stderr).toBeFalsy();
       });
@@ -118,7 +120,7 @@ describe('ember-template-lint executable', function() {
           cwd: './test/fixtures/without-errors',
         });
 
-        expect(result.code).toEqual(0);
+        expect(result.exitCode).toEqual(0);
         expect(result.stdout).toBeFalsy();
         expect(result.stderr).toBeFalsy();
       });
@@ -134,14 +136,13 @@ describe('ember-template-lint executable', function() {
           cwd: './test/fixtures/with-errors',
         });
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout.split('\n')).toEqual([
           path.resolve('./test/fixtures/with-errors/app/templates/application.hbs'),
           '  1:4  error  Non-translated string used  no-bare-strings',
           '  2:5  error  Non-translated string used  no-bare-strings',
           '',
           '✖ 2 problems (2 errors, 0 warnings)',
-          '',
         ]);
         expect(result.stderr).toBeFalsy();
       });
@@ -151,7 +152,7 @@ describe('ember-template-lint executable', function() {
           cwd: './test/fixtures/with-errors-and-warnings',
         });
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout.split('\n')).toEqual([
           path.resolve('./test/fixtures/with-errors-and-warnings/app/templates/application.hbs'),
           '  1:4  error  Non-translated string used  no-bare-strings',
@@ -159,7 +160,6 @@ describe('ember-template-lint executable', function() {
           '  3:0  warning  HTML comment detected  no-html-comments',
           '',
           '✖ 3 problems (2 errors, 1 warnings)',
-          '',
         ]);
         expect(result.stderr).toBeFalsy();
       });
@@ -171,14 +171,13 @@ describe('ember-template-lint executable', function() {
           cwd: './test/fixtures/with-errors-and-warnings',
         });
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout.split('\n')).toEqual([
           path.resolve('./test/fixtures/with-errors-and-warnings/app/templates/application.hbs'),
           '  1:4  error  Non-translated string used  no-bare-strings',
           '  2:5  error  Non-translated string used  no-bare-strings',
           '',
           '✖ 2 problems (2 errors, 0 warnings)',
-          '',
         ]);
         expect(result.stderr).toBeFalsy();
       });
@@ -188,7 +187,7 @@ describe('ember-template-lint executable', function() {
           cwd: './test/fixtures/with-warnings',
         });
 
-        expect(result.code).toEqual(0);
+        expect(result.exitCode).toEqual(0);
         expect(result.stdout).toBeFalsy();
         expect(result.stderr).toBeFalsy();
       });
@@ -225,7 +224,7 @@ describe('ember-template-lint executable', function() {
           },
         ];
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -262,7 +261,7 @@ describe('ember-template-lint executable', function() {
           },
         ];
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -278,7 +277,7 @@ describe('ember-template-lint executable', function() {
         let expectedOutputData = {};
         expectedOutputData[fullTemplateFilePath] = [];
 
-        expect(result.code).toEqual(0);
+        expect(result.exitCode).toEqual(0);
         expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -294,7 +293,7 @@ describe('ember-template-lint executable', function() {
             }
           );
 
-          expect(result.code).toEqual(0);
+          expect(result.exitCode).toEqual(0);
           expect(result.stdout).toBeFalsy();
           expect(result.stderr).toBeFalsy();
         });
@@ -304,13 +303,12 @@ describe('ember-template-lint executable', function() {
             cwd: './test/fixtures/rules-subset',
           });
 
-          expect(result.code).toEqual(1);
+          expect(result.exitCode).toEqual(1);
           expect(result.stdout.split('\n')).toEqual([
             path.resolve('./test/fixtures/rules-subset/template.hbs'),
             '  2:4  error  Ambiguous element used (`div`)  no-shadowed-elements',
             '',
             '✖ 1 problems (1 errors, 0 warnings)',
-            '',
           ]);
           expect(result.stderr).toBeFalsy();
         });
@@ -322,14 +320,13 @@ describe('ember-template-lint executable', function() {
             cwd: './test/fixtures/without-errors',
           });
 
-          expect(result.code).toEqual(1);
+          expect(result.exitCode).toEqual(1);
           expect(result.stdout.split('\n')).toEqual([
             path.resolve('./test/fixtures/without-errors/app/templates/application.hbs'),
             '  1:4  error  Non-translated string used  no-bare-strings',
             '  2:5  error  Non-translated string used  no-bare-strings',
             '',
             '✖ 2 problems (2 errors, 0 warnings)',
-            '',
           ]);
           expect(result.stderr).toBeFalsy();
         });
@@ -341,7 +338,7 @@ describe('ember-template-lint executable', function() {
             cwd: './test/fixtures/with-errors',
           });
 
-          expect(result.code).toEqual(0);
+          expect(result.exitCode).toEqual(0);
           expect(result.stdout).toBeFalsy();
           expect(result.stderr).toBeFalsy();
         });
@@ -355,9 +352,9 @@ describe('ember-template-lint executable', function() {
         });
 
         let expectedOutputData =
-          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings",\n      "no-html-comments"\n    ]\n  }\n]\n';
+          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings",\n      "no-html-comments"\n    ]\n  }\n]';
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -368,9 +365,9 @@ describe('ember-template-lint executable', function() {
         });
 
         let expectedOutputData =
-          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: []\n';
+          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: []';
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -381,9 +378,9 @@ describe('ember-template-lint executable', function() {
         });
 
         let expectedOutputData =
-          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings"\n    ]\n  }\n]\n';
+          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings"\n    ]\n  }\n]';
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -402,7 +399,7 @@ describe('ember-template-lint executable', function() {
           },
         ];
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -419,7 +416,7 @@ describe('ember-template-lint executable', function() {
           env: { GITHUB_ACTIONS: 'true' },
         });
 
-        expect(result.code).toEqual(1);
+        expect(result.exitCode).toEqual(1);
         expect(result.stdout.split('\n')).toEqual([
           filePath,
           '  1:4  error  Non-translated string used  no-bare-strings',
@@ -428,7 +425,6 @@ describe('ember-template-lint executable', function() {
           '✖ 2 problems (2 errors, 0 warnings)',
           `::error file=${filePath},line=1,col=4::Non-translated string used`,
           `::error file=${filePath},line=2,col=5::Non-translated string used`,
-          '',
         ]);
         expect(result.stderr).toBeFalsy();
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2154,6 +2154,21 @@ execa@^3.2.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+execa@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.0.tgz#7f37d6ec17f09e6b8fc53288611695b6d12b9daf"
+  integrity sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==
+  dependencies:
+    cross-spawn "^7.0.0"
+    get-stream "^5.0.0"
+    human-signals "^1.1.1"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.0"
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
+    strip-final-newline "^2.0.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"


### PR DESCRIPTION
Primary issues here were:

* execa changed `result.code` to `result.exitCode`
* execa fixed a number of bugs around stripping the final newline
* execa properly inherits stdio settings, which makes `chalk` work in
  the executed subprocess (and therefore fail the tests)