### PR TITLE
Use updated mechanism to disable chalk.

### DIFF
--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -749,7 +749,7 @@ describe('public api', function() {
 
   describe('Linter.errorsToMessages', function() {
     beforeEach(() => {
-      chalk.enabled = false;
+      chalk.level = 0;
     });
 
     it('formats error with rule, message and moduleId', function() {

--- a/test/printers/pretty-test.js
+++ b/test/printers/pretty-test.js
@@ -3,7 +3,7 @@ const Printer = require('../../lib/printers/pretty');
 
 describe('Linter.errorsToMessages', function() {
   beforeEach(() => {
-    chalk.enabled = false;
+    chalk.level = 0;
   });
 
   it('formats error with rule, message and moduleId', function() {


### PR DESCRIPTION
CI was passing for this because chalk specific checks for various CI
environments and disables itself.