### PR TITLE
Add internal `fixturify-project` based test helper.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "strip-bom": "^4.0.0"
   },
   "devDependencies": {
-    "broccoli-test-helper": "^2.0.0",
     "common-tags": "^1.8.0",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^6.10.0",
@@ -44,6 +43,7 @@
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "execa": "^4.0.0",
+    "fixturify-project": "^2.1.0",
     "jest": "^25.1.0",
     "lerna-changelog": "^1.0.0",
     "markdownlint-cli": "^0.22.0",

--- a/test/helpers/fake-project.js
+++ b/test/helpers/fake-project.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const path = require('path');
+const FixturifyProject = require('fixturify-project');
+
+const ROOT = process.cwd();
+
+module.exports = class FakeProject extends FixturifyProject {
+  constructor() {
+    super('fake-project');
+  }
+
+  setConfig(config) {
+    this.files['.template-lintrc.js'] = `module.exports = ${JSON.stringify(config, null, 2)};`;
+
+    this.writeSync();
+  }
+
+  path(subPath) {
+    return subPath ? path.join(this.baseDir, subPath) : this.baseDir;
+  }
+
+  // behave like a TempDir from broccoli-test-helper
+  write(dirJSON) {
+    Object.assign(this.files, dirJSON);
+    this.writeSync();
+  }
+
+  chdir() {
+    this._dirChanged = true;
+
+    // ensure the directory structure is created initially
+    this.writeSync();
+
+    process.chdir(this.baseDir);
+  }
+
+  dispose() {
+    if (this._dirChanged) {
+      process.chdir(ROOT);
+    }
+
+    return super.dispose();
+  }
+};

--- a/test/unit/get-editor-config-test.js
+++ b/test/unit/get-editor-config-test.js
@@ -1,24 +1,22 @@
 'use strict';
 
-const path = require('path');
 const EditorConfigResolver = require('../../lib/get-editor-config');
-const { createTempDir } = require('broccoli-test-helper');
-
-const initialCWD = process.cwd();
+const Project = require('../helpers/fake-project');
 
 describe('get-editor-config', function() {
   let project = null;
-  beforeEach(async function() {
-    project = await createTempDir();
-    process.chdir(project.path());
+
+  beforeEach(function() {
+    project = new Project();
+    project.chdir();
   });
+
   afterEach(async function() {
-    process.chdir(initialCWD);
     await project.dispose();
   });
 
   it('able to read and add info from .editorconfig file if exists', function() {
-    let filePath = path.join(project.path(), 'app.hbs');
+    let filePath = project.path('app.hbs');
 
     project.write({
       'app.hbs': '',
@@ -72,7 +70,7 @@ trim_trailing_whitespace = false
   });
 
   it('return empty object if no config found', function() {
-    let filePath = path.join(project.path(), 'app.hbs');
+    let filePath = project.path('app.hbs');
 
     project.write({
       'app.hbs': '',
@@ -82,7 +80,7 @@ trim_trailing_whitespace = false
   });
 
   it('able to merge different editor config files', function() {
-    let filePath = path.join(project.path(), 'app', 'app.hbs');
+    let filePath = project.path('app/app.hbs');
 
     project.write({
       app: {
@@ -110,7 +108,7 @@ indent_size = 5
   });
 
   it('able to merge different config sections', function() {
-    let filePath = path.join(project.path(), 'app.hbs');
+    let filePath = project.path('app.hbs');
 
     project.write({
       'app.hbs': '',
@@ -152,7 +150,7 @@ indent_style = space
   });
 
   it('able to resolve config with custom name', function() {
-    let filePath = path.join(project.path(), 'app.hbs');
+    let filePath = project.path('app.hbs');
 
     project.write({
       'app.hbs': '',
@@ -180,14 +178,14 @@ insert_final_newline = true
   });
 
   it('return default values if no hbs in editor config', function() {
-    let filePath = path.join(project.path(), 'app.hbs');
+    let filePath = project.path('app.hbs');
 
     project.write({
       'app.hbs': '',
       '.editorconfig': `
 [*]
 indent_style = space
-indent_size = 5      
+indent_size = 5
 `,
     });
 
@@ -199,14 +197,14 @@ indent_size = 5
   });
 
   it('return empty object if editor config not relevant', function() {
-    let filePath = path.join(project.path(), 'app.hbs');
+    let filePath = project.path('app.hbs');
 
     project.write({
       'app.hbs': '',
       '.editorconfig': `
 [*.css]
 indent_style = space
-indent_size = 5      
+indent_size = 5
 `,
     });
 
@@ -214,7 +212,7 @@ indent_size = 5
   });
 
   it('allow specify custom editorconfig for file', function() {
-    let filePath = path.join(project.path(), 'items/app.hbs');
+    let filePath = project.path('items/app.hbs');
 
     project.write({
       'app.hbs': '',

--- a/yarn.lock
+++ b/yarn.lock
@@ -536,7 +536,14 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/glob@^7.1.1":
+"@types/fs-extra@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-8.1.0.tgz#1114834b53c3914806cd03b3304b37b3bd221a4d"
+  integrity sha512-UoOfVEzAUpeSPmjm7h1uk5MH6KZma2z2O7a75onTGjnNvAvMVrPzPL/vBbT65iIGHWj6rokwfmYcmxmlSf2uwg==
+  dependencies:
+    "@types/node" "*"
+
+"@types/glob@*", "@types/glob@^7.1.1":
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.1.1.tgz#aa59a1c6e3fbc421e07ccd31a944c30eba521575"
   integrity sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==
@@ -565,7 +572,7 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
-"@types/minimatch@*":
+"@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
@@ -574,6 +581,14 @@
   version "13.7.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.4.tgz#76c3cb3a12909510f52e5dc04a6298cdf9504ffd"
   integrity sha512-oVeL12C6gQS/GAExndigSaLxTrKpQPxewx9bOcwfvJiJge4rr7wNaph4J+ns5hrmIV2as5qxqN8YKthn9qh0jw==
+
+"@types/rimraf@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/rimraf/-/rimraf-2.0.3.tgz#0199a46af106729ba14213fda7b981278d8c84f2"
+  integrity sha512-dZfyfL/u9l/oi984hEXdmAjX3JHry7TLWw43u1HQ8HhPv6KtfxnrZ3T/bleJ0GEvnk9t5sM7eePkgMqz3yBcGg==
+  dependencies:
+    "@types/glob" "*"
+    "@types/node" "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -1821,7 +1836,7 @@ end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   dependencies:
     once "^1.4.0"
 
-ensure-posix-path@^1.0.0:
+ensure-posix-path@^1.0.0, ensure-posix-path@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ensure-posix-path/-/ensure-posix-path-1.1.1.tgz#3c62bdb19fa4681544289edb2b382adc029179ce"
   integrity sha512-VWU0/zXzVbeJNXvME/5EmLuEj2TauvoaTz6aFYK1Z92JCBlDlZ3Gu0tuGR42kpW1754ywTs+QB0g5TP0oj9Zaw==
@@ -2386,6 +2401,15 @@ findup-sync@^2.0.0:
     micromatch "^3.0.4"
     resolve-dir "^1.0.1"
 
+fixturify-project@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fixturify-project/-/fixturify-project-2.1.0.tgz#1677be3f116ec3f6b2b2ebb75b393d5860c4668e"
+  integrity sha512-B59wD4I5HDbokvmZatZTyNIjuSBjZzcZoEYdr9kdG9qRc/FSDjzUzzvHbrZL7oWfu9qsbyJBjzf0R0WC5hIZsA==
+  dependencies:
+    fixturify "^2.1.0"
+    tmp "^0.0.33"
+    type-fest "^0.11.0"
+
 fixturify@^0.3.2:
   version "0.3.4"
   resolved "https://registry.yarnpkg.com/fixturify/-/fixturify-0.3.4.tgz#c676de404a7f8ee8e64d0b76118e62ec95ab7b25"
@@ -2393,6 +2417,18 @@ fixturify@^0.3.2:
   dependencies:
     fs-extra "^0.30.0"
     matcher-collection "^1.0.4"
+
+fixturify@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fixturify/-/fixturify-2.1.0.tgz#a0437faac9b6e4aeb35910a1214df866aeec5d75"
+  integrity sha512-gHq6UCv8DE91EpiaRSzrmvLoRvFOBzI961IQ3gXE5wfmMM1TtApDcZAonG2hnp6GJrVFCxHwP01wSw9VQJiJ1w==
+  dependencies:
+    "@types/fs-extra" "^8.1.0"
+    "@types/minimatch" "^3.0.3"
+    "@types/rimraf" "^2.0.3"
+    fs-extra "^8.1.0"
+    matcher-collection "^2.0.1"
+    walk-sync "^2.0.2"
 
 flat-cache@^2.0.1:
   version "2.0.1"
@@ -2476,6 +2512,15 @@ fs-extra@^0.30.0:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
 
 fs-minipass@^2.0.0:
   version "2.1.0"
@@ -2696,7 +2741,7 @@ got@9.6.0, got@^9.6.0:
     to-readable-stream "^1.0.0"
     url-parse-lax "^3.0.0"
 
-graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
+graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
   integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
@@ -3833,6 +3878,13 @@ jsonfile@^2.1.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
+  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -4219,6 +4271,14 @@ matcher-collection@^1.0.0, matcher-collection@^1.0.4:
   resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-1.1.2.tgz#1076f506f10ca85897b53d14ef54f90a5c426838"
   integrity sha512-YQ/teqaOIIfUHedRam08PB3NK7Mjct6BvzRnJmpGDm8uFXpNr1sbY4yuflI5JcEs6COpYA0FpRQhSDBf1tT95g==
   dependencies:
+    minimatch "^3.0.2"
+
+matcher-collection@^2.0.0, matcher-collection@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/matcher-collection/-/matcher-collection-2.0.1.tgz#90be1a4cf58d6f2949864f65bb3b0f3e41303b29"
+  integrity sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
     minimatch "^3.0.2"
 
 mdurl@^1.0.1:
@@ -6282,6 +6342,11 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
+type-fest@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
+  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+
 type-fest@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
@@ -6364,6 +6429,11 @@ universal-user-agent@^5.0.0:
   integrity sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==
   dependencies:
     os-name "^3.1.0"
+
+universalify@^0.1.0:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
+  integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
 unpipe@~1.0.0:
   version "1.0.0"
@@ -6505,6 +6575,15 @@ walk-sync@^0.3.3:
   dependencies:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
+
+walk-sync@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-2.0.2.tgz#5ea8a28377c8be68c92d50f4007ea381725da14b"
+  integrity sha512-dCZkrxfHjPn7tIvdYrX3uMD/R0beVrHpA8lROQ5wWrl8psJgR6xwCkwqTFes0dNujbS2o/ITpvSYgIFsLsf13A==
+  dependencies:
+    "@types/minimatch" "^3.0.3"
+    ensure-posix-path "^1.1.0"
+    matcher-collection "^2.0.0"
 
 walker@^1.0.7, walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
This simplifies the usage of fixturify style tests by moving from `broccoli-test-helper`'s `createTempDir` to using [fixturify-project](https://github.com/stefanpenner/node-fixturify-project) with a custom subclass (for common functionality).

This is an initial step towards fixing https://github.com/ember-template-lint/ember-template-lint/issues/1150, once landed tests that use a real node modules structure are massively simpler.