### PR TITLE
Extract `Linter.prototype.buildRule` internal helper method to build rule instances.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -68,27 +68,80 @@ class Linter {
     return ERROR_SEVERITY;
   }
 
-  buildRules(config) {
+  /**
+   * Builds the rule specified. The rule constructor is loaded from the list of
+   * known rules (will include both the list of internal rules and any from
+   * plugins).
+   *
+   * @private
+   * @param {string} ruleName The name of the rule to build
+   * @param {Object} options See buildRules for detailed properties
+   * @returns {Rule} The rule that was built
+   */
+  _buildRule(ruleName, options, addToResults) {
+    let loadedRules = this.config.loadedRules;
+    let Rule = loadedRules[ruleName];
+
+    let ruleOptions = Object.assign(
+      {
+        name: ruleName,
+        config: this.config.rules[ruleName],
+        console: this.console,
+        log: addToResults,
+        defaultSeverity: this._defaultSeverityForRule(ruleName, options.pending),
+        ruleNames: Object.keys(loadedRules),
+      },
+      options
+    );
+
+    ruleOptions.configResolver = Object.assign(
+      {
+        editorConfig: () => {
+          return this.editorConfigResolver.getEditorConfigData(options.filePath);
+        },
+      },
+      options.configResolver
+    );
+
+    let rule = new Rule(ruleOptions);
+
+    return rule;
+  }
+
+  /**
+   * Builds an array of rules to be ran for the current configuration, on a specific file.
+   *
+   * @private
+   * @param {Object} options
+   * @param {Array} options.results The array of results (will be mutated by rule instance while linting)
+   * @param {boolean} options.pending Indicates if this module + rule combination are configured as pending
+   * @param {string} options.filePath The full on-disk path to the file being linted
+   * @param {string} options.moduleId The pseudo path for the file being linted (when using ember-cli-template-lint, this is effectively the "runtime module" for the template). Usage of `moduleId` should be avoided (favoring `filePath` instead)
+   * @param {string} options.moduleName Same as `moduleId`, see above
+   * @param {string} options.rawSource - The source for the file to be linted
+   * @param {Object} [options.configResolver] A simple way to provide additional configuration into a rule. Currently used by plugins desiring `editorconfig` support, but to be expanded in the future
+   * @returns {Array<Rule>} The array of rules for the provided set of options
+   */
+  buildRules(options) {
     let rules = [];
 
-    let loadedRules = this.config.loadedRules;
     let configuredRules = this.config.rules;
 
     function addToResults(result) {
-      config.results.push(result);
+      options.results.push(result);
     }
 
+    let loadedRules = this.config.loadedRules;
     for (let ruleName in configuredRules) {
       if (configuredRules[ruleName] === false) {
         continue;
       }
 
-      let Rule = loadedRules[ruleName];
-      if (!Rule) {
+      if (!loadedRules[ruleName]) {
         addToResults({
           severity: 2,
-          filePath: config.filePath,
-          moduleId: config.moduleId,
+          moduleId: options.moduleId,
+          filePath: options.filePath,
           message: `Definition for rule '${ruleName}' was not found`,
         });
 
@@ -96,26 +149,11 @@ class Linter {
       }
 
       try {
-        let rule = new Rule({
-          name: ruleName,
-          config: this.config.rules[ruleName],
-          console: this.console,
-          log: addToResults,
-          defaultSeverity: this._defaultSeverityForRule(ruleName, config.pending),
-          ruleNames: Object.keys(loadedRules),
-          configResolver: config.configResolver || {
-            editorConfig: () => {
-              return this.editorConfigResolver.getEditorConfigData(config.filePath);
-            },
-          },
-          filePath: config.filePath,
-          moduleName: config.moduleName,
-          rawSource: config.rawSource,
-        });
-
+        let rule = this._buildRule(ruleName, options, addToResults);
         rules.push(rule);
       } catch (error) {
-        let message = buildErrorMessage(config.filePath, config.moduleId, error);
+        let message = buildErrorMessage(options.filePath, options.moduleId, error);
+
         addToResults(message);
       }
     }
@@ -233,8 +271,11 @@ class Linter {
       results: messages,
       pending: pendingStatus,
       filePath: options.filePath,
+
+      // TODO: deprecate moduleId and moduleName
       moduleId: options.moduleId,
       moduleName: options.moduleId,
+
       configResolver: options.configResolver,
       rawSource: source,
     });


### PR DESCRIPTION
While reviewing the code for adding `filePath` I found the previous logic quite difficult to follow (what the heck was in the options object passed all over the place !?!?).