### PR TITLE
Refactor rule logging to track results locally.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -112,17 +112,19 @@ class Linter {
    * Builds an array of rules to be ran for the current configuration, on a specific file.
    *
    * @private
+   *
    * @param {Object} options
-   * @param {Array} options.results The array of results (will be mutated by rule instance while linting)
    * @param {boolean} options.pending Indicates if this module + rule combination are configured as pending
    * @param {string} options.filePath The full on-disk path to the file being linted
    * @param {string} options.moduleId The pseudo path for the file being linted (when using ember-cli-template-lint, this is effectively the "runtime module" for the template). Usage of `moduleId` should be avoided (favoring `filePath` instead)
    * @param {string} options.moduleName Same as `moduleId`, see above
    * @param {string} options.rawSource - The source for the file to be linted
    * @param {Object} [options.configResolver] A simple way to provide additional configuration into a rule. Currently used by plugins desiring `editorconfig` support, but to be expanded in the future
-   * @returns {Array<Rule>} The array of rules for the provided set of options
+   *
+   * @returns {Object} An object with an array of rule load failures, and an array of rule instances
    */
   buildRules(options) {
+    let failures = [];
     let rules = [];
 
     let configuredRules = this.config.rules;
@@ -138,7 +140,7 @@ class Linter {
       }
 
       if (!loadedRules[ruleName]) {
-        addToResults({
+        failures.push({
           severity: 2,
           moduleId: options.moduleId,
           filePath: options.filePath,
@@ -154,11 +156,14 @@ class Linter {
       } catch (error) {
         let message = buildErrorMessage(options.filePath, options.moduleId, error);
 
-        addToResults(message);
+        failures.push(message);
       }
     }
 
-    return rules;
+    return {
+      failures,
+      rules,
+    };
   }
 
   statusForModule(type, moduleId) {
@@ -238,22 +243,23 @@ class Linter {
   }
 
   /**
-   * The main function for the Linter class.
-   * It takes the source code to lint and returns the lint messages.
+   * The main function for the Linter class.  It takes the source code to lint
+   * and returns the results.
+   *
    * @param {Object} options
    * @param {string} options.source - The source code to verify.
    * @param {string} options.filePath
    * @param {string} options.moduleId
    * @param {string} options.configResolver
-   * @returns {Object[]} result.messages - The lint messages.
+   * @returns {Object[]} results - The lint results.
    */
   verify(options) {
-    let messages = [];
+    let results = [];
     let pendingStatus = this.statusForModule('pending', options.moduleId);
     let shouldIgnore = this.statusForModule('ignore', options.moduleId);
 
     if (shouldIgnore) {
-      return messages;
+      return results;
     }
 
     let source = stripBom(options.source);
@@ -264,11 +270,10 @@ class Linter {
       templateAST = parse(source);
     } catch (error) {
       let message = buildErrorMessage(options.filePath, options.moduleId, error);
-      messages.push(message);
+      results.push(message);
     }
 
-    let rules = this.buildRules({
-      results: messages,
+    let { failures, rules } = this.buildRules({
       pending: pendingStatus,
       filePath: options.filePath,
 
@@ -279,19 +284,21 @@ class Linter {
       configResolver: options.configResolver,
       rawSource: source,
     });
+    results.push(...failures);
 
     for (let rule of rules) {
       try {
         transform(templateAST, () => rule.getVisitor());
+        results.push(...rule.results);
       } catch (error) {
         let message = buildErrorMessage(options.filePath, options.moduleId, error);
-        messages.push(message);
+        results.push(message);
       }
     }
 
     if (pendingStatus) {
-      if (messages.length === 0) {
-        messages.push({
+      if (results.length === 0) {
+        results.push({
           rule: 'invalid-pending-module',
           message: `Pending module (\`${options.moduleId}\`) passes all rules. Please remove \`${options.moduleId}\` from pending list.`,
           filePath: options.filePath,
@@ -300,11 +307,11 @@ class Linter {
         });
       } else {
         if (pendingStatus.only) {
-          let failedRules = messages.reduce((rules, message) => rules.add(message.rule), new Set());
+          let failedRules = results.reduce((rules, message) => rules.add(message.rule), new Set());
 
           pendingStatus.only.forEach(pendingRule => {
             if (!failedRules.has(pendingRule)) {
-              messages.push({
+              results.push({
                 rule: 'invalid-pending-module-rule',
                 message: `Pending module (\`${options.moduleId}\`) passes \`${pendingRule}\` rule. Please remove \`${pendingRule}\` from pending rules list.`,
                 filePath: options.filePath,
@@ -317,7 +324,7 @@ class Linter {
       }
     }
 
-    return messages;
+    return results;
   }
 
   // this should eventually be removed but is currently still used by ember-cli-template-lint

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -40,10 +40,11 @@ module.exports = class BaseRule {
   constructor(options) {
     this.ruleName = options.name;
     this._console = options.console || console;
-    this._log = options.log;
     this._configResolver = options.configResolver;
     this._ruleNames = options.ruleNames;
+
     this.severity = options.defaultSeverity;
+    this.results = [];
 
     // To support DOM-scoped configuration instructions, we need to maintain
     // a stack of our configurations so we can restore the previous one when
@@ -493,7 +494,7 @@ module.exports = class BaseRule {
     }
     let reportedResult = Object.assign({}, defaults, result);
 
-    this._log(reportedResult);
+    this.results.push(reportedResult);
   }
 
   detect() {


### PR DESCRIPTION
Instead of passing a "please log this" function into each rule, this allows the rule itself to manage its own local results array.

IMHO, this nicely separates the concerns of the various pieces (the rule pushes into its own local results listing, the linter runs the rules and checks the results, etc).