### PR TITLE
Introduce rule visitor based fixing support.

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const assert = require('assert');
-
 const Linter = require('../index');
 
 function parseMeta(item) {
@@ -225,6 +224,22 @@ module.exports = function generateRuleTests({
           let actual = linter.verify(options);
 
           assert.deepStrictEqual(actual, []);
+        });
+      }
+
+      if (item.fixedTemplate) {
+        testOrOnly(`\`${item.template}\` -> ${item.fixedTemplate}\``, function() {
+          let options = prepare(item.template, item.config);
+          let result = linter.verifyAndFix(options);
+
+          assert.deepStrictEqual(result.output, item.fixedTemplate);
+        });
+
+        testOrOnly(`${item.fixedTemplate}\` is idempotent`, function() {
+          let options = prepare(item.fixedTemplate, item.config);
+          let result = linter.verifyAndFix(options);
+
+          assert.deepStrictEqual(result.output, item.fixedTemplate);
         });
       }
     });

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -9,16 +9,6 @@ const MAX_AUTOFIX_PASSES = 10;
 const WARNING_SEVERITY = 1;
 const ERROR_SEVERITY = 2;
 
-/**
- * @param {Object} options
- * @param {string} options.source - The source code to fix.
- * @param {Object[]} messages - The lint messages.
- * @returns {string} output - The fixed source.
- */
-function applyFixes(options /* messages */) {
-  return options.source;
-}
-
 function buildErrorMessage(filePath, moduleId, error) {
   let message = {
     fatal: true,
@@ -225,7 +215,7 @@ class Linter {
       shouldVerify = false;
 
       if (iterations < MAX_AUTOFIX_PASSES) {
-        const output = applyFixes(options, messages);
+        const output = this._applyFixes(options, messages);
 
         // let's lint one more time if source was modified
         shouldVerify = output !== currentSource;
@@ -239,6 +229,43 @@ class Linter {
       output: currentSource,
       messages,
     };
+  }
+
+  /**
+   * @param {Object} options
+   * @param {string} options.source - The source code to verify.
+   * @param {string} options.filePath
+   * @param {string} options.moduleId
+   * @param {Object[]} results - The lint messages.
+   *
+   * @returns {string} output - The fixed source.
+   */
+  _applyFixes(options, results) {
+    let fixableIssues = results.filter(r => r.isFixable);
+
+    // nothing to do, bail out
+    if (fixableIssues.length === 0) {
+      return options.source;
+    }
+
+    let currentSource = options.source;
+
+    let pending = this.statusForModule('pending', options.moduleId);
+    let ruleNames = new Set(fixableIssues.map(r => r.rule));
+    for (let ruleName of ruleNames) {
+      let rule = this._buildRule(ruleName, {
+        pending,
+        shouldFix: true,
+        filePath: options.filePath,
+        rawSource: currentSource,
+        fileConfig: getConfigForFile(this.config, options.filePath),
+      });
+
+      let { code } = transform(currentSource, () => rule.getVisitor());
+      currentSource = code;
+    }
+
+    return currentSource;
   }
 
   /**

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -45,6 +45,7 @@ module.exports = class BaseRule {
 
     this.severity = options.defaultSeverity;
     this.results = [];
+    this.mode = options.shouldFix ? 'fix' : 'report';
 
     // To support DOM-scoped configuration instructions, we need to maintain
     // a stack of our configurations so we can restore the previous one when

--- a/test/acceptance/rule-test.js
+++ b/test/acceptance/rule-test.js
@@ -94,4 +94,67 @@ describe('rule public api', function() {
       ],
     });
   });
+
+  describe('mode === fix', function() {
+    generateRuleTests({
+      plugins: [
+        {
+          name: 'fix-test',
+          rules: {
+            'can-fix': class extends Rule {
+              visitor() {
+                return {
+                  ElementNode(node) {
+                    if (node.tag !== 'MySpecialThing') {
+                      return;
+                    }
+
+                    if (this.mode === 'fix') {
+                      node.tag = 'EvenBettererThing';
+                    } else {
+                      this.log({
+                        isFixable: true,
+                        message: 'Do not use MySpecialThing',
+                        line: node.loc && node.loc.start.line,
+                        column: node.loc && node.loc.start.column,
+                        source: this.sourceForNode(node),
+                      });
+                    }
+                  },
+                };
+              }
+            },
+          },
+        },
+      ],
+
+      name: 'can-fix',
+      config: true,
+
+      bad: [
+        {
+          template: '<MySpecialThing/>',
+          result: {
+            column: 0,
+            line: 1,
+            isFixable: true,
+            message: 'Do not use MySpecialThing',
+            source: '<MySpecialThing/>',
+          },
+          fixedTemplate: '<EvenBettererThing/>',
+        },
+        {
+          template: '<MySpecialThing>contents here</MySpecialThing>',
+          result: {
+            column: 0,
+            line: 1,
+            isFixable: true,
+            message: 'Do not use MySpecialThing',
+            source: '<MySpecialThing>contents here</MySpecialThing>',
+          },
+          fixedTemplate: '<EvenBettererThing>contents here</EvenBettererThing>',
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
This is an alternative take on https://github.com/ember-template-lint/ember-template-lint/pull/1025.

The idea here is to leverage the rule instance's pre-existing visitor to along with checking the `this.mode` (will either be `fix` or `report`) to mutate the AST _during_ traversal.

This makes it _effectively_ the same as if the rule's visitor was passed to ember-template-recast's `transform`.

TODO:

- [x] Add test harness support for testing fixers
  - [x] Confirm that the fix is idempotent
  - [x] Allow specifying the input and output strings


Closes #1025 