### PR TITLE
Ensure accessing `this.editorConfig` in a rule instance does not error.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -97,6 +97,10 @@ class Linter {
     ruleOptions.configResolver = Object.assign(
       {
         editorConfig: () => {
+          if (!options.filePath) {
+            return {};
+          }
+
           return this.editorConfigResolver.getEditorConfigData(options.filePath);
         },
       },

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -63,7 +63,7 @@ module.exports = class BaseRule {
   }
 
   get editorConfig() {
-    return this._configResolver.editorConfig() || {};
+    return this._configResolver.editorConfig();
   }
 
   // The `name !== this.ruleName` check isn't strictly necessary, but allows

--- a/test/helpers/fake-project.js
+++ b/test/helpers/fake-project.js
@@ -5,13 +5,69 @@ const FixturifyProject = require('fixturify-project');
 
 const ROOT = process.cwd();
 
+// this is the default .editorconfig file for new ember-cli apps, taken from:
+// https://github.com/ember-cli/ember-new-output/blob/stable/.editorconfig
+const DEFAULT_EDITOR_CONFIG = `
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.hbs]
+insert_final_newline = false
+
+[*.{diff,md}]
+trim_trailing_whitespace = false
+`;
+
+// this is the default .template-lintrc.js used by ember-cli apps, taken from:
+// https://github.com/ember-cli/ember-new-output/blob/stable/.template-lintrc.js
+const DEFAULT_TEMPLATE_LINTRC = `
+'use strict';
+
+module.exports = {
+  extends: 'octane'
+};
+`;
+
 module.exports = class FakeProject extends FixturifyProject {
+  static defaultSetup() {
+    let project = new this();
+
+    project.files['.template-lintrc.js'] = DEFAULT_TEMPLATE_LINTRC;
+    project.files['.editorconfig'] = DEFAULT_EDITOR_CONFIG;
+
+    project.writeSync();
+
+    return project;
+  }
+
   constructor(name = 'fake-project', ...args) {
     super(name, ...args);
   }
 
   setConfig(config) {
-    this.files['.template-lintrc.js'] = `module.exports = ${JSON.stringify(config, null, 2)};`;
+    let configFileContents =
+      config === undefined
+        ? DEFAULT_TEMPLATE_LINTRC
+        : `module.exports = ${JSON.stringify(config, null, 2)};`;
+
+    this.files['.template-lintrc.js'] = configFileContents;
+
+    this.writeSync();
+  }
+
+  setEditorConfig(value = DEFAULT_EDITOR_CONFIG) {
+    this.files['.editorconfig'] = value;
 
     this.writeSync();
   }

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -5,16 +5,43 @@ const Rule = require('./../../lib/rules/base');
 const { readdirSync, existsSync, readFileSync } = require('fs');
 const { join, parse: parsePath } = require('path');
 const ruleNames = Object.keys(require('../../lib/rules'));
+const Project = require('../helpers/fake-project');
+const EditorConfigResolver = require('../../lib/get-editor-config');
 
 describe('base plugin', function() {
+  let project, editorConfigResolver;
+  beforeEach(() => {
+    project = Project.defaultSetup();
+
+    editorConfigResolver = new EditorConfigResolver();
+    editorConfigResolver.resolveEditorConfigFiles();
+  });
+
+  afterEach(async () => {
+    await project.dispose();
+  });
+
   function runRules(template, rules) {
     let ast = parse(template);
 
     for (let ruleConfig of rules) {
       let { Rule } = ruleConfig;
       let options = Object.assign({}, ruleConfig, {
-        moduleName: 'layout.hbs',
+        filePath: 'layout.hbs',
+        moduleId: 'layout',
+        moduleName: 'layout',
         rawSource: template,
+        ruleNames,
+      });
+
+      options.configResolver = Object.assign({}, ruleConfig.configResolver, {
+        editorConfig: () => {
+          if (!options.filePath) {
+            //return {};
+          }
+
+          return editorConfigResolver.getEditorConfigData(options.filePath);
+        },
       });
 
       let rule = new Rule(options);
@@ -53,7 +80,7 @@ describe('base plugin', function() {
   }
 
   function plugin(Rule, name, config) {
-    return { Rule, name, config, ruleNames };
+    return { Rule, name, config };
   }
 
   it('all presets correctly reexported', function() {

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -26,18 +26,22 @@ describe('base plugin', function() {
 
     for (let ruleConfig of rules) {
       let { Rule } = ruleConfig;
-      let options = Object.assign({}, ruleConfig, {
-        filePath: 'layout.hbs',
-        moduleId: 'layout',
-        moduleName: 'layout',
-        rawSource: template,
-        ruleNames,
-      });
+      let options = Object.assign(
+        {},
+        {
+          filePath: 'layout.hbs',
+          moduleId: 'layout',
+          moduleName: 'layout',
+          rawSource: template,
+          ruleNames,
+        },
+        ruleConfig
+      );
 
       options.configResolver = Object.assign({}, ruleConfig.configResolver, {
         editorConfig: () => {
           if (!options.filePath) {
-            //return {};
+            return {};
           }
 
           return editorConfigResolver.getEditorConfigData(options.filePath);
@@ -96,6 +100,30 @@ describe('base plugin', function() {
     const exportedPresetNames = Object.keys(exportedPresets);
 
     expect(exportedPresetNames).toEqual(presetFiles);
+  });
+
+  describe('rule APIs', function() {
+    it('can access editorConfig', function() {
+      class AwesomeRule extends Rule {
+        visitor() {
+          expect(this.editorConfig.insert_final_newline).toBe(false);
+        }
+      }
+
+      runRules('foo', [plugin(AwesomeRule, 'awesome-rule', true)]);
+    });
+
+    it('does not error when accessing editorConfig when no filePath is passed', function() {
+      class AwesomeRule extends Rule {
+        visitor() {
+          expect(this.editorConfig.insert_final_newline).toBe(undefined);
+        }
+      }
+
+      runRules('foo', [
+        { Rule: AwesomeRule, name: 'awesome-rule', config: true, filePath: undefined },
+      ]);
+    });
   });
 
   describe('rules setup is correct', function() {


### PR DESCRIPTION
This ensures that `this.editorConfig` within a rule instance will **always** return an object (even if we don't find an editor config file, if we don't provide a filePath, etc).

Prior to this, any rule that would use `this.editorConfig` would error when consumed through tooling that does not provide `filePath`. This includes `ember-cli-template-lint` and `eslint-plugin-hbs`.

Fixes #1161