### PR TITLE
Add support to `test.only` in the test harness.

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -71,6 +71,7 @@ function getVerifyOptions(template, meta) {
  * @param  {Function} groupingMethodEach  - function to call before test setup is defined (mocha - beforeEach, qunit - beforeEach)
  * @param  {Function} groupingMethod      - function to call when test setup is defined (mocha - describe, qunit - module)
  * @param  {Function} testMethod          - function to call when test block is to be run (mocha - it, qunit - test)
+ * @param  {Function} [focusMethod]       - function to call when a specific test is to be run on its own (mocha - it.only, qunit - QUnit.only)
  * @param  {Boolean}  skipDisabledTests   - boolean to skip disabled tests or not
  * @param  {Object}   config
  * @param  {Array}    plugins             - an array of plugins to load
@@ -83,6 +84,7 @@ module.exports = function generateRuleTests({
   groupingMethod,
   groupMethodBefore,
   testMethod,
+  focusMethod,
   skipDisabledTests,
   config: passedConfig,
   plugins,
@@ -160,7 +162,10 @@ module.exports = function generateRuleTests({
     bad.forEach(function(badItem) {
       let template = badItem.template;
 
-      testMethod(`logs a message in the console when given \`${template}\``, function() {
+      let shouldFocus = badItem.focus === true && typeof focusMethod === 'function';
+      let testOrOnly = shouldFocus ? focusMethod : testMethod;
+
+      testOrOnly(`logs a message in the console when given \`${template}\``, function() {
         let expectedResults = badItem.results || [badItem.result];
 
         let options = prepare(badItem, badItem.config);
@@ -178,7 +183,7 @@ module.exports = function generateRuleTests({
       });
 
       if (!skipDisabledTests) {
-        testMethod(`passes with \`${template}\` when rule is disabled`, function() {
+        testOrOnly(`passes with \`${template}\` when rule is disabled`, function() {
           let config = false;
           let options = prepare(badItem, config);
           let actual = linter.verify(options);
@@ -186,7 +191,7 @@ module.exports = function generateRuleTests({
           assert.deepStrictEqual(actual, []);
         });
 
-        testMethod(
+        testOrOnly(
           `passes with \`${template}\` when disabled via inline comment - single rule`,
           function() {
             let options = prepare(`${DISABLE_ONE}\n${template}`);
@@ -196,7 +201,7 @@ module.exports = function generateRuleTests({
           }
         );
 
-        testMethod(
+        testOrOnly(
           `passes with \`${template}\` when disabled via long-form inline comment - single rule`,
           function() {
             let options = prepare(`${DISABLE_ONE_LONG}\n${template}`);
@@ -206,7 +211,7 @@ module.exports = function generateRuleTests({
           }
         );
 
-        testMethod(
+        testOrOnly(
           `passes with \`${template}\` when disabled via inline comment - all rules`,
           function() {
             let options = prepare(`${DISABLE_ALL}\n${template}`);
@@ -220,8 +225,10 @@ module.exports = function generateRuleTests({
 
     good.forEach(function(goodItem) {
       let template = typeof goodItem === 'string' ? goodItem : goodItem.template;
+      let shouldFocus = goodItem.focus === true && typeof focusMethod === 'function';
+      let testOrOnly = shouldFocus ? focusMethod : testMethod;
 
-      testMethod(`passes when given \`${template}\``, function() {
+      testOrOnly(`passes when given \`${template}\``, function() {
         let options = prepare(goodItem, goodItem.config);
         let actual = linter.verify(options);
 
@@ -232,9 +239,11 @@ module.exports = function generateRuleTests({
     error.forEach(item => {
       let { config, template } = item;
 
+      let shouldFocus = item.focus === true && typeof focusMethod === 'function';
+      let testOrOnly = shouldFocus ? focusMethod : testMethod;
       let friendlyConfig = JSON.stringify(config);
 
-      testMethod(`errors when given \`${template}\` with config \`${friendlyConfig}\``, function() {
+      testOrOnly(`errors when given \`${template}\` with config \`${friendlyConfig}\``, function() {
         let expectedResults = item.results || [item.result];
         expectedResults = expectedResults.map(parseResult);
 

--- a/test/helpers/rule-test-harness.js
+++ b/test/helpers/rule-test-harness.js
@@ -7,7 +7,8 @@ module.exports = function(options) {
     Object.assign({}, options, {
       groupMethodBefore: beforeEach,
       groupingMethod: describe,
-      testMethod: it,
+      testMethod: test,
+      focusMethod: test.only,
     })
   );
 };


### PR DESCRIPTION
This brings back the capability to focus specific tests by adding `focus: true` to a a `good`, `bad`, or `errors` test item.

Specifying a test like this:

```js
{
  template: 'some template here',
  focus: true,
}
```

Will run that test with `test.only` (or whatever is configured by your test harness integration).