### PR TITLE
Remove left over argument to `Linter.prototype._buildRule`.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -78,7 +78,7 @@ class Linter {
    * @param {Object} options See buildRules for detailed properties
    * @returns {Rule} The rule that was built
    */
-  _buildRule(ruleName, options, addToResults) {
+  _buildRule(ruleName, options) {
     let fileConfig = options.fileConfig;
     let Rule = fileConfig.loadedRules[ruleName];
 
@@ -87,7 +87,6 @@ class Linter {
         name: ruleName,
         config: fileConfig.rules[ruleName],
         console: this.console,
-        log: addToResults,
         defaultSeverity: this._defaultSeverityForRule(ruleName, options.pending),
         ruleNames: Object.keys(fileConfig.loadedRules),
       },
@@ -134,10 +133,6 @@ class Linter {
     let fileConfig = getConfigForFile(this.config, options.filePath);
     options.fileConfig = fileConfig;
 
-    function addToResults(result) {
-      options.results.push(result);
-    }
-
     for (let ruleName in fileConfig.rules) {
       if (fileConfig.rules[ruleName] === false) {
         continue;
@@ -155,7 +150,7 @@ class Linter {
       }
 
       try {
-        let rule = this._buildRule(ruleName, options, addToResults);
+        let rule = this._buildRule(ruleName, options);
         rules.push(rule);
       } catch (error) {
         let message = buildErrorMessage(options.filePath, options.moduleId, error);


### PR DESCRIPTION
The `options.log` has been unused since #1157, this cleans up passing it around.