### PR TITLE
Add test harness features (naming test cases, snapshot support, etc).

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -181,8 +181,11 @@ module.exports = function generateRuleTests({
           assert.strictEqual(actual.length, 1); // can't have more than one fatal error
           delete actual[0].source; // remove the source (stack trace is not easy to assert)
           assert.deepStrictEqual(actual[0], item.fatal);
+        } else if (item.verifyResults) {
+          item.verifyResults(actual);
         } else {
-          expectedResults = expectedResults.map(parseResult);
+          let results = item.results || [item.result];
+          let expectedResults = results.map(parseResult);
 
           assert.deepStrictEqual(actual, expectedResults);
         }

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -32,6 +32,7 @@ function getVerifyOptions(template, meta) {
  * allows tests to be defined without needing to setup test infrastructure every time
  * @param  {Array}  [bad=[]]            - an array of items that describe the use case that should fail
  *  [{
+     name: 'prevents debugger',
      template: '{{debugger}}',
 
      result: {
@@ -46,6 +47,7 @@ function getVerifyOptions(template, meta) {
  *
  * @param  {Array}  [error=[]]            - an array of items that describe the use case that should error
  *  [{
+     name: 'errors for "sometimes"',
      config: 'sometimes',
      template: 'test',
 
@@ -57,7 +59,7 @@ function getVerifyOptions(template, meta) {
      },
    }]
  *
- * @param  {Array}    [good=[]]          - an array of strings that define templates that should not fail
+ * @param  {Array}    [good=[]]          - an array of items that should not fail
  * [
      '<img alt="hullo">',
      '<img alt={{foo}}>',
@@ -65,6 +67,11 @@ function getVerifyOptions(template, meta) {
      '<img aria-hidden="true">',
      '<img alt="">',
      '<img alt>',
+     {
+       name: 'works with custom config',
+       config: 'customized',
+       template: '<img>',
+     }
    ]
  *
  * @param  {String}   name                - a name to describe which lint rule is being tested
@@ -159,22 +166,21 @@ module.exports = function generateRuleTests({
       return Object.assign({}, defaults, result);
     }
 
-    bad.forEach(function(badItem) {
-      let template = badItem.template;
+    bad.forEach(item => {
+      let template = item.template;
 
-      let shouldFocus = badItem.focus === true && typeof focusMethod === 'function';
+      let shouldFocus = item.focus === true && typeof focusMethod === 'function';
       let testOrOnly = shouldFocus ? focusMethod : testMethod;
+      let testName = item.name ? item.name : template;
 
-      testOrOnly(`logs a message in the console when given \`${template}\``, function() {
-        let expectedResults = badItem.results || [badItem.result];
-
-        let options = prepare(badItem, badItem.config);
+      testOrOnly(`${testName}: logs errors`, function() {
+        let options = prepare(item, item.config);
         let actual = linter.verify(options);
 
-        if (badItem.fatal) {
+        if (item.fatal) {
           assert.strictEqual(actual.length, 1); // can't have more than one fatal error
           delete actual[0].source; // remove the source (stack trace is not easy to assert)
-          assert.deepStrictEqual(actual[0], badItem.fatal);
+          assert.deepStrictEqual(actual[0], item.fatal);
         } else {
           expectedResults = expectedResults.map(parseResult);
 
@@ -183,16 +189,16 @@ module.exports = function generateRuleTests({
       });
 
       if (!skipDisabledTests) {
-        testOrOnly(`passes with \`${template}\` when rule is disabled`, function() {
+        testOrOnly(`${testName}: passes when rule is disabled`, function() {
           let config = false;
-          let options = prepare(badItem, config);
+          let options = prepare(item, config);
           let actual = linter.verify(options);
 
           assert.deepStrictEqual(actual, []);
         });
 
         testOrOnly(
-          `passes with \`${template}\` when disabled via inline comment - single rule`,
+          `${testName}: passes when disabled via inline comment - single rule`,
           function() {
             let options = prepare(`${DISABLE_ONE}\n${template}`);
             let actual = linter.verify(options);
@@ -202,7 +208,7 @@ module.exports = function generateRuleTests({
         );
 
         testOrOnly(
-          `passes with \`${template}\` when disabled via long-form inline comment - single rule`,
+          `${testName}: passes when disabled via long-form inline comment - single rule`,
           function() {
             let options = prepare(`${DISABLE_ONE_LONG}\n${template}`);
             let actual = linter.verify(options);
@@ -211,25 +217,23 @@ module.exports = function generateRuleTests({
           }
         );
 
-        testOrOnly(
-          `passes with \`${template}\` when disabled via inline comment - all rules`,
-          function() {
-            let options = prepare(`${DISABLE_ALL}\n${template}`);
-            let actual = linter.verify(options);
+        testOrOnly(`${testName}: passes when disabled via inline comment - all rules`, function() {
+          let options = prepare(`${DISABLE_ALL}\n${template}`);
+          let actual = linter.verify(options);
 
-            assert.deepStrictEqual(actual, []);
-          }
-        );
+          assert.deepStrictEqual(actual, []);
+        });
       }
     });
 
-    good.forEach(function(goodItem) {
-      let template = typeof goodItem === 'string' ? goodItem : goodItem.template;
-      let shouldFocus = goodItem.focus === true && typeof focusMethod === 'function';
+    good.forEach(_item => {
+      let item = typeof _item === 'string' ? { template: _item } : _item;
+      let shouldFocus = item.focus === true && typeof focusMethod === 'function';
       let testOrOnly = shouldFocus ? focusMethod : testMethod;
+      let testName = item.name ? item.name : item.template;
 
-      testOrOnly(`passes when given \`${template}\``, function() {
-        let options = prepare(goodItem, goodItem.config);
+      testOrOnly(`${testName}: passes`, function() {
+        let options = prepare(item, item.config);
         let actual = linter.verify(options);
 
         assert.deepStrictEqual(actual, []);
@@ -237,13 +241,14 @@ module.exports = function generateRuleTests({
     });
 
     error.forEach(item => {
-      let { config, template } = item;
+      let { name, config, template } = item;
 
       let shouldFocus = item.focus === true && typeof focusMethod === 'function';
       let testOrOnly = shouldFocus ? focusMethod : testMethod;
       let friendlyConfig = JSON.stringify(config);
+      let testName = name ? name : template;
 
-      testOrOnly(`errors when given \`${template}\` with config \`${friendlyConfig}\``, function() {
+      testOrOnly(`${testName}: errors with config \`${friendlyConfig}\``, function() {
         let expectedResults = item.results || [item.result];
         expectedResults = expectedResults.map(parseResult);
 

--- a/test/acceptance/__snapshots__/rule-test.js.snap
+++ b/test/acceptance/__snapshots__/rule-test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rule public api general test harness support no-elements can use verifyResults directly (with external snapshots): logs errors 1`] = `
+Array [
+  Object {
+    "column": 0,
+    "filePath": "layout.hbs",
+    "line": 1,
+    "message": "Do not use any HTML elements!",
+    "moduleId": "layout",
+    "rule": "no-elements",
+    "severity": 2,
+    "source": "<div></div>",
+  },
+]
+`;

--- a/test/acceptance/rule-test.js
+++ b/test/acceptance/rule-test.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const Rule = require('../../lib/rules/base');
+const generateRuleTests = require('../helpers/rule-test-harness');
+
+describe('rule public api', function() {
+  describe('general test harness support', function() {
+    generateRuleTests({
+      plugins: [
+        {
+          name: 'test',
+          rules: {
+            'no-elements': class extends Rule {
+              visitor() {
+                return {
+                  ElementNode(node) {
+                    this.log({
+                      message: 'Do not use any HTML elements!',
+                      line: node.loc && node.loc.start.line,
+                      column: node.loc && node.loc.start.column,
+                      source: this.sourceForNode(node),
+                    });
+                  },
+                };
+              }
+            },
+          },
+        },
+      ],
+
+      name: 'no-elements',
+      config: true,
+
+      good: ['{{haha-wtf}}'],
+
+      bad: [
+        {
+          name: 'uses static result - multiple',
+          template: '<div></div><div></div>',
+          results: [
+            {
+              column: 0,
+              line: 1,
+              message: 'Do not use any HTML elements!',
+              source: '<div></div>',
+            },
+            {
+              column: 11,
+              line: 1,
+              message: 'Do not use any HTML elements!',
+              source: '<div></div>',
+            },
+          ],
+        },
+        {
+          name: 'uses static result - multiple',
+          template: '<div></div>',
+          result: {
+            column: 0,
+            line: 1,
+            message: 'Do not use any HTML elements!',
+            source: '<div></div>',
+          },
+        },
+      ],
+    });
+  });
+});

--- a/test/acceptance/rule-test.js
+++ b/test/acceptance/rule-test.js
@@ -3,6 +3,10 @@
 const Rule = require('../../lib/rules/base');
 const generateRuleTests = require('../helpers/rule-test-harness');
 
+function verifyWithExternalSnapshot(results) {
+  expect(results).toMatchSnapshot();
+}
+
 describe('rule public api', function() {
   describe('general test harness support', function() {
     generateRuleTests({
@@ -61,6 +65,31 @@ describe('rule public api', function() {
             message: 'Do not use any HTML elements!',
             source: '<div></div>',
           },
+        },
+        {
+          name: 'can use verifyResults directly (with inline snapshots)',
+          template: '<div></div>',
+          verifyResults(results) {
+            expect(results).toMatchInlineSnapshot(`
+              Array [
+                Object {
+                  "column": 0,
+                  "filePath": "layout.hbs",
+                  "line": 1,
+                  "message": "Do not use any HTML elements!",
+                  "moduleId": "layout",
+                  "rule": "no-elements",
+                  "severity": 2,
+                  "source": "<div></div>",
+                },
+              ]
+            `);
+          },
+        },
+        {
+          name: 'can use verifyResults directly (with external snapshots)',
+          template: '<div></div>',
+          verifyResults: verifyWithExternalSnapshot,
         },
       ],
     });


### PR DESCRIPTION
* Add a basic acceptance test for the test harness usage.
* Add support for using snapshots (inline or external) to test harness.

By adding a customized `verifyResults` function you can run your own
assertions against the results. This allows users of `jest` to write
something like:

```js
generateRuleTests({
 name: 'whatever',
 config: true,

  bad: [
   {
     name: 'zomg inline snapshots!!!!',
     template: '<Whatever><Here /></Whatever>',
     verifyResults(results) {
       expect(results).toMatchInlineSnapshot();
     }
   }
 ]
});
```

* Add support for naming test cases (making matching tests massively
  simpler, and making it clearer what a given `bad` or `good` scenario
  is actually testing).

For the You can add a `name` property to any of the `good` or `bad` test cases,
and that name will be used for the test prefixing.

Using something like:

```js
generateRuleTests({
 name: 'whatever',
 config: true,

  bad: [
   {
     name: 'some awesome name',
     ...otherFields
   }
 ]
});
```

You can get test output like:

```
✓ some awesome name: logs errors (7ms)
✓ some awesome name: passes when rule is disabled (1ms)
✓ some awesome name: passes when disabled via inline comment - single rule (2ms)
✓ some awesome name: passes when disabled via long-form inline comment - single rule (1ms)
✓ some awesome name: passes when disabled via inline comment - all rules (1ms)
```