### PR TITLE
require-button-type: Implement `fix` mode

### DIFF
--- a/lib/rules/require-button-type.js
+++ b/lib/rules/require-button-type.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { builders: b } = require('ember-template-recast');
+
 const Rule = require('./base');
 
 const ERROR_MESSAGE = 'All `<button>` elements should have a valid `type` attribute';
@@ -11,6 +13,7 @@ module.exports = class RequireButtonType extends Rule {
       line: node.loc && node.loc.start.line,
       column: node.loc && node.loc.start.column,
       source: this.sourceForNode(node),
+      isFixable: true,
     });
   }
 
@@ -25,7 +28,12 @@ module.exports = class RequireButtonType extends Rule {
 
         let typeAttribute = attributes.find(it => it.name === 'type');
         if (!typeAttribute) {
-          return this.logNode({ node, message: ERROR_MESSAGE });
+          if (this.mode === 'fix') {
+            attributes.push(b.attr('type', b.text('button')));
+          } else {
+            this.logNode({ node, message: ERROR_MESSAGE });
+          }
+          return;
         }
 
         let { value } = typeAttribute;
@@ -35,7 +43,12 @@ module.exports = class RequireButtonType extends Rule {
 
         let { chars } = value;
         if (!['button', 'submit', 'reset'].includes(chars)) {
-          return this.logNode({ node, message: ERROR_MESSAGE });
+          if (this.mode === 'fix') {
+            let index = attributes.indexOf(typeAttribute);
+            attributes[index] = b.attr('type', b.text('button'));
+          } else {
+            this.logNode({ node, message: ERROR_MESSAGE });
+          }
         }
       },
     };

--- a/test/unit/rules/require-button-type-test.js
+++ b/test/unit/rules/require-button-type-test.js
@@ -27,52 +27,62 @@ generateRuleTests({
   bad: [
     {
       template: '<button/>',
+      fixedTemplate: '<button type="button" />',
 
       result: {
         message: ERROR_MESSAGE,
         source: '<button/>',
         line: 1,
         column: 0,
+        isFixable: true,
       },
     },
     {
       template: '<button>label</button>',
+      fixedTemplate: '<button type="button">label</button>',
 
       result: {
         message: ERROR_MESSAGE,
         source: '<button>label</button>',
         line: 1,
         column: 0,
+        isFixable: true,
       },
     },
     {
       template: '<button type="" />',
+      fixedTemplate: '<button type="button" />',
 
       result: {
         message: ERROR_MESSAGE,
         source: '<button type="" />',
         line: 1,
         column: 0,
+        isFixable: true,
       },
     },
     {
       template: '<button type="foo" />',
+      fixedTemplate: '<button type="button" />',
 
       result: {
         message: ERROR_MESSAGE,
         source: '<button type="foo" />',
         line: 1,
         column: 0,
+        isFixable: true,
       },
     },
     {
       template: '<button type=42 />',
+      fixedTemplate: '<button type="button" />',
 
       result: {
         message: ERROR_MESSAGE,
         source: '<button type=42 />',
         line: 1,
         column: 0,
+        isFixable: true,
       },
     },
   ],


### PR DESCRIPTION
This PR implements the `--fix` mode for the `require-button-type` rule, based on the implementation in https://github.com/ember-template-lint/ember-template-lint/pull/1158