### PR TITLE
inline-link-to: Implement `fix` mode

### DIFF
--- a/lib/rules/inline-link-to.js
+++ b/lib/rules/inline-link-to.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { builders: b } = require('ember-template-recast');
+
 const Rule = require('./base');
 
 const message = 'The inline form of link-to is not allowed. Use the block form instead.';
@@ -7,14 +9,35 @@ const message = 'The inline form of link-to is not allowed. Use the block form i
 module.exports = class InlineLinkTo extends Rule {
   visitor() {
     return {
-      MustacheStatement(node) {
+      MustacheStatement(node, { parentNode, parentKey }) {
         if (node.path.original === 'link-to') {
-          this.log({
-            message,
-            line: node.loc && node.loc.start.line,
-            column: node.loc && node.loc.start.column,
-            source: this.sourceForNode(node),
-          });
+          let titleNode = node.params[0];
+          let isFixable = titleNode.type === 'SubExpression' || titleNode.type === 'StringLiteral';
+
+          if (this.mode === 'fix' && isFixable) {
+            let newBody;
+            if (titleNode.type === 'SubExpression') {
+              newBody = b.mustache(titleNode.path, titleNode.params, titleNode.hash);
+            } else if (titleNode.type === 'StringLiteral') {
+              newBody = b.text(titleNode.value);
+            }
+
+            let index = parentNode[parentKey].indexOf(node);
+            parentNode[parentKey][index] = b.block(
+              node.path,
+              node.params.slice(1),
+              node.hash,
+              b.blockItself([newBody])
+            );
+          } else {
+            this.log({
+              message,
+              line: node.loc && node.loc.start.line,
+              column: node.loc && node.loc.start.column,
+              source: this.sourceForNode(node),
+              isFixable,
+            });
+          }
         }
       },
     };

--- a/test/unit/rules/inline-link-to-test.js
+++ b/test/unit/rules/inline-link-to-test.js
@@ -16,22 +16,49 @@ generateRuleTests({
   bad: [
     {
       template: "{{link-to 'Link text' 'routeName'}}",
+      fixedTemplate: "{{#link-to 'routeName' }}Link text{{/link-to}}",
 
       result: {
         message,
         source: "{{link-to 'Link text' 'routeName'}}",
         line: 1,
         column: 0,
+        isFixable: true,
       },
     },
     {
       template: "{{link-to 'Link text' 'routeName' one two}}",
+      fixedTemplate: "{{#link-to 'routeName' one two }}Link text{{/link-to}}",
 
       result: {
         message,
         source: "{{link-to 'Link text' 'routeName' one two}}",
         line: 1,
         column: 0,
+        isFixable: true,
+      },
+    },
+    {
+      template: "{{link-to (concat 'Hello' @username) 'routeName' one two}}",
+      fixedTemplate: "{{#link-to 'routeName' one two }}{{concat 'Hello' @username }}{{/link-to}}",
+
+      result: {
+        message,
+        source: "{{link-to (concat 'Hello' @username) 'routeName' one two}}",
+        line: 1,
+        column: 0,
+        isFixable: true,
+      },
+    },
+    {
+      template: "{{link-to 1234 'routeName' one two}}",
+
+      result: {
+        message,
+        source: "{{link-to 1234 'routeName' one two}}",
+        line: 1,
+        column: 0,
+        isFixable: false,
       },
     },
   ],


### PR DESCRIPTION
This PR implements the `--fix` mode for the `inline-link-to` rule, based on the implementation in #1158