### PR TITLE
Ensure the exported class name matches the rule name

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -106,6 +106,12 @@ module.exports = {
       },
     },
     {
+      files: ['lib/rules/**/*.js'],
+      rules: {
+        'filenames/match-exported': ['error', 'kebab'],
+      }
+    },
+    {
       files: ['test/**/*.js'],
       env: {
         jest: true,

--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -108,7 +108,7 @@ function reason(node) {
   return null;
 }
 
-module.exports = function isInteractive(node) {
+module.exports = function isInteractiveElement(node) {
   return reason(node) !== null;
 };
 

--- a/lib/rules/attribute-indentation.js
+++ b/lib/rules/attribute-indentation.js
@@ -37,7 +37,7 @@ function canApplyRule(node, type, config) {
   return true;
 }
 
-module.exports = class AttributeSpacing extends Rule {
+module.exports = class AttributeIndentation extends Rule {
   getLineIndentation(node) {
     let currentLine = this.source[node.loc.start.line - 1];
     let leadingWhitespace = getWhiteSpaceLength(currentLine);

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -36,7 +36,7 @@ function unquote(str) {
   return str;
 }
 
-module.exports = class BaseRule {
+module.exports = class Base {
   constructor(options) {
     this.ruleName = options.name;
     this._console = options.console || console;

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -26,7 +26,7 @@ const matchMap = {
   crlf: '\r\n',
 };
 
-module.exports = class LineBreakStyle extends Rule {
+module.exports = class LinebreakStyle extends Rule {
   constructor(options) {
     super(options);
     const configuredIndent = this.editorConfig['end_of_line'];

--- a/lib/rules/no-args-paths.js
+++ b/lib/rules/no-args-paths.js
@@ -2,7 +2,7 @@
 
 const Rule = require('./base');
 
-module.exports = class LintNoArgsPaths extends Rule {
+module.exports = class NoArgsPaths extends Rule {
   visitor() {
     const isLocal = this.isLocal.bind(this);
     const sourceForNode = this.sourceForNode.bind(this);

--- a/lib/rules/no-attrs-in-components.js
+++ b/lib/rules/no-attrs-in-components.js
@@ -6,7 +6,7 @@ const componentTemplateRegex = new RegExp(
   'templates/components|components/.*/template|ui/components|-components/'
 );
 
-module.exports = class LinkNoAttrComponent extends Rule {
+module.exports = class NoAttrsInComponents extends Rule {
   isComponentTemplate() {
     return componentTemplateRegex.test(this._moduleName);
   }

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -138,7 +138,7 @@ function sanitizeConfigArray(whitelist = []) {
   return whitelist.filter(option => option !== '').sort((a, b) => b.length - a.length);
 }
 
-module.exports = class LogStaticStrings extends Rule {
+module.exports = class NoBareStrings extends Rule {
   constructor(options) {
     super(options);
     this._elementStack = [];

--- a/lib/rules/no-duplicate-attributes.js
+++ b/lib/rules/no-duplicate-attributes.js
@@ -23,7 +23,7 @@ function logDuplicateAttributes(node, attributes, identifier, type) {
   });
 }
 
-module.exports = class DuplicateAttributes extends Rule {
+module.exports = class NoDuplicateAttributes extends Rule {
   visitor() {
     return {
       ElementNode(node) {

--- a/lib/rules/no-extra-mut-helper-argument.js
+++ b/lib/rules/no-extra-mut-helper-argument.js
@@ -5,7 +5,7 @@ const Rule = require('./base');
 const ERROR_MESSAGE =
   'The handlebars `mut(attr)` helper should only have one argument passed to it. To pass a value, use: `(action (mut attr) value)`.';
 
-module.exports = class MutSingleArg extends Rule {
+module.exports = class NoExtraMutHelperArgument extends Rule {
   visitor() {
     return {
       SubExpression(node) {

--- a/lib/rules/no-html-comments.js
+++ b/lib/rules/no-html-comments.js
@@ -4,7 +4,7 @@ const AstNodeInfo = require('../helpers/ast-node-info');
 const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
 
-module.exports = class LogHtmlComments extends Rule {
+module.exports = class NoHtmlComments extends Rule {
   parseConfig(config) {
     let configType = typeof config;
 

--- a/lib/rules/no-implicit-this.js
+++ b/lib/rules/no-implicit-this.js
@@ -40,7 +40,7 @@ const ARGLESS_BUILTINS = [
 // arg'less Components / Helpers in default ember-cli blueprint
 const ARGLESS_DEFAULT_BLUEPRINT = ['welcome-page'];
 
-module.exports = class StrictPaths extends Rule {
+module.exports = class NoImplicitThis extends Rule {
   parseConfig(config) {
     if (config === false || config === undefined) {
       return false;

--- a/lib/rules/no-index-component-invocation.js
+++ b/lib/rules/no-index-component-invocation.js
@@ -2,7 +2,7 @@
 
 const Rule = require('./base');
 
-module.exports = class LintNoIndexComponentInvocation extends Rule {
+module.exports = class NoIndexComponentInvocation extends Rule {
   visitor() {
     const log = (invocation, replacement, node) => {
       return this.log({

--- a/lib/rules/no-inline-styles.js
+++ b/lib/rules/no-inline-styles.js
@@ -22,7 +22,7 @@ const createErrorMessage = require('../helpers/create-error-message');
 
 const DEFAULT_CONFIG = { allowDynamicStyles: true };
 
-module.exports = class InlineStyles extends Rule {
+module.exports = class NoInlineStyles extends Rule {
   parseConfig(config) {
     let configType = typeof config;
 

--- a/lib/rules/no-invalid-interactive.js
+++ b/lib/rules/no-invalid-interactive.js
@@ -28,7 +28,7 @@ function isDisallowedDomEvent(name) {
   return nameLower.startsWith('on') && DISALLOWED_DOM_EVENTS.includes(name.substring(2));
 }
 
-module.exports = class InvalidInteractive extends Rule {
+module.exports = class NoInvalidInteractive extends Rule {
   parseConfig(config) {
     return parseConfig(this.ruleName, config);
   }

--- a/lib/rules/no-nested-interactive.js
+++ b/lib/rules/no-nested-interactive.js
@@ -20,7 +20,7 @@ const Rule = require('./base');
 const isInteractiveElement = require('../helpers/is-interactive-element');
 const parseConfig = require('../helpers/parse-interactive-element-config');
 
-module.exports = class LogNestedInteractive extends Rule {
+module.exports = class NoNestedInteractive extends Rule {
   parseConfig(config) {
     return parseConfig(this.ruleName, config);
   }

--- a/lib/rules/no-triple-curlies.js
+++ b/lib/rules/no-triple-curlies.js
@@ -3,7 +3,7 @@
 const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
 
-module.exports = class LogTripleCurlies extends Rule {
+module.exports = class NoTripleCurlies extends Rule {
   parseConfig(config) {
     let configType = typeof config;
 

--- a/lib/rules/no-unused-block-params.js
+++ b/lib/rules/no-unused-block-params.js
@@ -42,7 +42,7 @@
 
 const Rule = require('./base');
 
-module.exports = class UnusedBlockParams extends Rule {
+module.exports = class NoUnusedBlockParams extends Rule {
   visitor() {
     return {
       Block: {

--- a/lib/rules/no-yield-only.js
+++ b/lib/rules/no-yield-only.js
@@ -4,7 +4,7 @@ const Rule = require('./base');
 
 const ERROR_MESSAGE = '{{yield}}-only templates are not allowed';
 
-module.exports = class NoMultipleEmptyLines extends Rule {
+module.exports = class NoYieldOnly extends Rule {
   visitor() {
     if (this._rawSource.trim() !== '{{yield}}') {
       return;

--- a/lib/rules/require-iframe-title.js
+++ b/lib/rules/require-iframe-title.js
@@ -6,7 +6,7 @@ const Rule = require('./base');
 const errorMessage = '<iframe> elements must have a unique title property.';
 
 // iframes have to have titles for "Name,  Role, Value" - https://www.w3.org/TR/UNDERSTANDING-WCAG20/ensure-compat-rsv.html
-module.exports = class IframeHasTitle extends Rule {
+module.exports = class RequireIframeTitle extends Rule {
   logNode({ message, node }) {
     this.log({
       message,

--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -12,7 +12,7 @@ const REDUNDANT_WORDS = ['image', 'photo', 'picture', 'logo', 'spacer'];
 const ERROR_MESSAGE =
   'Invalid alt attribute. Words such as `image`, `photo,` or `picture` are already announced by screen readers.';
 
-module.exports = class A11yLintAltText extends Rule {
+module.exports = class RequireValidAltText extends Rule {
   logNode({ node, message }) {
     return this.log({
       message,

--- a/lib/rules/self-closing-void-elements.js
+++ b/lib/rules/self-closing-void-elements.js
@@ -42,7 +42,7 @@ const VOID_TAGS = {
   wbr: true,
 };
 
-module.exports = class LogSelfClosingVoidElements extends Rule {
+module.exports = class SelfClosingVoidElements extends Rule {
   parseConfig(config) {
     let configType = typeof config;
 

--- a/lib/rules/simple-unless.js
+++ b/lib/rules/simple-unless.js
@@ -33,7 +33,7 @@ function isValidConfigObjectFormat(config) {
   return true;
 }
 
-module.exports = class LintSimpleUnless extends Rule {
+module.exports = class SimpleUnless extends Rule {
   parseConfig(config) {
     let configType = typeof config;
 

--- a/lib/rules/style-concatenation.js
+++ b/lib/rules/style-concatenation.js
@@ -5,7 +5,7 @@ const Rule = require('./base');
 
 const ERROR_MESSAGE = 'Concatenated styles must be marked as `htmlSafe`.';
 
-module.exports = class StyleConcat extends Rule {
+module.exports = class StyleConcatenation extends Rule {
   visitor() {
     return {
       ElementNode(node) {

--- a/lib/rules/template-length.js
+++ b/lib/rules/template-length.js
@@ -38,7 +38,7 @@ function isValidConfigObjectFormat(config) {
   return true;
 }
 
-module.exports = class LengthValidation extends Rule {
+module.exports = class TemplateLength extends Rule {
   parseConfig(config) {
     let configType = typeof config;
 


### PR DESCRIPTION
Fixes lots of incorrect/outdated class names.

Enforces this using the [filenames/match-exported](https://github.com/selaux/eslint-plugin-filenames#matching-exported-values-match-exported) lint rule.