### PR TITLE
.template-lintrc.js: Resolve ember-template-lint-plugin-* packages

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -52,7 +52,7 @@ Sample plugin object:
 
 In order to enable a plugin, you must add it to the `plugins` key in your configuration file.
 
-`plugins` accepts an array of either plugin objects or strings to be passed to `require` which resolve to plugin objects.
+`plugins` accepts an array of either plugin objects or strings to be passed to `require` which resolve to plugin objects. The string can either be a module name to resolve to or if it follows `ember-template-lint-plugin-*` pattern, the suffix.
 
 ```javascript
 // .template-lintrc.js
@@ -70,6 +70,7 @@ module.exports = {
     // Define a plugin that is exported elsewhere (i.e. a third-party plugin)
     './plugins/some-local-plugin',
     'some-npm-package/third-party-plugin',
+    'foo', // where npm package is ember-template-lint-plugin-foo
   ],
 
   extends: [

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -29,14 +29,26 @@ function requirePlugin(pluginName, fromConfigPath) {
     return resolve.sync(name, { basedir });
   }
 
+  // attemps to find the plugin by its name
   try {
-    // throws exception if not found
     pluginPath = getPluginPath(pluginName);
-  } catch (error) {
+  } catch (e) {
+    let isModuleMissingError = ALLOWED_ERROR_CODES.includes(e.code);
+    if (!isModuleMissingError) {
+      throw e;
+    }
+
+    // attemps to find the plugin its name prefixed with `ember-template-lint-plugin`
+    // throws exception if not found
     try {
       pluginPath = getPluginPath(`ember-template-lint-plugin-${pluginName}`);
-    } catch (_) {
-      throw error;
+    } catch (e) {
+      let isModuleMissingError = ALLOWED_ERROR_CODES.includes(e.code);
+      if (!isModuleMissingError) {
+        throw e;
+      }
+
+      throw new Error(`The plugin (${pluginName}) could not be found. Aborting.`);
     }
   }
 

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -22,10 +22,23 @@ const ALLOWED_ERROR_CODES = [
 ];
 
 function requirePlugin(pluginName, fromConfigPath) {
-  let basedir = fromConfigPath === undefined ? process.cwd() : path.dirname(fromConfigPath);
+  let pluginPath;
 
-  // throws exception if not found
-  let pluginPath = resolve.sync(pluginName, { basedir });
+  function getPluginPath(name) {
+    let basedir = fromConfigPath === undefined ? process.cwd() : path.dirname(fromConfigPath);
+    return resolve.sync(name, { basedir });
+  }
+
+  try {
+    // throws exception if not found
+    pluginPath = getPluginPath(pluginName);
+  } catch (error) {
+    try {
+      pluginPath = getPluginPath(`ember-template-lint-plugin-${pluginName}`);
+    } catch (_) {
+      throw error;
+    }
+  }
 
   return require(pluginPath); // eslint-disable-line import/no-dynamic-require
 }

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -261,6 +261,56 @@ describe('get-config', function() {
     expect(actual.rules['quotes']).toBe('single');
   });
 
+  it('favors foo plugin over ember-template-lint-plugin-foo', function() {
+    let console = buildFakeConsole();
+
+    project.setConfig({
+      extends: ['my-awesome-thing:stylistic'],
+      plugins: ['my-awesome-thing'],
+    });
+
+    project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
+      dep.files['index.js'] = stripIndent`
+        module.exports = {
+          name: 'my-awesome-thing',
+
+          configurations: {
+            stylistic: {
+              rules: {
+                quotes: 'double',
+              }
+            }
+          }
+        };
+      `;
+    });
+
+    project.addDevDependency('ember-template-lint-plugin-my-awesome-thing', '0.0.0', dep => {
+      dep.files['index.js'] = stripIndent`
+        module.exports = {
+          name: 'my-awesome-thing',
+
+          configurations: {
+            stylistic: {
+              rules: {
+                quotes: 'single',
+              }
+            }
+          }
+        };
+      `;
+    });
+
+    project.chdir();
+
+    let actual = getProjectConfig({
+      console,
+    });
+
+    expect(console.stdout).toEqual('');
+    expect(actual.rules['quotes']).toBe('double');
+  });
+
   it('extending multiple configurations allows subsequent configs to override earlier ones', function() {
     let actual = getProjectConfig({
       config: {

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -311,6 +311,18 @@ describe('get-config', function() {
     expect(actual.rules['quotes']).toBe('double');
   });
 
+  it('throws exception when neither foo nor ember-template-lint-plugin-foo is found', function() {
+    let nonExistentPlugin = 'foo';
+
+    expect(function() {
+      getProjectConfig({
+        config: {
+          plugins: [nonExistentPlugin],
+        },
+      });
+    }).toThrow();
+  });
+
   it('extending multiple configurations allows subsequent configs to override earlier ones', function() {
     let actual = getProjectConfig({
       config: {

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -227,6 +227,40 @@ describe('get-config', function() {
     expect(actual.rules['quotes']).toBe('single');
   });
 
+  it('resolves plugins by string, adding ember-template-lint-plugin prefix', function() {
+    let console = buildFakeConsole();
+
+    project.setConfig({
+      extends: ['my-awesome-thing:stylistic'],
+      plugins: ['my-awesome-thing'],
+    });
+
+    project.addDevDependency('ember-template-lint-plugin-my-awesome-thing', '0.0.0', dep => {
+      dep.files['index.js'] = stripIndent`
+        module.exports = {
+          name: 'my-awesome-thing',
+
+          configurations: {
+            stylistic: {
+              rules: {
+                quotes: 'single',
+              }
+            }
+          }
+        };
+      `;
+    });
+
+    project.chdir();
+
+    let actual = getProjectConfig({
+      console,
+    });
+
+    expect(console.stdout).toEqual('');
+    expect(actual.rules['quotes']).toBe('single');
+  });
+
   it('extending multiple configurations allows subsequent configs to override earlier ones', function() {
     let actual = getProjectConfig({
       config: {


### PR DESCRIPTION
A plugin / package named `ember-template-lint-plugin-mypackage` could be used with the following config:

`.template-lintrc.js`:
```js
{
  plugins: 'mypackage',
  extends: ['mypackage:recommended']
}
```

For now, it is only possible to load it with:
```js
{
  plugins: 'ember-template-lint-plugin-mypackage',
  extends: ['ember-template-lint-plugin-mypackage:recommended']
}
```

If the idea sounds good, I will update the file `docs/plugins.md`.