### PR TITLE
Ensure resolvable plugins work when the config is not resolved.

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -22,8 +22,10 @@ const ALLOWED_ERROR_CODES = [
 ];
 
 function requirePlugin(pluginName, fromConfigPath) {
+  let basedir = fromConfigPath === undefined ? process.cwd() : path.dirname(fromConfigPath);
+
   // throws exception if not found
-  let pluginPath = resolve.sync(pluginName, { basedir: path.dirname(fromConfigPath) });
+  let pluginPath = resolve.sync(pluginName, { basedir });
 
   return require(pluginPath); // eslint-disable-line import/no-dynamic-require
 }

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -192,6 +192,41 @@ describe('get-config', function() {
     expect(actual.rules['quotes']).toBe('single');
   });
 
+  it('resolves plugins by string when using specified config (not resolved project config)', function() {
+    let console = buildFakeConsole();
+
+    project.setConfig();
+
+    project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
+      dep.files['index.js'] = stripIndent`
+        module.exports = {
+          name: 'my-awesome-thing',
+
+          configurations: {
+            stylistic: {
+              rules: {
+                quotes: 'single',
+              }
+            }
+          }
+        };
+      `;
+    });
+
+    project.chdir();
+
+    let actual = getProjectConfig({
+      console,
+      config: {
+        extends: ['my-awesome-thing:stylistic'],
+        plugins: ['my-awesome-thing'],
+      },
+    });
+
+    expect(console.stdout).toEqual('');
+    expect(actual.rules['quotes']).toBe('single');
+  });
+
   it('extending multiple configurations allows subsequent configs to override earlier ones', function() {
     let actual = getProjectConfig({
       config: {


### PR DESCRIPTION
When creating the linter with specific config (aka **not** allowing the linter to resolve its own config), we would throw an error when attempting to resolve any specified plugins by string.