### PR TITLE
Ensure BOM is preserved when using `--fix`.

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,6 +1,5 @@
 const { parse, transform } = require('ember-template-recast');
 const { getProjectConfig, getConfigForFile } = require('./get-config');
-const stripBom = require('strip-bom');
 const EditorConfigResolver = require('./get-editor-config');
 let path = require('path');
 
@@ -200,9 +199,12 @@ class Linter {
    * @returns {string} result.output - The fixed source.
    */
   verifyAndFix(options) {
-    const originalSource = stripBom(options.source);
+    const originalSource = options.source;
 
-    let currentSource = originalSource;
+    let hasBOM = originalSource.charCodeAt(0) === 0xfeff;
+    let byteOrderMarkPrefix = hasBOM ? '\uFEFF' : '';
+
+    let currentSource = hasBOM ? originalSource.slice(1) : originalSource;
     let shouldVerify = true;
     let iterations = 0;
     let messages = [];
@@ -226,7 +228,7 @@ class Linter {
 
     return {
       isFixed: currentSource !== originalSource,
-      output: currentSource,
+      output: hasBOM ? byteOrderMarkPrefix + currentSource : currentSource,
       messages,
     };
   }
@@ -288,7 +290,8 @@ class Linter {
       return results;
     }
 
-    let source = stripBom(options.source);
+    let hasBOM = options.source.charCodeAt(0) === 0xfeff;
+    let source = hasBOM ? options.source.slice(1) : options.source;
 
     let templateAST;
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
     "find-up": "^4.1.0",
     "globby": "^11.0.0",
     "micromatch": "^4.0.2",
-    "resolve": "^1.15.1",
-    "strip-bom": "^4.0.0"
+    "resolve": "^1.15.1"
   },
   "devDependencies": {
     "common-tags": "^1.8.0",


### PR DESCRIPTION
From Wikipedia:

> The Unicode Standard permits the BOM in UTF-8, but does not require nor recommend its use. Byte order has no meaning in UTF-8.

[byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark#UTF-8) (BOM)


