### PR TITLE
Refactor printers.

### DIFF
--- a/lib/helpers/process-results.js
+++ b/lib/helpers/process-results.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const Linter = require('../linter');
+
+/**
+  Expects a single argument which is expected to be in the format of `Message[]` (the result of
+ `this.log` from within a rule). Emits the following interface:
+
+  interface Message {
+    rule: string;
+    severity: 0 | 1 | 2;
+    filePath?: string;
+    moduleId?: string;
+    message: string;
+    line: number;
+    column: number;
+    source: string;
+    isFixable?: boolean;
+  }
+
+  interface FileResult {
+    filePath: string;
+    messages: Message[];
+    errorCount: number;
+    warningCount: number;
+    fixableErrorCount: number;
+    fixableWarningCount: number;
+  }
+
+  interface TemplateLintResult {
+    files: {
+      [filePath: string]: FileResult;
+    }
+
+    errorCount: number;
+    warningCount: number;
+    fixableErrorCount: number;
+    fixableWarningCount: number;
+  }
+ */
+module.exports = function(messages) {
+  let errorCount = 0;
+  let fixableErrorCount = 0;
+  let warningCount = 0;
+  let fixableWarningCount = 0;
+  let files = {};
+
+  for (let item of messages) {
+    let filePath = item.filePath || item.moduleId;
+    let fileResults = files[filePath];
+    if (fileResults === undefined) {
+      fileResults = {
+        filePath,
+        messages: [],
+        errorCount: 0,
+        warningCount: 0,
+        fixableErrorCount: 0,
+        fixableWarningCount: 0,
+      };
+    }
+
+    fileResults.messages.push(item);
+
+    switch (item.severity) {
+      case Linter.IGNORE_SEVERITY:
+        continue;
+      case Linter.ERROR_SEVERITY:
+        errorCount++;
+        fileResults.errorCount++;
+        if (item.isFixable) {
+          fixableErrorCount++;
+          fileResults.fixableErrorCount++;
+        }
+        break;
+      case Linter.WARNING_SEVERITY:
+        warningCount++;
+        fileResults.warningCount++;
+        if (item.isFixable) {
+          fixableWarningCount++;
+          fileResults.fixableWarningCount++;
+        }
+        break;
+    }
+
+    files[filePath] = fileResults;
+  }
+
+  let output = {
+    files,
+    errorCount,
+    warningCount,
+    fixableErrorCount,
+    fixableWarningCount,
+  };
+
+  return output;
+};

--- a/lib/printers/default.js
+++ b/lib/printers/default.js
@@ -18,9 +18,9 @@ class DefaultPrinter {
     }
   }
 
-  print(errors) {
+  print(results) {
     for (let delegate of this.delegates) {
-      delegate.print(errors);
+      delegate.print(results);
     }
   }
 }

--- a/lib/printers/github-actions.js
+++ b/lib/printers/github-actions.js
@@ -5,11 +5,11 @@ class GitHubActionsPrinter {
     this.console = options.console || console;
   }
 
-  print(errors) {
-    let files = Object.keys(errors);
+  print(results) {
+    let files = Object.keys(results.files);
     for (let file of files) {
-      let fileErrors = errors[file];
-      for (let error of fileErrors) {
+      let fileResults = results.files[file];
+      for (let error of fileResults.messages) {
         if (
           error.severity === Linter.ERROR_SEVERITY ||
           error.severity === Linter.WARNING_SEVERITY

--- a/lib/printers/json.js
+++ b/lib/printers/json.js
@@ -6,10 +6,10 @@ class JsonPrinter {
     this.console = options.console || console;
   }
 
-  print(errors) {
+  print(results) {
     let filteredErrors = {};
-    for (let filePath of Object.keys(errors)) {
-      let fileErrors = errors[filePath] || [];
+    for (let filePath of Object.keys(results.files)) {
+      let fileErrors = results.files[filePath].messages;
 
       let errorsFiltered = fileErrors.filter(error => error.severity === Linter.ERROR_SEVERITY);
       let warnings = this.options.quiet

--- a/lib/printers/pretty.js
+++ b/lib/printers/pretty.js
@@ -7,47 +7,34 @@ class PrettyPrinter {
     this.console = options.console || console;
   }
 
-  print(errors) {
-    let errorCount = 0;
-    let fixableErrorCount = 0;
-    let warningCount = 0;
-    let fixableWarningCount = 0;
+  print(results) {
+    for (const filePath of Object.keys(results.files)) {
+      let fileResults = results.files[filePath];
+      let messages = this.options.quiet
+        ? fileResults.messages.filter(r => r.severity !== Linter.WARNING_SEVERITY)
+        : fileResults.messages;
 
-    for (const filePath of Object.keys(errors)) {
-      let fileErrors = errors[filePath] || [];
-
-      let errorsFiltered = fileErrors.filter(error => error.severity === Linter.ERROR_SEVERITY);
-      let warnings = this.options.quiet
-        ? []
-        : fileErrors.filter(error => error.severity === Linter.WARNING_SEVERITY);
-
-      errorCount += errorsFiltered.length;
-      fixableErrorCount = errorsFiltered.filter(r => r.isFixable).length;
-      warningCount += warnings.length;
-      fixableWarningCount = warnings.filter(r => r.isFixable).length;
-
-      let allIssues = errorsFiltered.concat(warnings);
-
-      let messages = PrettyPrinter.errorsToMessages(filePath, allIssues, this.options);
-      if (messages !== '') {
-        this.console.log(messages);
+      let output = PrettyPrinter.errorsToMessages(filePath, messages, this.options);
+      if (output !== '') {
+        this.console.log(output);
       }
     }
 
-    let count = errorCount + warningCount;
+    let warningCount = this.options.quiet ? 0 : results.warningCount;
+    let count = results.errorCount + warningCount;
 
     if (count > 0) {
       this.console.log(
         chalk.red(
-          chalk.bold(`✖ ${count} problems (${errorCount} errors, ${warningCount} warnings)`)
+          chalk.bold(`✖ ${count} problems (${results.errorCount} errors, ${warningCount} warnings)`)
         )
       );
 
-      if (fixableErrorCount > 0 || fixableWarningCount > 0) {
+      if (results.fixableErrorCount > 0 || results.fixableWarningCount > 0) {
         this.console.log(
           chalk.red(
             chalk.bold(
-              `  ${fixableErrorCount} errors and ${fixableWarningCount} warnings potentially fixable with the \`--fix\` option.`
+              `  ${results.fixableErrorCount} errors and ${results.fixableWarningCount} warnings potentially fixable with the \`--fix\` option.`
             )
           )
         );

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -175,7 +175,7 @@ describe('ember-template-lint executable', function() {
 
         expect(result.exitCode).toEqual(1);
         expect(result.stdout.split('\n')).toEqual([
-          project.path('app/templates/application.hbs'),
+          'app/templates/application.hbs',
           '  1:4  error  Non-translated string used  no-bare-strings',
           '  1:25  error  Non-translated string used  no-bare-strings',
           '',
@@ -190,7 +190,7 @@ describe('ember-template-lint executable', function() {
 
         expect(result.exitCode).toEqual(1);
         expect(result.stdout.split('\n')).toEqual([
-          project.path('app/templates/application.hbs'),
+          'app/templates/application.hbs',
           '  1:4  error  Non-translated string used  no-bare-strings',
           '  1:24  error  Non-translated string used  no-bare-strings',
           '  1:53  warning  HTML comment detected  no-html-comments',
@@ -220,7 +220,7 @@ describe('ember-template-lint executable', function() {
         expect(result.exitCode).toEqual(1);
 
         expect(result.stdout.split('\n')).toEqual([
-          project.path('app/components/click-me-button.hbs'),
+          'app/components/click-me-button.hbs',
           '  1:0  error  All `<button>` elements should have a valid `type` attribute  require-button-type',
           '',
           '✖ 1 problems (1 errors, 0 warnings)',
@@ -237,7 +237,7 @@ describe('ember-template-lint executable', function() {
 
         expect(result.exitCode).toEqual(1);
         expect(result.stdout.split('\n')).toEqual([
-          project.path('app/templates/application.hbs'),
+          'app/templates/application.hbs',
           '  1:4  error  Non-translated string used  no-bare-strings',
           '  1:24  error  Non-translated string used  no-bare-strings',
           '',
@@ -279,9 +279,8 @@ describe('ember-template-lint executable', function() {
         setProjectConfigForErrors();
         let result = run(['.', '--json']);
 
-        let fullTemplateFilePath = project.path('app/templates/application.hbs');
         let expectedOutputData = {};
-        expectedOutputData[fullTemplateFilePath] = [
+        expectedOutputData['app/templates/application.hbs'] = [
           {
             column: 4,
             line: 1,
@@ -326,9 +325,8 @@ describe('ember-template-lint executable', function() {
 
         let result = run(['.', '--json']);
 
-        let fullTemplateFilePath = project.path('app/components/click-me-button.hbs');
         let expectedOutputData = {};
-        expectedOutputData[fullTemplateFilePath] = [
+        expectedOutputData['app/components/click-me-button.hbs'] = [
           {
             column: 0,
             line: 1,
@@ -353,9 +351,8 @@ describe('ember-template-lint executable', function() {
         setProjectConfigForErrorsAndWarning();
         let result = run(['.', '--json', '--quiet']);
 
-        let fullTemplateFilePath = project.path('app/templates/application.hbs');
         let expectedOutputData = {};
-        expectedOutputData[fullTemplateFilePath] = [
+        expectedOutputData['app/templates/application.hbs'] = [
           {
             column: 4,
             line: 1,
@@ -405,9 +402,8 @@ describe('ember-template-lint executable', function() {
         });
         let result = run(['.', '--json', '--quiet']);
 
-        let fullTemplateFilePath = project.path('app/templates/application.hbs');
         let expectedOutputData = {};
-        expectedOutputData[fullTemplateFilePath] = [];
+        expectedOutputData['app/templates/application.hbs'] = [];
 
         expect(result.exitCode).toEqual(0);
         expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
@@ -440,7 +436,7 @@ describe('ember-template-lint executable', function() {
 
           expect(result.exitCode).toEqual(1);
           expect(result.stdout.split('\n')).toEqual([
-            project.path('template.hbs'),
+            'template.hbs',
             '  1:23  error  Ambiguous element used (`div`)  no-shadowed-elements',
             '',
             '✖ 1 problems (1 errors, 0 warnings)',
@@ -465,7 +461,7 @@ describe('ember-template-lint executable', function() {
 
           expect(result.exitCode).toEqual(1);
           expect(result.stdout.split('\n')).toEqual([
-            project.path('app/templates/application.hbs'),
+            'app/templates/application.hbs',
             '  1:4  error  Non-translated string used  no-bare-strings',
             '  1:39  error  Non-translated string used  no-bare-strings',
             '',
@@ -505,7 +501,6 @@ describe('ember-template-lint executable', function() {
         let expectedOutputData =
           'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings",\n      "no-html-comments"\n    ]\n  }\n]';
 
-        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -537,7 +532,6 @@ describe('ember-template-lint executable', function() {
         let expectedOutputData =
           'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: []';
 
-        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -567,7 +561,6 @@ describe('ember-template-lint executable', function() {
         let expectedOutputData =
           'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings"\n    ]\n  }\n]';
 
-        expect(result.exitCode).toEqual(1);
         expect(result.stdout).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -586,7 +579,6 @@ describe('ember-template-lint executable', function() {
           },
         ];
 
-        expect(result.exitCode).toEqual(1);
         expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
       });
@@ -598,21 +590,19 @@ describe('ember-template-lint executable', function() {
       it('should print GitHub Actions annotations', function() {
         setProjectConfigForErrors();
 
-        let filePath = project.path('app/templates/application.hbs');
-
         let result = run(['.'], {
           env: { GITHUB_ACTIONS: 'true' },
         });
 
         expect(result.exitCode).toEqual(1);
         expect(result.stdout.split('\n')).toEqual([
-          filePath,
+          'app/templates/application.hbs',
           '  1:4  error  Non-translated string used  no-bare-strings',
           '  1:25  error  Non-translated string used  no-bare-strings',
           '',
           '✖ 2 problems (2 errors, 0 warnings)',
-          `::error file=${filePath},line=1,col=4::Non-translated string used`,
-          `::error file=${filePath},line=1,col=25::Non-translated string used`,
+          '::error file=app/templates/application.hbs,line=1,col=4::Non-translated string used',
+          '::error file=app/templates/application.hbs,line=1,col=25::Non-translated string used',
         ]);
         expect(result.stderr).toBeFalsy();
       });
@@ -631,7 +621,7 @@ describe('ember-template-lint executable', function() {
       expect(result.stdout).toBeFalsy();
       expect(result.stderr).toBeFalsy();
 
-      let fileContents = readFileSync(`${project.path()}/require-button-type.hbs`, {
+      let fileContents = readFileSync(project.path('require-button-type.hbs'), {
         encoding: 'utf8',
       });
 


### PR DESCRIPTION
Refactor the argument passed in to each printer into the following interface:

```ts
interface Message {
  rule: string;
  severity: 0 | 1 | 2;
  filePath?: string;
  moduleId?: string;
  message: string;
  line: number;
  column: number;
  source: string;
  isFixable?: boolean;
}

interface FileResult {
  filePath: string;
  messages: Message[];
  errorCount: number;
  warningCount: number;
  fixableErrorCount: number;
  fixableWarningCount: number;
}

interface TemplateLintResult {
  files: {
    [filePath: string]: FileResult;
  }

  errorCount: number;
  warningCount: number;
  fixableErrorCount: number;
  fixableWarningCount: number;
}
```

This simplifies the work the printers need to do, and also makes the logic a bit less "hairy" in the bin script. This also ensures that the relative file path is printed (vs printing the absolute path).