### PR TITLE
Add v2 migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@
 
 ## v2.0.0 (2020-02-22)
 
+See the [migration guide](docs/migration/v2.md) for this release.
+
 #### :boom: Breaking Change
 * [#1067](https://github.com/ember-template-lint/ember-template-lint/pull/1067) Remove deprecated `templateEnvironmentData` rule property ([@bmish](https://github.com/bmish))
 * [#1060](https://github.com/ember-template-lint/ember-template-lint/pull/1060) Add more rules to `stylistic` config ([@bmish](https://github.com/bmish))

--- a/docs/migration/v2.md
+++ b/docs/migration/v2.md
@@ -1,0 +1,63 @@
+# Migrating to v2.0.0
+
+This guide is intended to walk you though the breaking changes in the ember-template-lint [v2.0.0](https://github.com/ember-template-lint/ember-template-lint/releases/tag/v2.0.0) major release (February 2020).
+
+## Node 10+ now required
+
+Support has been dropped for Node 6, 8, 11.
+
+## Recommended configuration changes
+
+Rules have been added to and removed from the [recommended](lib/config/recommended.js) configuration.
+
+### Rule additions
+
+* [link-href-attributes](docs/rules/link-href-attributes.md)
+* [no-abstract-roles](docs/rules/no-abstract-roles.md)
+* [no-args-path](docs/rules/no-args-path.md)
+* [no-extra-mut-helper-argument](docs/rules/no-extra-mut-helper-argument.md)
+* [no-index-component-invocation](docs/rules/no-index-component-invocation.md)
+* [no-invalid-link-text](docs/rules/no-invalid-link-text.md)
+* [no-invalid-meta](docs/rules/no-invalid-meta.md)
+* [no-invalid-role](docs/rules/no-invalid-role.md)
+* [no-negated-condition](docs/rules/no-negated-condition.md)
+* [no-obsolete-elements](docs/rules/no-obsolete-elements.md)
+* [no-positive-tabindex](docs/rules/no-positive-tabindex.md)
+* [no-unnecessary-component-helper](docs/rules/no-unnecessary-component-helper.md)
+* [require-button-type](docs/rules/require-button-type.md)
+* [require-iframe-title](docs/rules/require-iframe-title.md)
+* [require-valid-alt-text](docs/rules/require-valid-alt-text.md)
+
+### Rule removals
+
+Stylistic rules have been moved to a new [stylistic](lib/config/stylistic.js) configuration. You can enable this new configuration to maintain the previous behavior, or alternatively adopt [ember-template-lint-plugin-prettier](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier).
+
+* [block-indentation](docs/rules/block-indentation.md)
+* [linebreak-style](docs/rules/linebreak-style.md)
+* [no-unnecessary-concat](docs/rules/no-unnecessary-concat.md)
+* [quotes](docs/rules/quotes.md)
+* [self-closing-void-elements](docs/rules/self-closing-void-elements.md)
+
+## Changes to rule options
+
+* [block-indentation](docs/rules/block-indentation.md) now reads from `.editorconfig`
+* [linebreak-style](docs/rules/linebreak-style.md) now reads from `.editorconfig`
+* [link-rel-noopener](docs/rules/link-rel-noopener.md) now defaults to `strict`
+* [no-inline-styles](docs/rules/no-inline-styles.md) now defaults to `allowDynamicStyles`
+* [no-nested-interactive](docs/rules/no-nested-interactive.md) has had its deprecated array configuration format removed
+
+## Deprecation removals
+
+### Rule deletions
+
+The following rules have been deleted:
+
+* img-alt-attributes (replaced by [require-valid-alt-text](docs/rules/require-valid-alt-text.md))
+* no-meta-redirect-with-time-limit (replaced by [no-invalid-meta](docs/rules/no-invalid-meta.md))
+* no-trailing-dot-in-path-expression
+
+### Other removals
+
+* HTML comment configuration (`<!-- template-lint no-bare-strings=false -->`) has been removed [#844](https://github.com/ember-template-lint/ember-template-lint/pull/844)
+* The `templateEnvironmentData` internal rule property has been removed [#1067](https://github.com/ember-template-lint/ember-template-lint/pull/1067)
+* Support for using most old rule names has been removed [#1069](https://github.com/ember-template-lint/ember-template-lint/pull/1069)


### PR DESCRIPTION
The goal is to summarize and make it easier to understand the many breaking changes in the v2 release.

Modeled after the [eslint v6 migration guide](https://eslint.org/docs/user-guide/migrating-to-6.0.0).