### PR TITLE
Fix ember-template-lint-plugin-* packages resolution

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -33,19 +33,19 @@ function requirePlugin(pluginName, fromConfigPath) {
     return resolve.sync(name, { basedir });
   }
 
-  // attemps to find the plugin by its name
+  // attemps to find the plugin its name prefixed with `ember-template-lint-plugin`
   try {
-    pluginPath = getPluginPath(pluginName);
+    pluginPath = getPluginPath(`ember-template-lint-plugin-${pluginName}`);
   } catch (e) {
     let isModuleMissingError = ALLOWED_ERROR_CODES.includes(e.code);
     if (!isModuleMissingError) {
       throw e;
     }
 
-    // attemps to find the plugin its name prefixed with `ember-template-lint-plugin`
+    // attemps to find the plugin by its name
     // throws exception if not found
     try {
-      pluginPath = getPluginPath(`ember-template-lint-plugin-${pluginName}`);
+      pluginPath = getPluginPath(pluginName);
     } catch (e) {
       let isModuleMissingError = ALLOWED_ERROR_CODES.includes(e.code);
       if (!isModuleMissingError) {

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -350,7 +350,7 @@ describe('get-config', function() {
       expect(actual.rules['quotes']).toEqual({ config: 'single', severity: 2 });
     });
 
-    it('favors foo plugin over ember-template-lint-plugin-foo', function() {
+    it('favors ember-template-lint-plugin-foo plugin over foo', function() {
       let console = buildFakeConsole();
 
       project.setConfig({
@@ -397,7 +397,7 @@ describe('get-config', function() {
       });
 
       expect(console.stdout).toEqual('');
-      expect(actual.rules['quotes']).toEqual({ config: 'double', severity: 2 });
+      expect(actual.rules['quotes']).toEqual({ config: 'single', severity: 2 });
     });
   });
 

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -238,16 +238,17 @@ describe('get-config', function() {
     expect(console.stdout).toMatch(/Cannot find configuration for extends/);
   });
 
-  it('resolves plugins by string', function() {
-    let console = buildFakeConsole();
+  describe('requirePlugin', function() {
+    it('resolves plugins by string', function() {
+      let console = buildFakeConsole();
 
-    project.setConfig({
-      extends: ['my-awesome-thing:stylistic'],
-      plugins: ['my-awesome-thing'],
-    });
+      project.setConfig({
+        extends: ['my-awesome-thing:stylistic'],
+        plugins: ['my-awesome-thing'],
+      });
 
-    project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
-      dep.files['index.js'] = stripIndent`
+      project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
+        dep.files['index.js'] = stripIndent`
         module.exports = {
           name: 'my-awesome-thing',
 
@@ -260,25 +261,25 @@ describe('get-config', function() {
           }
         };
       `;
+      });
+
+      project.chdir();
+
+      let actual = getProjectConfig({
+        console,
+      });
+
+      expect(console.stdout).toEqual('');
+      expect(actual.rules['quotes']).toEqual({ config: 'single', severity: 2 });
     });
 
-    project.chdir();
+    it('resolves plugins by string when using specified config (not resolved project config)', function() {
+      let console = buildFakeConsole();
 
-    let actual = getProjectConfig({
-      console,
-    });
+      project.setConfig();
 
-    expect(console.stdout).toEqual('');
-    expect(actual.rules['quotes']).toEqual({ config: 'single', severity: 2 });
-  });
-
-  it('resolves plugins by string when using specified config (not resolved project config)', function() {
-    let console = buildFakeConsole();
-
-    project.setConfig();
-
-    project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
-      dep.files['index.js'] = stripIndent`
+      project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
+        dep.files['index.js'] = stripIndent`
         module.exports = {
           name: 'my-awesome-thing',
 
@@ -291,32 +292,32 @@ describe('get-config', function() {
           }
         };
       `;
+      });
+
+      project.chdir();
+
+      let actual = getProjectConfig({
+        console,
+        config: {
+          extends: ['my-awesome-thing:stylistic'],
+          plugins: ['my-awesome-thing'],
+        },
+      });
+
+      expect(console.stdout).toEqual('');
+      expect(actual.rules['quotes']).toEqual({ config: 'single', severity: 2 });
     });
 
-    project.chdir();
+    it('resolves plugins by string, adding ember-template-lint-plugin prefix', function() {
+      let console = buildFakeConsole();
 
-    let actual = getProjectConfig({
-      console,
-      config: {
+      project.setConfig({
         extends: ['my-awesome-thing:stylistic'],
         plugins: ['my-awesome-thing'],
-      },
-    });
+      });
 
-    expect(console.stdout).toEqual('');
-    expect(actual.rules['quotes']).toEqual({ config: 'single', severity: 2 });
-  });
-
-  it('resolves plugins by string, adding ember-template-lint-plugin prefix', function() {
-    let console = buildFakeConsole();
-
-    project.setConfig({
-      extends: ['my-awesome-thing:stylistic'],
-      plugins: ['my-awesome-thing'],
-    });
-
-    project.addDevDependency('ember-template-lint-plugin-my-awesome-thing', '0.0.0', dep => {
-      dep.files['index.js'] = stripIndent`
+      project.addDevDependency('ember-template-lint-plugin-my-awesome-thing', '0.0.0', dep => {
+        dep.files['index.js'] = stripIndent`
         module.exports = {
           name: 'my-awesome-thing',
 
@@ -329,28 +330,28 @@ describe('get-config', function() {
           }
         };
       `;
+      });
+
+      project.chdir();
+
+      let actual = getProjectConfig({
+        console,
+      });
+
+      expect(console.stdout).toEqual('');
+      expect(actual.rules['quotes']).toEqual({ config: 'single', severity: 2 });
     });
 
-    project.chdir();
+    it('favors foo plugin over ember-template-lint-plugin-foo', function() {
+      let console = buildFakeConsole();
 
-    let actual = getProjectConfig({
-      console,
-    });
+      project.setConfig({
+        extends: ['my-awesome-thing:stylistic'],
+        plugins: ['my-awesome-thing'],
+      });
 
-    expect(console.stdout).toEqual('');
-    expect(actual.rules['quotes']).toEqual({ config: 'single', severity: 2 });
-  });
-
-  it('favors foo plugin over ember-template-lint-plugin-foo', function() {
-    let console = buildFakeConsole();
-
-    project.setConfig({
-      extends: ['my-awesome-thing:stylistic'],
-      plugins: ['my-awesome-thing'],
-    });
-
-    project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
-      dep.files['index.js'] = stripIndent`
+      project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
+        dep.files['index.js'] = stripIndent`
         module.exports = {
           name: 'my-awesome-thing',
 
@@ -363,10 +364,10 @@ describe('get-config', function() {
           }
         };
       `;
-    });
+      });
 
-    project.addDevDependency('ember-template-lint-plugin-my-awesome-thing', '0.0.0', dep => {
-      dep.files['index.js'] = stripIndent`
+      project.addDevDependency('ember-template-lint-plugin-my-awesome-thing', '0.0.0', dep => {
+        dep.files['index.js'] = stripIndent`
         module.exports = {
           name: 'my-awesome-thing',
 
@@ -379,16 +380,17 @@ describe('get-config', function() {
           }
         };
       `;
+      });
+
+      project.chdir();
+
+      let actual = getProjectConfig({
+        console,
+      });
+
+      expect(console.stdout).toEqual('');
+      expect(actual.rules['quotes']).toEqual({ config: 'double', severity: 2 });
     });
-
-    project.chdir();
-
-    let actual = getProjectConfig({
-      console,
-    });
-
-    expect(console.stdout).toEqual('');
-    expect(actual.rules['quotes']).toEqual({ config: 'double', severity: 2 });
   });
 
   it('throws exception when neither foo nor ember-template-lint-plugin-foo is found', function() {

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -243,14 +243,14 @@ describe('get-config', function() {
       let console = buildFakeConsole();
 
       project.setConfig({
-        extends: ['my-awesome-thing:stylistic'],
-        plugins: ['my-awesome-thing'],
+        extends: ['foo:stylistic'],
+        plugins: ['foo'],
       });
 
-      project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
+      project.addDevDependency('foo', '0.0.0', dep => {
         dep.files['index.js'] = stripIndent`
         module.exports = {
-          name: 'my-awesome-thing',
+          name: 'foo',
 
           configurations: {
             stylistic: {
@@ -278,10 +278,10 @@ describe('get-config', function() {
 
       project.setConfig();
 
-      project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
+      project.addDevDependency('foo', '0.0.0', dep => {
         dep.files['index.js'] = stripIndent`
         module.exports = {
-          name: 'my-awesome-thing',
+          name: 'foo',
 
           configurations: {
             stylistic: {
@@ -299,8 +299,8 @@ describe('get-config', function() {
       let actual = getProjectConfig({
         console,
         config: {
-          extends: ['my-awesome-thing:stylistic'],
-          plugins: ['my-awesome-thing'],
+          extends: ['foo:stylistic'],
+          plugins: ['foo'],
         },
       });
 
@@ -312,14 +312,14 @@ describe('get-config', function() {
       let console = buildFakeConsole();
 
       project.setConfig({
-        extends: ['my-awesome-thing:stylistic'],
-        plugins: ['my-awesome-thing'],
+        extends: ['foo:stylistic'],
+        plugins: ['foo'],
       });
 
-      project.addDevDependency('ember-template-lint-plugin-my-awesome-thing', '0.0.0', dep => {
+      project.addDevDependency('ember-template-lint-plugin-foo', '0.0.0', dep => {
         dep.files['index.js'] = stripIndent`
         module.exports = {
-          name: 'my-awesome-thing',
+          name: 'foo',
 
           configurations: {
             stylistic: {
@@ -346,14 +346,14 @@ describe('get-config', function() {
       let console = buildFakeConsole();
 
       project.setConfig({
-        extends: ['my-awesome-thing:stylistic'],
-        plugins: ['my-awesome-thing'],
+        extends: ['foo:stylistic'],
+        plugins: ['foo'],
       });
 
-      project.addDevDependency('my-awesome-thing', '0.0.0', dep => {
+      project.addDevDependency('foo', '0.0.0', dep => {
         dep.files['index.js'] = stripIndent`
         module.exports = {
-          name: 'my-awesome-thing',
+          name: 'foo',
 
           configurations: {
             stylistic: {
@@ -366,10 +366,10 @@ describe('get-config', function() {
       `;
       });
 
-      project.addDevDependency('ember-template-lint-plugin-my-awesome-thing', '0.0.0', dep => {
+      project.addDevDependency('ember-template-lint-plugin-foo', '0.0.0', dep => {
         dep.files['index.js'] = stripIndent`
         module.exports = {
-          name: 'my-awesome-thing',
+          name: 'foo',
 
           configurations: {
             stylistic: {

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -316,6 +316,14 @@ describe('get-config', function() {
         plugins: ['foo'],
       });
 
+      project.addDevDependency('foo', '0.0.0', dep => {
+        dep.files['index.js'] = stripIndent`
+        module.exports = {
+          description: 'This is not a template-lint-plugin 🤭'
+        };
+      `;
+      });
+
       project.addDevDependency('ember-template-lint-plugin-foo', '0.0.0', dep => {
         dep.files['index.js'] = stripIndent`
         module.exports = {


### PR DESCRIPTION
## Description

I implemented https://github.com/ember-template-lint/ember-template-lint/pull/1184 to be able to load `ember-template-lint-plugin-foo` with this config:

```js
module.exports = {
  plugins: ['foo'],

  extends: ['recommended', 'foo:recommended']
};
```
instead of
```js
module.exports = {
  plugins: ['ember-template-lint-plugin-foo'],

  extends: ['recommended', 'ember-template-lint-plugin-foo:recommended']
};
```

But with that implementation, if `foo` is a valid module, template-lint will try to load `foo` instead of `ember-template-lint-plugin-foo`.

## Fix

This PR proposes to adjust the first implementation. With this PR, template-lint would first try to load `ember-template-lint-plugin-foo` and then, if the first attempt fails, `foo`.

Note that if `ember-template-lint-plugin-foo` is absent and `foo` is not a template-lint plugin, user would get a warning (I added a test for this scenario).