### PR TITLE
Add `--ignore-pattern` and `--no-ignore-pattern` command line flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Example usage:
 ./node_modules/.bin/ember-template-lint app/templates/application.hbs --print-pending
 
 # specify custom ignore pattern `['**/dist/**', '**/tmp/**', '**/node_modules/**']` by default
-./node_modules/.bin/ember-template-lint /tmp/template.hbs --ignore-pattern "**/foo/**" "**/bar/**"
+./node_modules/.bin/ember-template-lint /tmp/template.hbs --ignore-pattern "**/foo/**" --ignore-pattern "**/bar/**"
 
 # disable ignore pattern entirely
 ./node_modules/.bin/ember-template-lint /tmp/template.hbs --no-ignore-pattern

--- a/README.md
+++ b/README.md
@@ -81,8 +81,11 @@ Example usage:
 # print list of formated rules for use with `pending` in config file
 ./node_modules/.bin/ember-template-lint app/templates/application.hbs --print-pending
 
-# do not ignore `['**/dist/**', '**/tmp/**', '**/node_modules/**']` by default
-./node_modules/.bin/ember-template-lint /tmp/template.hbs --disable-ignore-patterns
+# specify custom ignore pattern `['**/dist/**', '**/tmp/**', '**/node_modules/**']` by default
+./node_modules/.bin/ember-template-lint /tmp/template.hbs --ignore-pattern "**/foo/**" "**/bar/**"
+
+# disable ignore pattern entirely
+./node_modules/.bin/ember-template-lint /tmp/template.hbs --no-ignore-pattern
 ```
 
 ### ESLint

--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Example usage:
 
 # print list of formated rules for use with `pending` in config file
 ./node_modules/.bin/ember-template-lint app/templates/application.hbs --print-pending
+
+# do not ignore `['**/dist/**', '**/tmp/**', '**/node_modules/**']` by default
+./node_modules/.bin/ember-template-lint /tmp/template.hbs --disable-ignore-patterns
 ```
 
 ### ESLint

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -84,6 +84,10 @@ function parseArgv(_argv) {
     .help()
     .version();
 
+  parser.parserConfiguration({
+    'greedy-arrays': false,
+  });
+
   if (_argv.length === 0) {
     parser.showHelp();
     parser.exit(1);

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -29,19 +29,20 @@ describe('ember-template-lint executable', function() {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path    Define a custom config path
+            --config-path              Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --quiet          Ignore warnings and only show errors                [boolean]
-            --filename       Used to indicate the filename to be assumed for contents from
-                             STDIN                                                [string]
-            --fix            Fix any errors that are reported as fixable
+            --quiet                    Ignore warnings and only show errors      [boolean]
+            --filename                 Used to indicate the filename to be assumed for
+                                       contents from STDIN                        [string]
+            --fix                      Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --json           Format output as json
-            --verbose        Output errors with source description               [boolean]
-            --print-pending  Print list of formated rules for use with \`pending\` in config
-                             file                                                [boolean]
-            --help           Show help                                           [boolean]
-            --version        Show version number                                 [boolean]"
+            --json                     Format output as json
+            --verbose                  Output errors with source description     [boolean]
+            --print-pending            Print list of formated rules for use with \`pending\`
+                                       in config file                            [boolean]
+            --disable-ignore-patterns  Disable default ignore patterns           [boolean]
+            --help                     Show help                                 [boolean]
+            --version                  Show version number                       [boolean]"
         `);
       });
     });
@@ -55,19 +56,20 @@ describe('ember-template-lint executable', function() {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path    Define a custom config path
+            --config-path              Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --quiet          Ignore warnings and only show errors                [boolean]
-            --filename       Used to indicate the filename to be assumed for contents from
-                             STDIN                                                [string]
-            --fix            Fix any errors that are reported as fixable
+            --quiet                    Ignore warnings and only show errors      [boolean]
+            --filename                 Used to indicate the filename to be assumed for
+                                       contents from STDIN                        [string]
+            --fix                      Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --json           Format output as json
-            --verbose        Output errors with source description               [boolean]
-            --print-pending  Print list of formated rules for use with \`pending\` in config
-                             file                                                [boolean]
-            --help           Show help                                           [boolean]
-            --version        Show version number                                 [boolean]"
+            --json                     Format output as json
+            --verbose                  Output errors with source description     [boolean]
+            --print-pending            Print list of formated rules for use with \`pending\`
+                                       in config file                            [boolean]
+            --disable-ignore-patterns  Disable default ignore patterns           [boolean]
+            --help                     Show help                                 [boolean]
+            --version                  Show version number                       [boolean]"
         `);
       });
     });
@@ -135,19 +137,20 @@ describe('ember-template-lint executable', function() {
 "ember-template-lint [options] [files..]
 
 Options:
-  --config-path    Define a custom config path
+  --config-path              Define a custom config path
                                        [string] [default: \\".template-lintrc.js\\"]
-  --quiet          Ignore warnings and only show errors                [boolean]
-  --filename       Used to indicate the filename to be assumed for contents from
-                   STDIN                                                [string]
-  --fix            Fix any errors that are reported as fixable
+  --quiet                    Ignore warnings and only show errors      [boolean]
+  --filename                 Used to indicate the filename to be assumed for
+                             contents from STDIN                        [string]
+  --fix                      Fix any errors that are reported as fixable
                                                       [boolean] [default: false]
-  --json           Format output as json
-  --verbose        Output errors with source description               [boolean]
-  --print-pending  Print list of formated rules for use with \`pending\` in config
-                   file                                                [boolean]
-  --help           Show help                                           [boolean]
-  --version        Show version number                                 [boolean]"
+  --json                     Format output as json
+  --verbose                  Output errors with source description     [boolean]
+  --print-pending            Print list of formated rules for use with \`pending\`
+                             in config file                            [boolean]
+  --disable-ignore-patterns  Disable default ignore patterns           [boolean]
+  --help                     Show help                                 [boolean]
+  --version                  Show version number                       [boolean]"
 `);
       });
     });
@@ -309,6 +312,36 @@ Options:
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toBeFalsy();
+        expect(result.stderr).toBeFalsy();
+      });
+    });
+
+    describe('with/without --disable-ignore-patterns', function() {
+      it('should respect dirs ignored by default', function() {
+        setProjectConfigForErrorsWithIgnoredDir();
+
+        let result = run(['app/**/*']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toEqual('');
+        expect(result.stderr).toBeFalsy();
+      });
+
+      it('should allow to disable dirs ignored by default', function() {
+        setProjectConfigForErrorsWithIgnoredDir();
+
+        let result = run(['app/**/*', '--disable-ignore-patterns']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toEqual(
+          `app/dist/application.hbs
+  1:4  error  Non-translated string used  no-bare-strings
+  1:24  error  Non-translated string used  no-bare-strings
+  1:53  error  HTML comment detected  no-html-comments
+
+✖ 3 problems (3 errors, 0 warnings)`
+        );
+
         expect(result.stderr).toBeFalsy();
       });
     });
@@ -699,6 +732,29 @@ Options:
       app: {
         templates: {
           'application.hbs': '<h2>Love for bare strings!!!</h2> <div>Bare strings are great!</div>',
+        },
+      },
+    });
+  }
+
+  function setProjectConfigForErrorsWithIgnoredDir() {
+    project.setConfig({
+      rules: {
+        'no-bare-strings': true,
+        'no-html-comments': true,
+      },
+      pending: [
+        {
+          moduleId: 'app/templates/application',
+          only: ['no-html-comments'],
+        },
+      ],
+    });
+    project.write({
+      app: {
+        dist: {
+          'application.hbs':
+            '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
         },
       },
     });

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -359,10 +359,47 @@ Options:
               'application.hbs':
                 '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
             },
+            bar: {
+              'application.hbs':
+                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+            },
           },
         });
 
         let result = run(['app/**/*', '--ignore-pattern', '"**/foo/**"', '"**/bar/**"']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toEqual('');
+        expect(result.stderr).toBeFalsy();
+      });
+
+      it('should allow to pass custom ignore pattern (via multiple args)', function() {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+            'no-html-comments': true,
+          },
+        });
+        project.write({
+          app: {
+            foo: {
+              'application.hbs':
+                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+            },
+            bar: {
+              'application.hbs':
+                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+            },
+          },
+        });
+
+        let result = run([
+          'app/**/*',
+          '--ignore-pattern',
+          '"**/foo/**"',
+          '--ignore-pattern',
+          '"**/bar/**"',
+        ]);
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toEqual('');

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -29,20 +29,22 @@ describe('ember-template-lint executable', function() {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path              Define a custom config path
+            --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --quiet                    Ignore warnings and only show errors      [boolean]
-            --filename                 Used to indicate the filename to be assumed for
-                                       contents from STDIN                        [string]
-            --fix                      Fix any errors that are reported as fixable
+            --quiet           Ignore warnings and only show errors               [boolean]
+            --filename        Used to indicate the filename to be assumed for contents
+                              from STDIN                                          [string]
+            --fix             Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --json                     Format output as json
-            --verbose                  Output errors with source description     [boolean]
-            --print-pending            Print list of formated rules for use with \`pending\`
-                                       in config file                            [boolean]
-            --disable-ignore-patterns  Disable default ignore patterns           [boolean]
-            --help                     Show help                                 [boolean]
-            --version                  Show version number                       [boolean]"
+            --json            Format output as json
+            --verbose         Output errors with source description              [boolean]
+            --print-pending   Print list of formated rules for use with \`pending\` in
+                              config file                                        [boolean]
+            --ignore-pattern  Specify custom ignore pattern (can be disabled with
+                              --no-ignore-pattern)
+                        [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
+            --help            Show help                                          [boolean]
+            --version         Show version number                                [boolean]"
         `);
       });
     });
@@ -56,20 +58,22 @@ describe('ember-template-lint executable', function() {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path              Define a custom config path
+            --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --quiet                    Ignore warnings and only show errors      [boolean]
-            --filename                 Used to indicate the filename to be assumed for
-                                       contents from STDIN                        [string]
-            --fix                      Fix any errors that are reported as fixable
+            --quiet           Ignore warnings and only show errors               [boolean]
+            --filename        Used to indicate the filename to be assumed for contents
+                              from STDIN                                          [string]
+            --fix             Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --json                     Format output as json
-            --verbose                  Output errors with source description     [boolean]
-            --print-pending            Print list of formated rules for use with \`pending\`
-                                       in config file                            [boolean]
-            --disable-ignore-patterns  Disable default ignore patterns           [boolean]
-            --help                     Show help                                 [boolean]
-            --version                  Show version number                       [boolean]"
+            --json            Format output as json
+            --verbose         Output errors with source description              [boolean]
+            --print-pending   Print list of formated rules for use with \`pending\` in
+                              config file                                        [boolean]
+            --ignore-pattern  Specify custom ignore pattern (can be disabled with
+                              --no-ignore-pattern)
+                        [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
+            --help            Show help                                          [boolean]
+            --version         Show version number                                [boolean]"
         `);
       });
     });
@@ -137,20 +141,22 @@ describe('ember-template-lint executable', function() {
 "ember-template-lint [options] [files..]
 
 Options:
-  --config-path              Define a custom config path
+  --config-path     Define a custom config path
                                        [string] [default: \\".template-lintrc.js\\"]
-  --quiet                    Ignore warnings and only show errors      [boolean]
-  --filename                 Used to indicate the filename to be assumed for
-                             contents from STDIN                        [string]
-  --fix                      Fix any errors that are reported as fixable
+  --quiet           Ignore warnings and only show errors               [boolean]
+  --filename        Used to indicate the filename to be assumed for contents
+                    from STDIN                                          [string]
+  --fix             Fix any errors that are reported as fixable
                                                       [boolean] [default: false]
-  --json                     Format output as json
-  --verbose                  Output errors with source description     [boolean]
-  --print-pending            Print list of formated rules for use with \`pending\`
-                             in config file                            [boolean]
-  --disable-ignore-patterns  Disable default ignore patterns           [boolean]
-  --help                     Show help                                 [boolean]
-  --version                  Show version number                       [boolean]"
+  --json            Format output as json
+  --verbose         Output errors with source description              [boolean]
+  --print-pending   Print list of formated rules for use with \`pending\` in
+                    config file                                        [boolean]
+  --ignore-pattern  Specify custom ignore pattern (can be disabled with
+                    --no-ignore-pattern)
+              [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
+  --help            Show help                                          [boolean]
+  --version         Show version number                                [boolean]"
 `);
       });
     });
@@ -316,7 +322,7 @@ Options:
       });
     });
 
-    describe('with/without --disable-ignore-patterns', function() {
+    describe('with/without --ignore-pattern', function() {
       it('should respect dirs ignored by default', function() {
         project.setConfig({
           rules: {
@@ -340,6 +346,29 @@ Options:
         expect(result.stderr).toBeFalsy();
       });
 
+      it('should allow to pass custom ignore pattern', function() {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+            'no-html-comments': true,
+          },
+        });
+        project.write({
+          app: {
+            foo: {
+              'application.hbs':
+                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+            },
+          },
+        });
+
+        let result = run(['app/**/*', '--ignore-pattern', '"**/foo/**"', '"**/bar/**"']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toEqual('');
+        expect(result.stderr).toBeFalsy();
+      });
+
       it('should allow to disable dirs ignored by default', function() {
         project.setConfig({
           rules: {
@@ -356,7 +385,7 @@ Options:
           },
         });
 
-        let result = run(['app/**/*', '--disable-ignore-patterns']);
+        let result = run(['app/**/*', '--no-ignore-pattern']);
 
         expect(result.exitCode).toEqual(1);
         expect(result.stdout).toEqual(

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -366,33 +366,6 @@ Options:
           },
         });
 
-        let result = run(['app/**/*', '--ignore-pattern', '"**/foo/**"', '"**/bar/**"']);
-
-        expect(result.exitCode).toEqual(0);
-        expect(result.stdout).toEqual('');
-        expect(result.stderr).toBeFalsy();
-      });
-
-      it('should allow to pass custom ignore pattern (via multiple args)', function() {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-            'no-html-comments': true,
-          },
-        });
-        project.write({
-          app: {
-            foo: {
-              'application.hbs':
-                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
-            },
-            bar: {
-              'application.hbs':
-                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
-            },
-          },
-        });
-
         let result = run([
           'app/**/*',
           '--ignore-pattern',

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -318,7 +318,20 @@ Options:
 
     describe('with/without --disable-ignore-patterns', function() {
       it('should respect dirs ignored by default', function() {
-        setProjectConfigForErrorsWithIgnoredDir();
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+            'no-html-comments': true,
+          },
+        });
+        project.write({
+          app: {
+            dist: {
+              'application.hbs':
+                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+            },
+          },
+        });
 
         let result = run(['app/**/*']);
 
@@ -328,7 +341,20 @@ Options:
       });
 
       it('should allow to disable dirs ignored by default', function() {
-        setProjectConfigForErrorsWithIgnoredDir();
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+            'no-html-comments': true,
+          },
+        });
+        project.write({
+          app: {
+            dist: {
+              'application.hbs':
+                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+            },
+          },
+        });
 
         let result = run(['app/**/*', '--disable-ignore-patterns']);
 
@@ -732,29 +758,6 @@ Options:
       app: {
         templates: {
           'application.hbs': '<h2>Love for bare strings!!!</h2> <div>Bare strings are great!</div>',
-        },
-      },
-    });
-  }
-
-  function setProjectConfigForErrorsWithIgnoredDir() {
-    project.setConfig({
-      rules: {
-        'no-bare-strings': true,
-        'no-html-comments': true,
-      },
-      pending: [
-        {
-          moduleId: 'app/templates/application',
-          only: ['no-html-comments'],
-        },
-      ],
-    });
-    project.write({
-      app: {
-        dist: {
-          'application.hbs':
-            '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
         },
       },
     });


### PR DESCRIPTION
Based on https://github.com/ember-template-lint/ember-template-lint/pull/938, adds `--disable-ignore-patterns` flag.

I originally went with `--no-ignore-patterns` only to find out (after a bit of hair pulling) that [yargs treats `--no` -prefixed args in a special way](https://github.com/yargs/yargs/blob/master/docs/tricks.md#negating-boolean-arguments) 🤦‍♂The other option would be smth like `--no-ignore-patterns=false` which is a mouthful. I'm already not quite happy with the "disable ignore" double negative but at least there's no need for a value.

Let me know if anything else is needed here. Shall we also add `--ignore-patterns`?