### PR TITLE
bugfix: flase-positive rule for invalid block param definition

### DIFF
--- a/lib/rules/no-invalid-block-param-definition.js
+++ b/lib/rules/no-invalid-block-param-definition.js
@@ -32,7 +32,8 @@ module.exports = class NoInvalidBlockParamDefinition extends Rule {
         return this.sourceForNode(el);
       });
     const modifiers = node.modifiers.map(el => this.sourceForNode(el));
-    const pureNodeSource = [...attributes, ...modifiers].reduce((result, src) => {
+    const children = node.children.map(el => this.sourceForNode(el));
+    const pureNodeSource = [...attributes, ...modifiers, ...children].reduce((result, src) => {
       return result.replace(src, '');
     }, source);
 

--- a/test/unit/rules/no-invalid-block-param-definition-test.js
+++ b/test/unit/rules/no-invalid-block-param-definition-test.js
@@ -33,8 +33,7 @@ as
   </MyComponent>
 </div>
 `,
-    `
-<MyComponent as |boo|>
+    `<MyComponent as |boo|>
   <MyComponent>
     {{#each this.foo as |bar|}}
       {{bar}}{{boo}}

--- a/test/unit/rules/no-invalid-block-param-definition-test.js
+++ b/test/unit/rules/no-invalid-block-param-definition-test.js
@@ -25,6 +25,26 @@ as
 | boo |
   >{{boo}}</FooBar>
 `,
+    `
+<div>
+  <MyComponent>
+    {{#each this.foo as |bar|}}
+      {{bar}}
+    {{/each}}
+  </MyComponent>
+</div>
+`,
+    `
+<MyComponent as |boo|>
+  <MyComponent>
+    {{#each this.foo as |bar|}}
+      {{bar}}{{boo}}
+    {{else}}
+      {{foo}}
+    {{/each}}
+  </MyComponent>
+</MyComponent>
+`,
   ],
 
   bad: [

--- a/test/unit/rules/no-invalid-block-param-definition-test.js
+++ b/test/unit/rules/no-invalid-block-param-definition-test.js
@@ -25,8 +25,7 @@ as
 | boo |
   >{{boo}}</FooBar>
 `,
-    `
-<div>
+    `<div>
   <MyComponent>
     {{#each this.foo as |bar|}}
       {{bar}}


### PR DESCRIPTION
going to remove children from node source before block params checking
Closes https://github.com/ember-template-lint/ember-template-lint/issues/1193