### PR TITLE
Re-run `npm init rwjblue-release-it-setup --update`.

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@ have been merged since the last release have been labeled with the appropriate
 represent something that would make sense to our users. Some great information
 on why this is important can be found at
 [keepachangelog.com](https://keepachangelog.com/en/1.0.0/), but the overall
-guiding principles here is that changelogs are for humans, not machines.
+guiding principle here is that changelogs are for humans, not machines.
 
 When reviewing merged PR's the labels to be used are:
 
@@ -24,16 +24,42 @@ When reviewing merged PR's the labels to be used are:
 * internal - Used for internal changes that still require a mention in the
   changelog/release notes.
 
-## Commands
+## Releasing
 
 Once the prep work is completed, the actual release is straight forward:
 
-```shell
-yarn install
-yarn release
+* First ensure that you have `release-it` installed globally, generally done by
+  using one of the following commands:
+
+```sh
+# using https://volta.sh
+volta install release-it
+
+# using Yarn
+yarn global add release-it
+
+# using npm
+npm install --global release-it
 ```
 
-The `release` script leverages
-[release-it](https://github.com/release-it/release-it/) to do the mechanical
-release process. It will prompt you through the process of choosing the version
-number, tagging, pushing the tag and commits, etc.
+* Second, ensure that you have installed your projects dependencies:
+
+```sh
+yarn install
+```
+
+* And last (but not least 😁) do your release. It requires a
+  [GitHub personal access token](https://github.com/settings/tokens) as
+  `$GITHUB_AUTH` environment variable. Only "repo" access is needed; no "admin"
+  or other scopes are required.
+
+```sh
+export GITHUB_AUTH="f941e0..."
+release-it
+```
+
+[release-it](https://github.com/release-it/release-it/) manages the actual
+release process. It will prompt you to to choose the version number after which
+you will have the chance to hand tweak the changelog to be used (for the
+`CHANGELOG.md` and GitHub release), then `release-it` continues on to tagging,
+pushing the tag and commits, etc.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,15 @@
     "test": "npm-run-all lint:* test:*",
     "test:jest": "jest"
   },
+  "jest": {
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/node_modules/",
+      "<rootDir>/test/"
+    ],
+    "testMatch": [
+      "<rootDir>/test/**/*-test.js"
+    ]
+  },
   "dependencies": {
     "chalk": "^3.0.0",
     "ember-template-recast": "^4.1.1",
@@ -50,7 +59,7 @@
     "markdownlint-cli": "^0.22.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
-    "release-it": "^13.1.0",
+    "release-it": "^13.1.1",
     "release-it-lerna-changelog": "^2.0.0"
   },
   "engines": {
@@ -62,23 +71,16 @@
   "release-it": {
     "plugins": {
       "release-it-lerna-changelog": {
-        "infile": "CHANGELOG.md"
+        "infile": "CHANGELOG.md",
+        "launchEditor": true
       }
     },
     "git": {
       "tagName": "v${version}"
     },
     "github": {
-      "release": true
+      "release": true,
+      "tokenRef": "GITHUB_AUTH"
     }
-  },
-  "jest": {
-    "coveragePathIgnorePatterns": [
-      "<rootDir>/node_modules/",
-      "<rootDir>/test/"
-    ],
-    "testMatch": [
-      "<rootDir>/test/**/*-test.js"
-    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2608,12 +2608,7 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.0.tgz#71e87f931de3fe09e56661ab9a29aadec707b491"
   integrity sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==
 
-http-cache-semantics@^4.0.0:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz#13eeb612424bb113d52172c28a13109c46fa85d7"
-  integrity sha512-Z2EICWNJou7Tr9Bd2M2UqDJq3A9F2ePG9w3lIpjoyuSyXFP9QbniJVu3XQYytuw5ebmG7dXSXO9PgAjJG8DDKA==
-
-http-cache-semantics@^4.0.3:
+http-cache-semantics@^4.0.0, http-cache-semantics@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz#49e91c5cbf36c9b94bcfcd71c23d5249ec74e390"
   integrity sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
@@ -4833,10 +4828,10 @@ release-it-lerna-changelog@^2.0.0:
     release-it "^13.0.2"
     tmp "^0.1.0"
 
-release-it@^13.0.2, release-it@^13.1.0:
-  version "13.1.0"
-  resolved "https://registry.yarnpkg.com/release-it/-/release-it-13.1.0.tgz#c6777aaf06c59fedae4984a4c72bcc759ad14fbb"
-  integrity sha512-VcNP0QiYlEpDRN6ktoGb/WVoBm6F4H0qGHygRT3gtpmw3nnD74ATNLHTTvGHnhMqxjN1zG/neyVhobx2HmILEA==
+release-it@^13.0.2, release-it@^13.1.1:
+  version "13.1.1"
+  resolved "https://registry.yarnpkg.com/release-it/-/release-it-13.1.1.tgz#64c9e84cf1049f6261e95ab1427849c61ffd9137"
+  integrity sha512-3JrbRMkUnup+PGtTR78MBjfrgEDd1UBJtW0eZF4MQRMvhv2am1VyYzz5i7Vv1xkomsaxhy06gZVjVFAa+Qn4JA==
   dependencies:
     "@iarna/toml" "2.2.3"
     "@octokit/rest" "17.1.0"


### PR DESCRIPTION
Updates the default configuration to the latest, fixing typos and whatnot in `RELEASE.md`.