### PR TITLE
feature/use-concat-for-string-concatenation

### DIFF
--- a/docs/rule/use-concat-for-string-concatenation.md
+++ b/docs/rule/use-concat-for-string-concatenation.md
@@ -1,0 +1,24 @@
+# use-concat-for-string-concatenation
+
+This rule requires the usage of `concat` helper to build strings for element attributes, which ideally prevents common formatting errors (i.e. CMD + P + `Format`) with plain concatenation.
+
+## Forbidden
+
+```hbs
+<div class="flex-{{if this.show "100" "50"}}"></div>
+```
+
+## Allowed
+
+```hbs
+<div class={{concat "flex-" (if this.show "100" "50")}}></div>
+```
+
+## Configuration
+
+* TODO
+
+## Related Rules
+
+* [no-unnecesarry-concat](no-unnecesary-concat.md)
+* [style-concatenation](style-concatenation.md)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -63,6 +63,7 @@
 * [style-concatenation](rule/style-concatenation.md)
 * [table-groups](rule/table-groups.md)
 * [template-length](rule/template-length.md)
+* [use-concat-for-string-concatenation](rule/use-concat-for-string-concatenation.md)
 
 ## Deprecations
 

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -67,4 +67,5 @@ module.exports = {
   'style-concatenation': require('./style-concatenation'),
   'table-groups': require('./table-groups'),
   'template-length': require('./template-length'),
+  'use-concat-for-string-concatenation': require('./use-concat-for-string-concatenation'),
 };

--- a/lib/rules/use-concat-for-string-concatenation.js
+++ b/lib/rules/use-concat-for-string-concatenation.js
@@ -14,7 +14,7 @@ module.exports = class UseConcatForStringConcatenation extends Rule {
           return AttrNode.value.type === 'ConcatStatement';
         });
 
-        if (classAttrNodesWithConcatStatement.length === 0) return;
+        if (classAttrNodesWithConcatStatement.length === 0) { return };
 
         this.log({
           message: ERROR_MESSAGE,

--- a/lib/rules/use-concat-for-string-concatenation.js
+++ b/lib/rules/use-concat-for-string-concatenation.js
@@ -10,11 +10,11 @@ module.exports = class UseConcatForStringConcatenation extends Rule {
       ElementNode(node) {
         let { attributes } = node;
 
-        let classAttrNodesWithConcatStatement = attributes.filter(AttrNode => {
-          return AttrNode.value.type === 'ConcatStatement';
+        let found = attributes.find(AttrNode => {
+          return AttrNode.value.type === "ConcatStatement";
         });
-
-        if (classAttrNodesWithConcatStatement.length === 0) { return };
+  
+        if(!found) { return; }
 
         this.log({
           message: ERROR_MESSAGE,

--- a/lib/rules/use-concat-for-string-concatenation.js
+++ b/lib/rules/use-concat-for-string-concatenation.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const Rule = require('./base');
+
+const ERROR_MESSAGE = 'Found string concatenation without {{concat}} helper';
+
+module.exports = class UseConcatForStringConcatenation extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        let { attributes } = node;
+
+        let classAttrNodesWithConcatStatement = attributes.filter(AttrNode => {
+          return AttrNode.value.type === 'ConcatStatement';
+        });
+
+        if (classAttrNodesWithConcatStatement.length === 0) return;
+
+        this.log({
+          message: ERROR_MESSAGE,
+          line: node.loc && node.loc.start.line,
+          column: node.loc && node.loc.start.column,
+          source: this.sourceForNode(node),
+        });
+      },
+    };
+  }
+};

--- a/lib/rules/use-concat-for-string-concatenation.js
+++ b/lib/rules/use-concat-for-string-concatenation.js
@@ -11,7 +11,7 @@ module.exports = class UseConcatForStringConcatenation extends Rule {
         let { attributes } = node;
 
         let found = attributes.find(AttrNode => {
-          return AttrNode.value.type === "ConcatStatement";
+          return AttrNode.value.type === 'ConcatStatement';
         });
   
         if(!found) { return; }

--- a/test/unit/rules/use-concat-for-string-concatenation.js
+++ b/test/unit/rules/use-concat-for-string-concatenation.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'use-concat-for-string-concatenation',
+
+  config: true,
+
+  good: [
+    '<div class={{concat "flex-" (if this.show "100" "50")}}></div>',
+    '<div id={{concat "input-" this.inputId}}></div>',
+  ],
+
+  bad: [
+    {
+      template: '<a href="https://myurl.com?{{this.queryParams}}">click here</a>',
+      result: {
+        message: 'Found string concatenation without {{concat}} helper',
+        source: '<a href="https://myurl.com?{{this.queryParams}}">click here</a>',
+        line: 1,
+        column: 4,
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This is a draft PR, just wanted some feedback.

Found a bug in some parts of our codebase where strings were concatenated inside quotes, this caused that CMD + P + Format added newlines `\n`, breaking the UI.

This is the solution I came up with, but not sure if it's valid. Also, I just learned to do this thanks via the ast-workshop, so thank you @Turbo87 !
