### PR TITLE
Ensure each rule documentation file has the right title and an examples section

### DIFF
--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -2,7 +2,9 @@
 
 This rule requires the positional params, attributes, and block params of the helper/component to be indented by moving them to multiple lines when the open invocation has more than 80 characters (configurable).
 
-## Forbidden
+## Examples
+
+### Forbidden
 
 Non-Block form
 
@@ -30,7 +32,7 @@ Block form (HTML)
 <a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>
 ```
 
-## Allowed
+### Allowed
 
 Non-Block form
 

--- a/docs/rule/eol-last.md
+++ b/docs/rule/eol-last.md
@@ -2,6 +2,8 @@
 
 Require or disallow newline at the end of files.
 
+## Examples
+
 Enforce either (without newline at end):
 
 ```hbs

--- a/docs/rule/linebreak-style.md
+++ b/docs/rule/linebreak-style.md
@@ -2,6 +2,10 @@
 
 Having consistent linebreaks is important to make sure that the source code is rendered correctly in editors.
 
+## Examples
+
+N/A
+
 ## Configuration
 
 This rule is configured with a boolean, or a string value:

--- a/docs/rule/no-abstract-roles.md
+++ b/docs/rule/no-abstract-roles.md
@@ -15,7 +15,7 @@ The HTML attribute `role` must never have the following values:
 * `widget`
 * `window`
 
-## `<* role>`
+## Examples
 
 This rule **forbids** the following:
 

--- a/docs/rule/no-implicit-this.md
+++ b/docs/rule/no-implicit-this.md
@@ -13,7 +13,7 @@ ambiguous, as it could be referring to a local variable (block param), a helper
 with no arguments, a closed over component, or a property on the component
 class.
 
-## Exemplar
+## Examples
 
 Consider the following example where the ambiguity can cause issues:
 

--- a/docs/rule/quotes.md
+++ b/docs/rule/quotes.md
@@ -2,6 +2,8 @@
 
 Enforce the consistent use of either double or single quotes.
 
+## Examples
+
 Enforce either:
 
 ```hbs

--- a/docs/rule/require-input-label.md
+++ b/docs/rule/require-input-label.md
@@ -1,4 +1,4 @@
-# require-valid-label
+# require-input-label
 
 Users with assistive technology need `<input>` elements to have associated labels. It's so essential for users that failure to provide an associated label for an `<input>` element will cause failure of **three** different WCAG success criteria: [1.3.1, Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html), [3.3.2, Labels or Instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html), and [4.1.2, Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html). It is also associated with common failure [#68: Failure of Success Criterion 4.1.2 due to a user interface control not having a programmatically determined name](https://www.w3.org/WAI/WCAG21/Techniques/failures/F68).
 

--- a/docs/rule/require-valid-alt-text.md
+++ b/docs/rule/require-valid-alt-text.md
@@ -4,9 +4,11 @@ Enforce that all elements that require alternative text have meaningful informat
 
 Enforce `img` alt attribute does not contain the word image, picture, or photo. Screen readers already announce `img` elements as an image. There is no need to use words such as *image*, *photo*, and/or *picture*. The rule will first check if `aria-hidden` is true to determine whether to enforce the rule. If the image is hidden, then rule will always succeed.
 
+## Examples
+
 This rule **forbids** the following:
 
-## `<img>`
+### `<img>`
 
 An `<img>` must have the `alt` attribute. It must have either meaningful text, or be an empty string. If it is an empty string, the `<img>` element tag must also have `role="presentation"` or `role="none"`.
 
@@ -41,7 +43,7 @@ This rule **allows** the following:
 <img src="foo" alt="" role="presentation"> // This is valid because it has a role of presentation.
 ```
 
-## `<object>`
+### `<object>`
 
 Add alternative text to all embedded `<object>` elements using either inner text, setting the `title` prop, or using the `aria-label` or `aria-labelledby` props.
 
@@ -59,7 +61,7 @@ This rule **allows** the following:
 <object width="128" height="256" aria-labelledby="id-12345"></object>
 ```
 
-## `<input type="image">`
+### `<input type="image">`
 
 All `<input type="image">` elements must have a non-empty `alt` prop set with a meaningful description of the image or have the `aria-label` or `aria-labelledby` props set.
 
@@ -75,7 +77,7 @@ This rule **allows** the following:
 <input type="image" alt="Select image to upload">
 ```
 
-## `<area>`
+### `<area>`
 
 All clickable `<area>` elements within an image map have an `alt`, `aria-label` or `aria-labelledby` prop that describes the purpose of the link.
 

--- a/docs/rule/template-length.md
+++ b/docs/rule/template-length.md
@@ -14,6 +14,10 @@ Some ember shops try to put some guard-rails on the length of templates for the 
 - Templates that are extremely short might be better off inlined into the
   component itself rather than existing as a separate `.hbs` file.
 
+## Examples
+
+N/A
+
 ## Configuration
 
 This rule is configured with a boolean, or a string value:

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -131,12 +131,16 @@ describe('base plugin', function() {
     const rulesEntryPath = join(__dirname, '../../lib/rules');
     const files = readdirSync(rulesEntryPath);
     const deprecatedFiles = readdirSync(join(rulesEntryPath, 'deprecations'));
-    const deprecatedRules = deprecatedFiles.filter(fileName => {
-      return fileName.endsWith('.js');
-    });
-    const expectedRules = files.filter(fileName => {
-      return fileName.endsWith('.js') && !['base.js', 'index.js'].includes(fileName);
-    });
+    const deprecatedRules = deprecatedFiles
+      .filter(fileName => {
+        return fileName.endsWith('.js');
+      })
+      .map(fileName => fileName.replace('.js', ''));
+    const expectedRules = files
+      .filter(fileName => {
+        return fileName.endsWith('.js') && !['base.js', 'index.js'].includes(fileName);
+      })
+      .map(fileName => fileName.replace('.js', ''));
 
     it('has correct rules reexport', function() {
       const defaultExport = require(rulesEntryPath);
@@ -154,16 +158,15 @@ describe('base plugin', function() {
     });
 
     it('has docs/rule reference for each item', function() {
-      function transformFileName(fileName) {
-        return fileName.replace('.js', '.md');
-      }
       const ruleDocsFolder = join(__dirname, '../../docs/rule');
-      deprecatedFiles.forEach(ruleFileName => {
-        const docFilePath = join(ruleDocsFolder, 'deprecations', transformFileName(ruleFileName));
+      deprecatedRules.forEach(ruleName => {
+        const docFileName = `${ruleName}.md`;
+        const docFilePath = join(ruleDocsFolder, 'deprecations', docFileName);
         expect(existsSync(docFilePath)).toBe(true);
       });
-      expectedRules.forEach(ruleFileName => {
-        const docFilePath = join(ruleDocsFolder, transformFileName(ruleFileName));
+      expectedRules.forEach(ruleName => {
+        const docFileName = `${ruleName}.md`;
+        const docFilePath = join(ruleDocsFolder, docFileName);
         expect(existsSync(docFilePath)).toBe(true);
       });
     });
@@ -195,12 +198,30 @@ describe('base plugin', function() {
         name.endsWith('-test.js')
       );
       expectedRules.forEach(ruleFileName => {
-        const ruleTestFileName = ruleFileName.replace('.js', '-test.js');
+        const ruleTestFileName = `${ruleFileName}-test.js`;
         expect(ruleFiles.includes(ruleTestFileName)).toBe(true);
       });
       deprecatedRules.forEach(ruleFileName => {
-        const ruleTestFileName = ruleFileName.replace('.js', '-test.js');
+        const ruleTestFileName = `${ruleFileName}-test.js`;
         expect(deprecatedRuleFiles.includes(ruleTestFileName)).toBe(true);
+      });
+    });
+
+    it('should have the right contents (title, examples) for each rule documentation file', function() {
+      deprecatedRules.forEach(ruleName => {
+        const path = join(__dirname, '..', '..', 'docs', 'rule', 'deprecations', `${ruleName}.md`);
+        const file = readFileSync(path, 'utf8');
+
+        expect(file).toContain(`# ${ruleName}`); // Title header.
+        expect(file).toContain('## Examples'); // Examples section header.
+      });
+
+      expectedRules.forEach(ruleName => {
+        const path = join(__dirname, '..', '..', 'docs', 'rule', `${ruleName}.md`);
+        const file = readFileSync(path, 'utf8');
+
+        expect(file).toContain(`# ${ruleName}`); // Title header.
+        expect(file).toContain('## Examples'); // Examples section header.
       });
     });
   });


### PR DESCRIPTION
Fixes some mistakes and adds a test to enforce this.

A title and an examples section are the two parts that every rule documentation file should have.

Modeled off of this PR: https://github.com/ember-cli/eslint-plugin-ember/pull/713