### PR TITLE
Add new rule: no-unbalanced-curlies

### DIFF
--- a/docs/rule/no-unbalanced-curlies.md
+++ b/docs/rule/no-unbalanced-curlies.md
@@ -1,0 +1,53 @@
+# TODO: rule-name-goes-here
+
+TODO: context about the problem goes here
+
+TODO: what the rule does goes here
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+{{!-- TODO: Example 1  --}}
+```
+
+```hbs
+{{!-- TODO: Example 2  --}}
+```
+
+This rule **allows** the following:
+
+```hbs
+{{!-- TODO: Example 1  --}}
+```
+
+```hbs
+{{!-- TODO: Example 2  --}}
+```
+
+## Migration
+
+TODO: suggest any fast/automated techniques for fixing violations in a large codebase
+
+* TODO: suggestion on how to fix violations using find-and-replace / regexp
+* TODO: suggestion on how to fix violations using a codemod
+
+## Configuration
+
+TODO: exclude this section if the rule has no extra configuration
+
+* object -- containing the following properties:
+  * string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
+  * boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
+
+## Related Rules
+
+* [TODO-related-rule-name1](related-rule-name1.md)
+* [TODO-related-rule-name2](related-rule-name2.md)
+
+## References
+
+* TODO: link to relevant documentation goes here
+* TODO: link to relevant function spec goes here
+* TODO: link to relevant guide goes here

--- a/docs/rule/no-unbalanced-curlies.md
+++ b/docs/rule/no-unbalanced-curlies.md
@@ -1,53 +1,45 @@
-# TODO: rule-name-goes-here
+# no-unbalanced-curlies
 
-TODO: context about the problem goes here
+Normally, the compiler will find stray curlies and throw a syntax error. However, it won't be able to catch every case.
 
-TODO: what the rule does goes here
+For example, these are all syntax errors:
+
+```hbs
+{{ x }
+{{ x }}}
+{{{ x }
+{{{ x }}
+```
+
+Whereas these are not:
+
+```hbs
+{ x }}
+{ x }
+}
+}}
+}}}
+}}}}... (any number of closing curlies past one)
+```
+
+This rule focuses on closing double `}}` and triple `}}}` curlies with no matching opening curlies.
 
 ## Examples
 
 This rule **forbids** the following:
 
 ```hbs
-{{!-- TODO: Example 1  --}}
-```
-
-```hbs
-{{!-- TODO: Example 2  --}}
-```
-
-This rule **allows** the following:
-
-```hbs
-{{!-- TODO: Example 1  --}}
-```
-
-```hbs
-{{!-- TODO: Example 2  --}}
+foo}}
+{foo}}
+foo}}}
+{foo}}}
 ```
 
 ## Migration
 
-TODO: suggest any fast/automated techniques for fixing violations in a large codebase
+If you have curlies in your code that you wish to show verbatim, but are flagged by this rule, you can formulate them as a handlebars expression:
 
-* TODO: suggestion on how to fix violations using find-and-replace / regexp
-* TODO: suggestion on how to fix violations using a codemod
-
-## Configuration
-
-TODO: exclude this section if the rule has no extra configuration
-
-* object -- containing the following properties:
-  * string -- `parameterName1` -- TODO: description of parameter including the possible values and default value
-  * boolean -- `parameterName2` -- TODO: description of parameter including the possible values and default value
-
-## Related Rules
-
-* [TODO-related-rule-name1](related-rule-name1.md)
-* [TODO-related-rule-name2](related-rule-name2.md)
-
-## References
-
-* TODO: link to relevant documentation goes here
-* TODO: link to relevant function spec goes here
-* TODO: link to relevant guide goes here
+```hbs
+<p>This is a closing double curly: {{ '}}' }}</p>
+<p>This is a closing triple curly: {{ '}}}' }}</p>
+```

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -70,3 +70,5 @@
 * [deprecated-each-syntax](rule/deprecations/deprecated-each-syntax.md)
 * [deprecated-inline-view-helper](rule/deprecations/deprecated-inline-view-helper.md)
 * [deprecated-render-helper](rule/deprecations/deprecated-render-helper.md)
+
+* [no-unbalanced-curlies](rule/no-unbalanced-curlies.md)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -46,6 +46,7 @@
 * [no-shadowed-elements](rule/no-shadowed-elements.md)
 * [no-trailing-spaces](rule/no-trailing-spaces.md)
 * [no-triple-curlies](rule/no-triple-curlies.md)
+* [no-unbalanced-curlies](rule/no-unbalanced-curlies.md)
 * [no-unbound](rule/no-unbound.md)
 * [no-unnecessary-component-helper](rule/no-unnecessary-component-helper.md)
 * [no-unnecessary-concat](rule/no-unnecessary-concat.md)
@@ -70,5 +71,3 @@
 * [deprecated-each-syntax](rule/deprecations/deprecated-each-syntax.md)
 * [deprecated-inline-view-helper](rule/deprecations/deprecated-inline-view-helper.md)
 * [deprecated-render-helper](rule/deprecations/deprecated-render-helper.md)
-
-* [no-unbalanced-curlies](rule/no-unbalanced-curlies.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -68,4 +68,5 @@ module.exports = {
   'style-concatenation': require('./style-concatenation'),
   'table-groups': require('./table-groups'),
   'template-length': require('./template-length'),
+  'no-unbalanced-curlies': require('./no-unbalanced-curlies'),
 };

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -50,6 +50,7 @@ module.exports = {
   'no-shadowed-elements': require('./no-shadowed-elements'),
   'no-trailing-spaces': require('./no-trailing-spaces'),
   'no-triple-curlies': require('./no-triple-curlies'),
+  'no-unbalanced-curlies': require('./no-unbalanced-curlies'),
   'no-unbound': require('./no-unbound'),
   'no-unnecessary-component-helper': require('./no-unnecessary-component-helper'),
   'no-unnecessary-concat': require('./no-unnecessary-concat'),
@@ -68,5 +69,4 @@ module.exports = {
   'style-concatenation': require('./style-concatenation'),
   'table-groups': require('./table-groups'),
   'template-length': require('./template-length'),
-  'no-unbalanced-curlies': require('./no-unbalanced-curlies'),
 };

--- a/lib/rules/no-unbalanced-curlies.js
+++ b/lib/rules/no-unbalanced-curlies.js
@@ -1,24 +1,21 @@
 'use strict';
 
 const Rule = require('./base');
-const AstNodeInfo = require('../helpers/ast-node-info');
 
-// TODO Change template to the real error message that you want to report
-const ERROR_MESSAGE = 'Error Message to Report';
+const ERROR_MESSAGE = 'Unbalanced curlies detected';
+const DISALLOWED_CHARS = '}}';
 
 module.exports = class NoUnbalancedCurlies extends Rule {
   visitor() {
     return {
-      // Simple template example: disallowed text present in TextNode
       TextNode(node) {
-        let source = this.sourceForNode(node);
-        let disallowedText = 'DisallowedText';
-        let failingCondition = source.includes(disallowedText);
-        if (failingCondition) {
+        let chars = node.chars;
+        if (chars.includes(DISALLOWED_CHARS)) {
+          let loc = node.loc;
           this.log({
             message: ERROR_MESSAGE,
-            line: node.loc && node.loc.start.line,
-            column: node.loc && node.loc.start.column,
+            line: loc && loc.start.line,
+            column: loc && loc.start.column + chars.indexOf(DISALLOWED_CHARS),
             source: this.sourceForNode(node),
           });
         }

--- a/lib/rules/no-unbalanced-curlies.js
+++ b/lib/rules/no-unbalanced-curlies.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const Rule = require('./base');
+const AstNodeInfo = require('../helpers/ast-node-info');
+
+// TODO Change template to the real error message that you want to report
+const ERROR_MESSAGE = 'Error Message to Report';
+
+module.exports = class NoUnbalancedCurlies extends Rule {
+  visitor() {
+    return {
+      // Simple template example: disallowed text present in TextNode
+      TextNode(node) {
+        let source = this.sourceForNode(node);
+        let disallowedText = 'DisallowedText';
+        let failingCondition = source.includes(disallowedText);
+        if (failingCondition) {
+          this.log({
+            message: ERROR_MESSAGE,
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
+        }
+      },
+    };
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-unbalanced-curlies.js
+++ b/lib/rules/no-unbalanced-curlies.js
@@ -5,19 +5,42 @@ const Rule = require('./base');
 const ERROR_MESSAGE = 'Unbalanced curlies detected';
 const DISALLOWED_CHARS = '}}';
 
+const reLines = /(.*?(?:\r\n?|\n|$))/gm;
+
 module.exports = class NoUnbalancedCurlies extends Rule {
   visitor() {
     return {
       TextNode(node) {
-        let chars = node.chars;
-        if (chars.includes(DISALLOWED_CHARS)) {
-          let loc = node.loc;
+        let { chars } = node;
+        if (!chars.includes(DISALLOWED_CHARS)) {
+          return;
+        }
+        let { loc } = node;
+
+        if (!loc) {
           this.log({
             message: ERROR_MESSAGE,
-            line: loc && loc.start.line,
-            column: loc && loc.start.column + chars.indexOf(DISALLOWED_CHARS),
             source: this.sourceForNode(node),
           });
+          return;
+        }
+
+        let lineNum = loc.start.line;
+        let colNum = loc.start.column;
+        let lines = chars.match(reLines);
+        for (let i = 0; i < lines.length; i++) {
+          let line = lines[i];
+
+          if (line.includes(DISALLOWED_CHARS)) {
+            this.log({
+              message: ERROR_MESSAGE,
+              line: lineNum,
+              column: colNum + line.indexOf(DISALLOWED_CHARS),
+              source: this.sourceForNode(node),
+            });
+          }
+          lineNum++;
+          colNum = 1;
         }
       },
     };

--- a/test/unit/rules/no-unbalanced-curlies-test.js
+++ b/test/unit/rules/no-unbalanced-curlies-test.js
@@ -9,7 +9,7 @@ generateRuleTests({
 
   config: true,
 
-  good: ['{foo}', '{{foo}}', '{{{foo}}}'],
+  good: ['{foo}', '{{foo}}', '{{{foo}}}', '{{{foo\n}}}'],
 
   bad: [
     {
@@ -46,6 +46,42 @@ generateRuleTests({
         line: 1,
         column: 4,
         source: '{foo}}}',
+      },
+    },
+    {
+      template: '{foo\n}}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 2,
+        column: 1,
+        source: '{foo\n}}}',
+      },
+    },
+    {
+      template: '{foo\n}}}\nbar',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 2,
+        column: 1,
+        source: '{foo\n}}}\nbar',
+      },
+    },
+    {
+      template: '{foo\r\nbar\r\n\r\nbaz}}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 4,
+        column: 4,
+        source: '{foo\r\nbar\r\n\r\nbaz}}}',
+      },
+    },
+    {
+      template: '{foo\rbar\r\rbaz}}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 4,
+        column: 4,
+        source: '{foo\rbar\r\rbaz}}}',
       },
     },
   ],

--- a/test/unit/rules/no-unbalanced-curlies-test.js
+++ b/test/unit/rules/no-unbalanced-curlies-test.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+const ERROR_MESSAGE = require('../../../lib/rules/no-unbalanced-curlies').ERROR_MESSAGE;
+
+generateRuleTests({
+  name: 'no-unbalanced-curlies',
+
+  config: true,
+
+  // TODO update with a good example that should pass
+  good: ['passingTest00'],
+
+  // TODO update with tests that should fail
+  bad: [
+    {
+      template: 'FailingTest00 -- contains DisallowedText',
+      result: {
+        moduleId: 'layout.hbs',
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 0,
+        source: 'FailingTest00 -- contains DisallowedText',
+      },
+    },
+  ],
+});

--- a/test/unit/rules/no-unbalanced-curlies-test.js
+++ b/test/unit/rules/no-unbalanced-curlies-test.js
@@ -10,18 +10,44 @@ generateRuleTests({
   config: true,
 
   // TODO update with a good example that should pass
-  good: ['passingTest00'],
+  good: ['{foo}', '{{foo}}', '{{{foo}}}'],
 
   // TODO update with tests that should fail
   bad: [
     {
-      template: 'FailingTest00 -- contains DisallowedText',
+      template: 'foo}}',
       result: {
-        moduleId: 'layout.hbs',
         message: ERROR_MESSAGE,
         line: 1,
-        column: 0,
-        source: 'FailingTest00 -- contains DisallowedText',
+        column: 3,
+        source: 'foo}}',
+      },
+    },
+    {
+      template: '{foo}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 4,
+        source: '{foo}}',
+      },
+    },
+    {
+      template: 'foo}}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 3,
+        source: 'foo}}}',
+      },
+    },
+    {
+      template: '{foo}}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 4,
+        source: '{foo}}}',
       },
     },
   ],

--- a/test/unit/rules/no-unbalanced-curlies-test.js
+++ b/test/unit/rules/no-unbalanced-curlies-test.js
@@ -9,10 +9,8 @@ generateRuleTests({
 
   config: true,
 
-  // TODO update with a good example that should pass
   good: ['{foo}', '{{foo}}', '{{{foo}}}'],
 
-  // TODO update with tests that should fail
   bad: [
     {
       template: 'foo}}',


### PR DESCRIPTION
Here's a first approach at solving https://github.com/ember-template-lint/ember-template-lint/issues/1192

Implementation is as suggested in the issue, but this leaves me wondering if there should be a bit more, or if the name of the rule should be different.

If the rule was triggered at any curly, opening or closing, we'd also be able to detect `{ x }`, `{` and `}`. These strike me as unlikely things to find in a template, and have alternatives.

Also note that the list of syntax errors vs. valid text (in `docs/rule/no-unbalanced-curlies.md`) has been corrected from that in the original issue, which was incorrect.