### PR TITLE
Ensure template parsing errors are only reported once (not once per-rule)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -269,6 +269,7 @@ class Linter {
     } catch (error) {
       let message = buildErrorMessage(options.filePath, options.moduleId, error);
       results.push(message);
+      return results;
     }
 
     let { failures, rules } = this.buildRules({

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -272,6 +272,29 @@ describe('public api', function () {
       expect(result.isFixed).toEqual(false);
     });
 
+    it('ensures template parsing errors are only reported once (not once per-rule)', function () {
+      let templateContents = '{{#ach this.foo as |bar|}}{{/each}}';
+      project.write({
+        app: {
+          templates: {
+            'other.hbs': templateContents,
+          },
+        },
+      });
+
+      let templatePath = project.path('app/templates/other.hbs');
+
+      let result = linter.verifyAndFix({
+        source: templateContents,
+        filePath: templatePath,
+        moduleId: templatePath.slice(0, -4),
+      });
+
+      expect(result.messages.length).toEqual(1);
+      expect(result.messages[0].message).toEqual("ach doesn't match each - 1:3");
+      expect(result.messages[0].fatal).toEqual(true);
+    });
+
     it('includes updated output when fixable', function () {
       let templateContents = '<button>LOL, Click me!</button>';
 

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -696,9 +696,9 @@ generateRuleTests({
       results: [
         {
           fatal: true,
-          message: "ach doesn't match each - 3:9"
-        }
-      ]
+          message: "ach doesn't match each - 3:9",
+        },
+      ],
     },
   ],
 });

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -687,4 +687,18 @@ generateRuleTests({
       ],
     },
   ],
+  errors: [
+    {
+      template: `
+      {{#ach this.foo as |bar|}}
+        <li>{{bar}}</li>
+      {{/each}}`,
+      results: [
+        {
+          fatal: true,
+          message: "ach doesn't match each - 3:9"
+        }
+      ]
+    },
+  ],
 });

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -687,18 +687,4 @@ generateRuleTests({
       ],
     },
   ],
-  errors: [
-    {
-      template: `
-      {{#ach this.foo as |bar|}}
-        <li>{{bar}}</li>
-      {{/each}}`,
-      results: [
-        {
-          fatal: true,
-          message: "ach doesn't match each - 3:9",
-        },
-      ],
-    },
-  ],
 });


### PR DESCRIPTION
Fixes https://github.com/ember-template-lint/ember-template-lint/issues/1217

Issue root cause is:
while linting, we trying to parse file and collect parsing errors, but, we don't exit from linting after parsing error and continue rules processing, as result - we have strange errors in each rule (because we don't have AST itself)

Fix: fail fast on parsing error