### PR TITLE
Add new rule: `require-form-method`

### DIFF
--- a/docs/rule/require-form-method.md
+++ b/docs/rule/require-form-method.md
@@ -1,0 +1,47 @@
+# require-form-method
+
+This rule requires all `<form>` elements to have `method` attribute with `POST`, `GET` or `DIALOG` value.
+
+By default `form` elements without `method` attribute are submitted as `GET` requests.
+In usual applications `submit` event listeners are attached to `form` elements and `event.preventDefault()` is called to avoid form submission.
+
+However in case of failure to prevent default action, form submission as `GET` request can leak sensitive end-user information.
+
+Example uses of `GET` requests:
+
+* non-secure data
+* bookmarking the submission result
+* data search query strings
+
+**Caution** - this rules does not check for `formmethod` attribute on `form` elements themselves.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<form>Hello world!</form>
+<form method="">Hello world!</form>
+<form method="random">Hello world!</form>
+```
+
+This rule **allows** the following:
+
+```hbs
+<form method="post">Hello world!</form>
+<form method="get">Hello world!</form>
+<form method="dialog">Hello world!</form>
+```
+
+## Configuration
+
+The following values are valid configuration:
+
+* boolean - `true` to enable / `false` to disable
+* object -- An object with the following keys:
+  * `allowedMethods` -- An array of allowed form `method` attribute values, default: `['POST', 'GET', 'DIALOG']`
+
+## References
+
+* [MDN - form method attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-method)
+* [HTML spec - form method attribute](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method)

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -58,6 +58,7 @@
 * [require-iframe-title](rule/require-iframe-title.md)
 * [require-input-label](rule/require-input-label.md)
 * [require-valid-alt-text](rule/require-valid-alt-text.md)
+* [require-form-method](rule/require-form-method.md)
 * [self-closing-void-elements](rule/self-closing-void-elements.md)
 * [simple-unless](rule/simple-unless.md)
 * [style-concatenation](rule/style-concatenation.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -62,6 +62,7 @@ module.exports = {
   'require-iframe-title': require('./require-iframe-title'),
   'require-input-label': require('./require-input-label'),
   'require-valid-alt-text': require('./require-valid-alt-text'),
+  'require-form-method': require('./require-form-method'),
   'self-closing-void-elements': require('./self-closing-void-elements'),
   'simple-unless': require('./simple-unless'),
   'style-concatenation': require('./style-concatenation'),

--- a/lib/rules/require-form-method.js
+++ b/lib/rules/require-form-method.js
@@ -1,0 +1,103 @@
+'use strict';
+
+const Rule = require('./base');
+const createErrorMessage = require('../helpers/create-error-message');
+
+// Form `method` attribute keywords:
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method
+const VALID_FORM_METHODS = ['POST', 'GET', 'DIALOG'];
+
+const DEFAULT_CONFIG = {
+  allowedMethods: VALID_FORM_METHODS,
+};
+
+module.exports = class RequireFormMethod extends Rule {
+  logNode({ node, message }) {
+    return this.log({
+      message,
+      line: node.loc && node.loc.start.line,
+      column: node.loc && node.loc.start.column,
+      source: this.sourceForNode(node),
+      isFixable: false,
+    });
+  }
+
+  parseConfig(config) {
+    let configType = typeof config;
+
+    switch (configType) {
+      case 'boolean':
+        return config ? DEFAULT_CONFIG : false;
+      case 'object':
+        if (Array.isArray(config.allowedMethods)) {
+          let allowedMethods = config.allowedMethods.map((m) => String(m).toUpperCase());
+          let hasAnyInvalidMethod = allowedMethods.find((m) => {
+            return !VALID_FORM_METHODS.includes(m);
+          });
+
+          if (hasAnyInvalidMethod) {
+            break;
+          }
+
+          return {
+            allowedMethods,
+          };
+        }
+        break;
+      case 'undefined':
+        return false;
+    }
+
+    let errorMessage = createErrorMessage(
+      this.ruleName,
+      [
+        '  * boolean - `true` to enable / `false` to disable',
+        '  * object -- An object with the following keys:',
+        `    * \`allowedMethods\` -- An array of allowed form \`method\` attribute values of \`${VALID_FORM_METHODS}\``,
+      ],
+      config
+    );
+
+    throw new Error(errorMessage);
+  }
+
+  visitor() {
+    return {
+      ElementNode(node) {
+        let { tag, attributes } = node;
+
+        if (tag !== 'form') {
+          return;
+        }
+
+        let typeAttribute = attributes.find((it) => it.name === 'method');
+        if (!typeAttribute) {
+          this.logNode({
+            node,
+            message: makeErrorMessage(this.config.allowedMethods),
+          });
+          return;
+        }
+
+        let { value } = typeAttribute;
+        if (value.type !== 'TextNode') {
+          return;
+        }
+
+        let { chars } = value;
+        if (!this.config.allowedMethods.includes(chars.toUpperCase())) {
+          this.logNode({
+            node,
+            message: makeErrorMessage(this.config.allowedMethods),
+          });
+        }
+      },
+    };
+  }
+};
+
+function makeErrorMessage(methods) {
+  return `All \`<form>\` elements should have \`method\` attribute with value of \`${methods}\``;
+}
+
+module.exports.makeErrorMessage = makeErrorMessage;

--- a/test/unit/rules/require-form-method-test.js
+++ b/test/unit/rules/require-form-method-test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+const { makeErrorMessage } = require('../../../lib/rules/require-form-method');
+
+generateRuleTests({
+  name: 'require-form-method',
+
+  config: true,
+
+  good: [
+    {
+      config: {
+        allowedMethods: ['get'],
+      },
+      template: '<form method="GET"></form>',
+    },
+
+    '<form method="POST"></form>',
+    '<form method="post"></form>',
+    '<form method="GET"></form>',
+    '<form method="get"></form>',
+    '<form method="DIALOG"></form>',
+    '<form method="dialog"></form>',
+
+    // dynamic values
+    '<form method="{{formMethod}}"></form>',
+    '<form method={{formMethod}}></form>',
+
+    '<div/>',
+    '<div></div>',
+    '<div method="randomType"></div>',
+  ],
+
+  bad: [
+    {
+      config: {
+        allowedMethods: ['get'],
+      },
+      template: '<form method="POST"></form>',
+      result: {
+        message: makeErrorMessage('GET'),
+        isFixable: false,
+        line: 1,
+        column: 0,
+        source: '<form method="POST"></form>',
+      },
+    },
+    {
+      config: {
+        allowedMethods: ['POST'],
+      },
+      template: '<form method="GET"></form>',
+      result: {
+        message: makeErrorMessage('POST'),
+        isFixable: false,
+        line: 1,
+        column: 0,
+        source: '<form method="GET"></form>',
+      },
+    },
+    {
+      template: '<form></form>',
+      result: {
+        message: makeErrorMessage('POST,GET,DIALOG'),
+        isFixable: false,
+        line: 1,
+        column: 0,
+        source: '<form></form>',
+      },
+    },
+    {
+      template: '<form method=""></form>',
+      result: {
+        message: makeErrorMessage('POST,GET,DIALOG'),
+        isFixable: false,
+        line: 1,
+        column: 0,
+        source: '<form method=""></form>',
+      },
+    },
+    {
+      template: '<form method=42></form>',
+      result: {
+        message: makeErrorMessage('POST,GET,DIALOG'),
+        isFixable: false,
+        line: 1,
+        column: 0,
+        source: '<form method=42></form>',
+      },
+    },
+    {
+      template: '<form method=" ge t "></form>',
+      result: {
+        message: makeErrorMessage('POST,GET,DIALOG'),
+        isFixable: false,
+        line: 1,
+        column: 0,
+        source: '<form method=" ge t "></form>',
+      },
+    },
+    {
+      template: '<form method=" pos t "></form>',
+      result: {
+        message: makeErrorMessage('POST,GET,DIALOG'),
+        isFixable: false,
+        line: 1,
+        column: 0,
+        source: '<form method=" pos t "></form>',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds new rule for form elements to require method attribute with value `POST/post` or `GET/get`.

Closes: https://github.com/ember-template-lint/ember-template-lint/issues/1203