### PR TITLE
Update each rule doc to mention what config enables the rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,11 @@ ember-template-lint into your normal eslint workflow.
 
 ### Presets
 
-Name   | Description |
-|:-----|:------------|
-| [recommended](lib/config/recommended.js) | enables the recommended rules |
-| [octane](lib/config/octane.js) | extends the `recommended` preset by enabling Ember Octane rules |
-| [stylistic](lib/config/stylistic.js) | enables stylistic rules for those who aren't ready to adopt [ember-template-lint-plugin-prettier](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier) (including stylistic rules that were previously in the `recommended` preset in ember-template-lint v1) |
+|    | Name   | Description |
+|:---|:-----|:------------|
+| :white_check_mark: | [recommended](lib/config/recommended.js) | enables the recommended rules |
+| :car: | [octane](lib/config/octane.js) | extends the `recommended` preset by enabling Ember Octane rules |
+| :dress: | [stylistic](lib/config/stylistic.js) | enables stylistic rules for those who aren't ready to adopt [ember-template-lint-plugin-prettier](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier) (including stylistic rules that were previously in the `recommended` preset in ember-template-lint v1) |
 
 ### Project Wide
 

--- a/docs/rule/block-indentation.md
+++ b/docs/rule/block-indentation.md
@@ -1,5 +1,7 @@
 # block-indentation
 
+:dress: The `extends: 'stylistic'` property in a configuration file enables this rule.
+
 Good indentation is crucial for long-term maintenance of templates. For example, having blocks misaligned is a common cause of logic errors.
 
 ## Examples

--- a/docs/rule/deprecations/deprecated-render-helper.md
+++ b/docs/rule/deprecations/deprecated-render-helper.md
@@ -1,5 +1,7 @@
 # deprecated-render-helper
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 In Ember 2.6 and newer, support for using the `{{render}}` helper has been deprecated.
 
 ## Examples

--- a/docs/rule/eol-last.md
+++ b/docs/rule/eol-last.md
@@ -1,5 +1,7 @@
 # eol-last
 
+:dress: The `extends: 'stylistic'` property in a configuration file enables this rule.
+
 Require or disallow newline at the end of files.
 
 ## Examples

--- a/docs/rule/linebreak-style.md
+++ b/docs/rule/linebreak-style.md
@@ -1,5 +1,7 @@
 # linebreak-style
 
+:dress: The `extends: 'stylistic'` property in a configuration file enables this rule.
+
 Having consistent linebreaks is important to make sure that the source code is rendered correctly in editors.
 
 ## Examples

--- a/docs/rule/link-href-attributes.md
+++ b/docs/rule/link-href-attributes.md
@@ -1,5 +1,7 @@
 # link-href-attributes
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 It's common to treat anchor tags as buttons. However, this is a bad practice! The resulting anchor tag without an `href` is completely unfocusable (cannot use keyboard navigation to to land on it, cannot be seen from a screen reader). The most discernible difference between a link (`<a>`) and a `<button>` is that a link navigates the user to a new URL (thus taking the user away from the current context). A `button` toggles something in the interface or triggers new content in that same context (i.e., a popup menu using `aria-haspopup`).
 
 One of the differences between `<a>` elements and `<button>` elements is how they work- the `<button>` can be triggered by either the `SPACEBAR` or the `ENTER` key, while the `<a>` is only triggered by the `ENTER` key. This is important to know, so you can provide appropriately for users who rely UI elements to work in a consistent way.

--- a/docs/rule/link-rel-noopener.md
+++ b/docs/rule/link-rel-noopener.md
@@ -1,5 +1,7 @@
 # link-rel-noopener
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 When you want to link to an external page from your app, it is very common to use `<a href="url" target="_blank"></a>`
 to make the browser open this link in a new tab.
 

--- a/docs/rule/no-abstract-roles.md
+++ b/docs/rule/no-abstract-roles.md
@@ -1,5 +1,7 @@
 # no-abstract-roles
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 The HTML attribute `role` must never have the following values:
 
 * `command`

--- a/docs/rule/no-action.md
+++ b/docs/rule/no-action.md
@@ -1,5 +1,7 @@
 # no-action
 
+:car: The `extends: 'octane'` property in a configuration file enables this rule.
+
 What's wrong with `{{action}}`?
 
 "Action" is an overloaded term in Ember parlance. Actions are:

--- a/docs/rule/no-args-paths.md
+++ b/docs/rule/no-args-paths.md
@@ -1,5 +1,7 @@
 # no-args-paths
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Arguments that are passed to components are prefixed with the `@` symbol in Angle bracket syntax.
 Ember Octane leverages this in the component's templates by allowing users to directly refer to an argument using the same prefix:
 

--- a/docs/rule/no-attrs-in-components.md
+++ b/docs/rule/no-attrs-in-components.md
@@ -1,5 +1,7 @@
 # no-attrs-in-components
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 This rule prevents the usage of `attrs` property to access values passed to the component since all the values can be accessed directly from the template.
 
 ## Examples

--- a/docs/rule/no-curly-component-invocation.md
+++ b/docs/rule/no-curly-component-invocation.md
@@ -1,5 +1,7 @@
 # no-curly-component-invocation
 
+:car: The `extends: 'octane'` property in a configuration file enables this rule.
+
 There are two ways to invoke a component in a template: curly component syntax
 (`{{my-component}}`), and angle bracket syntax (`<MyComponent />`). The
 difference between them is syntactical. You should favour angle bracket syntax

--- a/docs/rule/no-debugger.md
+++ b/docs/rule/no-debugger.md
@@ -1,5 +1,7 @@
 # no-debugger
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 The `{{debugger}}` helper is equivalent to a JavaScript `debugger` statement. This will halt execution if the browser developer tools are open. That is undesirable in a production environment.
 
 ## Examples

--- a/docs/rule/no-duplicate-attributes.md
+++ b/docs/rule/no-duplicate-attributes.md
@@ -1,5 +1,7 @@
 # no-duplicate-attributes
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 This rule forbids multiple attributes passed to a Component, Helper, or an ElementNode with the same name.
 
 ## Examples

--- a/docs/rule/no-extra-mut-helper-argument.md
+++ b/docs/rule/no-extra-mut-helper-argument.md
@@ -1,5 +1,7 @@
 # no-extra-mut-helper-argument
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 A common mistake when using the Ember handlebars template `mut(attr)` helper is to pass an extra `value` parameter to it when only `attr` should be passed. Instead, the `value` should be passed outside of `mut`.
 
 ## Examples

--- a/docs/rule/no-html-comments.md
+++ b/docs/rule/no-html-comments.md
@@ -1,5 +1,7 @@
 # no-html-comments
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 HTML comments in your templates will get compiled and rendered into the DOM at runtime. This is undesirable in a production environment. Instead, you can annotate your templates using Handlebars comments, which will be stripped out when the template is compiled and have no effect at runtime.
 
 ## Examples

--- a/docs/rule/no-implicit-this.md
+++ b/docs/rule/no-implicit-this.md
@@ -1,5 +1,7 @@
 # no-implicit-this
 
+:car: The `extends: 'octane'` property in a configuration file enables this rule.
+
 This rule aides in the migration path for [emberjs/rfcs#308](https://github.com/emberjs/rfcs/pull/308).
 
 ## Motivation

--- a/docs/rule/no-index-component-invocation.md
+++ b/docs/rule/no-index-component-invocation.md
@@ -1,5 +1,7 @@
 # no-index-component-invocation
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Components and Component Templates can be structured as `app/components/foo-bar/index.js` and
 `app/components/foo-bar/index.hbs`. This allows additional files related to the
 component (such as a `README.md` file) to be co-located on the filesystem.

--- a/docs/rule/no-inline-styles.md
+++ b/docs/rule/no-inline-styles.md
@@ -1,5 +1,7 @@
 # no-inline-styles
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Inline styles are not the best practice because they are hard to maintain and usually make the overall size of the project bigger. This rule forbids inline styles. Use CSS classes instead.
 
 ## Examples

--- a/docs/rule/no-input-block.md
+++ b/docs/rule/no-input-block.md
@@ -1,5 +1,7 @@
 # no-input-block
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Use of the block form of the handlebars `input` helper will result in an error at runtime.
 
 ## Examples

--- a/docs/rule/no-input-tagname.md
+++ b/docs/rule/no-input-tagname.md
@@ -1,5 +1,7 @@
 # no-input-tagname
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 `{{input tagName=x}}` will result in obtuse errors. Typically, the input will simply fail to render, whether used in block form or inline. The only valid `tagName` for the input helper is `input`. For `textarea`, `button`, and other input-like elements, you should instead create a new component or better use the DOM!
 
 ## Examples

--- a/docs/rule/no-invalid-interactive.md
+++ b/docs/rule/no-invalid-interactive.md
@@ -1,5 +1,7 @@
 # no-invalid-interactive
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Adding interactivity to an element that is not naturally interactive content leads to a very poor experience for
 users of assistive technology (i.e. screen readers). In order to ensure that screen readers can provide useful information to their users, we should add an appropriate `role` attribute when the underlying element would not have made that role obvious.
 

--- a/docs/rule/no-invalid-link-text.md
+++ b/docs/rule/no-invalid-link-text.md
@@ -1,5 +1,7 @@
 # no-invalid-link-text
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Screen readers call up a dialog box that has a list of links from the page, which users refer to decide where they will go. But if many of the links in that list simply say "click here" or "more" they will be unable to use this feature in their screen reader, which is a core navigation strategy.
 
 This rule checks links containing a few default words("click here" and "more"), and is configurable so additional words can be added as appropriate for your project. Disallowed list: click here, more info, read more, more.

--- a/docs/rule/no-invalid-meta.md
+++ b/docs/rule/no-invalid-meta.md
@@ -1,5 +1,7 @@
 # no-invalid-meta
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 This rule checks for these meta tag issues:
 
 - a meta with a redirect- if it exists, it checks for a timed delay greater than 0.

--- a/docs/rule/no-invalid-role.md
+++ b/docs/rule/no-invalid-role.md
@@ -1,5 +1,7 @@
 # no-invalid-role
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 This rule checks for invalid element/role combinations.
 
 Current list of checks:

--- a/docs/rule/no-log.md
+++ b/docs/rule/no-log.md
@@ -1,5 +1,7 @@
 # no-log
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 `{{log}}` will produce messages in the browser console. That is undesirable in a production environment.
 
 ## Examples

--- a/docs/rule/no-multiple-empty-lines.md
+++ b/docs/rule/no-multiple-empty-lines.md
@@ -1,5 +1,7 @@
 # no-multiple-empty-lines
 
+:dress: The `extends: 'stylistic'` property in a configuration file enables this rule.
+
 Some developers prefer to have multiple blank lines removed, while others feel
 that it helps improve readability. Whitespace is useful for separating logical
 sections of code, but excess whitespace takes up more of the screen.

--- a/docs/rule/no-negated-condition.md
+++ b/docs/rule/no-negated-condition.md
@@ -1,5 +1,7 @@
 # no-negated-condition
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 It can be hard to reason about negated conditions:
 
 * `if (not condition)`

--- a/docs/rule/no-nested-interactive.md
+++ b/docs/rule/no-nested-interactive.md
@@ -1,5 +1,7 @@
 # no-nested-interactive
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Usage of nested, interactive content can lead to UX problems, accessibility problems, bugs, and in some cases DOM errors. You should not put interactive content elements nested inside other interactive content elements. Instead of using nested interactive content elements, you should separate them, or use styling on a single element.
 
 ## Examples

--- a/docs/rule/no-obsolete-elements.md
+++ b/docs/rule/no-obsolete-elements.md
@@ -1,5 +1,7 @@
 # no-obsolete-elements
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Some elements are entirely obsolete and must not be used by authors.
 
 This rule forbids the use of obsolete elements.

--- a/docs/rule/no-outlet-outside-routes.md
+++ b/docs/rule/no-outlet-outside-routes.md
@@ -1,5 +1,7 @@
 # no-outlet-outside-routes
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 The `{{outlet}}` helper is used to specify locations into which routes may be rendered. Typically, to keep routing clear, only route templates should make use of `{{outlet}}`. Using `{{outlet}}` outside of a route template, e.g. in a component or a partial, will often lead to unexpected rendering locations for child routes.
 
 ## Examples

--- a/docs/rule/no-partial.md
+++ b/docs/rule/no-partial.md
@@ -1,5 +1,7 @@
 # no-partial
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Partials are a legacy hold over from the days in which Ember had little to no mechanism for sharing "template snippets". Today, we can use "contextual components" (and soon "named blocks"), which serves the original need for partials.
 
 In addition to having a better solution for the original problem, there are also a number of issues with partials:

--- a/docs/rule/no-positive-tabindex.md
+++ b/docs/rule/no-positive-tabindex.md
@@ -1,5 +1,7 @@
 # no-positive-tabindex
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 ## `<* tabindex>`
 
 Avoid positive tabIndex property values to synchronize the flow of the page with keyboard tab order.

--- a/docs/rule/no-quoteless-attributes.md
+++ b/docs/rule/no-quoteless-attributes.md
@@ -1,5 +1,7 @@
 # no-quoteless-attributes
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 In HTML, all attribute values are considered strings, regardless of whether they are quoted or not.
 
 The following two examples are _identical_ from the perspective of the browser:

--- a/docs/rule/no-shadowed-elements.md
+++ b/docs/rule/no-shadowed-elements.md
@@ -1,5 +1,7 @@
 # no-shadowed-elements
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 This rule prevents ambiguity in situations where a yielded block param which starts with a lower case letter is also
 used within the block itself as an element name.
 

--- a/docs/rule/no-trailing-spaces.md
+++ b/docs/rule/no-trailing-spaces.md
@@ -1,5 +1,7 @@
 # no-trailing-spaces
 
+:dress: The `extends: 'stylistic'` property in a configuration file enables this rule.
+
 Disallow trailing whitespace at the end of lines.
 
 ## Examples

--- a/docs/rule/no-triple-curlies.md
+++ b/docs/rule/no-triple-curlies.md
@@ -1,5 +1,7 @@
 # no-triple-curlies
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Usage of triple curly braces to allow raw HTML to be injected into the DOM is a large vector for exploits of your application (especially when the raw HTML is user-controllable). Instead of using `{{{foo}}}`, you should use appropriate helpers or computed properties that return a `SafeString` (via `Ember.String.htmlSafe` generally) and ensure that user-supplied data is properly escaped.
 
 ## Examples

--- a/docs/rule/no-unbound.md
+++ b/docs/rule/no-unbound.md
@@ -1,5 +1,7 @@
 # no-unbound
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 `{{unbound}}` is a legacy hold over from the days in which Ember's template engine was less performant. Its use today
 is vestigial, and it no longer offers performance benefits.
 

--- a/docs/rule/no-unnecessary-component-helper.md
+++ b/docs/rule/no-unnecessary-component-helper.md
@@ -1,5 +1,7 @@
 # no-unnecessary-component-helper
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 The `component` template helper can be used to dynamically pick the component being rendered based on the provided property. But if the component name is passed as a string because it's already known, then the component should be invoked directly, instead of using the `component` helper.
 
 ## Examples

--- a/docs/rule/no-unnecessary-concat.md
+++ b/docs/rule/no-unnecessary-concat.md
@@ -1,5 +1,7 @@
 # no-unnecessary-concat
 
+:dress: The `extends: 'stylistic'` property in a configuration file enables this rule.
+
 This rule forbids unnecessary use of quotes (`""`) around expressions like `{{myValue}}`.
 
 ## Examples

--- a/docs/rule/no-unused-block-params.md
+++ b/docs/rule/no-unused-block-params.md
@@ -1,5 +1,7 @@
 # no-unused-block-params
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 This rule forbids unused block parameters except when they are needed to access a later parameter.
 
 ## Examples

--- a/docs/rule/quotes.md
+++ b/docs/rule/quotes.md
@@ -1,5 +1,7 @@
 # quotes
 
+:dress: The `extends: 'stylistic'` property in a configuration file enables this rule.
+
 Enforce the consistent use of either double or single quotes.
 
 ## Examples

--- a/docs/rule/require-button-type.md
+++ b/docs/rule/require-button-type.md
@@ -1,5 +1,7 @@
 # require-button-type
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 This rule requires all `<button>` elements to have a valid `type` attribute.
 
 By default, the `type` attribute of `<button>` elements is `submit`. This can

--- a/docs/rule/require-iframe-title.md
+++ b/docs/rule/require-iframe-title.md
@@ -1,5 +1,7 @@
 # require-iframe-title
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 ## `<iframe>`
 
 `<iframe>` elements must have a unique title property to indicate its content to the user.

--- a/docs/rule/require-valid-alt-text.md
+++ b/docs/rule/require-valid-alt-text.md
@@ -1,5 +1,7 @@
 # require-valid-alt-text
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Enforce that all elements that require alternative text have meaningful information to relay back to the end user. This is a critical component of accessibility for screenreader users in order for them to understand the content's purpose on the page. By default, this rule checks for alternative text on the following elements: `<img>`, `<area>`, `<input type="image">`, and `<object>`.
 
 Enforce `img` alt attribute does not contain the word image, picture, or photo. Screen readers already announce `img` elements as an image. There is no need to use words such as *image*, *photo*, and/or *picture*. The rule will first check if `aria-hidden` is true to determine whether to enforce the rule. If the image is hidden, then rule will always succeed.

--- a/docs/rule/self-closing-void-elements.md
+++ b/docs/rule/self-closing-void-elements.md
@@ -1,5 +1,7 @@
 # self-closing-void-elements
 
+:dress: The `extends: 'stylistic'` property in a configuration file enables this rule.
+
 HTML has no self-closing tags. The HTML5 parser will ignore self-closing tag in the case of [void elements](https://www.w3.org/TR/html-markup/syntax.html#void-elements) (tags that shouldn't have a "closing tag"). Although the parser will ignore it, it's
 unnecessary and can lead to confusion with SVG/XML code.
 

--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -1,5 +1,7 @@
 # simple-unless
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 This rule strongly advises against `{{unless}}` blocks in the following situations:
 
 * With other block helpers (e.g. `{{else}}`, `{{else if}}`)

--- a/docs/rule/style-concatenation.md
+++ b/docs/rule/style-concatenation.md
@@ -1,5 +1,7 @@
 # style-concatenation
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Ember has a runtime warning that says:
 
 > Binding style attributes may introduce cross-site scripting vulnerabilities; please ensure that values being bound are properly escaped.

--- a/docs/rule/table-groups.md
+++ b/docs/rule/table-groups.md
@@ -1,5 +1,7 @@
 # table-groups
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 It is best practice to group table rows into one of:
 
 * `thead`

--- a/test/unit/rule-setup-test.js
+++ b/test/unit/rule-setup-test.js
@@ -1,5 +1,12 @@
 const { readdirSync, existsSync, readFileSync } = require('fs');
 const { join } = require('path');
+const configRecommended = require('../../lib/config/recommended');
+const configOctane = require('../../lib/config/octane');
+const configStylistic = require('../../lib/config/stylistic');
+
+const RULE_NAMES_RECOMMENDED = new Set(Object.keys(configRecommended.rules));
+const RULE_NAMES_OCTANE = new Set(Object.keys(configOctane.rules));
+const RULE_NAMES_STYLISTIC = new Set(Object.keys(configStylistic.rules));
 
 describe('rules setup is correct', function () {
   const rulesEntryPath = join(__dirname, '..', '..', 'lib', 'rules');
@@ -81,13 +88,38 @@ describe('rules setup is correct', function () {
     });
   });
 
-  it('should have the right contents (title, examples) for each rule documentation file', function () {
+  it('should have the right contents (title, examples, notices) for each rule documentation file', function () {
+    const CONFIG_MSG_RECOMMENDED =
+      ":white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.";
+    const CONFIG_MSG_OCTANE =
+      ":car: The `extends: 'octane'` property in a configuration file enables this rule.";
+    const CONFIG_MSG_STYLISTIC =
+      ":dress: The `extends: 'stylistic'` property in a configuration file enables this rule.";
+
     deprecatedRules.forEach((ruleName) => {
       const path = join(__dirname, '..', '..', 'docs', 'rule', 'deprecations', `${ruleName}.md`);
       const file = readFileSync(path, 'utf8');
 
       expect(file).toContain(`# ${ruleName}`); // Title header.
       expect(file).toContain('## Examples'); // Examples section header.
+
+      if (RULE_NAMES_RECOMMENDED.has(ruleName)) {
+        expect(file).toContain(CONFIG_MSG_RECOMMENDED);
+      } else {
+        expect(file).not.toContain(CONFIG_MSG_RECOMMENDED);
+      }
+
+      if (RULE_NAMES_OCTANE.has(ruleName)) {
+        expect(file).toContain(CONFIG_MSG_OCTANE);
+      } else {
+        expect(file).not.toContain(CONFIG_MSG_OCTANE);
+      }
+
+      if (RULE_NAMES_STYLISTIC.has(ruleName)) {
+        expect(file).toContain(CONFIG_MSG_STYLISTIC);
+      } else {
+        expect(file).not.toContain(CONFIG_MSG_STYLISTIC);
+      }
     });
 
     expectedRules.forEach((ruleName) => {
@@ -96,6 +128,24 @@ describe('rules setup is correct', function () {
 
       expect(file).toContain(`# ${ruleName}`); // Title header.
       expect(file).toContain('## Examples'); // Examples section header.
+
+      if (RULE_NAMES_RECOMMENDED.has(ruleName)) {
+        expect(file).toContain(CONFIG_MSG_RECOMMENDED);
+      } else {
+        expect(file).not.toContain(CONFIG_MSG_RECOMMENDED);
+      }
+
+      if (RULE_NAMES_OCTANE.has(ruleName)) {
+        expect(file).toContain(CONFIG_MSG_OCTANE);
+      } else {
+        expect(file).not.toContain(CONFIG_MSG_OCTANE);
+      }
+
+      if (RULE_NAMES_STYLISTIC.has(ruleName)) {
+        expect(file).toContain(CONFIG_MSG_STYLISTIC);
+      } else {
+        expect(file).not.toContain(CONFIG_MSG_STYLISTIC);
+      }
     });
   });
 });


### PR DESCRIPTION
Matches the eslint core plugin rule docs (example: https://eslint.org/docs/rules/no-extra-semi).

This makes it much easier to gain a complete picture of the rule by looking at its rule doc (without depending on the overall README.md / rules.md files).

And adds a test to ensure the docs are correct.

I made the same change in: https://github.com/ember-cli/eslint-plugin-ember/pull/759