### PR TITLE
Pass env from template-recast's transform callback to rules

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -232,7 +232,7 @@ class Linter {
         fileConfig,
       });
 
-      let { code } = transform(currentSource, () => rule.getVisitor());
+      let { code } = transform(currentSource, (env) => rule.getVisitor(env));
       currentSource = code;
     }
 

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -81,10 +81,10 @@ module.exports = class Base {
     return config;
   }
 
-  getVisitor() {
+  getVisitor(env) {
     let pluginContext = this;
     let visitor = {};
-    let ruleVisitor = this.visitor();
+    let ruleVisitor = this.visitor(env);
     // We use this structure to advise/unadvise on AST events. The walkers we
     // set up read this structure every time they get an AST event and call the
     // appropriate functions. Handlers get added to the before/after list

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -51,7 +51,7 @@ describe('base plugin', function () {
 
       let rule = new Rule(options);
 
-      transform(ast, () => rule.getVisitor());
+      transform(ast, (env) => rule.getVisitor(env));
     }
   }
 
@@ -124,6 +124,21 @@ describe('base plugin', function () {
       runRules('foo', [
         { Rule: AwesomeRule, name: 'awesome-rule', config: true, filePath: undefined },
       ]);
+    });
+
+    it('can access template-recast env', function () {
+      class AwesomeRule extends Rule {
+        visitor(env) {
+          let { syntax } = env;
+          expect(syntax).toHaveProperty('parse');
+          expect(syntax).toHaveProperty('builders');
+          expect(syntax).toHaveProperty('print');
+          expect(syntax).toHaveProperty('traverse');
+          expect(syntax).toHaveProperty('Walker');
+        }
+      }
+
+      runRules('foo', [plugin(AwesomeRule, 'awesome-rule', true)]);
     });
   });
 


### PR DESCRIPTION
That way, we don't need to import ember-template-recast from external plugins to fix the AST.