### PR TITLE
Fix Issue #1245: GitHub annotations does not distinguish between warnings and errors

### DIFF
--- a/lib/printers/github-actions.js
+++ b/lib/printers/github-actions.js
@@ -3,6 +3,7 @@ const Linter = require('../linter');
 class GitHubActionsPrinter {
   constructor(options = {}) {
     this.console = options.console || console;
+    this.quiet = Boolean(options.quiet);
   }
 
   print(results) {
@@ -12,7 +13,7 @@ class GitHubActionsPrinter {
       for (let error of fileResults.messages) {
         if (
           error.severity === Linter.ERROR_SEVERITY ||
-          error.severity === Linter.WARNING_SEVERITY
+          (error.severity === Linter.WARNING_SEVERITY && !this.quiet)
         ) {
           let line = error.line;
           let col = error.column;

--- a/lib/printers/github-actions.js
+++ b/lib/printers/github-actions.js
@@ -17,17 +17,21 @@ class GitHubActionsPrinter {
           let line = error.line;
           let col = error.column;
 
-          let annotation = this._formatAnnotation(error.message, { file, line, col });
+          let annotation = this._formatAnnotation(error.message, error.severity, {
+            file,
+            line,
+            col,
+          });
           this.console.log(annotation);
         }
       }
     }
   }
 
-  _formatAnnotation(message, options = {}) {
+  _formatAnnotation(message, errorSeverity, options = {}) {
     message = message || '';
 
-    let output = '::error';
+    let output = errorSeverity === Linter.ERROR_SEVERITY ? '::error' : '::warning';
 
     let outputOptions = Object.keys(options)
       .map((key) => `${key}=${escape(String(options[key]))}`)

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -725,7 +725,7 @@ Options:
       setupEnvVar('GITHUB_ACTIONS', 'true');
 
       it('should print GitHub Actions annotations', function () {
-        setProjectConfigForErrors();
+        setProjectConfigForErrorsAndWarning();
 
         let result = run(['.'], {
           env: { GITHUB_ACTIONS: 'true' },
@@ -735,13 +735,37 @@ Options:
         expect(result.stdout.split('\n')).toEqual([
           'app/templates/application.hbs',
           '  1:4  error  Non-translated string used  no-bare-strings',
-          '  1:25  error  Non-translated string used  no-bare-strings',
+          '  1:24  error  Non-translated string used  no-bare-strings',
+          '  1:53  warning  HTML comment detected  no-html-comments',
           '',
-          '✖ 2 problems (2 errors, 0 warnings)',
+          '✖ 3 problems (2 errors, 1 warnings)',
           '::error file=app/templates/application.hbs,line=1,col=4::Non-translated string used',
-          '::error file=app/templates/application.hbs,line=1,col=25::Non-translated string used',
+          '::error file=app/templates/application.hbs,line=1,col=24::Non-translated string used',
+          '::warning file=app/templates/application.hbs,line=1,col=53::HTML comment detected',
         ]);
         expect(result.stderr).toBeFalsy();
+      });
+
+      describe('with --quiet param', function () {
+        it('should print GitHub Actions annotations', function () {
+          setProjectConfigForErrorsAndWarning();
+
+          let result = run(['.', '--quiet'], {
+            env: { GITHUB_ACTIONS: 'true' },
+          });
+
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout.split('\n')).toEqual([
+            'app/templates/application.hbs',
+            '  1:4  error  Non-translated string used  no-bare-strings',
+            '  1:24  error  Non-translated string used  no-bare-strings',
+            '',
+            '✖ 2 problems (2 errors, 0 warnings)',
+            '::error file=app/templates/application.hbs,line=1,col=4::Non-translated string used',
+            '::error file=app/templates/application.hbs,line=1,col=24::Non-translated string used',
+          ]);
+          expect(result.stderr).toBeFalsy();
+        });
       });
     });
   });

--- a/test/unit/github-actions-test.js
+++ b/test/unit/github-actions-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Printer = require('../../lib/printers/github-actions');
+const Linter = require('../../lib/index');
 
 describe('GitHub Actions Annotations', function () {
   describe('_formatGitHubActionAnnotation', () => {
@@ -10,16 +11,33 @@ describe('GitHub Actions Annotations', function () {
     });
 
     test('formats error annotations', () => {
-      let output = printer._formatAnnotation('foo', { file: 'bar.hbs', line: 4, col: 5 });
-      expect(output).toEqual('::error file=bar.hbs,line=4,col=5::foo');
-    });
-
-    test('escapes correctly', () => {
-      let output = printer._formatAnnotation('wow!\r\nthis is a multiline\nmessage!!', {
-        file: 'semi;colon.hbs',
+      let output = printer._formatAnnotation('foo', Linter.ERROR_SEVERITY, {
+        file: 'bar.hbs',
         line: 4,
         col: 5,
       });
+      expect(output).toEqual('::error file=bar.hbs,line=4,col=5::foo');
+    });
+
+    test('formats warning annotations', () => {
+      let output = printer._formatAnnotation('foo', Linter.WARNING_SEVERITY, {
+        file: 'bar.hbs',
+        line: 4,
+        col: 5,
+      });
+      expect(output).toEqual('::warning file=bar.hbs,line=4,col=5::foo');
+    });
+
+    test('escapes correctly', () => {
+      let output = printer._formatAnnotation(
+        'wow!\r\nthis is a multiline\nmessage!!',
+        Linter.ERROR_SEVERITY,
+        {
+          file: 'semi;colon.hbs',
+          line: 4,
+          col: 5,
+        }
+      );
 
       expect(output).toEqual(
         '::error file=semi%3Bcolon.hbs,line=4,col=5::wow!%0D%0Athis is a multiline%0Amessage!!'


### PR DESCRIPTION
What does this PR do?
Addresses #1245   
- Makes the GitHub Actions printer distinguish between errors and warnings
- Makes the GitHub Actions printer respect the quiet flag
- Adds tests for each case