### PR TITLE
Expose `ember-template-recast` API on main entry point (e.g. `require('ember-template-lint').recast`)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,3 +3,4 @@
 module.exports = require('./linter');
 module.exports.Rule = require('./rules/base');
 module.exports.ASTHelpers = require('./helpers/ast-node-info');
+module.exports.recast = require('ember-template-recast');


### PR DESCRIPTION
This is a second take for https://github.com/ember-template-lint/ember-template-lint/pull/1251.