### PR TITLE
Add `--rule` and `--no-config-path` command line options

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ Example usage:
 
 # running a single rule with options
 ./node_modules/.bin/ember-template-lint --no-templaterc app/templates --rule '{ "rule": "no-implicit-this", "severity": 2, "config": { "allow": [] }}'
+
+# specify a config object to use instead of what exists locally
+./node_modules/.bin/ember-template-lint --config '{ "rules": { "no-implicit-this": { "severity": 2, "config": true } } }' test/fixtures/no-implicit-this-allow-with-regexp/app/templates
 ```
 
 ### ESLint

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Example usage:
 ./node_modules/.bin/ember-template-lint --no-config-path app/templates --rule 'no-implicit-this:error'
 
 # running a single rule with options
-./node_modules/.bin/ember-template-lint --no-config-path app/templates --rule '{ "rules": { "no-implicit-this": "error" } }'
+./node_modules/.bin/ember-template-lint --no-config-path app/templates --rule 'no-implicit-this:["error", { "allow": ["some-helper"] }]'
 
 # specify a config object to use instead of what exists locally
 ./node_modules/.bin/ember-template-lint --config '{ "rules": { "no-implicit-this": { "severity": 2, "config": true } } }' test/fixtures/no-implicit-this-allow-with-regexp/app/templates

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Example usage:
 ./node_modules/.bin/ember-template-lint --no-templaterc app/templates --rule 'no-implicit-this:error'
 
 # running a single rule with options
-./node_modules/.bin/ember-template-lint --no-templaterc app/templates --rule '{ "rule": "no-implicit-this", "severity": 2, "config": { "allow": [] }}'
+./node_modules/.bin/ember-template-lint --no-templaterc app/templates --rule '{ "rules": { "no-implicit-this": "error" } }'
 
 # specify a config object to use instead of what exists locally
 ./node_modules/.bin/ember-template-lint --config '{ "rules": { "no-implicit-this": { "severity": 2, "config": true } } }' test/fixtures/no-implicit-this-allow-with-regexp/app/templates

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Example usage:
 ./node_modules/.bin/ember-template-lint /tmp/template.hbs --no-ignore-pattern
 
 # running a single rule without options
-./node_modules/.bin/ember-template-lint --no-templaterc app/templates --rule 'no-implicit-this:2'
+./node_modules/.bin/ember-template-lint --no-templaterc app/templates --rule 'no-implicit-this:error'
 
 # running a single rule with options
 ./node_modules/.bin/ember-template-lint --no-templaterc app/templates --rule '{ "rule": "no-implicit-this", "severity": 2, "config": { "allow": [] }}'

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Example usage:
 
 # disable ignore pattern entirely
 ./node_modules/.bin/ember-template-lint /tmp/template.hbs --no-ignore-pattern
+
+# running a single rule without options
+./node_modules/.bin/ember-template-lint app/templates --rule 'no-implicit-this:2'
+
+# running a single rule with options
+./node_modules/.bin/ember-template-lint app/templates --rule '{ "rule": "no-implicit-this", "severity": 2, "config": { "allow": [] }}'
 ```
 
 ### ESLint

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ Example usage:
 ./node_modules/.bin/ember-template-lint /tmp/template.hbs --no-ignore-pattern
 
 # running a single rule without options
-./node_modules/.bin/ember-template-lint app/templates --rule 'no-implicit-this:2'
+./node_modules/.bin/ember-template-lint --no-templaterc app/templates --rule 'no-implicit-this:2'
 
 # running a single rule with options
-./node_modules/.bin/ember-template-lint app/templates --rule '{ "rule": "no-implicit-this", "severity": 2, "config": { "allow": [] }}'
+./node_modules/.bin/ember-template-lint --no-templaterc app/templates --rule '{ "rule": "no-implicit-this", "severity": 2, "config": { "allow": [] }}'
 ```
 
 ### ESLint

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -57,7 +57,7 @@ function parseArgv(_argv) {
       },
       rule: {
         describe:
-          'Specify a rule and it\'s severity to run that rule against required file paths (rule:severity) or can be specified as an json string "{ rule: String, severity: String, config: Object }"',
+          'Specify a rule and it\'s severity to add that rule to loaded rules - (rule:severity) or can be specified as an json string "{ rule: String, severity: String, config: Object }"',
         type: 'string',
       },
       filename: {
@@ -75,6 +75,10 @@ function parseArgv(_argv) {
       },
       verbose: {
         describe: 'Output errors with source description',
+        boolean: true,
+      },
+      'no-templaterc': {
+        describe: 'Does not use the local templaterc, will use a blank templaterc instead',
         boolean: true,
       },
       'print-pending': {
@@ -139,7 +143,11 @@ function run() {
 
   let linter;
   try {
-    linter = new Linter({ configPath: options.configPath, rule: options.rule });
+    linter = new Linter({
+      configPath: options.configPath,
+      rule: options.rule,
+      useConfig: options.templaterc,
+    });
   } catch (e) {
     console.error(e.message);
     process.exitCode = 1;

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -51,6 +51,10 @@ function parseArgv(_argv) {
         default: '.template-lintrc.js',
         type: 'string',
       },
+      config: {
+        describe: 'Define a custom config object - (--config \'{ "rules": { "no-implicit-this": { "severity": 2, "config": true } } }\')',
+        type: 'string',
+      },
       quiet: {
         describe: 'Ignore warnings and only show errors',
         boolean: true,
@@ -143,8 +147,19 @@ function run() {
 
   let linter;
   try {
+    let config;
+
+    if(options.config) {
+      try {
+        config = JSON.parse(options.config);
+      } catch(ex) {
+        console.debug('Could not parse options passed through --config')
+      }
+    }
+
     linter = new Linter({
       configPath: options.configPath,
+      overrideConfig: config,
       rule: options.rule,
       useConfig: options.templaterc,
     });

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -52,7 +52,8 @@ function parseArgv(_argv) {
         type: 'string',
       },
       config: {
-        describe: 'Define a custom config object - (--config \'{ "rules": { "no-implicit-this": { "severity": 2, "config": true } } }\')',
+        describe:
+          'Define a custom config object - (--config \'{ "rules": { "no-implicit-this": { "severity": 2, "config": true } } }\')',
         type: 'string',
       },
       quiet: {
@@ -149,11 +150,11 @@ function run() {
   try {
     let config;
 
-    if(options.config) {
+    if (options.config) {
       try {
         config = JSON.parse(options.config);
-      } catch(ex) {
-        console.debug('Could not parse options passed through --config')
+      } catch (ex) {
+        console.debug('Could not parse options passed through --config');
       }
     }
 

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -55,6 +55,11 @@ function parseArgv(_argv) {
         describe: 'Ignore warnings and only show errors',
         boolean: true,
       },
+      rule: {
+        describe:
+          'Specify a rule and it\'s severity to run that rule against required file paths (rule:severity) or can be specified as an json string "{ rule: String, severity: String, config: Object }"',
+        type: 'string',
+      },
       filename: {
         describe: 'Used to indicate the filename to be assumed for contents from STDIN',
         type: 'string',
@@ -134,7 +139,7 @@ function run() {
 
   let linter;
   try {
-    linter = new Linter({ configPath: options.configPath });
+    linter = new Linter({ configPath: options.configPath, rule: options.rule });
   } catch (e) {
     console.error(e.message);
     process.exitCode = 1;

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -62,7 +62,7 @@ function parseArgv(_argv) {
       },
       rule: {
         describe:
-          'Specify a rule and it\'s severity to add that rule to loaded rules - (rule:severity) or can be specified as an json string "{ rule: String, severity: String, config: Object }"',
+          'Specify a rule and its severity to add that rule to loaded rules - (e.g. `no-implicit-this:error` or `rule:["error", { "allow": ["some-helper"] }]`)',
         type: 'string',
       },
       filename: {

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -53,7 +53,7 @@ function parseArgv(_argv) {
       },
       config: {
         describe:
-          `Define a custom configuration to be used - (e.g. '{ "rules": { "no-implicit-this": "error" } }') `,
+          'Define a custom configuration to be used - (e.g. \'{ "rules": { "no-implicit-this": "error" } }\') ',
         type: 'string',
       },
       quiet: {
@@ -82,8 +82,9 @@ function parseArgv(_argv) {
         describe: 'Output errors with source description',
         boolean: true,
       },
-      'no-templaterc': {
-        describe: 'Does not use the local templaterc, will use a blank templaterc instead',
+      'no-config-path': {
+        describe:
+          'Does not use the local template-lintrc, will use a blank template-lintrc instead',
         boolean: true,
       },
       'print-pending': {
@@ -145,24 +146,28 @@ function printPending(results, options) {
 function run() {
   let options = parseArgv(process.argv.slice(2));
   let positional = options._;
+  let config;
+
+  if (options.config) {
+    try {
+      config = JSON.parse(options.config);
+    } catch (error) {
+      console.error('Could not parse specified `--config` as JSON');
+      process.exitCode = 1;
+      return;
+    }
+  }
 
   let linter;
   try {
-    let config;
-
-    if (options.config) {
-      try {
-        config = JSON.parse(options.config);
-      } catch (ex) {
-        console.debug('Could not parse options passed through --config');
-      }
+    if (options['no-config-path'] !== undefined) {
+      options.configPath = false;
     }
 
     linter = new Linter({
       configPath: options.configPath,
-      overrideConfig: config,
+      config,
       rule: options.rule,
-      useConfig: options.templaterc,
     });
   } catch (e) {
     console.error(e.message);

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -53,7 +53,7 @@ function parseArgv(_argv) {
       },
       config: {
         describe:
-          'Define a custom config object - (--config \'{ "rules": { "no-implicit-this": { "severity": 2, "config": true } } }\')',
+          `Define a custom configuration to be used - (e.g. '{ "rules": { "no-implicit-this": "error" } }') `,
         type: 'string',
       },
       quiet: {

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -158,12 +158,12 @@ function run() {
     }
   }
 
+  if (options['no-config-path'] !== undefined) {
+    options.configPath = false;
+  }
+
   let linter;
   try {
-    if (options['no-config-path'] !== undefined) {
-      options.configPath = false;
-    }
-
     linter = new Linter({
       configPath: options.configPath,
       config,

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -302,7 +302,7 @@ function getRuleFromString(rule) {
   if (ruleConfig.startsWith('[')) {
     try {
       ruleConfig = JSON.parse(ruleConfig);
-    } catch () {
+    } catch (ex) {
       throw new Error(`Error parsing specified \`--rule\` config ${rule} as JSON.`);
     }
   }

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -297,15 +297,15 @@ function getRuleFromString(rule) {
 
   // we have to split based on the index of the first instance of the separator because the separator could exist in the second half of the rule
   const name = rule.substring(0, indexOfSeparator - 1);
-  const ruleConfig = rule.substring(indexOfSeparator);
+  let ruleConfig = rule.substring(indexOfSeparator);
 
-if (ruleConfig.startsWith('[')) {
-  ruleConfig = JSON.parse(ruleConfig);
-}
+  if (ruleConfig.startsWith('[')) {
+    ruleConfig = JSON.parse(ruleConfig);
+  }
 
-const config = determineRuleConfig(ruleConfig);
+  const config = determineRuleConfig(ruleConfig);
 
-return { name, config };
+  return { name, config };
 }
 
 function validateRules(rules, loadedRules, options) {

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -301,13 +301,13 @@ function getRuleFromString(rule) {
   let config = true;
 
   // if we get passed an object that looks like no-implicit-this:["error", { "allow": ["some-helper"] }] we should split it accordingly
-  try {
+  if (!_determineConfigForSeverity(severity)) {
     const options = JSON.parse(severity);
 
-    severity = options[0];
-    config = options[1];
-  } catch (ex) {
-    // noop
+    if (Array.isArray(options)) {
+      severity = options[0];
+      config = options[1];
+    }
   }
 
   let { severity: _severity, config: defaultConfig } = _determineConfigForSeverity(severity);

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -475,12 +475,34 @@ function getProjectConfig(options) {
   return config;
 }
 
+function getEmptyProjectConfig(options) {
+  let source = {};
+  let config = { rules: {} };
+
+  ensureRootProperties(config, source);
+  migrateRulesFromRoot(config, source, options);
+
+  processPlugins(config, options);
+  processLoadedRules(config);
+  processLoadedConfigurations(config);
+  processExtends(config, options);
+  processIgnores(config);
+
+  validateRules(config.rules, config.loadedRules, options);
+  validateOverrides(config, options);
+
+  config._processed = true;
+
+  return config;
+}
+
 module.exports = {
   ERROR_SEVERITY,
   IGNORE_SEVERITY,
   WARNING_SEVERITY,
   getConfigForFile,
   getProjectConfig,
+  getEmptyProjectConfig,
   determineRuleConfig,
   processRules,
 };

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -299,29 +299,13 @@ function getRuleFromString(rule) {
   const name = rule.substring(0, indexOfSeparator - 1);
   const ruleConfig = rule.substring(indexOfSeparator);
 
-  // if we get passed an object that looks like no-implicit-this:["error", { "allow": ["some-helper"] }] we should split it accordingly
-  if (!_determineConfigForSeverity(ruleConfig)) {
-    const options = JSON.parse(ruleConfig);
+if (ruleConfig.startsWith('[')) {
+  ruleConfig = JSON.parse(ruleConfig);
+}
 
-    if (Array.isArray(options)) {
-      const { severity, config: defaultConfig } = _determineConfigForSeverity(options[0]);
-      const config = options[1];
+const config = determineRuleConfig(ruleConfig);
 
-      return {
-        name,
-        severity,
-        config: config || defaultConfig,
-      };
-    }
-  }
-
-  const { severity, config } = _determineConfigForSeverity(ruleConfig);
-
-  return {
-    name,
-    severity,
-    config,
-  };
+return { name, config };
 }
 
 function validateRules(rules, loadedRules, options) {

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -310,24 +310,12 @@ function getRuleFromString(rule) {
     // noop
   }
 
-  let _severity = 0;
-
-  switch (severity) {
-    case 'error':
-      _severity = ERROR_SEVERITY;
-      break;
-    case 'warn':
-      _severity = WARNING_SEVERITY;
-      break;
-    case 'off':
-    default:
-      _severity = IGNORE_SEVERITY;
-  }
+  let { severity: _severity, config: defaultConfig } = _determineConfigForSeverity(severity);
 
   return {
     name,
     severity: _severity,
-    config,
+    config: config || defaultConfig,
   };
 }
 

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -56,6 +56,9 @@ function resolveProjectConfig(options) {
         `The configuration file specified (${options.configPath}) could not be found. Aborting.`
       );
     }
+  } else if (options.configPath === false) {
+    // we are explicitly using `--no-config-path` flag
+    return {};
   } else {
     configPath = findUp.sync(CONFIG_FILE_NAME);
 
@@ -283,6 +286,51 @@ function processIgnores(config) {
   config.ignore = config.ignore.map((pattern) => micromatch.matcher(pattern));
 }
 
+/**
+ * we were passed a rule, add the rule being passed in, to the config.
+ * ex:
+ * rule:severity
+ * no-implicit-this:["error", { "allow": ["some-helper"] }]
+ */
+function getRuleFromString(rule) {
+  const indexOfSeparator = rule.indexOf(':') + 1;
+
+  // we have to split based on the index of the first instance of the separator because the separator could exist in the second half of the rule
+  const name = rule.substring(0, indexOfSeparator - 1);
+  let severity = rule.substring(indexOfSeparator);
+  let config = true;
+
+  // if we get passed an object that looks like no-implicit-this:["error", { "allow": ["some-helper"] }] we should split it accordingly
+  try {
+    const options = JSON.parse(severity);
+
+    severity = options[0];
+    config = options[1];
+  } catch (ex) {
+    // noop
+  }
+
+  let _severity = 0;
+
+  switch (severity) {
+    case 'error':
+      _severity = ERROR_SEVERITY;
+      break;
+    case 'warn':
+      _severity = WARNING_SEVERITY;
+      break;
+    case 'off':
+    default:
+      _severity = IGNORE_SEVERITY;
+  }
+
+  return {
+    name,
+    severity: _severity,
+    config,
+  };
+}
+
 function validateRules(rules, loadedRules, options) {
   let logger = options.console || console;
   let invalidKeysFound = [];
@@ -475,34 +523,14 @@ function getProjectConfig(options) {
   return config;
 }
 
-function getEmptyProjectConfig(options) {
-  let source = {};
-  let config = { rules: {} };
-
-  ensureRootProperties(config, source);
-  migrateRulesFromRoot(config, source, options);
-
-  processPlugins(config, options);
-  processLoadedRules(config);
-  processLoadedConfigurations(config);
-  processExtends(config, options);
-  processIgnores(config);
-
-  validateRules(config.rules, config.loadedRules, options);
-  validateOverrides(config, options);
-
-  config._processed = true;
-
-  return config;
-}
-
 module.exports = {
   ERROR_SEVERITY,
   IGNORE_SEVERITY,
   WARNING_SEVERITY,
   getConfigForFile,
   getProjectConfig,
-  getEmptyProjectConfig,
+  getRuleFromString,
+  resolveProjectConfig,
   determineRuleConfig,
   processRules,
 };

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -297,25 +297,30 @@ function getRuleFromString(rule) {
 
   // we have to split based on the index of the first instance of the separator because the separator could exist in the second half of the rule
   const name = rule.substring(0, indexOfSeparator - 1);
-  let severity = rule.substring(indexOfSeparator);
-  let config = true;
+  const ruleConfig = rule.substring(indexOfSeparator);
 
   // if we get passed an object that looks like no-implicit-this:["error", { "allow": ["some-helper"] }] we should split it accordingly
-  if (!_determineConfigForSeverity(severity)) {
-    const options = JSON.parse(severity);
+  if (!_determineConfigForSeverity(ruleConfig)) {
+    const options = JSON.parse(ruleConfig);
 
     if (Array.isArray(options)) {
-      severity = options[0];
-      config = options[1];
+      const { severity, config: defaultConfig } = _determineConfigForSeverity(options[0]);
+      const config = options[1];
+
+      return {
+        name,
+        severity,
+        config: config || defaultConfig,
+      };
     }
   }
 
-  let { severity: _severity, config: defaultConfig } = _determineConfigForSeverity(severity);
+  const { severity, config } = _determineConfigForSeverity(ruleConfig);
 
   return {
     name,
-    severity: _severity,
-    config: config || defaultConfig,
+    severity,
+    config,
   };
 }
 

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -300,7 +300,11 @@ function getRuleFromString(rule) {
   let ruleConfig = rule.substring(indexOfSeparator);
 
   if (ruleConfig.startsWith('[')) {
-    ruleConfig = JSON.parse(ruleConfig);
+    try {
+      ruleConfig = JSON.parse(ruleConfig);
+    } catch () {
+      throw new Error(`Error parsing specified \`--rule\` config ${rule} as JSON.`);
+    }
   }
 
   const config = determineRuleConfig(ruleConfig);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -36,6 +36,24 @@ class Linter {
     this.console = options.console || console;
 
     this.loadConfig();
+
+    // we were passed rule specfically to set for this linter
+    if (options.rule) {
+      try {
+        const { rule, severity = 'error', config = {} } = JSON.parse(options.rule);
+
+        this.config.rules = {
+          [rule]: { severity, config },
+        };
+      } catch (ex) {
+        const [name, severity] = options.rule.split(':');
+
+        this.config.rules = {
+          [name]: { severity: parseInt(severity, 10), config: true },
+        };
+      }
+    }
+
     this.constructor = Linter;
     this.editorConfigResolver = new EditorConfigResolver();
     this.editorConfigResolver.resolveEditorConfigFiles();

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,6 +1,7 @@
 const { parse, transform } = require('ember-template-recast');
 const {
   getProjectConfig,
+  getEmptyProjectConfig,
   getConfigForFile,
   WARNING_SEVERITY,
   ERROR_SEVERITY,
@@ -34,23 +35,20 @@ class Linter {
 
     this.options = options;
     this.console = options.console || console;
+    this.useConfig = options.useConfig !== undefined ? options.useConfig : true;
 
     this.loadConfig();
 
-    // we were passed rule specfically to set for this linter
+    // we were passed a rule, add the rule being passed in, to the config.
     if (options.rule) {
       try {
         const { rule, severity = 'error', config = {} } = JSON.parse(options.rule);
 
-        this.config.rules = {
-          [rule]: { severity, config },
-        };
+        this.config.rules[rule] = { severity, config };
       } catch (ex) {
         const [name, severity] = options.rule.split(':');
 
-        this.config.rules = {
-          [name]: { severity: parseInt(severity, 10), config: true },
-        };
+        this.config.rules[name] = { severity: parseInt(severity, 10), config: true };
       }
     }
 
@@ -60,7 +58,9 @@ class Linter {
   }
 
   loadConfig() {
-    this.config = getProjectConfig(this.options);
+    this.config = this.useConfig
+      ? getProjectConfig(this.options)
+      : getEmptyProjectConfig(this.options);
   }
 
   /**

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -35,9 +35,15 @@ class Linter {
 
     this.options = options;
     this.console = options.console || console;
-    this.useConfig = options.useConfig !== undefined ? options.useConfig : true;
+    // don't use the config on disk, if --no-templaterc or --config is specfied
+    this.useConfig = (options.useConfig !== undefined || options.overrideConfig) ? options.useConfig : true;
 
-    this.loadConfig();
+    this.loadConfig()
+
+    // if we have a config that is passed in, we should use that and override the loaded config
+    if(options.overrideConfig) {
+      this.config = Object.assign(this.config, options.overrideConfig);
+    }
 
     // we were passed a rule, add the rule being passed in, to the config.
     if (options.rule) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -36,12 +36,13 @@ class Linter {
     this.options = options;
     this.console = options.console || console;
     // don't use the config on disk, if --no-templaterc or --config is specfied
-    this.useConfig = (options.useConfig !== undefined || options.overrideConfig) ? options.useConfig : true;
+    this.useConfig =
+      options.useConfig !== undefined || options.overrideConfig ? options.useConfig : true;
 
-    this.loadConfig()
+    this.loadConfig();
 
     // if we have a config that is passed in, we should use that and override the loaded config
-    if(options.overrideConfig) {
+    if (options.overrideConfig) {
       this.config = Object.assign(this.config, options.overrideConfig);
     }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -38,16 +38,6 @@ class Linter {
 
     this.loadConfig();
 
-    // we were passed a rule, add the rule being passed in, to the config.
-    // ex:
-    // rule:severity
-    // no-implicit-this:["error", { "allow": ["some-helper"] }]
-    if (options.rule) {
-      const { name, severity, config } = getRuleFromString(options.rule);
-
-      this.config.rules[name] = { severity, config };
-    }
-
     this.constructor = Linter;
     this.editorConfigResolver = new EditorConfigResolver();
     this.editorConfigResolver.resolveEditorConfigFiles();
@@ -55,6 +45,16 @@ class Linter {
 
   loadConfig() {
     this.config = getProjectConfig(this.options);
+
+    // we were passed a rule, add the rule being passed in, to the config.
+    // ex:
+    // rule:severity
+    // no-implicit-this:["error", { "allow": ["some-helper"] }]
+    if (this.options.rule) {
+      const { name, severity, config } = getRuleFromString(this.options.rule);
+
+      this.config.rules[name] = { severity, config };
+    }
   }
 
   /**

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -51,9 +51,9 @@ class Linter {
     // rule:severity
     // no-implicit-this:["error", { "allow": ["some-helper"] }]
     if (this.options.rule) {
-      const { name, severity, config } = getRuleFromString(this.options.rule);
+      const { name, config } = getRuleFromString(this.options.rule);
 
-      this.config.rules[name] = { severity, config };
+      this.config.rules[name] = config;
     }
   }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,8 +1,8 @@
 const { parse, transform } = require('ember-template-recast');
 const {
   getProjectConfig,
-  getEmptyProjectConfig,
   getConfigForFile,
+  getRuleFromString,
   WARNING_SEVERITY,
   ERROR_SEVERITY,
   IGNORE_SEVERITY,
@@ -35,28 +35,17 @@ class Linter {
 
     this.options = options;
     this.console = options.console || console;
-    // don't use the config on disk, if --no-templaterc or --config is specfied
-    this.useConfig =
-      options.useConfig !== undefined || options.overrideConfig ? options.useConfig : true;
 
     this.loadConfig();
 
-    // if we have a config that is passed in, we should use that and override the loaded config
-    if (options.overrideConfig) {
-      this.config = Object.assign(this.config, options.overrideConfig);
-    }
-
     // we were passed a rule, add the rule being passed in, to the config.
+    // ex:
+    // rule:severity
+    // no-implicit-this:["error", { "allow": ["some-helper"] }]
     if (options.rule) {
-      try {
-        const { rule, severity = 'error', config = {} } = JSON.parse(options.rule);
+      const { name, severity, config } = getRuleFromString(options.rule);
 
-        this.config.rules[rule] = { severity, config };
-      } catch (ex) {
-        const [name, severity] = options.rule.split(':');
-
-        this.config.rules[name] = { severity: parseInt(severity, 10), config: true };
-      }
+      this.config.rules[name] = { severity, config };
     }
 
     this.constructor = Linter;
@@ -65,9 +54,7 @@ class Linter {
   }
 
   loadConfig() {
-    this.config = this.useConfig
-      ? getProjectConfig(this.options)
-      : getEmptyProjectConfig(this.options);
+    this.config = getProjectConfig(this.options);
   }
 
   /**

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -33,6 +33,9 @@ describe('ember-template-lint executable', function () {
           Options:
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
+            --config          Define a custom config object - (--config '{ \\"rules\\": {
+                              \\"no-implicit-this\\": { \\"severity\\": 2, \\"config\\": true } } }')
+                                                                                  [string]
             --quiet           Ignore warnings and only show errors               [boolean]
             --rule            Specify a rule and it's severity to add that rule to loaded
                               rules - (rule:severity) or can be specified as an json
@@ -68,6 +71,9 @@ describe('ember-template-lint executable', function () {
           Options:
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
+            --config          Define a custom config object - (--config '{ \\"rules\\": {
+                              \\"no-implicit-this\\": { \\"severity\\": 2, \\"config\\": true } } }')
+                                                                                  [string]
             --quiet           Ignore warnings and only show errors               [boolean]
             --rule            Specify a rule and it's severity to add that rule to loaded
                               rules - (rule:severity) or can be specified as an json
@@ -157,6 +163,9 @@ describe('ember-template-lint executable', function () {
           Options:
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
+            --config          Define a custom config object - (--config '{ \\"rules\\": {
+                              \\"no-implicit-this\\": { \\"severity\\": 2, \\"config\\": true } } }')
+                                                                                  [string]
             --quiet           Ignore warnings and only show errors               [boolean]
             --rule            Specify a rule and it's severity to add that rule to loaded
                               rules - (rule:severity) or can be specified as an json

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -301,12 +301,7 @@ describe('ember-template-lint executable', function () {
 
       it('should be able run a rule passed in (rule:[warn, config])', function () {
         setProjectConfigForErrorsAndWarning();
-        let result = run([
-          '.',
-          '--no-config-path',
-          '--rule',
-          'no-html-comments:["warn", true]',
-        ]);
+        let result = run(['.', '--no-config-path', '--rule', 'no-html-comments:["warn", true]']);
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout.split('\n')).toEqual([
@@ -320,12 +315,7 @@ describe('ember-template-lint executable', function () {
 
       it('should be able run a rule passed in (rule:[error, config])', function () {
         setProjectConfigForErrorsAndWarning();
-        let result = run([
-          '.',
-          '--no-config-path',
-          '--rule',
-          'no-html-comments:["error", true]',
-        ]);
+        let result = run(['.', '--no-config-path', '--rule', 'no-html-comments:["error", true]']);
 
         expect(result.exitCode).toEqual(1);
         expect(result.stdout.split('\n')).toEqual([

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -33,22 +33,20 @@ describe('ember-template-lint executable', function () {
           Options:
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config          Define a custom config object - (--config '{ \\"rules\\": {
-                              \\"no-implicit-this\\": { \\"severity\\": 2, \\"config\\": true } } }')
-                                                                                  [string]
+            --config          Define a custom configuration to be used - (e.g. '{
+                              \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')        [string]
             --quiet           Ignore warnings and only show errors               [boolean]
-            --rule            Specify a rule and it's severity to add that rule to loaded
-                              rules - (rule:severity) or can be specified as an json
-                              string \\"{ rule: String, severity: String, config: Object }\\"
-                                                                                  [string]
+            --rule            Specify a rule and its severity to add that rule to loaded
+                              rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\", {
+                              \\"allow\\": [\\"some-helper\\"] }]\`)                       [string]
             --filename        Used to indicate the filename to be assumed for contents
                               from STDIN                                          [string]
             --fix             Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
             --json            Format output as json                              [boolean]
             --verbose         Output errors with source description              [boolean]
-            --no-templaterc   Does not use the local templaterc, will use a blank
-                              templaterc instead                                 [boolean]
+            --no-config-path  Does not use the local template-lintrc, will use a blank
+                              template-lintrc instead                            [boolean]
             --print-pending   Print list of formated rules for use with \`pending\` in
                               config file                                        [boolean]
             --ignore-pattern  Specify custom ignore pattern (can be disabled with
@@ -71,22 +69,20 @@ describe('ember-template-lint executable', function () {
           Options:
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config          Define a custom config object - (--config '{ \\"rules\\": {
-                              \\"no-implicit-this\\": { \\"severity\\": 2, \\"config\\": true } } }')
-                                                                                  [string]
+            --config          Define a custom configuration to be used - (e.g. '{
+                              \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')        [string]
             --quiet           Ignore warnings and only show errors               [boolean]
-            --rule            Specify a rule and it's severity to add that rule to loaded
-                              rules - (rule:severity) or can be specified as an json
-                              string \\"{ rule: String, severity: String, config: Object }\\"
-                                                                                  [string]
+            --rule            Specify a rule and its severity to add that rule to loaded
+                              rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\", {
+                              \\"allow\\": [\\"some-helper\\"] }]\`)                       [string]
             --filename        Used to indicate the filename to be assumed for contents
                               from STDIN                                          [string]
             --fix             Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
             --json            Format output as json                              [boolean]
             --verbose         Output errors with source description              [boolean]
-            --no-templaterc   Does not use the local templaterc, will use a blank
-                              templaterc instead                                 [boolean]
+            --no-config-path  Does not use the local template-lintrc, will use a blank
+                              template-lintrc instead                            [boolean]
             --print-pending   Print list of formated rules for use with \`pending\` in
                               config file                                        [boolean]
             --ignore-pattern  Specify custom ignore pattern (can be disabled with
@@ -163,22 +159,20 @@ describe('ember-template-lint executable', function () {
           Options:
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config          Define a custom config object - (--config '{ \\"rules\\": {
-                              \\"no-implicit-this\\": { \\"severity\\": 2, \\"config\\": true } } }')
-                                                                                  [string]
+            --config          Define a custom configuration to be used - (e.g. '{
+                              \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')        [string]
             --quiet           Ignore warnings and only show errors               [boolean]
-            --rule            Specify a rule and it's severity to add that rule to loaded
-                              rules - (rule:severity) or can be specified as an json
-                              string \\"{ rule: String, severity: String, config: Object }\\"
-                                                                                  [string]
+            --rule            Specify a rule and its severity to add that rule to loaded
+                              rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\", {
+                              \\"allow\\": [\\"some-helper\\"] }]\`)                       [string]
             --filename        Used to indicate the filename to be assumed for contents
                               from STDIN                                          [string]
             --fix             Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
             --json            Format output as json                              [boolean]
             --verbose         Output errors with source description              [boolean]
-            --no-templaterc   Does not use the local templaterc, will use a blank
-                              templaterc instead                                 [boolean]
+            --no-config-path  Does not use the local template-lintrc, will use a blank
+                              template-lintrc instead                            [boolean]
             --print-pending   Print list of formated rules for use with \`pending\` in
                               config file                                        [boolean]
             --ignore-pattern  Specify custom ignore pattern (can be disabled with
@@ -277,9 +271,9 @@ describe('ember-template-lint executable', function () {
         expect(result.stderr).toBeFalsy();
       });
 
-      it('should be able to run only one rule at a time', function () {
+      it('should be able run a rule passed in (rule:warn)', function () {
         setProjectConfigForErrorsAndWarning();
-        let result = run(['.', '--no-templaterc', '--rule', 'no-html-comments:1']);
+        let result = run(['.', '--no-config-path', '--rule', 'no-html-comments:warn']);
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout.split('\n')).toEqual([
@@ -287,6 +281,58 @@ describe('ember-template-lint executable', function () {
           '  1:53  warning  HTML comment detected  no-html-comments',
           '',
           '✖ 1 problems (0 errors, 1 warnings)',
+        ]);
+        expect(result.stderr).toBeFalsy();
+      });
+
+      it('should be able run a rule passed in (rule:error)', function () {
+        setProjectConfigForErrorsAndWarning();
+        let result = run(['.', '--no-config-path', '--rule', 'no-html-comments:error']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout.split('\n')).toEqual([
+          'app/templates/application.hbs',
+          '  1:53  error  HTML comment detected  no-html-comments',
+          '',
+          '✖ 1 problems (1 errors, 0 warnings)',
+        ]);
+        expect(result.stderr).toBeFalsy();
+      });
+
+      it('should be able run a rule passed in (rule:[warn, config])', function () {
+        setProjectConfigForErrorsAndWarning();
+        let result = run([
+          '.',
+          '--no-config-path',
+          '--rule',
+          'no-html-comments:["warn", true]',
+        ]);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout.split('\n')).toEqual([
+          'app/templates/application.hbs',
+          '  1:53  warning  HTML comment detected  no-html-comments',
+          '',
+          '✖ 1 problems (0 errors, 1 warnings)',
+        ]);
+        expect(result.stderr).toBeFalsy();
+      });
+
+      it('should be able run a rule passed in (rule:[error, config])', function () {
+        setProjectConfigForErrorsAndWarning();
+        let result = run([
+          '.',
+          '--no-config-path',
+          '--rule',
+          'no-html-comments:["error", true]',
+        ]);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout.split('\n')).toEqual([
+          'app/templates/application.hbs',
+          '  1:53  error  HTML comment detected  no-html-comments',
+          '',
+          '✖ 1 problems (1 errors, 0 warnings)',
         ]);
         expect(result.stderr).toBeFalsy();
       });

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -34,6 +34,10 @@ describe('ember-template-lint executable', function () {
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
             --quiet           Ignore warnings and only show errors               [boolean]
+            --rule            Specify a rule and it's severity to run that rule against
+                              required file paths (rule:severity) or can be specified as
+                              an json string \\"{ rule: String, severity: String, config:
+                              Object }\\"                                           [string]
             --filename        Used to indicate the filename to be assumed for contents
                               from STDIN                                          [string]
             --fix             Fix any errors that are reported as fixable
@@ -63,6 +67,10 @@ describe('ember-template-lint executable', function () {
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
             --quiet           Ignore warnings and only show errors               [boolean]
+            --rule            Specify a rule and it's severity to run that rule against
+                              required file paths (rule:severity) or can be specified as
+                              an json string \\"{ rule: String, severity: String, config:
+                              Object }\\"                                           [string]
             --filename        Used to indicate the filename to be assumed for contents
                               from STDIN                                          [string]
             --fix             Fix any errors that are reported as fixable
@@ -146,6 +154,10 @@ describe('ember-template-lint executable', function () {
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
             --quiet           Ignore warnings and only show errors               [boolean]
+            --rule            Specify a rule and it's severity to run that rule against
+                              required file paths (rule:severity) or can be specified as
+                              an json string \\"{ rule: String, severity: String, config:
+                              Object }\\"                                           [string]
             --filename        Used to indicate the filename to be assumed for contents
                               from STDIN                                          [string]
             --fix             Fix any errors that are reported as fixable
@@ -246,6 +258,20 @@ describe('ember-template-lint executable', function () {
           '  1:53  warning  HTML comment detected  no-html-comments',
           '',
           '✖ 3 problems (2 errors, 1 warnings)',
+        ]);
+        expect(result.stderr).toBeFalsy();
+      });
+
+      it('should be able to run only one rule at a time', function () {
+        setProjectConfigForErrorsAndWarning();
+        let result = run(['.', '--rule', 'no-html-comments:1']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout.split('\n')).toEqual([
+          'app/templates/application.hbs',
+          '  1:53  warning  HTML comment detected  no-html-comments',
+          '',
+          '✖ 1 problems (0 errors, 1 warnings)',
         ]);
         expect(result.stderr).toBeFalsy();
       });

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -34,16 +34,18 @@ describe('ember-template-lint executable', function () {
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
             --quiet           Ignore warnings and only show errors               [boolean]
-            --rule            Specify a rule and it's severity to run that rule against
-                              required file paths (rule:severity) or can be specified as
-                              an json string \\"{ rule: String, severity: String, config:
-                              Object }\\"                                           [string]
+            --rule            Specify a rule and it's severity to add that rule to loaded
+                              rules - (rule:severity) or can be specified as an json
+                              string \\"{ rule: String, severity: String, config: Object }\\"
+                                                                                  [string]
             --filename        Used to indicate the filename to be assumed for contents
                               from STDIN                                          [string]
             --fix             Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
             --json            Format output as json                              [boolean]
             --verbose         Output errors with source description              [boolean]
+            --no-templaterc   Does not use the local templaterc, will use a blank
+                              templaterc instead                                 [boolean]
             --print-pending   Print list of formated rules for use with \`pending\` in
                               config file                                        [boolean]
             --ignore-pattern  Specify custom ignore pattern (can be disabled with
@@ -67,16 +69,18 @@ describe('ember-template-lint executable', function () {
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
             --quiet           Ignore warnings and only show errors               [boolean]
-            --rule            Specify a rule and it's severity to run that rule against
-                              required file paths (rule:severity) or can be specified as
-                              an json string \\"{ rule: String, severity: String, config:
-                              Object }\\"                                           [string]
+            --rule            Specify a rule and it's severity to add that rule to loaded
+                              rules - (rule:severity) or can be specified as an json
+                              string \\"{ rule: String, severity: String, config: Object }\\"
+                                                                                  [string]
             --filename        Used to indicate the filename to be assumed for contents
                               from STDIN                                          [string]
             --fix             Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
             --json            Format output as json                              [boolean]
             --verbose         Output errors with source description              [boolean]
+            --no-templaterc   Does not use the local templaterc, will use a blank
+                              templaterc instead                                 [boolean]
             --print-pending   Print list of formated rules for use with \`pending\` in
                               config file                                        [boolean]
             --ignore-pattern  Specify custom ignore pattern (can be disabled with
@@ -154,16 +158,18 @@ describe('ember-template-lint executable', function () {
             --config-path     Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
             --quiet           Ignore warnings and only show errors               [boolean]
-            --rule            Specify a rule and it's severity to run that rule against
-                              required file paths (rule:severity) or can be specified as
-                              an json string \\"{ rule: String, severity: String, config:
-                              Object }\\"                                           [string]
+            --rule            Specify a rule and it's severity to add that rule to loaded
+                              rules - (rule:severity) or can be specified as an json
+                              string \\"{ rule: String, severity: String, config: Object }\\"
+                                                                                  [string]
             --filename        Used to indicate the filename to be assumed for contents
                               from STDIN                                          [string]
             --fix             Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
             --json            Format output as json                              [boolean]
             --verbose         Output errors with source description              [boolean]
+            --no-templaterc   Does not use the local templaterc, will use a blank
+                              templaterc instead                                 [boolean]
             --print-pending   Print list of formated rules for use with \`pending\` in
                               config file                                        [boolean]
             --ignore-pattern  Specify custom ignore pattern (can be disabled with
@@ -264,7 +270,7 @@ describe('ember-template-lint executable', function () {
 
       it('should be able to run only one rule at a time', function () {
         setProjectConfigForErrorsAndWarning();
-        let result = run(['.', '--rule', 'no-html-comments:1']);
+        let result = run(['.', '--no-templaterc', '--rule', 'no-html-comments:1']);
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout.split('\n')).toEqual([

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -725,36 +725,39 @@ describe('getConfigForFile', function () {
   it('should be able to translate rule:severity to an object', function () {
     expect(getRuleFromString('no-implicit-this:error')).toEqual({
       name: 'no-implicit-this',
-      severity: 2,
-      config: true,
+      config: {
+        severity: 2,
+        config: true,
+      },
     });
     expect(getRuleFromString('no-implicit-this:warn')).toEqual({
       name: 'no-implicit-this',
-      severity: 1,
-      config: true,
+      config: {
+        severity: 1,
+        config: true,
+      },
     });
     expect(getRuleFromString('no-implicit-this:off')).toEqual({
       name: 'no-implicit-this',
-      severity: 0,
-      config: false,
+      config: {
+        severity: 0,
+        config: false,
+      },
     });
   });
 
   it('should be able to translate rule:["severity", { configObject }] to an object', function () {
     expect(getRuleFromString('no-implicit-this:["error", { "allow": ["some-helper"] }]')).toEqual({
       name: 'no-implicit-this',
-      severity: 2,
-      config: { allow: ['some-helper'] },
+      config: { severity: 2, config: { allow: ['some-helper'] } },
     });
     expect(getRuleFromString('no-implicit-this:["warn", { "allow": ["some-helper"] }]')).toEqual({
       name: 'no-implicit-this',
-      severity: 1,
-      config: { allow: ['some-helper'] },
+      config: { severity: 1, config: { allow: ['some-helper'] } },
     });
     expect(getRuleFromString('no-implicit-this:["off", { "allow": ["some-helper"] }]')).toEqual({
       name: 'no-implicit-this',
-      severity: 0,
-      config: { allow: ['some-helper'] },
+      config: { severity: 0, config: { allow: ['some-helper'] } },
     });
   });
 });

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -1,6 +1,12 @@
 'use strict';
 
-const { getProjectConfig, getConfigForFile, determineRuleConfig } = require('../../lib/get-config');
+const {
+  getProjectConfig,
+  getConfigForFile,
+  determineRuleConfig,
+  resolveProjectConfig,
+  getRuleFromString,
+} = require('../../lib/get-config');
 const recommendedConfig = require('../../lib/config/recommended');
 const buildFakeConsole = require('../helpers/console');
 const Project = require('../helpers/fake-project');
@@ -708,5 +714,47 @@ describe('getConfigForFile', function () {
     expect(
       getConfigForFile(config, { moduleId: `${process.cwd()}/foo/bar/baz` }).pendingStatus
     ).toBeTruthy();
+  });
+
+  it('should return an empty object when options.config is set explicitly false', function () {
+    const config = resolveProjectConfig({ config: false });
+
+    expect(config).toEqual({});
+  });
+
+  it('should be able to translate rule:severity to an object', function () {
+    expect(getRuleFromString('no-implicit-this:error')).toEqual({
+      name: 'no-implicit-this',
+      severity: 2,
+      config: true,
+    });
+    expect(getRuleFromString('no-implicit-this:warn')).toEqual({
+      name: 'no-implicit-this',
+      severity: 1,
+      config: true,
+    });
+    expect(getRuleFromString('no-implicit-this:off')).toEqual({
+      name: 'no-implicit-this',
+      severity: 0,
+      config: true,
+    });
+  });
+
+  it('should be able to translate rule:["severity", { configObject }] to an object', function () {
+    expect(getRuleFromString('no-implicit-this:["error", { "allow": ["some-helper"] }]')).toEqual({
+      name: 'no-implicit-this',
+      severity: 2,
+      config: { allow: ['some-helper'] },
+    });
+    expect(getRuleFromString('no-implicit-this:["warn", { "allow": ["some-helper"] }]')).toEqual({
+      name: 'no-implicit-this',
+      severity: 1,
+      config: { allow: ['some-helper'] },
+    });
+    expect(getRuleFromString('no-implicit-this:["off", { "allow": ["some-helper"] }]')).toEqual({
+      name: 'no-implicit-this',
+      severity: 0,
+      config: { allow: ['some-helper'] },
+    });
   });
 });

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -736,7 +736,7 @@ describe('getConfigForFile', function () {
     expect(getRuleFromString('no-implicit-this:off')).toEqual({
       name: 'no-implicit-this',
       severity: 0,
-      config: true,
+      config: false,
     });
   });
 

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -759,5 +759,16 @@ describe('getConfigForFile', function () {
       name: 'no-implicit-this',
       config: { severity: 0, config: { allow: ['some-helper'] } },
     });
+
+    try {
+      expect(getRuleFromString('no-implicit-this:["error", "allow": ["some-helper"] }]')).toEqual({
+        name: 'no-implicit-this',
+        config: { severity: 2, config: { allow: ['some-helper'] } },
+      });
+    } catch (ex) {
+      expect(ex.message).toEqual(
+        'Error parsing specified `--rule` config no-implicit-this:["error", "allow": ["some-helper"] }] as JSON.'
+      );
+    }
   });
 });


### PR DESCRIPTION
# Motivation

There are times where engineers on our team would like to run one rule at a time, just to get a sense of where we are with a migration. eslint has two flags that enable this `--no-eslintrc` and `--rule` cli option. I have added `--rule` and `--no-config-path` that does exactly this https://eslint.org/docs/user-guide/command-line-interface.

## Usage

```sh
# running a single rule without options
./node_modules/.bin/ember-template-lint --no-config-path app/templates --rule 'no-implicit-this:error'
 # running a single rule with options
./node_modules/.bin/ember-template-lint --no-config-path app/templates --rule 'no-implicit-this:["error", { "allow": ["some-helper"] }]'
```

## Screenshots

> Running in a project without a .template-lintrc file local to that project and specifying a rule to run

<img width="946" alt="Screen Shot 2020-04-16 at 1 23 51 AM" src="https://user-images.githubusercontent.com/1854811/79432716-10590680-7f81-11ea-9966-6e3ec91e7a05.png">
> Running in a project without a .template-lintrc file local to that project and specifying a rule to run with warnings as severity

<img width="946" alt="Screen Shot 2020-04-16 at 1 23 57 AM" src="https://user-images.githubusercontent.com/1854811/79432706-0df6ac80-7f81-11ea-97a7-9018a522807a.png">

> Running in a project without a .template-lintrc file local to that project and specifying a rule to run with warnings as severity and specifying additional options

<img width="946" alt="Screen Shot 2020-04-16 at 1 23 32 AM" src="https://user-images.githubusercontent.com/1854811/79432691-06cf9e80-7f81-11ea-808a-c1e3f5b29ff1.png">
> Running in a project without a .template-lintrc file local to that project and specifying a rule to run with error as severity and specifying additional options

<img width="946" alt="Screen Shot 2020-04-16 at 1 23 22 AM" src="https://user-images.githubusercontent.com/1854811/79432680-03d4ae00-7f81-11ea-9b1b-fbeff97c7b9d.png">

fixes #1262 