### PR TITLE
test(cli): Set LC_ALL env var to en_US

### DIFF
--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -7,6 +7,7 @@ const Project = require('../helpers/fake-project');
 describe('ember-template-lint executable', function () {
   setupEnvVar('GITHUB_ACTIONS', null);
   setupEnvVar('FORCE_COLOR', '0');
+  setupEnvVar('LC_ALL', 'en_US');
 
   // Fake project
   let project;


### PR DESCRIPTION
We test --help option in this file with jest snapshots. As this option
is provided by yargs, it has a localized output.

Let's set LC_ALL env var to have a consistent output between various
environments.