### PR TITLE
Bump GH actions/checkout to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
@@ -50,7 +50,7 @@ jobs:
         node-version: [10.x, 13.x]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
@@ -79,7 +79,7 @@ jobs:
     needs: [node12]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x


### PR DESCRIPTION
### Description

I suspect it can fix the CI in the two other PRs I opened a few minutes ago.

It would be great if these dependencies were bumped by dependabot 🤔.

### Links
In https://github.com/actions/checkout, see issue 188 and 23