### PR TITLE
Start testing editor integrations

### DIFF
--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -3,6 +3,7 @@ const { readFileSync } = require('fs');
 
 const execa = require('execa');
 const Project = require('../helpers/fake-project');
+const setupEnvVar = require('../helpers/setup-env-var');
 
 describe('ember-template-lint executable', function () {
   setupEnvVar('GITHUB_ACTIONS', null);
@@ -855,25 +856,3 @@ describe('ember-template-lint executable', function () {
     return execa.sync(require.resolve('../../bin/ember-template-lint.js'), args, options);
   }
 });
-
-function setupEnvVar(name, value) {
-  let oldValue;
-
-  beforeEach(function () {
-    oldValue = name in process.env ? process.env[name] : null;
-
-    if (value === null) {
-      delete process.env[name];
-    } else {
-      process.env[name] = value;
-    }
-  });
-
-  afterEach(function () {
-    if (oldValue === null) {
-      delete process.env[name];
-    } else {
-      process.env[name] = oldValue;
-    }
-  });
-}

--- a/test/acceptance/editors-integration-test.js
+++ b/test/acceptance/editors-integration-test.js
@@ -1,0 +1,64 @@
+'use strict';
+const execa = require('execa');
+const Project = require('../helpers/fake-project');
+const setupEnvVar = require('../helpers/setup-env-var');
+
+function setForBasicDebuggerError(project) {
+  project.setConfig({ rules: { 'no-debugger': true } });
+  project.write({ 'template.hbs': '{{debugger}}' });
+}
+
+function run(project, args, options = {}) {
+  options.reject = false;
+  options.cwd = options.cwd || project.path('.');
+  return execa.sync(require.resolve('../../bin/ember-template-lint.js'), args, options);
+}
+
+describe('editors integration', function () {
+  setupEnvVar('GITHUB_ACTIONS', null);
+  setupEnvVar('FORCE_COLOR', '0');
+  setupEnvVar('LC_ALL', 'en_US');
+
+  // Fake project
+  let project;
+  beforeEach(function () {
+    project = Project.defaultSetup();
+    project.chdir();
+  });
+
+  afterEach(async function () {
+    await project.dispose();
+  });
+
+  describe('reading from stdin', function () {
+    it('prints valid JSON strings with error', function () {
+      setForBasicDebuggerError(project);
+
+      let result = run(
+        project,
+        ['--json', '--filename', 'template.hbs', '/dev/stdin', '<', 'template.hbs'],
+        {
+          shell: true,
+        }
+      );
+
+      let expectedOutputData = {};
+      expectedOutputData['template.hbs'] = [
+        {
+          column: 0,
+          line: 1,
+          message: 'Unexpected {{debugger}} usage.',
+          filePath: 'template.hbs',
+          moduleId: 'template',
+          rule: 'no-debugger',
+          severity: 2,
+          source: '{{debugger}}',
+        },
+      ];
+
+      expect(result.exitCode).toEqual(1);
+      expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
+      expect(result.stderr).toBeFalsy();
+    });
+  });
+});

--- a/test/helpers/setup-env-var.js
+++ b/test/helpers/setup-env-var.js
@@ -1,0 +1,21 @@
+module.exports = function setupEnvVar(name, value) {
+  let oldValue;
+
+  beforeEach(function () {
+    oldValue = name in process.env ? process.env[name] : null;
+
+    if (value === null) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  });
+
+  afterEach(function () {
+    if (oldValue === null) {
+      delete process.env[name];
+    } else {
+      process.env[name] = oldValue;
+    }
+  });
+};


### PR DESCRIPTION
I've investigated why ALE plugin for vim is not working starting with version 2.0.0-beta.0 until today. I'm writting down my findings here.

#### How does ALE plugin lint files?
How does the plugin works? It copies a temporary copy of the current file to `/var/some-path`. Then it runs the command `ember-template-lint --json /var/some-path`.

#### An issue in globby
This command used to work in template-lint v1. It stopped working in v2.0.0-beta.1 when we upgraded globby from v9.2.0 to v10 (and then upgrading to v11 didn't solve this issue). Today, if we reverted globby to v9.2.0, ALE plugin would start working again.

#### A path forward
In template-lint v1.6.0 was introduced the ability to lint from stdin. So I opened a PR to update ALE command to: `ember-template-lint --json --filename current-file.hbs < currentFile`.

#### Testing editor integrations
In this PR, I'm adding a test to cover this command to make sure we don't have a similar regression in the future. Maybe the issue between globby and the temporary files might have been caught with a test?

I could improve the command if someone had a better suggestion.


/cc @mwpastore (as I noticed you opened a similar issue in ALE).