### PR TITLE
Reproduce two bugs w/ globby

### DIFF
--- a/test/acceptance/editors-integration-test.js
+++ b/test/acceptance/editors-integration-test.js
@@ -8,9 +8,9 @@ function setForBasicDebuggerError(project) {
   project.write({ 'template.hbs': '{{debugger}}' });
 }
 
-function run(project, args, options = {}) {
+function run(args, options = {}) {
   options.reject = false;
-  options.cwd = options.cwd || project.path('.');
+  options.shell = true;
   return execa.sync(require.resolve('../../bin/ember-template-lint.js'), args, options);
 }
 
@@ -23,6 +23,7 @@ describe('editors integration', function () {
   let project;
   beforeEach(function () {
     project = Project.defaultSetup();
+    setForBasicDebuggerError(project);
     project.chdir();
   });
 
@@ -32,13 +33,11 @@ describe('editors integration', function () {
 
   describe('reading from stdin', function () {
     it('prints valid JSON strings with error', function () {
-      setForBasicDebuggerError(project);
-
       let result = run(
         project,
         ['--json', '--filename', 'template.hbs', '/dev/stdin', '<', 'template.hbs'],
         {
-          shell: true,
+          cwd: project.path('.'),
         }
       );
 

--- a/test/acceptance/editors-integration-test.js
+++ b/test/acceptance/editors-integration-test.js
@@ -60,4 +60,41 @@ describe('editors integration', function () {
       expect(result.stderr).toBeFalsy();
     });
   });
+
+  describe('creating a temporary file', function () {
+    let project;
+    beforeEach(function () {
+      project = new Project('another-fake-project');
+      project.write({ 'template.hbs': '{{debugger}}' });
+    });
+
+    afterEach(async function () {
+      await project.dispose();
+    });
+
+    it('prints valid JSON strings with error', function () {
+      let result = run(['--json', project.path('template.hbs')]);
+
+      let expectedOutputData = {};
+      expectedOutputData['template.hbs'] = [
+        {
+          column: 0,
+          line: 1,
+          message: 'Unexpected {{debugger}} usage.',
+          filePath: 'template.hbs',
+          moduleId: 'template',
+          rule: 'no-debugger',
+          severity: 2,
+          source: '{{debugger}}',
+        },
+      ];
+
+      // result is an error thrown by globby
+      expect(result).toEqual(1);
+
+      // expect(result.exitCode).toEqual(1);
+      // expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
+      // expect(result.stderr).toBeFalsy();
+    });
+  });
 });

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -8,47 +8,33 @@ describe('expandFileGlobs', function () {
 
   beforeEach(function () {
     project = Project.defaultSetup();
-  });
+    project.chdir();
 
+    project.write({ 'application.hbs': 'almost empty' });
+  });
   afterEach(async function () {
     await project.dispose();
   });
 
   describe('basic', function () {
-    beforeEach(function () {
-      project.chdir();
-    });
-
     it('resolves a basic pattern', function () {
-      project.write({ 'application.hbs': 'almost empty' });
-
       let files = expandFileGlobs(['application.hbs', 'other.hbs'], []);
       expect(files.has('application.hbs')).toBe(true);
     });
 
     it('respects a basic ignore option', function () {
-      project.write({ 'application.hbs': 'almost empty' });
-
       let files = expandFileGlobs(['application.hbs', 'other.hbs'], ['application.hbs']);
       expect(files.has('application.hbs')).toBe(false);
     });
   });
 
   describe('glob', function () {
-    beforeEach(function () {
-      project.chdir();
-    });
-
     it('resolves a glob pattern', function () {
-      project.write({ 'application.hbs': 'almost empty' });
-
       let files = expandFileGlobs(['*'], []);
       expect(files.has('application.hbs')).toBe(true);
     });
 
     it('respects a glob ignore option', function () {
-      project.write({ 'application.hbs': 'almost empty' });
-
       let files = expandFileGlobs(['application.hbs'], ['*']);
       expect(files.has('application.hbs')).toBe(false);
     });

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -4,6 +4,7 @@ const { _expandFileGlobs: expandFileGlobs } = require('../../../bin/ember-templa
 const Project = require('../../helpers/fake-project');
 
 describe('expandFileGlobs', function () {
+  let anotherProject = null;
   let project = null;
 
   beforeEach(function () {
@@ -11,9 +12,12 @@ describe('expandFileGlobs', function () {
     project.chdir();
 
     project.write({ 'application.hbs': 'almost empty' });
+
+    anotherProject = new Project('another-fake-project');
   });
   afterEach(async function () {
     await project.dispose();
+    await anotherProject.dispose();
   });
 
   describe('basic', function () {
@@ -57,7 +61,7 @@ describe('expandFileGlobs', function () {
 
       // we want to test `expandFileGlobs` with a relative path
       // so, let's change process.cwd to another tmp folder
-      new Project('another-fake-project').chdir();
+      anotherProject.chdir();
 
       let files = expandFileGlobs([relativePathToTemplate], []);
 

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -39,4 +39,30 @@ describe('expandFileGlobs', function () {
       expect(files.has('application.hbs')).toBe(false);
     });
   });
+
+  describe('relative path', function () {
+    it('resolves a relative path pattern', function () {
+      // To build a relative path from a tmp directory to another, we need the
+      // last two segments (a randomly generated directory name and  the name of
+      // our project: `fake-project`).
+      //
+      // For reference, here is how the node package `tmp` creates file paths:
+      // https://github.com/raszi/node-tmp/blob/b6465b0665b9d7a788460386a1d9b04870d72532/lib/tmp.js#L470
+      //
+      // So, from `project`'s absolute path, we take the last two segments.
+      let projectSegments = project.path().split('/');
+      let randomDirectoryName = projectSegments[projectSegments.length - 2];
+      let projectName = projectSegments[projectSegments.length - 1];
+      let relativePathToTemplate = `../../${randomDirectoryName}/${projectName}/application.hbs`;
+
+      // we want to test `expandFileGlobs` with a relative path
+      // so, let's change process.cwd to another tmp folder
+      new Project('another-fake-project').chdir();
+
+      let files = expandFileGlobs([relativePathToTemplate], []);
+
+      // files is an error thrown by globby
+      expect(files).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
#### Description

First error is:
```
throw new Error(`Path ${p} is not in cwd ${cwd}`);
```
Second error is:
```
RangeError: path should be a `path.relative()`d string, but got "../../tmp-28160qlGvn65K8XAe/fake-project.js"
```

ALE plugin (for vim) is muted by the first error.

If you'd like to have a look to the stack trace, see the commit messages.

#### Context

This is a follow-up for https://github.com/ember-template-lint/ember-template-lint/pull/1270

Ideally, I'd like to merge these tests. But they might require a fix (or two) on globby side.