### PR TITLE
Use get-stdin dependency to read from stdin

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "chalk": "^4.0.0",
     "ember-template-recast": "^4.1.2",
     "find-up": "^4.1.0",
+    "get-stdin": "^7.0.0",
     "globby": "^11.0.0",
     "micromatch": "^4.0.2",
     "resolve": "^1.15.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2442,6 +2442,11 @@ get-stdin@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
+get-stdin@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
+  integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
+
 get-stdin@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"


### PR DESCRIPTION
`process.stdin.fd` is considered as a private NodeJs api. This PR proposes to retire it for `get-stdin`. This would implement a TODO that was in the code.