### PR TITLE
Use the correct title in generated rule doc when running `yarn new`

### DIFF
--- a/dev/new-rule/index.js
+++ b/dev/new-rule/index.js
@@ -63,7 +63,7 @@ function createNewRuleDocFile(newRuleName) {
   let pathDocTemplate = path.join(pathTemplates, 'doc.md');
   let pathDocNew = path.join(pathRoot, 'docs', 'rule', `${newRuleName}.md`);
   let orgContent = fs.readFileSync(pathDocTemplate, { encoding: 'utf8' });
-  let placeholderDocTemplate = '(TODO: rule-name-goes-here)';
+  let placeholderDocTemplate = 'TODO: rule-name-goes-here';
   let outContent = orgContent.replace(placeholderDocTemplate, newRuleName);
   fs.writeFileSync(pathDocNew, outContent);
   console.log(


### PR DESCRIPTION
This PR addresses a minor issue whereby the `$ yarn new` CLI utility does not correctly replace the template's placeholder text when generating the new rule doc file. Specifically, the placeholder text searched for searched for by the utility's `createNewRuleDocFile` function does not match the current template, so it never gets found or replaced. This PR updates that function accordingly.