### PR TITLE
Set a shorter timeout for Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   node12:
     name: Node 12.x
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v2
@@ -39,8 +40,8 @@ jobs:
 
   nodeX:
     name: Node ${{ matrix.node-version }}
-
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
 
     needs: [node12]
 
@@ -73,8 +74,8 @@ jobs:
 
   floating-dependencies:
     name: Floating Dependencies
-
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     needs: [node12]
 


### PR DESCRIPTION
Default is 360 minutes. It was reached with that PR: https://github.com/ember-template-lint/ember-template-lint/pull/1284