### PR TITLE
failing test for require-valid-alt-text

### DIFF
--- a/test/unit/rules/require-valid-alt-text-test.js
+++ b/test/unit/rules/require-valid-alt-text-test.js
@@ -47,6 +47,7 @@ generateRuleTests({
     '<area aria-hidden="true">',
     '<area aria-labelledby="some-alt">',
     '<area aria-label="some-alt">',
+    '<img role={{unless this.altText "presentation"}} alt={{this.altText}}>',
   ],
 
   bad: [


### PR DESCRIPTION
This is a demonstration for the issue mentioned in https://github.com/ember-template-lint/ember-template-lint/issues/1286