### PR TITLE
Add shell-specific tests for reading from stdin

### DIFF
--- a/test/acceptance/stdin-by-platform-test.js
+++ b/test/acceptance/stdin-by-platform-test.js
@@ -1,0 +1,139 @@
+'use strict';
+
+const execa = require('execa');
+const Project = require('../helpers/fake-project');
+const setupEnvVar = require('../helpers/setup-env-var');
+
+describe('ember-template-lint executable', function () {
+  setupEnvVar('GITHUB_ACTIONS', null);
+  setupEnvVar('FORCE_COLOR', '0');
+  setupEnvVar('LC_ALL', 'en_US');
+
+  // Fake project
+  let project;
+  beforeEach(function () {
+    project = Project.defaultSetup();
+    project.setConfig({
+      rules: {
+        'no-bare-strings': true,
+      },
+    });
+    project.write({
+      'template.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+      components: {
+        'foo.hbs': '{{fooData}}',
+      },
+    });
+    project.chdir();
+  });
+
+  afterEach(async function () {
+    await project.dispose();
+  });
+
+  if (process.platform === 'win32') {
+    describe('in Windows Command Prompt', function () {
+      describe('command: `node ember-template-lint --filename template.hbs < template.hbs`', function () {
+        it('reports errors to stdout', async function () {
+          let result = await execa(
+            process.execPath,
+            [
+              require.resolve('../../bin/ember-template-lint.js'),
+              '--filename',
+              'template.hbs',
+              '<',
+              'template.hbs',
+            ],
+            { shell: true, reject: false, cwd: project.path('.') }
+          );
+
+          expect(result.stdout).toMatchInlineSnapshot(`
+            "template.hbs
+              1:4  error  Non-translated string used  no-bare-strings
+              1:25  error  Non-translated string used  no-bare-strings
+
+            ✖ 2 problems (2 errors, 0 warnings)"
+          `);
+          expect(result.stderr).toBeFalsy();
+        });
+      });
+    });
+  }
+
+  if (process.platform === 'linux' || process.platform === 'darwin') {
+    describe('in unix bash', function () {
+      describe('command: `cat template.hbs | ember-template-lint --filename template.hbs`', function () {
+        it('has exit code 1 and reports errors to stdout', async function () {
+          let result = await execa(
+            'cat',
+            [
+              'template.hbs',
+              '|',
+              require.resolve('../../bin/ember-template-lint.js'),
+              '--filename',
+              'template.hbs',
+            ],
+            { shell: true, reject: false, cwd: project.path('.') }
+          );
+
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout).toMatchInlineSnapshot(`
+            "template.hbs
+              1:4  error  Non-translated string used  no-bare-strings
+              1:25  error  Non-translated string used  no-bare-strings
+
+            ✖ 2 problems (2 errors, 0 warnings)"
+          `);
+          expect(result.stderr).toBeFalsy();
+        });
+      });
+
+      describe('command: `cat template.hbs | ember-template-lint --filename template.hbs -`', function () {
+        it('has exit code 1 and reports errors to stdout', async function () {
+          let result = await execa(
+            'cat',
+            [
+              'template.hbs',
+              '|',
+              require.resolve('../../bin/ember-template-lint.js'),
+              '--filename',
+              'template.hbs',
+              '-',
+            ],
+            { shell: true, reject: false, cwd: project.path('.') }
+          );
+
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout).toMatchInlineSnapshot(`
+            "template.hbs
+              1:4  error  Non-translated string used  no-bare-strings
+              1:25  error  Non-translated string used  no-bare-strings
+
+            ✖ 2 problems (2 errors, 0 warnings)"
+          `);
+          expect(result.stderr).toBeFalsy();
+        });
+      });
+
+      describe('command: `ember-template-lint --filename template.hbs < template.hbs`', function () {
+        it('has exit code 1 and reports errors to stdout', async function () {
+          let result = await execa(
+            require.resolve('../../bin/ember-template-lint.js'),
+            ['--filename', 'template.hbs', '<', 'template.hbs'],
+            { shell: true, reject: false, cwd: project.path('.') }
+          );
+
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout).toMatchInlineSnapshot(`
+            "template.hbs
+              1:4  error  Non-translated string used  no-bare-strings
+              1:25  error  Non-translated string used  no-bare-strings
+
+            ✖ 2 problems (2 errors, 0 warnings)"
+          `);
+          expect(result.stderr).toBeFalsy();
+        });
+      });
+    });
+  }
+});

--- a/test/acceptance/stdin-by-platform-test.js
+++ b/test/acceptance/stdin-by-platform-test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const execa = require('execa');
 const Project = require('../helpers/fake-project');
 const setupEnvVar = require('../helpers/setup-env-var');
@@ -31,63 +33,56 @@ describe('ember-template-lint executable', function () {
     await project.dispose();
   });
 
-  if (process.platform === 'win32') {
-    describe('in Windows Command Prompt', function () {
-      describe('command: `node ember-template-lint --filename template.hbs < template.hbs`', function () {
-        it('reports errors to stdout', async function () {
-          let result = await execa(
-            process.execPath,
-            [
-              require.resolve('../../bin/ember-template-lint.js'),
-              '--filename',
-              'template.hbs',
-              '<',
-              'template.hbs',
-            ],
-            { shell: true, reject: false, cwd: project.path('.') }
-          );
+  describe('command: `node ember-template-lint --filename template.hbs < template.hbs`', function () {
+    it('reports errors to stdout', async function () {
+      let result = await execa(
+        process.execPath,
+        [
+          require.resolve('../../bin/ember-template-lint.js'),
+          '--filename',
+          'template.hbs',
+          '<',
+          'template.hbs',
+        ],
+        { shell: true, reject: false, cwd: project.path('.') }
+      );
 
-          expect(result.stdout).toMatchInlineSnapshot(`
+      expect(result.stdout).toMatchInlineSnapshot(`
             "template.hbs
               1:4  error  Non-translated string used  no-bare-strings
               1:25  error  Non-translated string used  no-bare-strings
 
             ✖ 2 problems (2 errors, 0 warnings)"
           `);
-          expect(result.stderr).toBeFalsy();
-        });
-      });
+      expect(result.stderr).toBeFalsy();
     });
-  }
 
-  if (process.platform === 'linux' || process.platform === 'darwin') {
-    describe('in unix bash', function () {
-      describe('command: `cat template.hbs | ember-template-lint --filename template.hbs`', function () {
-        it('has exit code 1 and reports errors to stdout', async function () {
-          let result = await execa(
-            'cat',
-            [
-              'template.hbs',
-              '|',
-              require.resolve('../../bin/ember-template-lint.js'),
-              '--filename',
-              'template.hbs',
-            ],
-            { shell: true, reject: false, cwd: project.path('.') }
-          );
+    it('has exit code 1 and reports errors to stdout', async function () {
+      let result = await execa(
+        process.execPath,
+        [require.resolve('../../bin/ember-template-lint.js'), '--filename', 'template.hbs'],
+        {
+          shell: false,
+          reject: false,
+          cwd: project.path('.'),
+          input: fs.readFileSync(path.resolve('template.hbs')),
+        }
+      );
 
-          expect(result.exitCode).toEqual(1);
-          expect(result.stdout).toMatchInlineSnapshot(`
+      expect(result.exitCode).toEqual(1);
+      expect(result.stdout).toMatchInlineSnapshot(`
             "template.hbs
               1:4  error  Non-translated string used  no-bare-strings
               1:25  error  Non-translated string used  no-bare-strings
 
             ✖ 2 problems (2 errors, 0 warnings)"
           `);
-          expect(result.stderr).toBeFalsy();
-        });
-      });
+      expect(result.stderr).toBeFalsy();
+    });
+  });
 
+  if (process.platform !== 'win32') {
+    describe('posix environments', function () {
       describe('command: `cat template.hbs | ember-template-lint --filename template.hbs -`', function () {
         it('has exit code 1 and reports errors to stdout', async function () {
           let result = await execa(
@@ -100,26 +95,6 @@ describe('ember-template-lint executable', function () {
               'template.hbs',
               '-',
             ],
-            { shell: true, reject: false, cwd: project.path('.') }
-          );
-
-          expect(result.exitCode).toEqual(1);
-          expect(result.stdout).toMatchInlineSnapshot(`
-            "template.hbs
-              1:4  error  Non-translated string used  no-bare-strings
-              1:25  error  Non-translated string used  no-bare-strings
-
-            ✖ 2 problems (2 errors, 0 warnings)"
-          `);
-          expect(result.stderr).toBeFalsy();
-        });
-      });
-
-      describe('command: `ember-template-lint --filename template.hbs < template.hbs`', function () {
-        it('has exit code 1 and reports errors to stdout', async function () {
-          let result = await execa(
-            require.resolve('../../bin/ember-template-lint.js'),
-            ['--filename', 'template.hbs', '<', 'template.hbs'],
             { shell: true, reject: false, cwd: project.path('.') }
           );
 


### PR DESCRIPTION
https://github.com/ember-template-lint/ember-template-lint/pull/1282 should be settled first

In unix shells, test the following commands (with the option `shell: true` for execa):
```
cat template.hbs | ember-template-lint --filename template.hbs
cat template.hbs | ember-template-lint --filename template.hbs -
ember-template-lint --filename template.hbs < template.hbs
```

In Windows command prompt, test (with the option `shell: true` for execa):
```
node ember-template-lint --filename template.hbs < template.hbs
```

I'd have like to add a test for the command in Windows PowerShell, but AFAICT execa doesn't support passing commands to PowerShell.

With this safety net, I think we'd have catched the issue on Windows (https://github.com/ember-template-lint/ember-template-lint/issues/1281) more easily.