### PR TITLE
Tweak Installation section of `README.md` to clarify that `ember-template-lint` is installed by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ the `no-bare-strings` rule found an error.
 
 ## Install
 
+This addon is installed by default with new Ember apps, so check your package.json before installing to see if you need to install it.
+
 To install ember-template-lint
 
 ```shell


### PR DESCRIPTION
Update installation instructions with note that this addon is included by default in new Ember apps, and to check the app's package.json before installing.