### PR TITLE
Bug: Fixed invalid URL syntax in documentation reference for no-invalid-link-title rule

### DIFF
--- a/docs/rule/no-invalid-link-title.md
+++ b/docs/rule/no-invalid-link-title.md
@@ -24,5 +24,5 @@ This rule **allows** the following:
 
 ## References
 
-* [Supplementing link text with the title attribute](<https://www.w3.org/TR/WCAG20-TECHS/H33.html)>
+* [Supplementing link text with the title attribute](https://www.w3.org/TR/WCAG20-TECHS/H33.html)
 * [Understanding Link Purpose](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-refs.html)


### PR DESCRIPTION
Updating syntax of reference link so it will be a valid URL.