### PR TITLE
Refactor CI setup.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ on:
     - cron:  '0 3 * * *' # daily, at 3am
 
 jobs:
-  node12:
-    name: Node 12.x
+  test:
+    name: Node 12.x - ubuntu
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -30,7 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 10
 
-    needs: [node12]
+    needs: [test]
 
     strategy:
       matrix:
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
-    needs: [node12]
+    needs: [test]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,6 @@ jobs:
         with:
           node-version: 12.x
 
-      - name: get yarn cache dir
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-node-12.x-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: install dependencies
         run: yarn install --frozen-lockfile
 
@@ -56,17 +45,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: get yarn cache dir
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-node-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
       - name: install dependencies
         run: yarn install --frozen-lockfile --ignore-engines
 
@@ -84,17 +62,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12.x
-
-      - name: get yarn cache dir
-        id: yarn-cache
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        with:
-          path: ${{ steps.yarn-cache.outputs.dir }}
-          key: ${{ runner.os }}-yarn-floating-dependencies-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
 
       - name: install dependencies
         run: yarn install --no-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
+      - uses: volta-cli/action@v1
 
       - name: install dependencies
         run: yarn install --frozen-lockfile
@@ -41,7 +39,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: volta-cli/action@v1
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -59,7 +57,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: volta-cli/action@v1
         with:
           node-version: 12.x
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ jobs:
       - name: install dependencies
         run: yarn install --frozen-lockfile
 
-      - run: yarn test
+      - run: yarn lint
+      - run: yarn test:jest
 
   nodeX:
     name: Node ${{ matrix.node-version }} - ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: install dependencies
         run: yarn install --frozen-lockfile --ignore-engines
 
-      - run: yarn test
+      - run: yarn test:jest
 
   floating-dependencies:
     name: Floating Dependencies
@@ -69,4 +69,4 @@ jobs:
       - name: install dependencies
         run: yarn install --no-lockfile
 
-      - run: yarn test
+      - run: yarn test:jest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows]
-        node-version: [10.x, 13.x, 14.x]
+        node-version: [10.x, 12.x, 13.x, 14.x]
+
+        # excluded because it is the `test` job above
+        exclude:
+          - os: ubuntu
+            node-version: 12.x
 
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -83,5 +83,9 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
+  },
+  "volta": {
+    "node": "12.16.3",
+    "yarn": "1.22.4"
   }
 }


### PR DESCRIPTION
* Run linting separate from tests
* Run `test:jest` from non-default jobs
* Ensure we run all combos of 10,12,13,14 for each platform
* Rename the default CI job `test`
* Use volta-cli/action
* Remove actions/cache usage