### PR TITLE
Add new rule: `no-positional-data-test-selectors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Each rule has emojis denoting:
 | :white_check_mark:         | [no-outlet-outside-routes](./docs/rule/no-outlet-outside-routes.md)                        |
 | :white_check_mark:         | [no-partial](./docs/rule/no-partial.md)                                                    |
 |                            | [no-passed-in-event-handlers](./docs/rule/no-passed-in-event-handlers.md)                  |
+| :wrench:                   | [no-positional-data-test-selectors](./docs/rule/no-positional-data-test-selectors.md)      |
 | :white_check_mark:         | [no-positive-tabindex](./docs/rule/no-positive-tabindex.md)                                |
 | :white_check_mark:         | [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md)                          |
 |                            | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)                    |

--- a/docs/rule/no-positional-data-test-selectors.md
+++ b/docs/rule/no-positional-data-test-selectors.md
@@ -34,8 +34,8 @@ And suggests using the following instead:
 {{/foo-bar}}
 ```
 
-Additionally, this rule implements `--fix` support to automatically convert the "bad" examples into "good" ones.
+:wrench: The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
 
 ## References
 
-[Not Supported](https://github.com/simplabs/ember-test-selectors/commit/d47f73d76b3ccbc9f0be5df3b897afd08b1636a6)
+- [ember-test-selectors#d47f73d](https://github.com/simplabs/ember-test-selectors/commit/d47f73d76b3ccbc9f0be5df3b897afd08b1636a6)

--- a/docs/rule/no-positional-data-test-selectors.md
+++ b/docs/rule/no-positional-data-test-selectors.md
@@ -1,0 +1,41 @@
+# no-positional-data-test-selectors
+
+## Motivation
+
+[ember-test-selectors](https://github.com/simplabs/ember-test-selectors) is a very popular library that enables better element selectors for testing.
+
+One of the features that had been added to ember-test-selectors over the years was to allow passing a positional argument to curly component invocations as a shorthand (to avoid having to also add a named argument value).
+
+That would look like:
+
+```hbs
+{{some-thing data-test-foo}}
+```
+
+Internally, that was converted to an `attributeBinding` for `@ember/component`s. Unfortunately, that particular invocation syntax is in conflict with modern Ember Octane templates. For example, in the snippet above `data-test-foo` is actually referring to `this.data-test-foo` (and would be marked as an error by the `no-implicit-this` rule).
+
+Additionally, the nature of these "fake" local properties significantly confuses the codemods that are used to transition an application into Ember Octane (e.g. [ember-no-implicit-this-codemod](https://github.com/ember-codemods/ember-no-implicit-this-codemod) and [ember-angle-brackets-codemod](https://github.com/ember-codemods/ember-angle-brackets-codemod)).
+
+## Examples
+
+This rule forbids the following:
+
+```hbs
+{{foo-bar data-test-blah}}
+{{#foo-bar data-test-blah}}
+{{/foo-bar}}
+```
+
+And suggests using the following instead:
+
+```hbs
+{{foo-bar data-test-blah=true}}
+{{#foo-bar data-test-blah=true}}
+{{/foo-bar}}
+```
+
+Additionally, this rule implements `--fix` support to automatically convert the "bad" examples into "good" ones.
+
+## References
+
+[Not Supported](https://github.com/simplabs/ember-test-selectors/commit/d47f73d76b3ccbc9f0be5df3b897afd08b1636a6)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   'attribute-indentation': require('./attribute-indentation'),
   'block-indentation': require('./block-indentation'),
+  'no-positional-data-test-selectors': require('./no-positional-data-test-selectors'),
   'deprecated-each-syntax': require('./deprecations/deprecated-each-syntax'),
   'deprecated-inline-view-helper': require('./deprecations/deprecated-inline-view-helper'),
   'deprecated-render-helper': require('./deprecations/deprecated-render-helper'),

--- a/lib/rules/no-positional-data-test-selectors.js
+++ b/lib/rules/no-positional-data-test-selectors.js
@@ -3,7 +3,7 @@
 const Rule = require('./base');
 const { builders: b } = require('ember-template-recast');
 
-const BUILT_INS = [
+const BUILT_INS = new Set([
   'action',
   'array',
   'component',
@@ -35,7 +35,7 @@ const BUILT_INS = [
   'with',
   '-in-element',
   'in-element',
-];
+]);
 
 module.exports = class NoPositionalDataTestSelectors extends Rule {
   visitor() {
@@ -50,7 +50,7 @@ module.exports = class NoPositionalDataTestSelectors extends Rule {
   }
 
   process(node) {
-    if (BUILT_INS.includes(node.path.original)) {
+    if (BUILT_INS.has(node.path.original)) {
       return;
     }
 

--- a/lib/rules/no-positional-data-test-selectors.js
+++ b/lib/rules/no-positional-data-test-selectors.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const Rule = require('./base');
+const { builders: b } = require('ember-template-recast');
+
+const BUILT_INS = [
+  'action',
+  'array',
+  'component',
+  'concat',
+  'debugger',
+  'each',
+  'each-in',
+  'fn',
+  'get',
+  'hasBlock',
+  'has-block',
+  'has-block-params',
+  'hash',
+  'if',
+  'input',
+  'let',
+  'link-to',
+  'loc',
+  'log',
+  'mount',
+  'mut',
+  'on',
+  'outlet',
+  'partial',
+  'query-params',
+  'textarea',
+  'unbound',
+  'unless',
+  'with',
+  '-in-element',
+  'in-element',
+];
+
+module.exports = class NoPositionalDataTestSelectors extends Rule {
+  visitor() {
+    return {
+      MustacheStatement(node) {
+        this.process(node);
+      },
+      BlockStatement(node) {
+        this.process(node);
+      },
+    };
+  }
+
+  process(node) {
+    if (BUILT_INS.includes(node.path.original)) {
+      return;
+    }
+
+    let testSelectorParamIndex = node.params.findIndex(
+      (n) => n.type === 'PathExpression' && n.original.startsWith('data-test-')
+    );
+
+    if (testSelectorParamIndex === -1) {
+      return;
+    }
+
+    if (this.mode === 'fix') {
+      let selectorName = node.params[testSelectorParamIndex].original;
+
+      // remove the item from `params`
+      node.params.splice(testSelectorParamIndex, 1);
+
+      // add it as a HashPair
+      node.hash.pairs.unshift(b.pair(selectorName, b.boolean(true)));
+    } else {
+      this.log({
+        message:
+          'Passing a `data-test-*` positional param to a curly invocation should be avoided.',
+        line: node.loc && node.loc.start.line,
+        column: node.loc && node.loc.start.column,
+        source: this.sourceForNode(node),
+        isFixable: true,
+      });
+    }
+  }
+};

--- a/test/unit/rules/no-positional-data-test-selectors-test.js
+++ b/test/unit/rules/no-positional-data-test-selectors-test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'no-positional-data-test-selectors',
+  config: true,
+  good: [
+    `
+      {{#if data-test-foo}}
+      {{/if}}
+    `,
+    `
+      <div data-test-blah></div>
+    `,
+    `
+      <Foo data-test-derp />
+    `,
+    `
+      {{something data-test-lol=true}}
+    `,
+    `
+      {{#if dataSomething}}
+        <div> hello </div>
+      {{/if}}
+    `,
+    `
+      <div
+        data-test-msg-connections-typeahead-result={{true}}
+      >
+      </div>
+    `,
+    `
+      <div
+        data-test-msg-connections-typeahead-result="foo-bar"
+      >
+      </div>
+    `,
+    `
+      {{badge
+        data-test-profile-card-one-to-one-connection-distance=true
+        degreeText=(t "i18n_distance_v2" distance=recipientDistance)
+        degreeA11yText=(t "i18n_distance_a11y_v2" distance=recipientDistance)
+      }}
+    `,
+    `
+      {{badge
+        data-test-profile-card-one-to-one-connection-distance="foo-bar"
+        degreeText=(t "i18n_distance_v2" distance=recipientDistance)
+        degreeA11yText=(t "i18n_distance_a11y_v2" distance=recipientDistance)
+      }}
+    `,
+    `
+      <div
+        data-test-profile=true
+      >
+        hello
+      </div>
+    `,
+  ],
+  bad: [
+    {
+      template: `
+        {{badge
+          data-test-profile-card-one-to-one-connection-distance
+          degreeText=(t "i18n_distance_v2" distance=recipientDistance)
+          degreeA11yText=(t "i18n_distance_a11y_v2" distance=recipientDistance)
+        }}
+      `,
+      fixedTemplate: `
+        {{badge
+          data-test-profile-card-one-to-one-connection-distance=true
+          degreeText=(t "i18n_distance_v2" distance=recipientDistance)
+          degreeA11yText=(t "i18n_distance_a11y_v2" distance=recipientDistance)
+        }}
+      `,
+      result: {
+        message:
+          'Passing a `data-test-*` positional param to a curly invocation should be avoided.',
+        line: 2,
+        column: 8,
+        source:
+          '{{badge\n          data-test-profile-card-one-to-one-connection-distance\n          degreeText=(t "i18n_distance_v2" distance=recipientDistance)\n          degreeA11yText=(t "i18n_distance_a11y_v2" distance=recipientDistance)\n        }}',
+        isFixable: true,
+      },
+    },
+  ],
+});


### PR DESCRIPTION
# Motivation

[ember-test-selectors](https://github.com/simplabs/ember-test-selectors) is a very popular library that enables better element selectors for testing.

One of the features that had been added to ember-test-selectors over the years was to allow passing a positional argument to curly component invocations as a shorthand (to avoid having to also add a named argument value).

That would look like:

```hbs
{{some-thing data-test-foo}}
```

Internally, that was converted to an `attributeBinding` for `@ember/component`s. Unfortunately, that particular invocation syntax is in conflict with modern Ember Octane templates. For example, in the snippet above `data-test-foo` is actually referring to `this.data-test-foo` (and would be marked as an error by the `no-implicit-this` rule).

Additionally, the nature of these "fake" local properties significantly confuses the codemods that are used to transition an application into Ember Octane (e.g. [ember-no-implicit-this-codemod](https://github.com/ember-codemods/ember-no-implicit-this-codemod) and [ember-angle-brackets-codemod](https://github.com/ember-codemods/ember-angle-brackets-codemod)).

# Design

This rule forbids the following:

```hbs
{{foo-bar data-test-blah}}
{{#foo-bar data-test-blah}}
{{/foo-bar}}
```

And suggests using the following instead:

```hbs
{{foo-bar data-test-blah=true}}
{{#foo-bar data-test-blah=true}}
{{/foo-bar}}
```

Additionally, this rule implements `--fix` support to automatically convert the "bad" examples into "good" ones.