### PR TITLE
Avoid glob matching when no-glob is present (e.g. globs have already been replaced by shell expansion)

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ var results = linter.verify({ source: template, moduleId: 'template.hbs' });
 
 Basic `ember-template-lint` executable is provided, allowing for easy use within i.e. Git pre-commit/push hooks and development of appropriate plugins for text editors.
 
+> If using _ZSH_ wrap all glob patterns in quotes so that it won't be interpreted by the CLI. `./node_modules/.bin/ember-template-lint app/templates/**` (this will expand all paths in app/templates) and `./node_modules/.bin/ember-template-lint "app/templates/**"` (this will pass the glob to ember-template-lint and not interpret the glob).
+
 Example usage:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ var results = linter.verify({ source: template, moduleId: 'template.hbs' });
 
 Basic `ember-template-lint` executable is provided, allowing for easy use within i.e. Git pre-commit/push hooks and development of appropriate plugins for text editors.
 
-> If using _ZSH_ wrap all glob patterns in quotes so that it won't be interpreted by the CLI. `./node_modules/.bin/ember-template-lint app/templates/**` (this will expand all paths in app/templates) and `./node_modules/.bin/ember-template-lint "app/templates/**"` (this will pass the glob to ember-template-lint and not interpret the glob).
+> Ensure you wrap all glob patterns in quotes so that it won't be interpreted by the CLI. `./node_modules/.bin/ember-template-lint app/templates/**` (this will expand all paths in app/templates) and `./node_modules/.bin/ember-template-lint "app/templates/**"` (this will pass the glob to ember-template-lint and not interpret the glob).
 
 Example usage:
 

--- a/README.md
+++ b/README.md
@@ -62,34 +62,34 @@ Example usage:
 
 ```bash
 # basic usage
-./node_modules/.bin/ember-template-lint app/templates/application.hbs
+./node_modules/.bin/ember-template-lint "app/templates/application.hbs"
 
 # output errors with source description
-./node_modules/.bin/ember-template-lint app/templates/application.hbs --verbose
+./node_modules/.bin/ember-template-lint "app/templates/application.hbs" --verbose
 
 # multiple file/directory/wildcard paths are accepted
-./node_modules/.bin/ember-template-lint app/templates/components/**/* app/templates/application.hbs
+./node_modules/.bin/ember-template-lint "app/templates/components/**/*" "app/templates/application.hbs"
 
 # output errors as pretty-printed JSON string
-./node_modules/.bin/ember-template-lint app/templates/application.hbs --json
+./node_modules/.bin/ember-template-lint "app/templates/application.hbs" --json
 
 # ignore warnings / only report errors
-./node_modules/.bin/ember-template-lint app/templates/application.hbs --quiet
+./node_modules/.bin/ember-template-lint "app/templates/application.hbs" --quiet
 
 # define custom config path
-./node_modules/.bin/ember-template-lint app/templates/application.hbs --config-path .my-template-lintrc.js
+./node_modules/.bin/ember-template-lint "app/templates/application.hbs" --config-path .my-template-lintrc.js
 
 # read from stdin
 ./node_modules/.bin/ember-template-lint --filename app/templates/application.hbs < app/templates/application.hbs
 
 # print list of formated rules for use with `pending` in config file
-./node_modules/.bin/ember-template-lint app/templates/application.hbs --print-pending
+./node_modules/.bin/ember-template-lint "app/templates/application.hbs" --print-pending
 
 # specify custom ignore pattern `['**/dist/**', '**/tmp/**', '**/node_modules/**']` by default
-./node_modules/.bin/ember-template-lint /tmp/template.hbs --ignore-pattern "**/foo/**" --ignore-pattern "**/bar/**"
+./node_modules/.bin/ember-template-lint "/tmp/template.hbs" --ignore-pattern "**/foo/**" --ignore-pattern "**/bar/**"
 
 # disable ignore pattern entirely
-./node_modules/.bin/ember-template-lint /tmp/template.hbs --no-ignore-pattern
+./node_modules/.bin/ember-template-lint "/tmp/template.hbs" --no-ignore-pattern
 
 # running a single rule without options
 ./node_modules/.bin/ember-template-lint --no-config-path app/templates --rule 'no-implicit-this:error'

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -49,13 +49,14 @@ function expandFileGlobs(filePatterns, ignorePattern) {
   filePatterns.forEach((pattern) => {
     let isHBS = pattern.slice(-4) === '.hbs';
     let isLiteralPath = !isValidGlob(pattern) && fs.existsSync(pattern);
-    let isIgnored = !micromatch.isMatch(pattern, ignorePattern);
-    
+
     if (isHBS && isLiteralPath) {
+      let isIgnored = !micromatch.isMatch(pattern, ignorePattern);
+
       if (!isIgnored) {
         result.add(pattern);
       }
-      
+
       return;
     }
 

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -4,6 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const micromatch = require('micromatch');
 const getStdin = require('get-stdin');
 const globby = require('globby');
 const Linter = require('../lib/index');
@@ -46,8 +47,14 @@ function expandFileGlobs(filePatterns, ignorePattern) {
 
   filePatterns.forEach((pattern) => {
     // if we are passed items that are already globbed before we should not crawl them as directories
-    if(item.slice(-4) === '.hbs' && item.indexOf('*') === -1) {
-      result.add(item);
+    if (pattern.slice(-4) === '.hbs' && pattern.indexOf('*') === -1) {
+      if (
+        (ignorePattern.length === 0 || !micromatch.isMatch(pattern, ignorePattern)) &&
+        fs.existsSync(pattern)
+      ) {
+        result.add(pattern);
+      }
+
       return;
     }
 

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -47,15 +47,15 @@ function expandFileGlobs(filePatterns, ignorePattern) {
   let result = new Set();
 
   filePatterns.forEach((pattern) => {
-    // if we are passed items that are already globbed before we should not crawl them as directories
-    if (pattern.slice(-4) === '.hbs' && !isValidGlob(pattern)) {
-      if (
-        (ignorePattern.length === 0 || !micromatch.isMatch(pattern, ignorePattern)) &&
-        fs.existsSync(pattern)
-      ) {
+    let isHBS = pattern.slice(-4) === '.hbs';
+    let isLiteralPath = !isValidGlob(pattern) && fs.existsSync(pattern);
+    let isIgnored = !micromatch.isMatch(pattern, ignorePattern);
+    
+    if (isHBS && isLiteralPath) {
+      if (!isIgnored) {
         result.add(pattern);
       }
-
+      
       return;
     }
 

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -45,6 +45,12 @@ function expandFileGlobs(filePatterns, ignorePattern) {
   let result = new Set();
 
   filePatterns.forEach((pattern) => {
+    // if we are passed items that are already globbed before we should not crawl them as directories
+    if(item.slice(-4) === '.hbs' && item.indexOf('*') === -1) {
+      result.add(item);
+      return;
+    }
+
     globby
       // `--no-ignore-pattern` results in `ignorePattern === [false]`
       .sync(pattern, ignorePattern[0] === false ? {} : { ignore: ignorePattern, gitignore: true })

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -5,6 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const micromatch = require('micromatch');
+const isValidGlob = require('is-valid-glob');
 const getStdin = require('get-stdin');
 const globby = require('globby');
 const Linter = require('../lib/index');
@@ -47,7 +48,7 @@ function expandFileGlobs(filePatterns, ignorePattern) {
 
   filePatterns.forEach((pattern) => {
     // if we are passed items that are already globbed before we should not crawl them as directories
-    if (pattern.slice(-4) === '.hbs' && pattern.indexOf('*') === -1) {
+    if (pattern.slice(-4) === '.hbs' && !isValidGlob(pattern)) {
       if (
         (ignorePattern.length === 0 || !micromatch.isMatch(pattern, ignorePattern)) &&
         fs.existsSync(pattern)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "find-up": "^4.1.0",
     "get-stdin": "^7.0.0",
     "globby": "^11.0.0",
+    "is-valid-glob": "^1.0.0",
     "micromatch": "^4.0.2",
     "resolve": "^1.17.0",
     "yargs": "^15.3.1"

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -24,6 +24,7 @@ describe('expandFileGlobs', function () {
 
       let files = expandFileGlobs(['application.hbs', 'other.hbs'], []);
       expect(files.has('application.hbs')).toBe(true);
+      expect(files.has('other.hbs')).toBe(true);
     });
 
     it('respects a basic ignore option', function () {

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -24,7 +24,7 @@ describe('expandFileGlobs', function () {
 
       let files = expandFileGlobs(['application.hbs', 'other.hbs'], []);
       expect(files.has('application.hbs')).toBe(true);
-      expect(files.has('other.hbs')).toBe(true);
+      expect(files.has('other.hbs')).toBe(false);
     });
 
     it('respects a basic ignore option', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3143,6 +3143,11 @@ is-typedarray@^1.0.0, is-typedarray@~1.0.0:
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
 
+is-valid-glob@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-valid-glob/-/is-valid-glob-1.0.0.tgz#29bf3eff701be2d4d315dbacc39bc39fe8f601aa"
+  integrity sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"


### PR DESCRIPTION
Our company switched to the latest version of MacOS and ZSH is trying to expand the glob before passing it to the process.

# Example

## With quoted glob

```
$ time ember-template-lint "something/something/**"
$ 2.71s user 2.69s system 83% cpu 6.492 total
```

## Without quoted glob

```
$ time ember-template-lint something/something/**
$ 12.97s user 17.79s system 42% cpu 1:12.74 total
```

## How is discovered it?

I tried to glob a large directory and saw that zsh was trying to pass many arguments, so much so that it was unable to run the command.

```
> ember-template-lint **/*.hbs
> zsh: argument list too long
```

Another issue that was exposed through this was globbing paths that are already resolved, instead of trying to resolve them again. 