### PR TITLE
[fix] require-valid-alt-text parsing mustache statements

### DIFF
--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -50,7 +50,8 @@ module.exports = class RequireValidAltText extends Rule {
           const srcValue = AstNodeInfo.elementAttributeValue(node, 'src');
           const hasRole = AstNodeInfo.hasAttribute(node, 'role');
 
-          if (hasAltAttribute && hasRole) {
+          // if the role value is a mustache statement we can not validate it
+          if (hasAltAttribute && hasRole && !roleValue.type) {
             if (
               ['none', 'presentation'].includes(roleValue.trim().toLowerCase()) &&
               altValue !== ''

--- a/test/unit/rules/require-valid-alt-text-test.js
+++ b/test/unit/rules/require-valid-alt-text-test.js
@@ -47,6 +47,7 @@ generateRuleTests({
     '<area aria-hidden="true">',
     '<area aria-labelledby="some-alt">',
     '<area aria-label="some-alt">',
+    '<img role={{unless this.altText "presentation"}} alt={{this.altText}}>',
   ],
 
   bad: [


### PR DESCRIPTION
# Motivation

https://github.com/ember-template-lint/ember-template-lint/issues/1286 and instances in our application set the role based on a conditional statement. This will short circuit and not validate those alt tags. 