### PR TITLE
feat: Add no-element-args rule

### DIFF
--- a/docs/rule/no-element-args.md
+++ b/docs/rule/no-element-args.md
@@ -1,0 +1,30 @@
+# no-element-args
+
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
+Passing named arguments to HTML elements causes Ember to fail to render your application. Typically, these are added by accident when
+you actually mean to pass an attribute to the element.
+
+This rule forbids passing named arguments to HTML elements.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<a @href="https://example.com">example.com</a>
+```
+
+This rule **allows** the following:
+
+```hbs
+<a href="https://example.com">example.com</a>
+```
+
+```hbs
+<LinkTo @route="my-route">My Route</LinkTo>
+```
+
+## References
+
+* [Documentation](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/) for component arguments and HTML attributes

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -18,6 +18,7 @@
 * [no-debugger](rule/no-debugger.md)
 * [no-curly-component-invocation](rule/no-curly-component-invocation.md)
 * [no-duplicate-attributes](rule/no-duplicate-attributes.md)
+* [no-element-args](rule/no-element-args.md)
 * [no-element-event-actions](rule/no-element-event-actions.md)
 * [no-extra-mut-helper-argument](rule/no-extra-mut-helper-argument.md)
 * [no-heading-inside-button](rule/no-heading-inside-button.md)

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -10,6 +10,7 @@ module.exports = {
     'no-attrs-in-components': 'error',
     'no-debugger': 'error',
     'no-duplicate-attributes': 'error',
+    'no-element-args': 'error',
     'no-extra-mut-helper-argument': 'error',
     'no-html-comments': 'error',
     'no-index-component-invocation': 'error',

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -22,6 +22,7 @@ module.exports = {
   'no-curly-component-invocation': require('./no-curly-component-invocation'),
   'no-debugger': require('./no-debugger'),
   'no-duplicate-attributes': require('./no-duplicate-attributes'),
+  'no-element-args': require('./no-element-args'),
   'no-element-event-actions': require('./no-element-event-actions'),
   'no-extra-mut-helper-argument': require('./no-extra-mut-helper-argument'),
   'no-heading-inside-button': require('./no-heading-inside-button'),

--- a/lib/rules/no-element-args.js
+++ b/lib/rules/no-element-args.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const Rule = require('./base');
+
+const ERROR_MESSAGE =
+  'HTML elements do not support named arguments and will prevent your page from rendering.';
+
+function getArgumentNodes(node) {
+  const attributes = node.attributes || [];
+  return attributes.filter((attribute) => attribute.name.startsWith('@'));
+}
+
+function isHtmlNode(node) {
+  return node.tag === node.tag.toLowerCase();
+}
+
+module.exports = class NoElementArgs extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        if (!isHtmlNode(node)) {
+          return;
+        }
+
+        const argumentNodes = getArgumentNodes(node);
+        if (argumentNodes.length > 0) {
+          argumentNodes.forEach((argumentNode) =>
+            this.log({
+              message: ERROR_MESSAGE,
+              line: argumentNode.loc && argumentNode.loc.start.line,
+              column: argumentNode.loc && argumentNode.loc.start.column,
+              source: this.sourceForNode(argumentNode),
+            })
+          );
+        }
+      },
+    };
+  }
+};
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/no-element-args-test.js
+++ b/test/unit/rules/no-element-args-test.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+const ERROR_MESSAGE = require('../../../lib/rules/no-element-args').ERROR_MESSAGE;
+
+generateRuleTests({
+  name: 'no-element-args',
+
+  config: true,
+
+  good: [
+    '<button></button>',
+    '<button type="button" on={{action "myAction"}}></button>',
+    '<button type="button" onclick="myFunction()"></button>',
+    '<button type="button" {{action "myAction"}}></button>',
+    '<button type="button" value={{value}}></button>',
+    '{{my-component onclick=(action "myAction") someProperty=true}}',
+    '<SiteHeader @someFunction={{action "myAction"}} @user={{this.user}}/>',
+  ],
+
+  bad: [
+    {
+      template: '<button @hello="world">My button</button>',
+      result: {
+        message: ERROR_MESSAGE,
+        source: '@hello="world"',
+        line: 1,
+        column: 8,
+      },
+    },
+
+    {
+      template: '<input @value="my-value"/>',
+      result: {
+        message: ERROR_MESSAGE,
+        source: '@value="my-value"',
+        line: 1,
+        column: 7,
+      },
+    },
+
+    {
+      template: '<a @href="http://example.com" @target="_blank"/>',
+      results: [
+        {
+          message: ERROR_MESSAGE,
+          source: '@href="http://example.com"',
+          line: 1,
+          column: 3,
+        },
+        {
+          message: ERROR_MESSAGE,
+          source: '@target="_blank"',
+          line: 1,
+          column: 30,
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
Today, Ember will throw an error that causes the entire page to fail to render if you pass named arguments to an HTML element, like so:

```hbs
<a @size="mini">My awesome link</a>
```

This PR adds a lint rule that enforces against this usage, and protects people from making this mistake in code that isn't covered by tests.