### PR TITLE
bugfix: `no-implicit-this` rule allows built-in helpers

### DIFF
--- a/lib/rules/no-implicit-this.js
+++ b/lib/rules/no-implicit-this.js
@@ -27,12 +27,17 @@ function allowedFormat(value) {
 }
 
 // Allow Ember's builtin argless syntaxes
-const ARGLESS_BUILTINS = [
+const ARGLESS_BUILTIN_HELPERS = [
+  'array',
+  'concat',
   'debugger',
   'has-block',
   'hasBlock',
+  'hasBlockParams',
+  'hash',
   'input',
   'outlet',
+  'query-params',
   'textarea',
   'yield',
 ];
@@ -53,7 +58,7 @@ module.exports = class NoImplicitThis extends Rule {
       case 'boolean':
         if (config) {
           return {
-            allow: [].concat(ARGLESS_BUILTINS, ARGLESS_DEFAULT_BLUEPRINT),
+            allow: [].concat(ARGLESS_BUILTIN_HELPERS, ARGLESS_DEFAULT_BLUEPRINT),
           };
         } else {
           return false;
@@ -62,7 +67,7 @@ module.exports = class NoImplicitThis extends Rule {
       case 'object':
         if (Array.isArray(config.allow) && config.allow.every(allowedFormat)) {
           return {
-            allow: [].concat(ARGLESS_BUILTINS, ARGLESS_DEFAULT_BLUEPRINT, config.allow),
+            allow: [].concat(ARGLESS_BUILTIN_HELPERS, ARGLESS_DEFAULT_BLUEPRINT, config.allow),
           };
         }
         break;
@@ -140,4 +145,5 @@ module.exports = class NoImplicitThis extends Rule {
   }
 };
 
+module.exports.ARGLESS_BUILTIN_HELPERS = ARGLESS_BUILTIN_HELPERS;
 module.exports.message = message;

--- a/test/unit/rules/no-implicit-this-test.js
+++ b/test/unit/rules/no-implicit-this-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const message = require('../../../lib/rules/no-implicit-this').message;
+const { ARGLESS_BUILTIN_HELPERS, message } = require('../../../lib/rules/no-implicit-this');
 
 let statements = [
   (path) => `{{${path}}}`,
@@ -13,15 +13,13 @@ let statements = [
   (path) => `<div {{helper ${path}}}></div>`,
 ];
 
-let good = [
-  '{{debugger}}',
-  '{{has-block}}',
-  '{{hasBlock}}',
-  '{{input}}',
-  '{{outlet}}',
-  '{{textarea}}',
-  '{{yield}}',
+let builtins = ARGLESS_BUILTIN_HELPERS.reduce((accumulator, helper) => {
+  return accumulator.concat([`{{${helper}}}`, `{{"inline: " (${helper})}}`]);
+}, []);
+
+let good = builtins.concat([
   '{{welcome-page}}',
+  '<WelcomePage />',
   '<MyComponent @prop={{can "edit" @model}} />',
   {
     config: { allow: ['book-details'] },
@@ -31,7 +29,7 @@ let good = [
     config: { allow: [/^data-test-.+/] },
     template: '{{foo-bar data-test-foo}}',
   },
-];
+]);
 
 statements.forEach((statement) => {
   good.push(`${statement('@book')}`);


### PR DESCRIPTION
### What
- expands the list of built-in-helpers that `no-implicit-this` will ignore
- adds test cases for same both mustache & inline invocations of same

### Why
- fixes #1129 
- based additions to the list off of [this comment](https://github.com/ember-template-lint/ember-template-lint/issues/1129#issuecomment-590029672) by @lolmaus
- additionally added `query-params` helper, as I can imagine a use case where having it return an empty hash is desired