### PR TITLE
Add a test for fixing from stdin (povided a --filename is given)

### DIFF
--- a/test/acceptance/editors-integration-test.js
+++ b/test/acceptance/editors-integration-test.js
@@ -60,5 +60,22 @@ describe('editors integration', function () {
       expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
       expect(result.stderr).toBeFalsy();
     });
+
+    it('has exit code 0 and writes fixes if --filename is provided', async function () {
+      project.setConfig({ rules: { 'require-button-type': true } });
+      project.write({ 'template.hbs': '<button></button>' });
+
+      let result = await run(project, ['--json', '--filename', 'template.hbs', '--fix'], {
+        shell: false,
+        input: fs.readFileSync(path.resolve('template.hbs')),
+      });
+
+      expect(result.exitCode).toEqual(0);
+      expect(result.stdout).toBeFalsy();
+      expect(result.stderr).toBeFalsy();
+
+      let template = fs.readFileSync(path.resolve('template.hbs'), { encoding: 'utf8' });
+      expect(template).toBe('<button type="button"></button>');
+    });
   });
 });


### PR DESCRIPTION
This is the command I would use to support fixing templates with Ale. And in my local environement it seems to work.

We don't write to STDOUT but to the file provided with the `--filename` arg.

If this PR is accepted, it would be the last item of this issue checklist: https://github.com/ember-template-lint/ember-template-lint/issues/1180