### PR TITLE
Handle `unless` in `no-positive-tabindex` rule

### DIFF
--- a/lib/rules/no-positive-tabindex.js
+++ b/lib/rules/no-positive-tabindex.js
@@ -29,7 +29,10 @@ function parseTabIndexFromMustache(mustacheNode) {
 
   if (['NumberLiteral', 'StringLiteral'].includes(mustacheNode.path.type)) {
     tabindexValue = literalValueToNumber(mustacheNode.path);
-  } else if (mustacheNode.path.type === 'PathExpression' && mustacheNode.path.original === 'if') {
+  } else if (
+    mustacheNode.path.type === 'PathExpression' &&
+    (mustacheNode.path.original === 'if' || mustacheNode.path.original === 'unless')
+  ) {
     if (mustacheNode.params.length === 2 || mustacheNode.params.length === 3) {
       tabindexValue = maybeLiteralValue(mustacheNode.params[1], tabindexValue);
     }

--- a/test/unit/rules/no-positive-tabindex-test.js
+++ b/test/unit/rules/no-positive-tabindex-test.js
@@ -123,5 +123,25 @@ generateRuleTests({
         column: 0,
       },
     },
+    {
+      template: '<button tabindex="{{unless a 1}}"></button>',
+
+      result: {
+        message: 'Avoid positive integer values for tabindex.',
+        source: 'tabindex="{{unless a 1}}"',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<button tabindex="{{unless a -1 1}}"></button>',
+
+      result: {
+        message: 'Avoid positive integer values for tabindex.',
+        source: 'tabindex="{{unless a -1 1}}"',
+        line: 1,
+        column: 0,
+      },
+    },
   ],
 });


### PR DESCRIPTION
Follow-up to #788. CC: @lifeart 