### PR TITLE
`invocable-blacklist` rule should disallow empty blacklist config array

### DIFF
--- a/lib/rules/invocable-blacklist.js
+++ b/lib/rules/invocable-blacklist.js
@@ -13,7 +13,7 @@ module.exports = class InvocableBlacklist extends Rule {
         }
         break;
       case 'object':
-        if (Array.isArray(config)) {
+        if (Array.isArray(config) && config.length > 0) {
           return config;
         }
         break;

--- a/test/unit/rules/invocable-blacklist-test.js
+++ b/test/unit/rules/invocable-blacklist-test.js
@@ -261,5 +261,14 @@ generateRuleTests({
         message: 'You specified `{}`',
       },
     },
+    {
+      config: [],
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `[]`',
+      },
+    },
   ],
 });


### PR DESCRIPTION
There's no reason to enable this [rule](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/invocable-blacklist.md) with an empty blacklist.