### PR TITLE
Update `invocable-blacklist` rule to handle nested angle bracket component invocation

### DIFF
--- a/docs/rule/invocable-blacklist.md
+++ b/docs/rule/invocable-blacklist.md
@@ -7,19 +7,23 @@ Disallow certain components or helpers from being used. Use case is you bring in
 Given a config of:
 
 ```js
-'invocable-blacklist': ['foo']
+'invocable-blacklist': ['foo-bar']
 ```
 
 This rule **forbids** the following:
 
 ```hbs
-{{foo}}
+{{foo-bar}}
 ```
 
 ```hbs
-{{#foo}}{{/foo}}
+{{#foo-bar}}{{/foo-bar}}
+```
+
+```hbs
+<FooBar />
 ```
 
 ## Configuration
 
-* array of strings - helpers or components to blacklist
+* array of strings - helpers or components to blacklist (using kebab-case names like `nested-scope/component-name`)

--- a/lib/helpers/dasherize-component-name.js
+++ b/lib/helpers/dasherize-component-name.js
@@ -8,11 +8,13 @@ const SIMPLE_DASHERIZE_REGEXP = /[A-Z]/g;
 const ALPHA = /[A-Za-z]/;
 
 module.exports = function (key) {
-  return key.replace(SIMPLE_DASHERIZE_REGEXP, (char, index) => {
-    if (index === 0 || !ALPHA.test(key[index - 1])) {
-      return char.toLowerCase();
-    }
+  return key
+    .replace(SIMPLE_DASHERIZE_REGEXP, (char, index) => {
+      if (index === 0 || !ALPHA.test(key[index - 1])) {
+        return char.toLowerCase();
+      }
 
-    return `-${char.toLowerCase()}`;
-  });
+      return `-${char.toLowerCase()}`;
+    })
+    .replace('::', '/');
 };

--- a/lib/rules/invocable-blacklist.js
+++ b/lib/rules/invocable-blacklist.js
@@ -13,7 +13,14 @@ module.exports = class InvocableBlacklist extends Rule {
         }
         break;
       case 'object':
-        if (Array.isArray(config) && config.length > 0) {
+        if (
+          Array.isArray(config) &&
+          config.length > 0 &&
+          config.every(
+            // Ensure names are passed as kebab-case strings.
+            (name) => typeof name === 'string' && name.length > 0 && dasherize(name) === name
+          )
+        ) {
           return config;
         }
         break;
@@ -23,7 +30,9 @@ module.exports = class InvocableBlacklist extends Rule {
 
     let errorMessage = createErrorMessage(
       this.ruleName,
-      ['  * array of strings - helpers or components to blacklist'],
+      [
+        '  * array of strings - helpers or components to blacklist (using kebab-case names like `nested-scope/component-name`)',
+      ],
       config
     );
 

--- a/test/unit/rules/invocable-blacklist-test.js
+++ b/test/unit/rules/invocable-blacklist-test.js
@@ -5,7 +5,7 @@ const generateRuleTests = require('../../helpers/rule-test-harness');
 generateRuleTests({
   name: 'invocable-blacklist',
 
-  config: ['foo', 'bar'],
+  config: ['foo', 'bar', 'nested-scope/foo-bar'],
 
   good: [
     '{{baz}}',
@@ -28,6 +28,10 @@ generateRuleTests({
     '{{yield (baz (baz (baz) foo=(baz)))}}',
     '{{#baz as |foo|}}{{foo}}{{/baz}}',
     '{{#with (component "blah") as |Foo|}} <Foo /> {{/with}}',
+    '{{other/foo-bar}}',
+    '{{nested-scope/other}}',
+    '<Random/>',
+    '<NestedScope::Random/>',
   ],
 
   bad: [
@@ -231,6 +235,26 @@ generateRuleTests({
         column: 27,
       },
     },
+    {
+      template: '{{nested-scope/foo-bar}}',
+
+      result: {
+        message: "Cannot use blacklisted helper or component '{{nested-scope/foo-bar}}'",
+        source: '{{nested-scope/foo-bar}}',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<NestedScope::FooBar/>',
+
+      result: {
+        message: "Cannot use blacklisted helper or component '<NestedScope::FooBar />'",
+        source: '<NestedScope::FooBar/>',
+        line: 1,
+        column: 0,
+      },
+    },
   ],
 
   error: [
@@ -268,6 +292,66 @@ generateRuleTests({
       result: {
         fatal: true,
         message: 'You specified `[]`',
+      },
+    },
+    {
+      // Disallows non-string.
+      config: [123],
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `[123]`',
+      },
+    },
+    {
+      // Disallows empty string.
+      config: [''],
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `[""]`',
+      },
+    },
+    {
+      // Disallows incorrect naming format (disallows angle bracket invocation style).
+      config: ['MyComponent'],
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `["MyComponent"]`',
+      },
+    },
+    {
+      // Disallows incorrect naming format (disallows nested angle bracket invocation style).
+      config: ['MyComponent'],
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `["MyComponent"]`',
+      },
+    },
+    {
+      // Disallows incorrect naming format.
+      config: ['Scope/MyComponent'],
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `["Scope/MyComponent"]`',
+      },
+    },
+    {
+      // Disallows incorrect naming format.
+      config: ['scope::my-component'],
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `["scope::my-component"]`',
       },
     },
   ],


### PR DESCRIPTION
Fix so that the [rule](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/invocable-blacklist.md) handles this test case:

* Config: `['nested/foo-bar']`
* Disallows:
  ```hbs
  <Nested::FooBar />
  ```

RFC for this syntax: https://github.com/emberjs/rfcs/pull/457
