### PR TITLE
Allow specifying a custom error message in `invocable-blacklist` rule

### DIFF
--- a/docs/rule/invocable-blacklist.md
+++ b/docs/rule/invocable-blacklist.md
@@ -1,6 +1,11 @@
 # invocable-blacklist
 
-Disallow certain components or helpers from being used. Use case is you bring in some addon like ember-composable-helpers, but your team deems one or many of the helpers not suitable and wants to guard against their usage.
+Disallow certain components or helpers from being used.
+
+Use cases include:
+
+* You bring in some addon like ember-composable-helpers, but your team deems one or many of the helpers not suitable and wants to guard against their usage
+* You want to discourage use of a deprecated component
 
 ## Examples
 
@@ -26,4 +31,13 @@ This rule **forbids** the following:
 
 ## Configuration
 
-* array of strings - helpers or components to blacklist (using kebab-case names like `nested-scope/component-name`)
+One of these:
+
+* string[] - helpers or components to blacklist (using kebab-case names like `nested-scope/component-name`)
+* object[] - with the following keys:
+  * `names` - string[] - helpers or components to blacklist (using kebab-case names like `nested-scope/component-name`)
+  * `message` - string - custom error message to report for violations (typically a deprecation notice / explanation of why not to use it and a recommended replacement)
+
+## Related Rules
+
+* [ember/no-restricted-service-injections](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-restricted-service-injections.md)

--- a/lib/rules/invocable-blacklist.js
+++ b/lib/rules/invocable-blacklist.js
@@ -4,6 +4,15 @@ const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
 const dasherize = require('../helpers/dasherize-component-name');
 
+function isValidComponentOrHelperName(str) {
+  // Ensure names are passed as kebab-case strings.
+  return typeof str === 'string' && str.length > 0 && dasherize(str) === str;
+}
+
+function isValidCustomErrorMessage(str) {
+  return typeof str === 'string' && str.length > 0;
+}
+
 module.exports = class InvocableBlacklist extends Rule {
   parseConfig(config) {
     switch (typeof config) {
@@ -17,8 +26,13 @@ module.exports = class InvocableBlacklist extends Rule {
           Array.isArray(config) &&
           config.length > 0 &&
           config.every(
-            // Ensure names are passed as kebab-case strings.
-            (name) => typeof name === 'string' && name.length > 0 && dasherize(name) === name
+            (item) =>
+              (typeof item === 'string' && isValidComponentOrHelperName(item)) ||
+              (typeof item === 'object' &&
+                Array.isArray(item.names) &&
+                item.names.length > 0 &&
+                item.names.every(isValidComponentOrHelperName) &&
+                isValidCustomErrorMessage(item.message))
           )
         ) {
           return config;
@@ -31,7 +45,11 @@ module.exports = class InvocableBlacklist extends Rule {
     let errorMessage = createErrorMessage(
       this.ruleName,
       [
-        '  * array of strings - helpers or components to blacklist (using kebab-case names like `nested-scope/component-name`)',
+        '  One of these:',
+        '  * string[] - helpers or components to blacklist (using kebab-case names like `nested-scope/component-name`)',
+        '  * object[] - with the following keys:',
+        '    * `names` - string[] - helpers or components to blacklist (using kebab-case names like `nested-scope/component-name`)',
+        '    * `message` - string - custom error message to report for violations',
       ],
       config
     );
@@ -43,8 +61,14 @@ module.exports = class InvocableBlacklist extends Rule {
     let checkBlacklist = (node) => {
       let blacklist = this.config;
 
-      for (let name of blacklist) {
-        this._checkNode(node, name);
+      for (let blacklistItem of blacklist) {
+        if (typeof blacklistItem === 'object') {
+          for (let name of blacklistItem.names) {
+            this._checkNode(node, name, blacklistItem.message);
+          }
+        } else {
+          this._checkNode(node, blacklistItem);
+        }
       }
     };
 
@@ -56,25 +80,25 @@ module.exports = class InvocableBlacklist extends Rule {
     };
   }
 
-  _checkNode(node, name) {
+  _checkNode(node, name, message) {
     if (this.isLocal(node)) {
       return;
     }
 
     if (node.type === 'ElementNode') {
       if (dasherize(node.tag) === name || node.tag === name) {
-        this._logNode(node, `<${node.tag} />`);
+        this._logNode(node, `<${node.tag} />`, message);
       }
     } else {
       if (node.path.original === name || checkForComponentHelper(node, name)) {
-        this._logNode(node, `{{${name}}}`);
+        this._logNode(node, `{{${name}}}`, message);
       }
     }
   }
 
-  _logNode(node, name) {
+  _logNode(node, name, message) {
     this.log({
-      message: `Cannot use blacklisted helper or component '${name}'`,
+      message: message || `Cannot use blacklisted helper or component '${name}'`,
       line: node.loc && node.loc.start.line,
       column: node.loc && node.loc.start.column,
       source: this.sourceForNode(node),

--- a/test/unit/rules/invocable-blacklist-test.js
+++ b/test/unit/rules/invocable-blacklist-test.js
@@ -5,7 +5,15 @@ const generateRuleTests = require('../../helpers/rule-test-harness');
 generateRuleTests({
   name: 'invocable-blacklist',
 
-  config: ['foo', 'bar', 'nested-scope/foo-bar'],
+  config: [
+    'foo',
+    'bar',
+    'nested-scope/foo-bar',
+    {
+      names: ['deprecated-component'],
+      message: 'This component is deprecated; use component ABC instead.',
+    },
+  ],
 
   good: [
     '{{baz}}',
@@ -255,6 +263,16 @@ generateRuleTests({
         column: 0,
       },
     },
+    {
+      template: '{{deprecated-component}}',
+
+      result: {
+        message: 'This component is deprecated; use component ABC instead.',
+        source: '{{deprecated-component}}',
+        line: 1,
+        column: 0,
+      },
+    },
   ],
 
   error: [
@@ -352,6 +370,36 @@ generateRuleTests({
       result: {
         fatal: true,
         message: 'You specified `["scope::my-component"]`',
+      },
+    },
+    {
+      // Disallows empty object.
+      config: [{}],
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `[{}]`',
+      },
+    },
+    {
+      // Disallows object missing names array.
+      config: [{ message: 'Custom error message.' }],
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `[{"message":"Custom error message."}]`',
+      },
+    },
+    {
+      // Disallows object with empty names array.
+      config: [{ names: [], message: 'Custom error message.' }],
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `[{"names":[],"message":"Custom error message."}]`',
       },
     },
   ],


### PR DESCRIPTION
Use case: for a deprecated component, you may want to specify a custom error message that suggests the replacement.

Example config:

```
[
  {
    names: ['component-with-custom-message'],
    message: 'Reason why not to use this component and good alternative.'
  }
]
```