### PR TITLE
Save `seen ids` as Set; add Mustache + Concat

### DIFF
--- a/lib/rules/no-duplicate-id.js
+++ b/lib/rules/no-duplicate-id.js
@@ -4,67 +4,97 @@ const Rule = require('./base');
 
 const ERROR_MESSAGE = 'ID attribute values must be unique';
 
-function isValidIdAttrNode(attrNode) {
-  let isIdAttrTag = ['id', '@id'].includes(attrNode.name);
-  let isValidAttrNodeType = ['TextNode','MustacheStatement','ConcatStatement'].includes(attrNode.value.type);
-  return attrNode && isIdAttrTag && isValidAttrNodeType;
-};
+// Utility functions
+// -----------------
+
+// Visiting function node filter for AttrNodes: attribute name, node type
+function isValidIdAttrNode(node) {
+  let isIdAttrTag = ['id', '@id'].includes(node.name);
+  let isValidnodeType = ['TextNode', 'MustacheStatement', 'ConcatStatement'].includes(
+    node.value.type
+  );
+  return node && isIdAttrTag && isValidnodeType;
+}
+
+// MustacheStatement is StringLiteral
+function isMustacheString(node) {
+  return (
+    node && node.value.type === 'MustacheStatement' && node.value.path.type === 'StringLiteral'
+  );
+}
+
+// ConcatStatement has only StringLiteral parts
+function isConcatString(node) {
+  if (node.value.type === 'ConcatStatement') {
+    let allParts = node.value.parts;
+    let allPartsAreStrings = allParts.every(
+      part =>
+        part.type === 'TextNode' ||
+        (part.type === 'MustacheStatement' && part.path.type === 'StringLiteral')
+    );
+    return allPartsAreStrings;
+  } else {
+    return false;
+  }
+}
+
 module.exports = class NoDuplicateId extends Rule {
   visitor() {
     let attrIdSet = new Set();
     return {
       AttrNode(node) {
-
-        if ( !isValidIdAttrNode(node) ) {
+        // Only check relevant nodes
+        if (!isValidIdAttrNode(node)) {
           return;
         }
 
-        // Assign an idValue only if it is entirely Stringy, e.g.
+        // Assign an idValue only if it is entirely String, e.g.
         // id="id-value"
         // id={{"id-value"}}
         // id="id-{{"value"}}"
         // id="{{"id-"}}{{"value"}}"
+        // or similar
         let idValue;
 
+        // TextNode: unwrap
+        // ----------------
         // id="id-value"
         if (node.value.type === 'TextNode') {
           idValue = node.value.chars;
         }
 
+        // MustacheStatement: must be a String Literal
+        // -------------------------------------------
         // id={{"id-value"}}
-        if (node.value.type === 'MustacheStatement' && node.value.path.type === 'StringLiteral')  {
+        if (isMustacheString(node)) {
           idValue = node.value.path.value;
         }
 
-        // id="id-{{"value"}}"
-        // Make sure all `parts` of the ConcatStatement are Strings
-        if (node.value.type === 'ConcatStatement')  {
-          let allParts = node.value.parts;
-          let allPartsAreStrings = allParts.every(part => 
-            (part.type === 'TextNode') || (part.type === 'MustacheStatement' && part.path.type === 'StringLiteral')
-          );
-
-          // id="id-{{this.value}}" should bypass dynamic values
-          if (!allPartsAreStrings)  {
+        // ConcatStatement: all parts must be String Literals
+        // --------------------------------------------------
+        // id="id-{{"value"}}" is all String parts => continue
+        // id="id-{{this.value}}" has a dynamic part => bypass
+        if (node.value.type === 'ConcatStatement') {
+          let allPartsAreStrings = isConcatString(node);
+          if (!allPartsAreStrings) {
             return;
           }
 
           // Join `parts` if all Strings: "id-{{"value"}}" => "id-value"
-          idValue = allParts.map(part =>
-            part.type === 'TextNode' ?
-              part.chars :
-              part.path.value
-          ).join('');
+          let allParts = node.value.parts;
+          idValue = allParts
+            .map(part => (part.type === 'TextNode' ? part.chars : part.path.value))
+            .join('');
         }
-
-        // If idValue didn't get assigned, i.e., not entirely Stringy
-        if (!idValue )  {
+        // Bypass if idValue didn't get assigned by this point, i.e.,
+        // it is not entirely composed of StringLiteral components
+        if (!idValue) {
           return;
         }
 
         // Log if this is a duplicate idValue, add to the set if it is unique
         let isDuplicate = attrIdSet.has(idValue);
-        if (isDuplicate)  {
+        if (isDuplicate) {
           this.log({
             message: ERROR_MESSAGE,
             line: node.loc && node.loc.start.line,

--- a/lib/rules/no-duplicate-id.js
+++ b/lib/rules/no-duplicate-id.js
@@ -6,7 +6,7 @@ const ERROR_MESSAGE = 'ID attribute values must be unique';
 
 module.exports = class NoDuplicateId extends Rule {
   visitor() {
-    let attrIdStack = [];
+    let attrIdSet = new Set();
     return {
       AttrNode(node) {
         if (!(node.name === 'id')) {
@@ -17,19 +17,21 @@ module.exports = class NoDuplicateId extends Rule {
           return;
         }
 
-        attrIdStack.push(node.value.chars);
+        let idValue;
 
-        let hasDuplicates = attrIdStack.some(
-          idValue => attrIdStack.indexOf(idValue) !== attrIdStack.lastIndexOf(idValue)
-        );
+        idValue = node.value.chars;
 
-        if (hasDuplicates) {
+        let isDuplicate = attrIdSet.has(idValue);
+
+        if (isDuplicate) {
           this.log({
             message: ERROR_MESSAGE,
             line: node.loc && node.loc.start.line,
             column: node.loc && node.loc.start.column,
             source: this.sourceForNode(node),
           });
+        } else {
+          attrIdSet.add(idValue);
         }
       },
     };

--- a/lib/rules/no-duplicate-id.js
+++ b/lib/rules/no-duplicate-id.js
@@ -15,22 +15,56 @@ module.exports = class NoDuplicateId extends Rule {
     return {
       AttrNode(node) {
 
-        // TODO: Use isValidIdAttrNode
-        if (!(node.name === 'id')) {
-          return;
-        }
-        if (node.value.type !== 'TextNode') {
+        if ( !isValidIdAttrNode(node) ) {
           return;
         }
 
+        // Assign an idValue only if it is entirely Stringy, e.g.
+        // id="id-value"
+        // id={{"id-value"}}
+        // id="id-{{"value"}}"
+        // id="{{"id-"}}{{"value"}}"
         let idValue;
 
-        // TODO: Add Mustache + Concat
-        idValue = node.value.chars;
+        // id="id-value"
+        if (node.value.type === 'TextNode') {
+          idValue = node.value.chars;
+        }
 
+        // id={{"id-value"}}
+        if (node.value.type === 'MustacheStatement' && node.value.path.type === 'StringLiteral')  {
+          idValue = node.value.path.value;
+        }
+
+        // id="id-{{"value"}}"
+        // Make sure all `parts` of the ConcatStatement are Strings
+        if (node.value.type === 'ConcatStatement')  {
+          let allParts = node.value.parts;
+          let allPartsAreStrings = allParts.every(part => 
+            (part.type === 'TextNode') || (part.type === 'MustacheStatement' && part.path.type === 'StringLiteral')
+          );
+
+          // id="id-{{this.value}}" should bypass dynamic values
+          if (!allPartsAreStrings)  {
+            return;
+          }
+
+          // Join `parts` if all Strings: "id-{{"value"}}" => "id-value"
+          idValue = allParts.map(part =>
+            part.type === 'TextNode' ?
+              part.chars :
+              part.path.value
+          ).join('');
+        }
+
+        // If idValue didn't get assigned, i.e., not entirely Stringy
+        if (!idValue )  {
+          return;
+        }
+
+        // Log if this is a duplicate idValue, add to the set if it is unique
         let isDuplicate = attrIdSet.has(idValue);
-
-        if (isDuplicate) {
+        if (isDuplicate)  {
           this.log({
             message: ERROR_MESSAGE,
             line: node.loc && node.loc.start.line,

--- a/lib/rules/no-duplicate-id.js
+++ b/lib/rules/no-duplicate-id.js
@@ -4,21 +4,28 @@ const Rule = require('./base');
 
 const ERROR_MESSAGE = 'ID attribute values must be unique';
 
+function isValidIdAttrNode(attrNode) {
+  let isIdAttrTag = ['id', '@id'].includes(attrNode.name);
+  let isValidAttrNodeType = ['TextNode','MustacheStatement','ConcatStatement'].includes(attrNode.value.type);
+  return attrNode && isIdAttrTag && isValidAttrNodeType;
+};
 module.exports = class NoDuplicateId extends Rule {
   visitor() {
     let attrIdSet = new Set();
     return {
       AttrNode(node) {
+
+        // TODO: Use isValidIdAttrNode
         if (!(node.name === 'id')) {
           return;
         }
-
         if (node.value.type !== 'TextNode') {
           return;
         }
 
         let idValue;
 
+        // TODO: Add Mustache + Concat
         idValue = node.value.chars;
 
         let isDuplicate = attrIdSet.has(idValue);

--- a/test/unit/rules/no-duplicate-id-test.js
+++ b/test/unit/rules/no-duplicate-id-test.js
@@ -86,10 +86,6 @@ generateRuleTests({
         column: 27,
         source: 'id="{{"id"}}-00"',
       },
-
-      
     },
-
-
   ],
 });

--- a/test/unit/rules/no-duplicate-id-test.js
+++ b/test/unit/rules/no-duplicate-id-test.js
@@ -47,5 +47,49 @@ generateRuleTests({
         source: 'id="id-01"',
       },
     },
+
+    {
+      template: '<div id="id-00"></div><div id={{"id-00"}}></div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 27,
+        source: 'id={{"id-00"}}',
+      },
+    },
+
+    {
+      template: '<div id={{"id-00"}}></div><div id="id-00"></div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 31,
+        source: 'id="id-00"',
+      },
+    },
+
+    {
+      template: '<div id="id-00"></div><div id="id-{{"00"}}"></div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 27,
+        source: 'id="id-{{"00"}}"',
+      },
+    },
+
+    {
+      template: '<div id="id-00"></div><div id="{{"id"}}-00"></div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 27,
+        source: 'id="{{"id"}}-00"',
+      },
+
+      
+    },
+
+
   ],
 });


### PR DESCRIPTION
If merged, this PR will:
- change the data structure that tracks the `already seen` list of `id` values from an `Array` to a `Set`
- expand coverage of evaluated attribute names to include `@id`
- expand coverage of evaluated attribute types to include `MustacheStatement` and `ConcatStatement`

Although the net being cast is larger with `MustacheStatement` and `ConcatStatement` included, the leniency of the rule's logic is intended to stay the same as before (when only `TextNode` nodes were checked). Specifically, an attribute value must be made up entirely of StringLiteral components in order to be added to the `already seen` Set. In cases where at least one component of the attribute value is dynamic/computed/evaluated, that part is assumed to provide whatever 'uniqueness factor' is required for that `id`.

```hbs
{{!-- Reference --}}
<div id="id-00"></div>
{{!-- These would each get marked as duplicates --}}
<div id="id-00"></div>
<div id={{"id-00"}}></div>
<div id={{"id"}}{{"-"}}{{"00"}}></div>
<div id="{{"id"}}-00"></div>
{{!-- These would not be marked as duplicates --}}
<div id={{id-00}}></div>
<div id="{{id}}-00"></div>
<div id={{id}}{{"-"}}{{"00"}}></div>
```



