### PR TITLE
Add support for `BlockStatement` with `elementId`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "eslint.enable": true
+}

--- a/lib/rules/no-duplicate-id.js
+++ b/lib/rules/no-duplicate-id.js
@@ -23,19 +23,31 @@ function isMustacheString(node) {
   );
 }
 
-// ConcatStatement has only StringLiteral parts
+// Verify ConcatStatement has only StringLiteral parts
 function isConcatString(node) {
-  if (node.value.type === 'ConcatStatement') {
-    let allParts = node.value.parts;
-    let allPartsAreStrings = allParts.every(
-      part =>
-        part.type === 'TextNode' ||
-        (part.type === 'MustacheStatement' && part.path.type === 'StringLiteral')
+  // Helpers
+  function partIsString(part) {
+    return (
+      part &&
+      (part.type === 'TextNode' ||
+        (part.type === 'MustacheStatement' && part.path.type === 'StringLiteral'))
     );
-    return allPartsAreStrings;
-  } else {
-    return false;
   }
+  function allPartsAreStrings(parts) {
+    return parts.every(partIsString);
+  }
+  // Result
+  return node && node.value.type === 'ConcatStatement' && allPartsAreStrings(node.value.parts);
+}
+
+// Join ConcatStatement Parts
+function getJoinedConcatParts(node) {
+  // Helper
+  function getPartValue(part) {
+    return part.type === 'TextNode' ? part.chars : part.path.value;
+  }
+  // Result
+  return node.value.parts.map(getPartValue).join('');
 }
 
 module.exports = class NoDuplicateId extends Rule {
@@ -72,20 +84,13 @@ module.exports = class NoDuplicateId extends Rule {
 
         // ConcatStatement: all parts must be String Literals
         // --------------------------------------------------
-        // id="id-{{"value"}}" is all String parts => continue
-        // id="id-{{this.value}}" has a dynamic part => bypass
-        if (node.value.type === 'ConcatStatement') {
-          let allPartsAreStrings = isConcatString(node);
-          if (!allPartsAreStrings) {
-            return;
-          }
-
-          // Join `parts` if all Strings: "id-{{"value"}}" => "id-value"
-          let allParts = node.value.parts;
-          idValue = allParts
-            .map(part => (part.type === 'TextNode' ? part.chars : part.path.value))
-            .join('');
+        // id="id-{{"value"}}" is all String parts: continue
+        // id="id-{{this.value}}" has a dynamic part: bypass
+        if (isConcatString(node)) {
+          // Join `parts` if all Strings: "id-{{"value"}}": "id-value"
+          idValue = getJoinedConcatParts(node);
         }
+
         // Bypass if idValue didn't get assigned by this point, i.e.,
         // it is not entirely composed of StringLiteral components
         if (!idValue) {
@@ -93,6 +98,39 @@ module.exports = class NoDuplicateId extends Rule {
         }
 
         // Log if this is a duplicate idValue, add to the set if it is unique
+        let isDuplicate = attrIdSet.has(idValue);
+        if (isDuplicate) {
+          this.log({
+            message: ERROR_MESSAGE,
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
+        } else {
+          attrIdSet.add(idValue);
+        }
+      },
+
+      BlockStatement(node) {
+        // Helpers
+        function isElementIdHashPair(pair) {
+          return pair.key === 'elementId';
+        }
+        function getElementIdHashPair(hashPairs) {
+          return hashPairs.find(isElementIdHashPair);
+        }
+        function isValidElementIdHashPair(hashArg) {
+          return hashArg && hashArg.value.type === 'StringLiteral';
+        }
+        // Validate BlockStatement: elementId="some-StringLiteral"
+        let hashPairs = node.hash.pairs;
+        let elementIdHashArg = getElementIdHashPair(hashPairs);
+        if (!isValidElementIdHashPair(elementIdHashArg)) {
+          return;
+        }
+
+        let idValue = elementIdHashArg.value.value;
+
         let isDuplicate = attrIdSet.has(idValue);
         if (isDuplicate) {
           this.log({

--- a/test/unit/rules/no-duplicate-id-test.js
+++ b/test/unit/rules/no-duplicate-id-test.js
@@ -26,6 +26,10 @@ generateRuleTests({
     '<div id="id-00"></div><div id={{id-00}}></div>',
     '<div id="concat-{{id-00}}"></div><div id="concat-id-00"></div>',
     '<div id="concat-id-00"></div><div id="concat-{{id-00}}"></div>',
+
+    // BlockStatement
+    '<div id="id-00"></div>{{#foo elementId="id-01"}}{{/foo}}',
+    '{{#foo elementId="id-01"}}{{/foo}}<div id="id-00"></div>',
   ],
 
   bad: [
@@ -85,6 +89,77 @@ generateRuleTests({
         line: 1,
         column: 27,
         source: 'id="{{"id"}}-00"',
+      },
+    },
+
+    // BlockStatement
+    {
+      template: '<div id="id-00"></div>{{#foo elementId="id-00"}}{{/foo}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 22,
+        source: '{{#foo elementId="id-00"}}{{/foo}}',
+      },
+    },
+
+    {
+      template: '{{#foo elementId="id-00"}}{{/foo}}<div id="id-00"></div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 39,
+        source: 'id="id-00"',
+      },
+    },
+
+    {
+      template: '<div id={{"id-00"}}></div>{{#foo elementId="id-00"}}{{/foo}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 26,
+        source: '{{#foo elementId="id-00"}}{{/foo}}',
+      },
+    },
+
+    {
+      template: '{{#foo elementId="id-00"}}{{/foo}}<div id={{"id-00"}}></div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 39,
+        source: 'id={{"id-00"}}',
+      },
+    },
+
+    {
+      template: '<div id="id-{{"00"}}"></div>{{#foo elementId="id-00"}}{{/foo}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 28,
+        source: '{{#foo elementId="id-00"}}{{/foo}}',
+      },
+    },
+
+    {
+      template: '{{#foo elementId="id-00"}}{{/foo}}<div id="id-{{"00"}}"></div>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 39,
+        source: 'id="id-{{"00"}}"',
+      },
+    },
+
+    {
+      template: '{{#foo elementId="id-00"}}{{/foo}}{{#bar elementId="id-00"}}{{/bar}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 34,
+        source: '{{#bar elementId="id-00"}}{{/bar}}',
       },
     },
   ],


### PR DESCRIPTION
If merged, this PR adds support for `BlockStatement` nodes that use `elementId` to assign the `id` attribute. It is intended to provide the behavior requested by @rwjblue in the base branch PR (https://github.com/ember-template-lint/ember-template-lint/pull/1187#pullrequestreview-372789539). Similar to existing `attrNode` logic, there is a requirement that the value of the `elementId` must be a `StringLiteral`. Tests have been added for `BlockStatement` nodes occurring both before + after other node types: 

```hbs
{{!-- All marked as duplicates --}}

{{!-- TextNode --}}
<div id="id-00"></div>{{#foo elementId="id-00"}}{{/foo}}
{{#foo elementId="id-00"}}{{/foo}}<div id="id-00"></div>

{{!-- MustacheStatement --}}
<div id={{"id-00"}}></div>{{#foo elementId="id-00"}}{{/foo}}
{{#foo elementId="id-00"}}{{/foo}}<div id={{"id-00"}}></div>

{{!-- ConcatStatement --}}
<div id="id-{{"00"}}"></div>{{#foo elementId="id-00"}}{{/foo}}
{{#foo elementId="id-00"}}{{/foo}}<div id="id-{{"00"}}"></div>

{{!-- (Other) BlockStatement --}}
{{#foo elementId="id-00"}}{{/foo}}{{#bar elementId="id-00"}}{{/bar}}

```
