### PR TITLE
Add .markdownlintignore

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,3 @@
+CHANGELOG.md
+LICENSE.md
+node_modules

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "changelog": "lerna-changelog",
     "lint": "npm-run-all lint:* --continue-on-error",
-    "lint:docs": "markdownlint '**/*.md' -i CHANGELOG.md -i LICENSE.md -i node_modules",
+    "lint:docs": "markdownlint '**/*.md'",
     "lint:js": "eslint . --cache",
     "new": "node dev/new-rule/index.js",
     "release": "release-it",


### PR DESCRIPTION
This should prevent IDEs from autofixing or highlighting violations in files like CHANGELOG.md (which are autogenerated).

.markdownlintignore will be respected by anyone running markdownlint, regardless of whether they use our npm/yarn script to run it.

Same change as this: https://github.com/ember-cli/eslint-plugin-ember/pull/824