### PR TITLE
Improve message for `no-implicit-this` to mention using angle bracket invocation

### DIFF
--- a/lib/rules/no-implicit-this.js
+++ b/lib/rules/no-implicit-this.js
@@ -8,8 +8,9 @@ function message(original) {
     `Ambiguous path '${original}' is not allowed. ` +
     `Use '@${original}' if it is a named argument ` +
     `or 'this.${original}' if it is a property on 'this'. ` +
-    'If it is a helper or component that has no arguments ' +
-    "you must manually add it to the 'no-implicit-this' rule configuration, e.g. " +
+    'If it is a helper or component that has no arguments, ' +
+    'you must either convert it to an angle bracket invocation ' +
+    "or manually add it to the 'no-implicit-this' rule configuration, e.g. " +
     `'no-implicit-this': { allow: ['${original}'] }.`
   );
 }

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -475,7 +475,7 @@ describe('public api', function () {
 
       let expected = {
         message:
-          "Ambiguous path 'barData' is not allowed. Use '@barData' if it is a named argument or 'this.barData' if it is a property on 'this'. If it is a helper or component that has no arguments you must manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['barData'] }.",
+          "Ambiguous path 'barData' is not allowed. Use '@barData' if it is a named argument or 'this.barData' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['barData'] }.",
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
         line: 2,
@@ -574,7 +574,7 @@ describe('public api', function () {
           filePath: templatePath,
           line: 1,
           message:
-            "Ambiguous path 'fooData' is not allowed. Use '@fooData' if it is a named argument or 'this.fooData' if it is a property on 'this'. If it is a helper or component that has no arguments you must manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['fooData'] }.",
+            "Ambiguous path 'fooData' is not allowed. Use '@fooData' if it is a named argument or 'this.fooData' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['fooData'] }.",
           moduleId: templatePath.slice(0, -4),
           rule: 'no-implicit-this',
           severity: 2,
@@ -615,7 +615,7 @@ describe('public api', function () {
           filePath: templatePath,
           line: 1,
           message:
-            "Ambiguous path 'fooData' is not allowed. Use '@fooData' if it is a named argument or 'this.fooData' if it is a property on 'this'. If it is a helper or component that has no arguments you must manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['fooData'] }.",
+            "Ambiguous path 'fooData' is not allowed. Use '@fooData' if it is a named argument or 'this.fooData' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['fooData'] }.",
           moduleId: templatePath.slice(0, -4),
           rule: 'no-implicit-this',
           severity: 2,
@@ -662,7 +662,7 @@ describe('public api', function () {
           filePath: 'some/path/here.hbs',
           moduleId: 'some/path/here',
           message:
-            "Ambiguous path 'foo' is not allowed. Use '@foo' if it is a named argument or 'this.foo' if it is a property on 'this'. If it is a helper or component that has no arguments you must manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['foo'] }.",
+            "Ambiguous path 'foo' is not allowed. Use '@foo' if it is a named argument or 'this.foo' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['foo'] }.",
           line: 1,
           column: 19,
           source: 'foo',
@@ -712,7 +712,7 @@ describe('public api', function () {
           line: 1,
           filePath: templatePath,
           message:
-            "Ambiguous path 'fooData' is not allowed. Use '@fooData' if it is a named argument or 'this.fooData' if it is a property on 'this'. If it is a helper or component that has no arguments you must manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['fooData'] }.",
+            "Ambiguous path 'fooData' is not allowed. Use '@fooData' if it is a named argument or 'this.fooData' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['fooData'] }.",
           moduleId: templatePath.slice(0, -4),
           rule: 'no-implicit-this',
           severity: 2,


### PR DESCRIPTION
The existing message only suggested adding a no-argument helper or component, but in many cases, the best move for a developer may be to switch to an angle-bracket invocation. So: "Why not have both?"