### PR TITLE
Remove automatic `TextNode` unwrapping by `attributeValue` functions in `ast-node-info` helper

### DIFF
--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -43,31 +43,8 @@ function hasAttribute(node, attributeName) {
   return Boolean(attribute);
 }
 
-function hasAttributeValue(node, attributeName, nodeAttributeValue) {
-  const attributeNode = findAttribute(node, attributeName);
-  if (!attributeNode) {
-    return false;
-  }
-  return attributeValue(attributeNode) === nodeAttributeValue;
-}
-
-function elementAttributeValue(node, attributeName) {
-  return attributeValue(findAttribute(node, attributeName));
-}
-
 function hasAnyAttribute(node, attributeNames) {
   return attributeNames.map((name) => hasAttribute(node, name)).some((exists) => exists === true);
-}
-
-function attributeValue(attrNode) {
-  if (!attrNode) {
-    return;
-  }
-  if (attrNode.value && attrNode.value.type === 'TextNode') {
-    return attrNode.value.chars;
-  } else {
-    return attrNode.value;
-  }
 }
 
 function findAttribute(node, attributeName) {
@@ -109,9 +86,6 @@ module.exports = {
   hasAttribute,
   hasChildren,
   hasAnyAttribute,
-  hasAttributeValue,
-  attributeValue,
-  elementAttributeValue,
   isIf,
   isUnless,
   isEach,

--- a/lib/rules/no-heading-inside-button.js
+++ b/lib/rules/no-heading-inside-button.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const AstNodeInfo = require('../helpers/ast-node-info');
+const NodeMatcher = require('../helpers/node-matcher');
 const Rule = require('./base');
 
 const ERROR_MESSAGE = 'Buttons should not contain heading elements';
@@ -8,15 +8,29 @@ const HEADING_ELEMENTS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
 
 function hasButtonParent(path) {
   let parents = [...path.parents()];
-  let buttonElementInParentPath = parents.find(
-    (parent) => parent.node.type === 'ElementNode' && parent.node.tag === 'button'
-  );
-  let buttonRoleInParentPath = parents.find(
-    (parent) =>
-      parent.node.type === 'ElementNode' &&
-      AstNodeInfo.hasAttributeValue(parent.node, 'role', 'button')
-  );
-  if (buttonElementInParentPath || buttonRoleInParentPath) {
+  let refButtonNodes = [
+    // <button></button>
+    {
+      type: 'ElementNode',
+      tag: 'button',
+    },
+    // <div role="button"></div>
+    {
+      type: 'ElementNode',
+      attributes: [
+        {
+          type: 'AttrNode',
+          name: 'role',
+          value: {
+            type: 'TextNode',
+            chars: 'button',
+          },
+        },
+      ],
+    },
+  ];
+  let hasButtonParent = parents.find((parent) => NodeMatcher.match(parent.node, refButtonNodes));
+  if (hasButtonParent) {
     return true;
   }
   return false;

--- a/lib/rules/no-invalid-link-title.js
+++ b/lib/rules/no-invalid-link-title.js
@@ -24,10 +24,29 @@ module.exports = class NoInvalidLinkTitle extends Rule {
     return {
       ElementNode(node) {
         if (node.tag === 'a' || node.tag === 'LinkTo') {
-          let titleValues = [
-            AstNodeInfo.elementAttributeValue(node, 'title'),
-            node.tag === 'LinkTo' && AstNodeInfo.elementAttributeValue(node, '@title'),
-          ]
+          let hasTitleAttr = AstNodeInfo.hasAttribute(node, 'title');
+          let titleAttr, titleAttrValue;
+          if (hasTitleAttr) {
+            titleAttr = AstNodeInfo.findAttribute(node, 'title');
+            if (titleAttr.value.type === 'TextNode') {
+              titleAttrValue = titleAttr.value.chars;
+            } else {
+              titleAttrValue = titleAttr.value;
+            }
+          }
+
+          let hasTitleArg = AstNodeInfo.hasAttribute(node, '@title');
+          let titleArg, titleArgValue;
+          if (hasTitleArg) {
+            titleArg = AstNodeInfo.findAttribute(node, '@title');
+            if (titleArg.value.type === 'TextNode') {
+              titleArgValue = titleArg.value.chars;
+            } else {
+              titleArgValue = titleArg.value;
+            }
+          }
+
+          let titleValues = [titleAttrValue, node.tag === 'LinkTo' && titleArgValue]
             .filter((possibleValue) => typeof possibleValue === 'string')
             .map((value) => value.toLowerCase().trim());
 

--- a/lib/rules/no-invalid-meta.js
+++ b/lib/rules/no-invalid-meta.js
@@ -26,7 +26,13 @@ module.exports = class NoInvalidMeta extends Rule {
         const hasItemprop = AstNodeInfo.hasAttribute(node, 'itemprop');
         const hasIdentifier = hasName || hasProperty || hasItemprop;
 
-        const contentAttrValue = AstNodeInfo.elementAttributeValue(node, 'content');
+        let contentAttr, contentAttrValue;
+        if (hasContent) {
+          contentAttr = AstNodeInfo.findAttribute(node, 'content');
+          if (contentAttr.value.type === 'TextNode') {
+            contentAttrValue = contentAttr.value.chars;
+          }
+        }
 
         if ((hasIdentifier || hasHttpEquiv) && !hasContent) {
           this.log({

--- a/lib/rules/no-invalid-role.js
+++ b/lib/rules/no-invalid-role.js
@@ -209,7 +209,11 @@ module.exports = class NoInvalidRole extends Rule {
           return;
         }
 
-        const roleValue = AstNodeInfo.elementAttributeValue(node, 'role');
+        const roleAttrNode = AstNodeInfo.findAttribute(node, 'role');
+        let roleValue;
+        if (roleAttrNode.value.type === 'TextNode') {
+          roleValue = roleAttrNode.value.chars;
+        }
 
         if (
           ['presentation', 'none'].includes(roleValue) &&

--- a/lib/rules/no-nested-landmark.js
+++ b/lib/rules/no-nested-landmark.js
@@ -54,13 +54,31 @@ module.exports = class NoNestedLandmark extends Rule {
   }
 
   getLandmarkType(node) {
-    const roleValue = AstNodeInfo.elementAttributeValue(node, 'role');
+    let hasRoleAttr = AstNodeInfo.hasAttribute(node, 'role');
+    let roleAttr, roleValue;
+    if (hasRoleAttr) {
+      roleAttr = AstNodeInfo.findAttribute(node, 'role');
+      if (roleAttr.value.type === 'TextNode') {
+        roleValue = roleAttr.value.chars;
+      } else {
+        roleValue = roleAttr.value;
+      }
+    }
     const equivalentRole = EQUIVALENT_ROLE[node.tag];
     return roleValue || equivalentRole || node.tag;
   }
 
   isLandmarkElement(node) {
-    const roleValue = AstNodeInfo.elementAttributeValue(node, 'role');
+    let hasRoleAttr = AstNodeInfo.hasAttribute(node, 'role');
+    let roleAttr, roleValue;
+    if (hasRoleAttr) {
+      roleAttr = AstNodeInfo.findAttribute(node, 'role');
+      if (roleAttr.value.type === 'TextNode') {
+        roleValue = roleAttr.value.chars;
+      } else {
+        roleValue = roleAttr.value;
+      }
+    }
     return LANDMARK_ELEMENTS.has(node.tag) || ROLES.has(roleValue);
   }
 };

--- a/lib/rules/no-redundant-landmark-role.js
+++ b/lib/rules/no-redundant-landmark-role.js
@@ -56,7 +56,12 @@ module.exports = class NoRedundantLandmarkRole extends Rule {
           return;
         }
 
-        const roleValue = AstNodeInfo.elementAttributeValue(node, 'role') || '';
+        let roleAttrNode = AstNodeInfo.findAttribute(node, 'role');
+        let roleValue;
+        if (roleAttrNode.value.type === 'TextNode') {
+          roleValue = roleAttrNode.value.chars || '';
+        }
+
         const invalidLandmark = LANDMARK_ROLES.find((e) => {
           return e.name === node.tag && e.role === roleValue && !e.allow;
         });

--- a/lib/rules/require-lang-attribute.js
+++ b/lib/rules/require-lang-attribute.js
@@ -18,7 +18,15 @@ module.exports = class RequireLangAttribute extends Rule {
           });
         }
         const hasLangAttribute = AstNodeInfo.hasAttribute(node, 'lang');
-        const langAttributeValue = AstNodeInfo.elementAttributeValue(node, 'lang');
+        let langAttrNode, langAttributeValue;
+        if (hasLangAttribute) {
+          langAttrNode = AstNodeInfo.findAttribute(node, 'lang');
+          if (langAttrNode.value.type === 'TextNode') {
+            langAttributeValue = langAttrNode.value.chars;
+          } else {
+            langAttributeValue = langAttrNode.value;
+          }
+        }
 
         if (node.tag === 'html' && hasLangAttribute && !langAttributeValue) {
           this.log({

--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const AstNodeInfo = require('../helpers/ast-node-info');
+const NodeMatcher = require('../helpers/node-matcher');
 const Rule = require('./base');
 
 function hasAccessibleChild(node) {
@@ -29,8 +30,12 @@ module.exports = class RequireValidAltText extends Rule {
           return;
         }
 
-        if (AstNodeInfo.hasAttributeValue(node, 'aria-hidden', 'true')) {
-          return;
+        let hasAriaHiddenAttr = AstNodeInfo.hasAttribute(node, 'aria-hidden');
+        if (hasAriaHiddenAttr) {
+          let ariaHiddenAttr = AstNodeInfo.findAttribute(node, 'aria-hidden');
+          if (ariaHiddenAttr.value.type === 'TextNode' && ariaHiddenAttr.value.chars === 'true') {
+            return;
+          }
         }
 
         if (AstNodeInfo.hasAttribute(node, '...attributes')) {
@@ -44,10 +49,36 @@ module.exports = class RequireValidAltText extends Rule {
 
         if (isImg) {
           const hasAltAttribute = AstNodeInfo.hasAttribute(node, 'alt');
-          const altValue = AstNodeInfo.elementAttributeValue(node, 'alt');
-          const roleValue = AstNodeInfo.elementAttributeValue(node, 'role');
-          const srcValue = AstNodeInfo.elementAttributeValue(node, 'src');
+          let altAttribute, altValue;
+          if (hasAltAttribute) {
+            altAttribute = AstNodeInfo.findAttribute(node, 'alt');
+            if (altAttribute.value.type === 'TextNode') {
+              altValue = altAttribute.value.chars;
+            } else {
+              altValue = altAttribute.value;
+            }
+          }
           const hasRole = AstNodeInfo.hasAttribute(node, 'role');
+          let roleAttr, roleValue;
+          if (hasRole) {
+            roleAttr = AstNodeInfo.findAttribute(node, 'role');
+            if (roleAttr.value.type === 'TextNode') {
+              roleValue = roleAttr.value.chars;
+            } else {
+              roleValue = roleAttr.value;
+            }
+          }
+
+          let hasSrcAttr = AstNodeInfo.hasAttribute(node, 'src');
+          let srcAttr, srcValue;
+          if (hasSrcAttr) {
+            srcAttr = AstNodeInfo.findAttribute(node, 'src');
+            if (srcAttr.value.type === 'TextNode') {
+              srcValue = srcAttr.value.chars;
+            } else {
+              srcValue = srcAttr.value;
+            }
+          }
 
           // if the role value is a mustache statement we can not validate it
           if (hasAltAttribute && hasRole && !roleValue.type) {
@@ -126,7 +157,9 @@ module.exports = class RequireValidAltText extends Rule {
             }
           }
         } else if (isInput) {
-          const isImageInput = AstNodeInfo.hasAttributeValue(node, 'type', 'image');
+          const isImageInput = NodeMatcher.match(node, {
+            attributes: [{ name: 'type', value: { type: 'TextNode', chars: 'image' } }],
+          });
           if (!isImageInput) {
             return;
           }
@@ -144,7 +177,16 @@ module.exports = class RequireValidAltText extends Rule {
             });
           }
         } else if (isObj) {
-          const roleValue = AstNodeInfo.elementAttributeValue(node, 'role');
+          const hasRole = AstNodeInfo.hasAttribute(node, 'role');
+          let roleAttr, roleValue;
+          if (hasRole) {
+            roleAttr = AstNodeInfo.findAttribute(node, 'role');
+            if (roleAttr.value.type === 'TextNode') {
+              roleValue = roleAttr.value.chars;
+            } else {
+              roleValue = roleAttr.value;
+            }
+          }
           const hasValidAttributes = AstNodeInfo.hasAnyAttribute(node, [
             'aria-label',
             'aria-labelledby',


### PR DESCRIPTION
@MelSumner @rwjblue 

### Motivation / Synopsis:
I have seen a lot of discussion about the desire to update this helper, but I haven't found anything that includes a proposed implementation or detailed design. I'm interested in working on this, so if there is a spec, please let me know.

This PR aims to partially resolve a series of internal issues related to the current structure of the `ast-node-info` helper:

- Primary motivation: progress on #1168
- Directly addresses: issue summarized in #1358
- Known side-effects: partially unblocks #1327

Specifically, it aims to address the divergent return behavior of the `attributeValue` function, and by extension, those of `elementAttributeValue` and `hasAttributeValue`. The current implementation returns a `String` for a `TextNode`, but an `AST Node` otherwise. The auto-unwrap feature is a convenient abstraction for large number of use cases, because Strings/Literals are very common (if not the most common) type of attribute value encountered. However, it leads to substantial amounts of in-rule code duplication for rules that compare sets of attributes (e.g. `no-duplicate-id`, `require-input-label`, `no-duplicate-landmark-label`).

### Summary of Changes:
If merged, this PR (updated per review / to be in alignment with similar breaking changes anticipated as part of v3.0): 
- ~~removes the automatic `TextNode` unwrapping feature from the `attributeValue` family of functions~~
- ~~provides the option for unwrapping `TextNodes` **only** with a new, optional `boolean` parameter called `unwrapTextNode` (defaults to `false`)~~
- ~~adds relevant unit test suites~~
- ~~Updates all instances of affected function calls in the existing ruleset to accommodate the new behavior. This was done with the underlying assumption that the existing rules operate correctly in the 'automatic `TextNode` unwrapping' schema. Those function calls were uniformly updated by setting the `unwrapTextNode` option to `true`, and they may or may not all be relevant.~~
- removes `attributeValue()`, `hasAttributeValue()`, and `elementAttributeValue()` functions from `ast-node-info`
- migrates existing usages of these functions to using `findAttribute()` or the recently added `node-matcher`, as appropriate

### Migration Schema for Existing Rules:
For existing rules, occurrences of the `attributeValue()` family functions are primarily migrated **under the assumption that the (now-removed) automatic `TextNode` unwrapping behavior remains the desired behavior for these rules**.  The migration schema implemented here is considered to be a functional MVP that prioritizes resolving the troublesome behavior / existing issues as opposed to a complete overhaul of `ast-node-info`, feature additions to `node-matcher`, or an integration of the two helpers.

Specifically, the changes herein primarily take the form of a direct 'like-for-like' migration from `elementAttributeValue()` or `hasAttributeValue()` to `findAttribute()`. The primary drawback with this 'direct' approach is that there is an increase in the amount of in-rule code. This is because the rule now performs `TextNode` unwrapping (and associated assertions / pre-requisite checks) by itself. 

By (explicit) example, the following:

```js
const roleAttrValue = AstNodeInfo.elementAttributeValue(node, 'role');
```

would become:

```js
// Assert presence of `role` attribute
let hasRoleAttr = AstNodeInfo.hasAttribute(node, 'role');

let roleAttr, roleAttrValue;

if (hasRoleAttr) {

  // Get `AttrNode` for the `role` attribute
  roleAttr = AstNodeInfo.findAttribute(node, 'role');

  // Assign value of `role` attribute, preserving the existing behavior:
  // - check first for a `TextNode` and unrwap it automatically
  // - otherwise, return the attribute `value` node (some other `AST` type)
  if (roleAttr.value.type === 'TextNode') {
    roleAttrValue = roleAttr.value.chars;
  } else {
    roleAttrValue = roleAttr.value;
  }
}
```