### PR TITLE
Fix table groups ordering enforcement when whitespace is present in `table-groups` rule

### DIFF
--- a/docs/rule/table-groups.md
+++ b/docs/rule/table-groups.md
@@ -10,6 +10,14 @@ It is best practice to group table rows into one of:
 
 This helps avoid a very nuanced (and possibly deprecated in the future) feature of glimmer that auto-inserts these tags.
 
+This rule also enforces that all children of the `table` element are in the correct order:
+
+* `caption`
+* `colgroup`
+* `thead`
+* `tbody`
+* `tfoot`
+
 ## Examples
 
 This rule **forbids** the following:
@@ -25,6 +33,14 @@ This rule **forbids** the following:
 ```hbs
 <table>
   {{some-thing content=content}}
+</table>
+```
+
+```hbs
+<table>
+  <tfoot />
+  <tbody />
+  <thead />
 </table>
 ```
 
@@ -45,6 +61,14 @@ This rule **allows** the following:
   <tbody>
     {{some-thing content=content}}
   </tbody>
+</table>
+```
+
+```hbs
+<table>
+  <thead />
+  <tbody />
+  <tfoot />
 </table>
 ```
 

--- a/lib/rules/table-groups.js
+++ b/lib/rules/table-groups.js
@@ -77,16 +77,18 @@ module.exports = class TableGroups extends Rule {
               });
               break;
             }
-            if (allowedWithIndex.index > -1 && allowedWithIndex.index < currentAllowedIndex) {
-              this.log({
-                message: orderingMessage,
-                line: node.loc && node.loc.start.line,
-                column: node.loc && node.loc.start.column,
-                source: this.sourceForNode(node),
-              });
-              break;
+            if (allowedWithIndex.index > -1) {
+              if (allowedWithIndex.index < currentAllowedIndex) {
+                this.log({
+                  message: orderingMessage,
+                  line: node.loc && node.loc.start.line,
+                  column: node.loc && node.loc.start.column,
+                  source: this.sourceForNode(node),
+                });
+                break;
+              }
+              currentAllowedIndex = allowedWithIndex.index;
             }
-            currentAllowedIndex = allowedWithIndex.index;
           }
         }
       },

--- a/test/unit/rules/table-groups-test.js
+++ b/test/unit/rules/table-groups-test.js
@@ -15,6 +15,7 @@ generateRuleTests({
     {{#if showCaption}}
       <caption>Some Name</caption>
     {{/if}}
+    <colgroup></colgroup>
     {{#if foo}}
       <thead>
         <tr></tr>
@@ -24,7 +25,6 @@ generateRuleTests({
         <tr></tr>
       </tbody>
     {{/if}}
-    <colgroup></colgroup>
     </table>
     `,
     `
@@ -397,12 +397,20 @@ generateRuleTests({
       },
     },
     {
-      template: '<table><tbody /><colgroup /></table>',
+      template: `
+        <table>
+          <tbody />
+          <colgroup />
+        </table>
+      `,
       result: {
         message: orderingMessage,
-        source: '<table><tbody /><colgroup /></table>',
-        line: 1,
-        column: 0,
+        source: `<table>
+          <tbody />
+          <colgroup />
+        </table>`,
+        line: 2,
+        column: 8,
       },
     },
   ],


### PR DESCRIPTION
Previously encountering whitespace would incorrectly reset the `currentAllowedIndex` back to `-1`.