### PR TITLE
Refactor `no-restricted-invocations` rule to significantly improve performance

### DIFF
--- a/lib/rules/no-restricted-invocations.js
+++ b/lib/rules/no-restricted-invocations.js
@@ -57,13 +57,22 @@ module.exports = class NoRestrictedInvocations extends Rule {
     let checkDenylist = (node) => {
       let denylist = this.config;
 
+      const name = this._getComponentOrHelperName(node);
+      if (!name) {
+        return;
+      }
+
+      const nameToDisplay = node.type === 'ElementNode' ? `<${node.tag} />` : `{{${name}}}`;
+
       for (let denylistItem of denylist) {
         if (typeof denylistItem === 'object') {
-          for (let name of denylistItem.names) {
-            this._checkNode(node, name, denylistItem.message);
+          if (denylistItem.names.includes(name)) {
+            this._logNode(node, nameToDisplay, denylistItem.message);
           }
         } else {
-          this._checkNode(node, denylistItem);
+          if (denylistItem === name) {
+            this._logNode(node, nameToDisplay, denylistItem.message);
+          }
         }
       }
     };
@@ -76,18 +85,19 @@ module.exports = class NoRestrictedInvocations extends Rule {
     };
   }
 
-  _checkNode(node, name, message) {
+  _getComponentOrHelperName(node) {
     if (this.isLocal(node)) {
-      return;
+      return undefined;
     }
 
     if (node.type === 'ElementNode') {
-      if (dasherize(node.tag) === name || node.tag === name) {
-        this._logNode(node, `<${node.tag} />`, message);
-      }
+      // Convert from angle-bracket naming to kebab-case.
+      return dasherize(node.tag);
     } else {
-      if (node.path.original === name || checkForComponentHelper(node, name)) {
-        this._logNode(node, `{{${name}}}`, message);
+      if (node.path.original === 'component' && node.params[0]) {
+        return node.params[0].original;
+      } else {
+        return node.path.original;
       }
     }
   }
@@ -101,7 +111,3 @@ module.exports = class NoRestrictedInvocations extends Rule {
     });
   }
 };
-
-function checkForComponentHelper(node, name) {
-  return node.path.original === 'component' && node.params[0] && node.params[0].original === name;
-}

--- a/test/unit/rules/no-restricted-invocations-test.js
+++ b/test/unit/rules/no-restricted-invocations-test.js
@@ -22,6 +22,9 @@ generateRuleTests({
     '{{#baz}}{{/baz}}',
     '{{#baz foo=bar}}{{/baz}}',
     '{{#baz foo=(baz)}}{{/baz}}',
+
+    // Component helper:
+    '{{component}}',
     '{{component "baz"}}',
     '{{component "baz" foo=bar}}',
     '{{component "baz" foo=(baz)}}',
@@ -31,6 +34,7 @@ generateRuleTests({
     '{{yield (component "baz")}}',
     '{{yield (component "baz" foo=bar)}}',
     '{{yield (component "baz" foo=(baz))}}',
+
     '{{yield (baz (baz (baz) bar))}}',
     '{{yield (baz (baz (baz) (baz)))}}',
     '{{yield (baz (baz (baz) foo=(baz)))}}',
@@ -38,7 +42,10 @@ generateRuleTests({
     '{{#with (component "blah") as |Foo|}} <Foo /> {{/with}}',
     '{{other/foo-bar}}',
     '{{nested-scope/other}}',
+
+    // Angle bracket:
     '<Random/>',
+    '<HelloWorld/>',
     '<NestedScope::Random/>',
   ],
 


### PR DESCRIPTION
I have a large application with thousands of files. I use this rule to disallow invoking thousands of components.

This refactor results in an **85% decrease in running time** of this rule for my large application. The refactor switches the code from making many complex function calls inside a loop to instead just checking if the denylist arrays includes the component name.

| | Running Time |
| --- | --- |
| Before Refactor | 3 min 7 sec | 
| After Refactor | 27 sec |

CC: @mongoose700 