### PR TITLE
test-harness: Create a linter instance per test

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -103,9 +103,12 @@ module.exports = function generateRuleTests({
 
     function copyPlugins() {
       let pluginsCopy;
-      if (plugins.length) {
+      if (plugins && plugins.length > 0) {
         pluginsCopy = plugins.map(({ configurations, name, rules }) => {
-          let configurationsCopy = JSON.parse(JSON.stringify(configurations));
+          let configurationsCopy;
+          if (configurations) {
+            configurationsCopy = JSON.parse(JSON.stringify(configurations));
+          }
           return { configurations: configurationsCopy, name, rules };
         });
       }

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -100,9 +100,20 @@ module.exports = function generateRuleTests({
     let DISABLE_ONE = `{{! template-lint-disable ${name} }}`;
     let DISABLE_ONE_LONG = `{{!-- template-lint-disable ${name} --}}`;
 
+    function copyPlugins() {
+      let pluginsCopy;
+      if (plugins.length) {
+        pluginsCopy = plugins.map(({ configurations, name, rules }) => {
+          let configurationsCopy = JSON.parse(JSON.stringify(configurations));
+          return { configurations: configurationsCopy, name, rules };
+        });
+      }
+      return pluginsCopy;
+    }
+
     function initLinter(localConfig) {
       let config = {
-        plugins: JSON.parse(JSON.stringify(plugins)),
+        plugins: copyPlugins(plugins),
         rules: {},
       };
 

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -111,6 +111,12 @@ module.exports = function generateRuleTests({
       return pluginsCopy;
     }
 
+    /**
+     * Create a linter instance
+     *
+     * @param {boolean|Object} localConfig - a config given at a snippet level
+     * @returns {Object} options - the linter instance
+     */
     function initLinter(localConfig) {
       let config = {
         plugins: copyPlugins(plugins),
@@ -127,16 +133,13 @@ module.exports = function generateRuleTests({
     }
 
     /**
-     * Prepare an individual snippet to be linted in a test:
-     * - update linter config with the config passed along the snippet (optional)
-     * - return options, to be provided to linter
+     * Return options, to be provided to Linter
      *
      * @param {string|Object} item - a snippet to lint
      * @param {string} [item.template] - if item was an object, the snippet
-     * @param {boolean|Object} localConfig - the config passed along the snippet
      * @returns {Object} options - options to pass to the linter instance
      */
-    function prepare(item) {
+    function prepareOptions(item) {
       let template = typeof item === 'string' ? item : item.template;
       let meta = parseMeta(item);
 
@@ -177,7 +180,7 @@ module.exports = function generateRuleTests({
       testOrOnly(`${testName}: logs errors`, function () {
         let linter = initLinter(item.config);
 
-        let options = prepare(item);
+        let options = prepareOptions(item);
         let actual = linter.verify(options);
 
         if (item.fatal) {
@@ -199,7 +202,7 @@ module.exports = function generateRuleTests({
           let config = false;
           let linter = initLinter(config);
 
-          let options = prepare(item);
+          let options = prepareOptions(item);
           let actual = linter.verify(options);
 
           assert.deepStrictEqual(actual, []);
@@ -210,7 +213,7 @@ module.exports = function generateRuleTests({
           function () {
             let linter = initLinter();
 
-            let options = prepare(`${DISABLE_ONE}\n${template}`);
+            let options = prepareOptions(`${DISABLE_ONE}\n${template}`);
             let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
@@ -222,7 +225,7 @@ module.exports = function generateRuleTests({
           function () {
             let linter = initLinter();
 
-            let options = prepare(`${DISABLE_ONE_LONG}\n${template}`);
+            let options = prepareOptions(`${DISABLE_ONE_LONG}\n${template}`);
             let actual = linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
@@ -232,7 +235,7 @@ module.exports = function generateRuleTests({
         testOrOnly(`${testName}: passes when disabled via inline comment - all rules`, function () {
           let linter = initLinter();
 
-          let options = prepare(`${DISABLE_ALL}\n${template}`);
+          let options = prepareOptions(`${DISABLE_ALL}\n${template}`);
           let actual = linter.verify(options);
 
           assert.deepStrictEqual(actual, []);
@@ -243,7 +246,7 @@ module.exports = function generateRuleTests({
         testOrOnly(`\`${item.template}\` -> ${item.fixedTemplate}\``, function () {
           let linter = initLinter(item.config);
 
-          let options = prepare(item.template);
+          let options = prepareOptions(item.template);
           let result = linter.verifyAndFix(options);
 
           assert.deepStrictEqual(result.output, item.fixedTemplate);
@@ -252,7 +255,7 @@ module.exports = function generateRuleTests({
         testOrOnly(`${item.fixedTemplate}\` is idempotent`, function () {
           let linter = initLinter(item.config);
 
-          let options = prepare(item.fixedTemplate);
+          let options = prepareOptions(item.fixedTemplate);
           let result = linter.verifyAndFix(options);
 
           assert.deepStrictEqual(result.output, item.fixedTemplate);
@@ -269,7 +272,7 @@ module.exports = function generateRuleTests({
       testOrOnly(`${testName}: passes`, function () {
         let linter = initLinter(item.config);
 
-        let options = prepare(item, item.config);
+        let options = prepareOptions(item, item.config);
         let actual = linter.verify(options);
 
         assert.deepStrictEqual(actual, []);
@@ -290,7 +293,7 @@ module.exports = function generateRuleTests({
         let expectedResults = item.results || [item.result];
         expectedResults = expectedResults.map(parseResult);
 
-        let options = prepare(item);
+        let options = prepareOptions(item);
         let actual = linter.verify(options);
 
         for (const [i, element] of actual.entries()) {

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -2,7 +2,6 @@
 
 const assert = require('assert');
 const Linter = require('..');
-const { processRules } = require('../get-config');
 
 function parseMeta(item) {
   let meta = item !== undefined && typeof item === 'object' && item.meta ? item.meta : {};
@@ -101,15 +100,19 @@ module.exports = function generateRuleTests({
     let DISABLE_ONE = `{{! template-lint-disable ${name} }}`;
     let DISABLE_ONE_LONG = `{{!-- template-lint-disable ${name} --}}`;
 
-    let linter;
+    function initLinter(localConfig) {
+      let config = {
+        plugins: JSON.parse(JSON.stringify(plugins)),
+        rules: {},
+      };
 
-    function updateLinterConfig(localConfig) {
-      if (localConfig === undefined) {
-        return;
+      if (localConfig !== undefined) {
+        config.rules[name] = localConfig;
+      } else {
+        config.rules[name] = passedConfig;
       }
 
-      linter.config.rules[name] = localConfig;
-      linter.config.rules = processRules(linter.config);
+      return new Linter({ config });
     }
 
     /**
@@ -122,26 +125,12 @@ module.exports = function generateRuleTests({
      * @param {boolean|Object} localConfig - the config passed along the snippet
      * @returns {Object} options - options to pass to the linter instance
      */
-    function prepare(item, localConfig) {
+    function prepare(item) {
       let template = typeof item === 'string' ? item : item.template;
       let meta = parseMeta(item);
 
-      updateLinterConfig(localConfig);
-
       return getVerifyOptions(template, meta);
     }
-
-    groupMethodBefore(function () {
-      let initialConfig = {
-        plugins,
-        rules: {},
-      };
-      initialConfig.rules[name] = passedConfig;
-
-      linter = new Linter({
-        config: initialConfig,
-      });
-    });
 
     function parseResult(result) {
       let defaults = {
@@ -175,7 +164,9 @@ module.exports = function generateRuleTests({
       let testName = item.name ? item.name : template;
 
       testOrOnly(`${testName}: logs errors`, function () {
-        let options = prepare(item, item.config);
+        let linter = initLinter(item.config);
+
+        let options = prepare(item);
         let actual = linter.verify(options);
 
         if (item.fatal) {
@@ -195,7 +186,9 @@ module.exports = function generateRuleTests({
       if (!skipDisabledTests) {
         testOrOnly(`${testName}: passes when rule is disabled`, function () {
           let config = false;
-          let options = prepare(item, config);
+          let linter = initLinter(config);
+
+          let options = prepare(item);
           let actual = linter.verify(options);
 
           assert.deepStrictEqual(actual, []);
@@ -204,6 +197,8 @@ module.exports = function generateRuleTests({
         testOrOnly(
           `${testName}: passes when disabled via inline comment - single rule`,
           function () {
+            let linter = initLinter();
+
             let options = prepare(`${DISABLE_ONE}\n${template}`);
             let actual = linter.verify(options);
 
@@ -214,6 +209,8 @@ module.exports = function generateRuleTests({
         testOrOnly(
           `${testName}: passes when disabled via long-form inline comment - single rule`,
           function () {
+            let linter = initLinter();
+
             let options = prepare(`${DISABLE_ONE_LONG}\n${template}`);
             let actual = linter.verify(options);
 
@@ -222,6 +219,8 @@ module.exports = function generateRuleTests({
         );
 
         testOrOnly(`${testName}: passes when disabled via inline comment - all rules`, function () {
+          let linter = initLinter();
+
           let options = prepare(`${DISABLE_ALL}\n${template}`);
           let actual = linter.verify(options);
 
@@ -231,14 +230,18 @@ module.exports = function generateRuleTests({
 
       if (item.fixedTemplate) {
         testOrOnly(`\`${item.template}\` -> ${item.fixedTemplate}\``, function () {
-          let options = prepare(item.template, item.config);
+          let linter = initLinter(item.config);
+
+          let options = prepare(item.template);
           let result = linter.verifyAndFix(options);
 
           assert.deepStrictEqual(result.output, item.fixedTemplate);
         });
 
         testOrOnly(`${item.fixedTemplate}\` is idempotent`, function () {
-          let options = prepare(item.fixedTemplate, item.config);
+          let linter = initLinter(item.config);
+
+          let options = prepare(item.fixedTemplate);
           let result = linter.verifyAndFix(options);
 
           assert.deepStrictEqual(result.output, item.fixedTemplate);
@@ -253,6 +256,8 @@ module.exports = function generateRuleTests({
       let testName = item.name ? item.name : item.template;
 
       testOrOnly(`${testName}: passes`, function () {
+        let linter = initLinter(item.config);
+
         let options = prepare(item, item.config);
         let actual = linter.verify(options);
 
@@ -269,10 +274,12 @@ module.exports = function generateRuleTests({
       let testName = name ? name : template;
 
       testOrOnly(`${testName}: errors with config \`${friendlyConfig}\``, function () {
+        let linter = initLinter(item.config);
+
         let expectedResults = item.results || [item.result];
         expectedResults = expectedResults.map(parseResult);
 
-        let options = prepare(item, item.config);
+        let options = prepare(item);
         let actual = linter.verify(options);
 
         for (const [i, element] of actual.entries()) {

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -88,7 +88,8 @@ module.exports = function generateRuleTests({
   error = [],
   name,
   groupingMethod,
-  groupMethodBefore,
+  //  TODO: deprecate and remove this argument
+  groupMethodBefore, // eslint-disable-line no-unused-vars
   testMethod,
   focusMethod,
   skipDisabledTests,


### PR DESCRIPTION
Instead of mutating the linter instance's config.

Is it okay from a perf standpoint?

This would fix #1401 

I have tested it against https://github.com/ember-template-lint/ember-template-lint-plugin-prettier. The bug is reproduced in CI [there](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier/actions/runs/154852105)

Out of time for the moment :)
If someone wants to continue this, feel free.

cc @bmish 