### PR TITLE
get-config: Do not mutate the configuration's `plugins` key

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -196,7 +196,7 @@ function processPlugins(plugins = [], options, checkForCircularReference) {
   return pluginsHash;
 }
 
-function processLoadedRules(config) {
+function processLoadedRules(config, options = {}) {
   let loadedRules;
   if (config.loadedRules) {
     loadedRules = config.loadedRules;
@@ -206,25 +206,23 @@ function processLoadedRules(config) {
   }
 
   // load plugin rules
-  for (let name in config.plugins) {
-    let pluginRules = config.plugins[name].rules;
+  for (let pluginName in config.plugins) {
+    let pluginRules = config.plugins[pluginName].rules;
     if (pluginRules) {
       loadedRules = Object.assign(loadedRules, pluginRules);
     }
   }
 
   forEachPluginConfiguration(config.plugins, (configuration) => {
+    let plugins = processPlugins(configuration.plugins, options, config.plugins);
     // process plugins recursively
-    processLoadedRules({
-      plugins: configuration.plugins,
-      loadedRules,
-    });
+    processLoadedRules({ plugins, loadedRules });
   });
 
-  config.loadedRules = loadedRules;
+  return loadedRules;
 }
 
-function processLoadedConfigurations(config) {
+function processLoadedConfigurations(config, options = {}) {
   let loadedConfigurations;
   if (config.loadedConfigurations) {
     loadedConfigurations = config.loadedConfigurations;
@@ -238,13 +236,11 @@ function processLoadedConfigurations(config) {
     loadedConfigurations[name] = configuration;
 
     // load plugins recursively
-    processLoadedConfigurations({
-      plugins: configuration.plugins,
-      loadedConfigurations,
-    });
+    let plugins = processPlugins(configuration.plugins, options, config.plugins);
+    processLoadedConfigurations({ plugins, loadedConfigurations }, options);
   });
 
-  config.loadedConfigurations = loadedConfigurations;
+  return loadedConfigurations;
 }
 
 function processExtends(config, options) {
@@ -485,8 +481,8 @@ function getProjectConfig(options) {
     migrateRulesFromRoot(config, source, options);
 
     config.plugins = processPlugins(source.plugins, options);
-    processLoadedRules(config);
-    processLoadedConfigurations(config);
+    config.loadedRules = processLoadedRules(config, options);
+    config.loadedConfigurations = processLoadedConfigurations(config, options);
     processExtends(config, options);
     processIgnores(config);
 

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -121,7 +121,6 @@ function ensureRootProperties(config, source) {
   config.pending = (source.pending || []).slice();
   config.overrides = (source.overrides || []).slice();
   config.ignore = (source.ignore || []).slice();
-  config.plugins = (source.plugins || []).slice();
   config.extends = source.extends;
 }
 
@@ -151,10 +150,9 @@ function migrateRulesFromRoot(config, source, options) {
   }
 }
 
-function processPlugins(config, options, checkForCircularReference) {
+function processPlugins(configPlugins, options, checkForCircularReference) {
   let logger = options.console || console;
 
-  let configPlugins = config.plugins;
   let pluginsHash = {};
 
   if (configPlugins) {
@@ -194,10 +192,8 @@ function processPlugins(config, options, checkForCircularReference) {
 
   forEachPluginConfiguration(pluginsHash, (configuration) => {
     // process plugins recursively
-    Object.assign(pluginsHash, processPlugins(configuration, options, pluginsHash));
+    Object.assign(pluginsHash, processPlugins(configuration.plugins, options, pluginsHash));
   });
-
-  config.plugins = pluginsHash;
 
   return pluginsHash;
 }
@@ -490,7 +486,8 @@ function getProjectConfig(options) {
     ensureRootProperties(config, source);
     migrateRulesFromRoot(config, source, options);
 
-    processPlugins(config, options);
+    let plugins = (source.plugins || []).slice();
+    config.plugins = processPlugins(plugins, options);
     processLoadedRules(config);
     processLoadedConfigurations(config);
     processExtends(config, options);

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -196,7 +196,7 @@ function processPlugins(plugins = [], options, checkForCircularReference) {
   return pluginsHash;
 }
 
-function processLoadedRules(config, options = {}) {
+function processLoadedRules(config, options) {
   let loadedRules;
   if (config.loadedRules) {
     loadedRules = config.loadedRules;
@@ -222,7 +222,7 @@ function processLoadedRules(config, options = {}) {
   return loadedRules;
 }
 
-function processLoadedConfigurations(config, options = {}) {
+function processLoadedConfigurations(config, options) {
   let loadedConfigurations;
   if (config.loadedConfigurations) {
     loadedConfigurations = config.loadedConfigurations;

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -150,13 +150,13 @@ function migrateRulesFromRoot(config, source, options) {
   }
 }
 
-function processPlugins(configPlugins, options, checkForCircularReference) {
+function processPlugins(plugins, options, checkForCircularReference) {
   let logger = options.console || console;
 
   let pluginsHash = {};
 
-  if (configPlugins) {
-    for (let plugin of configPlugins) {
+  if (plugins) {
+    for (let plugin of plugins) {
       let pluginName;
 
       if (typeof plugin === 'string') {

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -150,43 +150,41 @@ function migrateRulesFromRoot(config, source, options) {
   }
 }
 
-function processPlugins(plugins, options, checkForCircularReference) {
+function processPlugins(plugins = [], options, checkForCircularReference) {
   let logger = options.console || console;
 
   let pluginsHash = {};
 
-  if (plugins) {
-    for (let plugin of plugins) {
-      let pluginName;
+  for (let plugin of plugins) {
+    let pluginName;
 
-      if (typeof plugin === 'string') {
-        pluginName = plugin;
-        // the second argument here should actually be the config file path for
-        // the _currently being processed_ config file (not neccesarily the one
-        // specified to the bin script)
-        plugin = requirePlugin(pluginName, options.resolvedConfigPath);
-      }
+    if (typeof plugin === 'string') {
+      pluginName = plugin;
+      // the second argument here should actually be the config file path for
+      // the _currently being processed_ config file (not neccesarily the one
+      // specified to the bin script)
+      plugin = requirePlugin(pluginName, options.resolvedConfigPath);
+    }
 
-      let errorMessage;
-      if (typeof plugin === 'object') {
-        if (plugin.name) {
-          if (!checkForCircularReference || !checkForCircularReference[plugin.name]) {
-            pluginsHash[plugin.name] = plugin;
-          }
-        } else if (pluginName) {
-          errorMessage = `Plugin (${pluginName}) has not defined the plugin \`name\` property`;
-        } else {
-          errorMessage = 'Inline plugin object has not defined the plugin `name` property';
+    let errorMessage;
+    if (typeof plugin === 'object') {
+      if (plugin.name) {
+        if (!checkForCircularReference || !checkForCircularReference[plugin.name]) {
+          pluginsHash[plugin.name] = plugin;
         }
       } else if (pluginName) {
-        errorMessage = `Plugin (${pluginName}) did not return a plain object`;
+        errorMessage = `Plugin (${pluginName}) has not defined the plugin \`name\` property`;
       } else {
-        errorMessage = 'Inline plugin is not a plain object';
+        errorMessage = 'Inline plugin object has not defined the plugin `name` property';
       }
+    } else if (pluginName) {
+      errorMessage = `Plugin (${pluginName}) did not return a plain object`;
+    } else {
+      errorMessage = 'Inline plugin is not a plain object';
+    }
 
-      if (errorMessage) {
-        logger.log(chalk.yellow(errorMessage));
-      }
+    if (errorMessage) {
+      logger.log(chalk.yellow(errorMessage));
     }
   }
 
@@ -486,8 +484,7 @@ function getProjectConfig(options) {
     ensureRootProperties(config, source);
     migrateRulesFromRoot(config, source, options);
 
-    let plugins = (source.plugins || []).slice();
-    config.plugins = processPlugins(plugins, options);
+    config.plugins = processPlugins(source.plugins, options);
     processLoadedRules(config);
     processLoadedConfigurations(config);
     processExtends(config, options);

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -771,4 +771,39 @@ describe('getConfigForFile', function () {
       );
     }
   });
+
+  it('processing config is idempotent', function () {
+    let config = {
+      plugins: [
+        {
+          name: 'foo',
+          configurations: {
+            recommended: {
+              rules: {
+                foo: true,
+              },
+            },
+          },
+          rules: {
+            foo: class Rule {},
+          },
+        },
+      ],
+      extends: ['foo:recommended'],
+      rules: {
+        bar: false,
+      },
+    };
+
+    let expected = {
+      foo: { config: true, severity: 2 },
+      bar: { config: false, severity: 0 },
+    };
+
+    let processedConfig = getProjectConfig({ config });
+    expect(processedConfig.rules).toEqual(expected);
+
+    let reprocessedConfig = getProjectConfig({ config });
+    expect(reprocessedConfig.rules).toEqual(expected);
+  });
 });


### PR DESCRIPTION
This is another take at https://github.com/ember-template-lint/ember-template-lint/pull/1402. It would close https://github.com/ember-template-lint/ember-template-lint/issues/1401.

## Bug cause

While parsing the config, `processPlugins()` function mutates `config.plugins`, but also `config.plugins.configuration.plugins` because of the recursion. Doing so, the `plugins` object gets mutated, which is something we want to avoid. Indeed, the configuration might be used multiple times, as in the test harness (where the bug surfaced).

## Fix description

With this PR, `processPlugins()` would return a `pluginsHash`, instead of mutating `config.plugins` in the function's body. 