### PR TITLE
README's rules list: Add  🔧 emoji to fixable rules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 /dist
 /docs
 /test
+/scripts
 .*
 *.tgz
 RELEASE.md

--- a/README.md
+++ b/README.md
@@ -171,6 +171,11 @@ The following properties are allowed in the root of the `.template-lintrc.js` co
 
 ## Rules
 
+Each rule has emojis denoting:
+
+- what configuration it belongs to
+- :wrench: if some problems reported by the rule are automatically fixable by the `--fix` command line option
+
 <!--RULES_TABLE_START-->
 
 |    | Rule ID |
@@ -181,7 +186,7 @@ The following properties are allowed in the root of the `.template-lintrc.js` co
 |  | [deprecated-inline-view-helper](./docs/rule/deprecations/deprecated-inline-view-helper.md) |
 | :white_check_mark: | [deprecated-render-helper](./docs/rule/deprecations/deprecated-render-helper.md) |
 | :dress: | [eol-last](./docs/rule/eol-last.md) |
-|  | [inline-link-to](./docs/rule/inline-link-to.md) |
+| :wrench: | [inline-link-to](./docs/rule/inline-link-to.md) |
 | :dress: | [linebreak-style](./docs/rule/linebreak-style.md) |
 | :white_check_mark: | [link-href-attributes](./docs/rule/link-href-attributes.md) |
 | :white_check_mark: | [link-rel-noopener](./docs/rule/link-rel-noopener.md) |
@@ -237,7 +242,7 @@ The following properties are allowed in the root of the `.template-lintrc.js` co
 |  | [no-whitespace-within-word](./docs/rule/no-whitespace-within-word.md) |
 |  | [no-yield-only](./docs/rule/no-yield-only.md) |
 | :dress: | [quotes](./docs/rule/quotes.md) |
-| :white_check_mark: | [require-button-type](./docs/rule/require-button-type.md) |
+| :white_check_mark::wrench: | [require-button-type](./docs/rule/require-button-type.md) |
 |  | [require-form-method](./docs/rule/require-form-method.md) |
 | :white_check_mark: | [require-iframe-title](./docs/rule/require-iframe-title.md) |
 |  | [require-input-label](./docs/rule/require-input-label.md) |

--- a/README.md
+++ b/README.md
@@ -38,19 +38,21 @@ Run templates through the linter's `verify` method like so:
 let TemplateLinter = require('ember-template-lint');
 
 let linter = new TemplateLinter();
-let template = fs.readFileSync('some/path/to/template.hbs', { encoding: 'utf8' });
+let template = fs.readFileSync('some/path/to/template.hbs', {
+  encoding: 'utf8',
+});
 let results = linter.verify({ source: template, moduleId: 'template.hbs' });
 ```
 
 `results` will be an array of objects which have the following properties:
 
-* `rule` - The name of the rule that triggered this warning/error.
-* `message` - The message that should be output.
-* `line` - The line on which the error occurred.
-* `column` - The column on which the error occurred.
-* `moduleId` - The module path for the file containing the error.
-* `source` - The source that caused the error.
-* `fix` - An object describing how to fix the error.
+- `rule` - The name of the rule that triggered this warning/error.
+- `message` - The message that should be output.
+- `line` - The line on which the error occurred.
+- `column` - The column on which the error occurred.
+- `moduleId` - The module path for the file containing the error.
+- `source` - The source that caused the error.
+- `fix` - An object describing how to fix the error.
 
 ### CLI executable
 
@@ -111,11 +113,11 @@ ember-template-lint into your normal eslint workflow.
 
 ### Presets
 
-|    | Name   | Description |
-|:---|:-----|:------------|
-| :white_check_mark: | [recommended](lib/config/recommended.js) | enables the recommended rules |
-| :car: | [octane](lib/config/octane.js) | extends the `recommended` preset by enabling Ember Octane rules |
-| :dress: | [stylistic](lib/config/stylistic.js) | enables stylistic rules for those who aren't ready to adopt [ember-template-lint-plugin-prettier](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier) (including stylistic rules that were previously in the `recommended` preset in ember-template-lint v1) |
+|                    | Name                                     | Description                                                                                                                                                                                                                                                                          |
+| :----------------- | :--------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| :white_check_mark: | [recommended](lib/config/recommended.js) | enables the recommended rules                                                                                                                                                                                                                                                        |
+| :car:              | [octane](lib/config/octane.js)           | extends the `recommended` preset by enabling Ember Octane rules                                                                                                                                                                                                                      |
+| :dress:            | [stylistic](lib/config/stylistic.js)     | enables stylistic rules for those who aren't ready to adopt [ember-template-lint-plugin-prettier](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier) (including stylistic rules that were previously in the `recommended` preset in ember-template-lint v1) |
 
 ### Project Wide
 
@@ -128,9 +130,9 @@ module.exports = {
   extends: 'recommended',
 
   rules: {
-    'no-bare-strings': true
-  }
-}
+    'no-bare-strings': true,
+  },
+};
 ```
 
 This extends from the builtin recommended configuration ([lib/config/recommended.js](lib/config/recommended.js)),
@@ -144,8 +146,8 @@ some "bare strings" that are allowed you might have:
 ```javascript
 module.exports = {
   rules: {
-    'no-bare-strings': ['ZOMG THIS IS ALLOWED!!!!']
-  }
+    'no-bare-strings': ['ZOMG THIS IS ALLOWED!!!!'],
+  },
 };
 ```
 
@@ -153,20 +155,20 @@ module.exports = {
 
 The following properties are allowed in the root of the `.template-lintrc.js` configuration file:
 
-* `rules` -- `Object`
+- `rules` -- `Object`
   This is an object containing rule specific configuration (see details for each rule below).
-* `extends` -- `string|string[]`
+- `extends` -- `string|string[]`
   Either a string or an array of strings. Each string allows you to specify an internally curated list of rules (we suggest `recommended` here).
-* `pending` -- `string[]`
+- `pending` -- `string[]`
   An array of module id's that are still pending. The goal of this array is to allow incorporating template linting
   into an existing project, without changing every single template file. You can add all existing templates to this `pending` listing
   and slowly work through them, while at the same time ensuring that new templates added to the project pass all defined rules.
-  * You can generate this list with the: `yarn ember-template-lint * --print-pending`
-* `ignore` -- `string[]|glob[]`
+  - You can generate this list with the: `yarn ember-template-lint * --print-pending`
+- `ignore` -- `string[]|glob[]`
   An array of module id's that are to be completely ignored. See [ignore documentation](docs/ignore.md) for more details.
-* `plugins` -- `(string|Object)[]`
+- `plugins` -- `(string|Object)[]`
   An array of plugin objects, or strings that resolve to files that export plugin objects. See [plugin documentation](docs/plugins.md) for more details.
-* `overrides` -- `Array`
+- `overrides` -- `Array`
   An array of overrides that would allow overriding of specific rules for user specified files/folders. See [overrides documentation](docs/overrides.md) for more details.
 
 ## Rules
@@ -178,80 +180,80 @@ Each rule has emojis denoting:
 
 <!--RULES_TABLE_START-->
 
-|    | Rule ID |
-|:---|:--------|
-|  | [attribute-indentation](./docs/rule/attribute-indentation.md) |
-| :dress: | [block-indentation](./docs/rule/block-indentation.md) |
-|  | [deprecated-each-syntax](./docs/rule/deprecations/deprecated-each-syntax.md) |
-|  | [deprecated-inline-view-helper](./docs/rule/deprecations/deprecated-inline-view-helper.md) |
-| :white_check_mark: | [deprecated-render-helper](./docs/rule/deprecations/deprecated-render-helper.md) |
-| :dress: | [eol-last](./docs/rule/eol-last.md) |
-| :wrench: | [inline-link-to](./docs/rule/inline-link-to.md) |
-| :dress: | [linebreak-style](./docs/rule/linebreak-style.md) |
-| :white_check_mark: | [link-href-attributes](./docs/rule/link-href-attributes.md) |
-| :white_check_mark: | [link-rel-noopener](./docs/rule/link-rel-noopener.md) |
-|  | [modifier-name-case](./docs/rule/modifier-name-case.md) |
-| :white_check_mark: | [no-abstract-roles](./docs/rule/no-abstract-roles.md) |
-| :car: | [no-action](./docs/rule/no-action.md) |
-|  | [no-action-modifiers](./docs/rule/no-action-modifiers.md) |
-| :white_check_mark: | [no-args-paths](./docs/rule/no-args-paths.md) |
-|  | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md) |
-| :white_check_mark: | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md) |
-|  | [no-bare-strings](./docs/rule/no-bare-strings.md) |
-| :car: | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md) |
-| :white_check_mark: | [no-debugger](./docs/rule/no-debugger.md) |
-| :white_check_mark: | [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md) |
-|  | [no-element-event-actions](./docs/rule/no-element-event-actions.md) |
-| :white_check_mark: | [no-extra-mut-helper-argument](./docs/rule/no-extra-mut-helper-argument.md) |
-|  | [no-forbidden-elements](./docs/rule/no-forbidden-elements.md) |
-|  | [no-heading-inside-button](./docs/rule/no-heading-inside-button.md) |
-| :white_check_mark: | [no-html-comments](./docs/rule/no-html-comments.md) |
-| :car: | [no-implicit-this](./docs/rule/no-implicit-this.md) |
-| :white_check_mark: | [no-index-component-invocation](./docs/rule/no-index-component-invocation.md) |
-| :white_check_mark: | [no-inline-styles](./docs/rule/no-inline-styles.md) |
-| :white_check_mark: | [no-input-block](./docs/rule/no-input-block.md) |
-| :white_check_mark: | [no-input-tagname](./docs/rule/no-input-tagname.md) |
-|  | [no-invalid-block-param-definition](./docs/rule/no-invalid-block-param-definition.md) |
-| :white_check_mark: | [no-invalid-interactive](./docs/rule/no-invalid-interactive.md) |
-| :white_check_mark: | [no-invalid-link-text](./docs/rule/no-invalid-link-text.md) |
-|  | [no-invalid-link-title](./docs/rule/no-invalid-link-title.md) |
-| :white_check_mark: | [no-invalid-meta](./docs/rule/no-invalid-meta.md) |
-| :white_check_mark: | [no-invalid-role](./docs/rule/no-invalid-role.md) |
-| :white_check_mark: | [no-log](./docs/rule/no-log.md) |
-| :dress: | [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md) |
-| :white_check_mark: | [no-negated-condition](./docs/rule/no-negated-condition.md) |
-| :white_check_mark: | [no-nested-interactive](./docs/rule/no-nested-interactive.md) |
-|  | [no-nested-landmark](./docs/rule/no-nested-landmark.md) |
-| :white_check_mark: | [no-obsolete-elements](./docs/rule/no-obsolete-elements.md) |
-| :white_check_mark: | [no-outlet-outside-routes](./docs/rule/no-outlet-outside-routes.md) |
-| :white_check_mark: | [no-partial](./docs/rule/no-partial.md) |
-|  | [no-passed-in-event-handlers](./docs/rule/no-passed-in-event-handlers.md) |
-| :white_check_mark: | [no-positive-tabindex](./docs/rule/no-positive-tabindex.md) |
-| :white_check_mark: | [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md) |
-|  | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md) |
-|  | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md) |
-| :white_check_mark: | [no-shadowed-elements](./docs/rule/no-shadowed-elements.md) |
-| :dress: | [no-trailing-spaces](./docs/rule/no-trailing-spaces.md) |
-| :white_check_mark: | [no-triple-curlies](./docs/rule/no-triple-curlies.md) |
-|  | [no-unbalanced-curlies](./docs/rule/no-unbalanced-curlies.md) |
-| :white_check_mark: | [no-unbound](./docs/rule/no-unbound.md) |
-| :white_check_mark: | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md) |
-| :dress: | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md) |
-| :white_check_mark: | [no-unused-block-params](./docs/rule/no-unused-block-params.md) |
-|  | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md) |
-|  | [no-whitespace-within-word](./docs/rule/no-whitespace-within-word.md) |
-|  | [no-yield-only](./docs/rule/no-yield-only.md) |
-| :dress: | [quotes](./docs/rule/quotes.md) |
-| :white_check_mark::wrench: | [require-button-type](./docs/rule/require-button-type.md) |
-|  | [require-form-method](./docs/rule/require-form-method.md) |
-| :white_check_mark: | [require-iframe-title](./docs/rule/require-iframe-title.md) |
-|  | [require-input-label](./docs/rule/require-input-label.md) |
-| :white_check_mark: | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md) |
-| :dress: | [self-closing-void-elements](./docs/rule/self-closing-void-elements.md) |
-| :white_check_mark: | [simple-unless](./docs/rule/simple-unless.md) |
-| :white_check_mark: | [style-concatenation](./docs/rule/style-concatenation.md) |
-| :white_check_mark: | [table-groups](./docs/rule/table-groups.md) |
-|  | [template-length](./docs/rule/template-length.md) |
+|                            | Rule ID                                                                                    |
+| :------------------------- | :----------------------------------------------------------------------------------------- |
+|                            | [attribute-indentation](./docs/rule/attribute-indentation.md)                              |
+| :dress:                    | [block-indentation](./docs/rule/block-indentation.md)                                      |
+|                            | [deprecated-each-syntax](./docs/rule/deprecations/deprecated-each-syntax.md)               |
+|                            | [deprecated-inline-view-helper](./docs/rule/deprecations/deprecated-inline-view-helper.md) |
+| :white_check_mark:         | [deprecated-render-helper](./docs/rule/deprecations/deprecated-render-helper.md)           |
+| :dress:                    | [eol-last](./docs/rule/eol-last.md)                                                        |
+| :wrench:                   | [inline-link-to](./docs/rule/inline-link-to.md)                                            |
+| :dress:                    | [linebreak-style](./docs/rule/linebreak-style.md)                                          |
+| :white_check_mark:         | [link-href-attributes](./docs/rule/link-href-attributes.md)                                |
+| :white_check_mark:         | [link-rel-noopener](./docs/rule/link-rel-noopener.md)                                      |
+|                            | [modifier-name-case](./docs/rule/modifier-name-case.md)                                    |
+| :white_check_mark:         | [no-abstract-roles](./docs/rule/no-abstract-roles.md)                                      |
+| :car:                      | [no-action](./docs/rule/no-action.md)                                                      |
+|                            | [no-action-modifiers](./docs/rule/no-action-modifiers.md)                                  |
+| :white_check_mark:         | [no-args-paths](./docs/rule/no-args-paths.md)                                              |
+|                            | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)            |
+| :white_check_mark:         | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                            |
+|                            | [no-bare-strings](./docs/rule/no-bare-strings.md)                                          |
+| :car:                      | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md)              |
+| :white_check_mark:         | [no-debugger](./docs/rule/no-debugger.md)                                                  |
+| :white_check_mark:         | [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                          |
+|                            | [no-element-event-actions](./docs/rule/no-element-event-actions.md)                        |
+| :white_check_mark:         | [no-extra-mut-helper-argument](./docs/rule/no-extra-mut-helper-argument.md)                |
+|                            | [no-forbidden-elements](./docs/rule/no-forbidden-elements.md)                              |
+|                            | [no-heading-inside-button](./docs/rule/no-heading-inside-button.md)                        |
+| :white_check_mark:         | [no-html-comments](./docs/rule/no-html-comments.md)                                        |
+| :car:                      | [no-implicit-this](./docs/rule/no-implicit-this.md)                                        |
+| :white_check_mark:         | [no-index-component-invocation](./docs/rule/no-index-component-invocation.md)              |
+| :white_check_mark:         | [no-inline-styles](./docs/rule/no-inline-styles.md)                                        |
+| :white_check_mark:         | [no-input-block](./docs/rule/no-input-block.md)                                            |
+| :white_check_mark:         | [no-input-tagname](./docs/rule/no-input-tagname.md)                                        |
+|                            | [no-invalid-block-param-definition](./docs/rule/no-invalid-block-param-definition.md)      |
+| :white_check_mark:         | [no-invalid-interactive](./docs/rule/no-invalid-interactive.md)                            |
+| :white_check_mark:         | [no-invalid-link-text](./docs/rule/no-invalid-link-text.md)                                |
+|                            | [no-invalid-link-title](./docs/rule/no-invalid-link-title.md)                              |
+| :white_check_mark:         | [no-invalid-meta](./docs/rule/no-invalid-meta.md)                                          |
+| :white_check_mark:         | [no-invalid-role](./docs/rule/no-invalid-role.md)                                          |
+| :white_check_mark:         | [no-log](./docs/rule/no-log.md)                                                            |
+| :dress:                    | [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                          |
+| :white_check_mark:         | [no-negated-condition](./docs/rule/no-negated-condition.md)                                |
+| :white_check_mark:         | [no-nested-interactive](./docs/rule/no-nested-interactive.md)                              |
+|                            | [no-nested-landmark](./docs/rule/no-nested-landmark.md)                                    |
+| :white_check_mark:         | [no-obsolete-elements](./docs/rule/no-obsolete-elements.md)                                |
+| :white_check_mark:         | [no-outlet-outside-routes](./docs/rule/no-outlet-outside-routes.md)                        |
+| :white_check_mark:         | [no-partial](./docs/rule/no-partial.md)                                                    |
+|                            | [no-passed-in-event-handlers](./docs/rule/no-passed-in-event-handlers.md)                  |
+| :white_check_mark:         | [no-positive-tabindex](./docs/rule/no-positive-tabindex.md)                                |
+| :white_check_mark:         | [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md)                          |
+|                            | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)                    |
+|                            | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md)                      |
+| :white_check_mark:         | [no-shadowed-elements](./docs/rule/no-shadowed-elements.md)                                |
+| :dress:                    | [no-trailing-spaces](./docs/rule/no-trailing-spaces.md)                                    |
+| :white_check_mark:         | [no-triple-curlies](./docs/rule/no-triple-curlies.md)                                      |
+|                            | [no-unbalanced-curlies](./docs/rule/no-unbalanced-curlies.md)                              |
+| :white_check_mark:         | [no-unbound](./docs/rule/no-unbound.md)                                                    |
+| :white_check_mark:         | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)          |
+| :dress:                    | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                              |
+| :white_check_mark:         | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                            |
+|                            | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                        |
+|                            | [no-whitespace-within-word](./docs/rule/no-whitespace-within-word.md)                      |
+|                            | [no-yield-only](./docs/rule/no-yield-only.md)                                              |
+| :dress:                    | [quotes](./docs/rule/quotes.md)                                                            |
+| :white_check_mark::wrench: | [require-button-type](./docs/rule/require-button-type.md)                                  |
+|                            | [require-form-method](./docs/rule/require-form-method.md)                                  |
+| :white_check_mark:         | [require-iframe-title](./docs/rule/require-iframe-title.md)                                |
+|                            | [require-input-label](./docs/rule/require-input-label.md)                                  |
+| :white_check_mark:         | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                            |
+| :dress:                    | [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)                    |
+| :white_check_mark:         | [simple-unless](./docs/rule/simple-unless.md)                                              |
+| :white_check_mark:         | [style-concatenation](./docs/rule/style-concatenation.md)                                  |
+| :white_check_mark:         | [table-groups](./docs/rule/table-groups.md)                                                |
+|                            | [template-length](./docs/rule/template-length.md)                                          |
 
 <!--RULES_TABLE_END-->
 

--- a/README.md
+++ b/README.md
@@ -111,14 +111,6 @@ ember-template-lint into your normal eslint workflow.
 
 ## Configuration
 
-### Presets
-
-|                    | Name                                     | Description                                                                                                                                                                                                                                                                          |
-| :----------------- | :--------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| :white_check_mark: | [recommended](lib/config/recommended.js) | enables the recommended rules                                                                                                                                                                                                                                                        |
-| :car:              | [octane](lib/config/octane.js)           | extends the `recommended` preset by enabling Ember Octane rules                                                                                                                                                                                                                      |
-| :dress:            | [stylistic](lib/config/stylistic.js)     | enables stylistic rules for those who aren't ready to adopt [ember-template-lint-plugin-prettier](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier) (including stylistic rules that were previously in the `recommended` preset in ember-template-lint v1) |
-
 ### Project Wide
 
 You can turn on specific rules by toggling them in a
@@ -170,6 +162,14 @@ The following properties are allowed in the root of the `.template-lintrc.js` co
   An array of plugin objects, or strings that resolve to files that export plugin objects. See [plugin documentation](docs/plugins.md) for more details.
 - `overrides` -- `Array`
   An array of overrides that would allow overriding of specific rules for user specified files/folders. See [overrides documentation](docs/overrides.md) for more details.
+
+### Presets
+
+|                    | Name                                     | Description                                                                                                                                                                                                                                                                          |
+| :----------------- | :--------------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| :white_check_mark: | [recommended](lib/config/recommended.js) | enables the recommended rules                                                                                                                                                                                                                                                        |
+| :car:              | [octane](lib/config/octane.js)           | extends the `recommended` preset by enabling Ember Octane rules                                                                                                                                                                                                                      |
+| :dress:            | [stylistic](lib/config/stylistic.js)     | enables stylistic rules for those who aren't ready to adopt [ember-template-lint-plugin-prettier](https://github.com/ember-template-lint/ember-template-lint-plugin-prettier) (including stylistic rules that were previously in the `recommended` preset in ember-template-lint v1) |
 
 ## Rules
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "yargs": "^15.4.0"
   },
   "devDependencies": {
+    "@babel/parser": "^7.10.4",
+    "@babel/traverse": "^7.10.4",
     "common-tags": "^1.8.0",
     "eslint": "^7.4.0",
     "eslint-config-prettier": "^6.11.0",

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -2,6 +2,10 @@
 
 const fs = require('fs');
 const path = require('path');
+
+const { parse } = require('@babel/parser');
+const { default: traverse } = require('@babel/traverse');
+
 const rules = require('../lib/rules');
 const { rules: recommendedRules } = require('../lib/config/recommended');
 const { rules: octaneRules } = require('../lib/config/octane');
@@ -15,6 +19,29 @@ const tablePlaceholder = /<!--RULES_TABLE_START-->[\S\s]*<!--RULES_TABLE_END-->/
 const EMOJI_STAR = ':white_check_mark:';
 const EMOJI_OCTANE = ':car:';
 const EMOJI_STYLISTIC = ':dress:';
+const EMOJI_FIXABLE = ':wrench:';
+
+function isRuleFixable(ruleName) {
+  const relativePath = ruleName.startsWith('deprecated-')
+    ? `../lib/rules/deprecations/${ruleName}.js`
+    : `../lib/rules/${ruleName}.js`;
+  const pathRule = path.resolve(__dirname, relativePath);
+  let rule = fs.readFileSync(pathRule, { encoding: 'utf8' });
+
+  let ast = parse(rule, { sourceType: 'module' });
+
+  let isFixable = false;
+
+  traverse(ast, {
+    ObjectProperty(path) {
+      if (path.node.key.name === 'isFixable' && path.node.value.value !== false) {
+        isFixable = true;
+      }
+    },
+  });
+
+  return isFixable;
+}
 
 // Generate rule table contents.
 const rulesTableContent = Object.keys(rules)
@@ -24,10 +51,13 @@ const rulesTableContent = Object.keys(rules)
     const isRecommended = Object.prototype.hasOwnProperty.call(recommendedRules, ruleName);
     const isOctane = Object.prototype.hasOwnProperty.call(octaneRules, ruleName);
     const isStylistic = Object.prototype.hasOwnProperty.call(stylisticRules, ruleName);
+    const isFixable = isRuleFixable(ruleName);
+
     const emoji = [
       isRecommended ? EMOJI_STAR : '',
       isOctane ? EMOJI_OCTANE : '',
       isStylistic ? EMOJI_STYLISTIC : '',
+      isFixable ? EMOJI_FIXABLE : '',
     ].join('');
 
     const url = ruleName.startsWith('deprecated-')

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -5,11 +5,17 @@ const path = require('path');
 
 const { parse } = require('@babel/parser');
 const { default: traverse } = require('@babel/traverse');
+const prettier = require('prettier');
 
 const rules = require('../lib/rules');
 const { rules: recommendedRules } = require('../lib/config/recommended');
 const { rules: octaneRules } = require('../lib/config/octane');
 const { rules: stylisticRules } = require('../lib/config/stylistic');
+
+const prettierConfig = {
+  ...require('../.prettierrc.js'),
+  parser: 'markdown',
+};
 
 const pathReadme = path.resolve(__dirname, '../README.md');
 const readmeContent = fs.readFileSync(pathReadme, 'utf8');
@@ -69,10 +75,11 @@ const rulesTableContent = Object.keys(rules)
   })
   .join('\n');
 
-fs.writeFileSync(
-  pathReadme,
-  readmeContent.replace(
-    tablePlaceholder,
-    `<!--RULES_TABLE_START-->\n\n|    | Rule ID |\n|:---|:--------|\n${rulesTableContent}\n\n<!--RULES_TABLE_END-->`
-  )
+const readmeNewContent = readmeContent.replace(
+  tablePlaceholder,
+  `<!--RULES_TABLE_START-->\n\n|    | Rule ID |\n|:---|:--------|\n${rulesTableContent}\n\n<!--RULES_TABLE_END-->`
 );
+
+const readmeFormattedNewContent = prettier.format(readmeNewContent, prettierConfig);
+
+fs.writeFileSync(pathReadme, readmeFormattedNewContent);

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -40,7 +40,11 @@ function isRuleFixable(ruleName) {
 
   traverse(ast, {
     ObjectProperty(path) {
-      if (path.node.key.name === 'isFixable' && path.node.value.value !== false) {
+      if (
+        path.node.key.type === 'Identifier' &&
+        path.node.key.name === 'isFixable' &&
+        !(path.node.value.type === 'Identifier' && path.node.value.value === false)
+      ) {
         isFixable = true;
       }
     },

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -43,7 +43,7 @@ function isRuleFixable(ruleName) {
       if (
         path.node.key.type === 'Identifier' &&
         path.node.key.name === 'isFixable' &&
-        !(path.node.value.type === 'Identifier' && path.node.value.value === false)
+        !(path.node.value.type === 'BooleanLiteral' && path.node.value.value === false)
       ) {
         isFixable = true;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,13 @@
   dependencies:
     "@babel/highlight" "^7.8.3"
 
+"@babel/code-frame@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.10.4.tgz#168da1a36e90da68ae8d49c0f1b48c7c6249213a"
+  integrity sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==
+  dependencies:
+    "@babel/highlight" "^7.10.4"
+
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.8.6.tgz#27d7df9258a45c2e686b6f18b6c659e563aa4636"
@@ -30,6 +37,16 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/generator@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.4.tgz#e49eeed9fe114b62fa5b181856a43a5e32f5f243"
+  integrity sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==
+  dependencies:
+    "@babel/types" "^7.10.4"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
 "@babel/generator@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.8.6.tgz#57adf96d370c9a63c241cd719f9111468578537a"
@@ -40,6 +57,15 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
+"@babel/helper-function-name@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz#d2d3b20c59ad8c47112fa7d2a94bc09d5ef82f1a"
+  integrity sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==
+  dependencies:
+    "@babel/helper-get-function-arity" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-function-name@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.8.3.tgz#eeeb665a01b1f11068e9fb86ad56a1cb1a824cca"
@@ -48,6 +74,13 @@
     "@babel/helper-get-function-arity" "^7.8.3"
     "@babel/template" "^7.8.3"
     "@babel/types" "^7.8.3"
+
+"@babel/helper-get-function-arity@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz#98c1cbea0e2332f33f9a4661b8ce1505b2c19ba2"
+  integrity sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==
+  dependencies:
+    "@babel/types" "^7.10.4"
 
 "@babel/helper-get-function-arity@^7.8.3":
   version "7.8.3"
@@ -61,12 +94,24 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
   integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
 
+"@babel/helper-split-export-declaration@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz#2c70576eaa3b5609b24cb99db2888cc3fc4251d1"
+  integrity sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==
+  dependencies:
+    "@babel/types" "^7.10.4"
+
 "@babel/helper-split-export-declaration@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
   integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
   dependencies:
     "@babel/types" "^7.8.3"
+
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
 "@babel/helper-validator-identifier@^7.9.5":
   version "7.9.5"
@@ -82,6 +127,15 @@
     "@babel/traverse" "^7.8.4"
     "@babel/types" "^7.8.3"
 
+"@babel/highlight@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.10.4.tgz#7d1bdfd65753538fabe6c38596cdb76d9ac60143"
+  integrity sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    chalk "^2.0.0"
+    js-tokens "^4.0.0"
+
 "@babel/highlight@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.8.3.tgz#28f173d04223eaaa59bc1d439a3836e6d1265797"
@@ -95,6 +149,11 @@
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.6.tgz#ba5c9910cddb77685a008e3c587af8d27b67962c"
   integrity sha512-trGNYSfwq5s0SgM1BMEB8hX3NDmO7EP2wsDGDexiaKMB92BaRpS+qZfpkMqUBhcsOTBwNy9B/jieo4ad/t/z2g==
+
+"@babel/parser@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.10.4.tgz#9eedf27e1998d87739fb5028a5120557c06a1a64"
+  integrity sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -174,6 +233,15 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
+"@babel/template@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.10.4.tgz#3251996c4200ebc71d1a8fc405fba940f36ba278"
+  integrity sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
+
 "@babel/template@^7.3.3", "@babel/template@^7.7.4", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
@@ -198,12 +266,36 @@
     globals "^11.1.0"
     lodash "^4.17.13"
 
+"@babel/traverse@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.10.4.tgz#e642e5395a3b09cc95c8e74a27432b484b697818"
+  integrity sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.10.4"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.10.4"
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.8.6.tgz#629ecc33c2557fcde7126e58053127afdb3e6d01"
   integrity sha512-wqz7pgWMIrht3gquyEFPVXeXCti72Rm8ep9b5tQKz9Yg9LzJA3HxosF1SB3Kc81KD1A3XBkkVYtJvCKS2Z/QrA==
   dependencies:
     esutils "^2.0.2"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.10.4.tgz#369517188352e18219981efd156bfdb199fff1ee"
+  integrity sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 


### PR DESCRIPTION
Update `scripts/update-readme.js` to:

- Add 🔧 emoji to fixable rules
- Format README with Prettier