### PR TITLE
Add v8-compile-cache to improve startup performance

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -2,6 +2,9 @@
 
 'use strict';
 
+// Use V8's code cache to speed up instantiation time:
+require('v8-compile-cache'); // eslint-disable-line import/no-unassigned-import
+
 const fs = require('fs');
 const path = require('path');
 const micromatch = require('micromatch');

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "is-valid-glob": "^1.0.0",
     "micromatch": "^4.0.2",
     "resolve": "^1.17.0",
+    "v8-compile-cache": "^2.1.1",
     "yargs": "^15.4.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6352,10 +6352,10 @@ uuid@^7.0.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
   integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
-v8-compile-cache@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
-  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
+  integrity sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==
 
 v8-to-istanbul@^4.1.3:
   version "4.1.3"


### PR DESCRIPTION
Running the ember-template-lint binary directly with no args is 9% faster with [v8-compile-cache](https://www.npmjs.com/package/v8-compile-cache):

```
~/Development/ember-template-lint hyperfine 'DISABLE_V8_COMPILE_CACHE=1 ./bin/ember-template-lint.js' './bin/ember-template-lint.js' --ignore-failure
Benchmark #1: DISABLE_V8_COMPILE_CACHE=1 ./bin/ember-template-lint.js
  Time (mean ± σ):     159.6 ms ±   3.1 ms    [User: 148.4 ms, System: 28.3 ms]
  Range (min … max):   153.7 ms … 165.5 ms    17 runs

  Warning: Ignoring non-zero exit code.

Benchmark #2: ./bin/ember-template-lint.js
  Time (mean ± σ):     146.2 ms ±   2.4 ms    [User: 135.1 ms, System: 28.7 ms]
  Range (min … max):   141.6 ms … 150.1 ms    19 runs

  Warning: Ignoring non-zero exit code.

Summary
  './bin/ember-template-lint.js' ran
    1.09 ± 0.03 times faster than 'DISABLE_V8_COMPILE_CACHE=1 ./bin/ember-template-lint.js'
```

ESLint uses this too: https://github.com/eslint/eslint/pull/11921

Do we think this small startup time savings is worthwhile?
