### PR TITLE
Add `--no-inline-config` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ yarn ember-template-lint --no-config-path app/templates --rule 'no-implicit-this
 # running a single rule with options
 yarn ember-template-lint --no-config-path app/templates --rule 'no-implicit-this:["error", { "allow": ["some-helper"] }]'
 
+# running a single rule, disabling inline configuration
+yarn ember-template-lint --no-config-path app/templates --rule 'no-implicit-this:error' --no-inline-config
+
 # specify a config object to use instead of what exists locally
 yarn ember-template-lint --config '{ "rules": { "no-implicit-this": { "severity": 2, "config": true } } }' test/fixtures/no-implicit-this-allow-with-regexp/app/templates
 ```

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -140,6 +140,10 @@ function parseArgv(_argv) {
         type: 'array',
         default: ['**/dist/**', '**/tmp/**', '**/node_modules/**'],
       },
+      'no-inline-config': {
+        describe: 'Prevent inline configuration comments from changing config or rules',
+        boolean: true,
+      },
     })
     .help()
     .version();
@@ -212,6 +216,7 @@ async function run() {
       configPath: options.configPath,
       config,
       rule: options.rule,
+      allowInlineConfig: !options.noInlineConfig,
     });
   } catch (error) {
     console.error(error.message);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -88,6 +88,7 @@ class Linter {
         console: this.console,
         defaultSeverity: severity,
         ruleNames: Object.keys(fileConfig.loadedRules),
+        allowInlineConfig: this.options.allowInlineConfig,
       },
       options
     );

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -42,6 +42,8 @@ module.exports = class Base {
     this._console = options.console || console;
     this._configResolver = options.configResolver;
     this._ruleNames = options.ruleNames;
+    this._allowInlineConfig =
+      typeof options.allowInlineConfig === 'boolean' ? options.allowInlineConfig : true;
 
     this.severity = options.defaultSeverity;
     this.results = [];
@@ -355,6 +357,11 @@ module.exports = class Base {
 
   // eslint-disable-next-line complexity
   _processInstructionNode(node) {
+    if (!this._allowInlineConfig) {
+      // inline configuration is disabled, do nothing
+      return null;
+    }
+
     let nodeValue = node.value.trim();
     let instructionName = nodeValue.split(reWhitespace)[0];
     let instructionArgs = nodeValue.slice(instructionName.length + 1).trim();
@@ -439,7 +446,7 @@ module.exports = class Base {
           });
           loggedNodes.push(node);
         }
-        return;
+        return null;
       }
 
       if (!this._refersToCurrentRule(firstArg)) {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -34,29 +34,31 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path     Define a custom config path
+            --config-path       Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config          Define a custom configuration to be used - (e.g. '{
-                              \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')        [string]
-            --quiet           Ignore warnings and only show errors               [boolean]
-            --rule            Specify a rule and its severity to add that rule to loaded
-                              rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\", {
-                              \\"allow\\": [\\"some-helper\\"] }]\`)                       [string]
-            --filename        Used to indicate the filename to be assumed for contents
-                              from STDIN                                          [string]
-            --fix             Fix any errors that are reported as fixable
+            --config            Define a custom configuration to be used - (e.g. '{
+                                \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')      [string]
+            --quiet             Ignore warnings and only show errors             [boolean]
+            --rule              Specify a rule and its severity to add that rule to loaded
+                                rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\",
+                                { \\"allow\\": [\\"some-helper\\"] }]\`)                   [string]
+            --filename          Used to indicate the filename to be assumed for contents
+                                from STDIN                                        [string]
+            --fix               Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --json            Format output as json                              [boolean]
-            --verbose         Output errors with source description              [boolean]
-            --no-config-path  Does not use the local template-lintrc, will use a blank
-                              template-lintrc instead                            [boolean]
-            --print-pending   Print list of formated rules for use with \`pending\` in
-                              config file                                        [boolean]
-            --ignore-pattern  Specify custom ignore pattern (can be disabled with
-                              --no-ignore-pattern)
+            --json              Format output as json                            [boolean]
+            --verbose           Output errors with source description            [boolean]
+            --no-config-path    Does not use the local template-lintrc, will use a blank
+                                template-lintrc instead                          [boolean]
+            --print-pending     Print list of formated rules for use with \`pending\` in
+                                config file                                      [boolean]
+            --ignore-pattern    Specify custom ignore pattern (can be disabled with
+                                --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --help            Show help                                          [boolean]
-            --version         Show version number                                [boolean]"
+            --no-inline-config  Prevent inline configuration comments from changing config
+                                or rules                                         [boolean]
+            --help              Show help                                        [boolean]
+            --version           Show version number                              [boolean]"
         `);
       });
     });
@@ -70,29 +72,31 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path     Define a custom config path
+            --config-path       Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config          Define a custom configuration to be used - (e.g. '{
-                              \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')        [string]
-            --quiet           Ignore warnings and only show errors               [boolean]
-            --rule            Specify a rule and its severity to add that rule to loaded
-                              rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\", {
-                              \\"allow\\": [\\"some-helper\\"] }]\`)                       [string]
-            --filename        Used to indicate the filename to be assumed for contents
-                              from STDIN                                          [string]
-            --fix             Fix any errors that are reported as fixable
+            --config            Define a custom configuration to be used - (e.g. '{
+                                \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')      [string]
+            --quiet             Ignore warnings and only show errors             [boolean]
+            --rule              Specify a rule and its severity to add that rule to loaded
+                                rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\",
+                                { \\"allow\\": [\\"some-helper\\"] }]\`)                   [string]
+            --filename          Used to indicate the filename to be assumed for contents
+                                from STDIN                                        [string]
+            --fix               Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --json            Format output as json                              [boolean]
-            --verbose         Output errors with source description              [boolean]
-            --no-config-path  Does not use the local template-lintrc, will use a blank
-                              template-lintrc instead                            [boolean]
-            --print-pending   Print list of formated rules for use with \`pending\` in
-                              config file                                        [boolean]
-            --ignore-pattern  Specify custom ignore pattern (can be disabled with
-                              --no-ignore-pattern)
+            --json              Format output as json                            [boolean]
+            --verbose           Output errors with source description            [boolean]
+            --no-config-path    Does not use the local template-lintrc, will use a blank
+                                template-lintrc instead                          [boolean]
+            --print-pending     Print list of formated rules for use with \`pending\` in
+                                config file                                      [boolean]
+            --ignore-pattern    Specify custom ignore pattern (can be disabled with
+                                --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --help            Show help                                          [boolean]
-            --version         Show version number                                [boolean]"
+            --no-inline-config  Prevent inline configuration comments from changing config
+                                or rules                                         [boolean]
+            --help              Show help                                        [boolean]
+            --version           Show version number                              [boolean]"
         `);
       });
     });
@@ -264,29 +268,31 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path     Define a custom config path
+            --config-path       Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config          Define a custom configuration to be used - (e.g. '{
-                              \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')        [string]
-            --quiet           Ignore warnings and only show errors               [boolean]
-            --rule            Specify a rule and its severity to add that rule to loaded
-                              rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\", {
-                              \\"allow\\": [\\"some-helper\\"] }]\`)                       [string]
-            --filename        Used to indicate the filename to be assumed for contents
-                              from STDIN                                          [string]
-            --fix             Fix any errors that are reported as fixable
+            --config            Define a custom configuration to be used - (e.g. '{
+                                \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')      [string]
+            --quiet             Ignore warnings and only show errors             [boolean]
+            --rule              Specify a rule and its severity to add that rule to loaded
+                                rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\",
+                                { \\"allow\\": [\\"some-helper\\"] }]\`)                   [string]
+            --filename          Used to indicate the filename to be assumed for contents
+                                from STDIN                                        [string]
+            --fix               Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --json            Format output as json                              [boolean]
-            --verbose         Output errors with source description              [boolean]
-            --no-config-path  Does not use the local template-lintrc, will use a blank
-                              template-lintrc instead                            [boolean]
-            --print-pending   Print list of formated rules for use with \`pending\` in
-                              config file                                        [boolean]
-            --ignore-pattern  Specify custom ignore pattern (can be disabled with
-                              --no-ignore-pattern)
+            --json              Format output as json                            [boolean]
+            --verbose           Output errors with source description            [boolean]
+            --no-config-path    Does not use the local template-lintrc, will use a blank
+                                template-lintrc instead                          [boolean]
+            --print-pending     Print list of formated rules for use with \`pending\` in
+                                config file                                      [boolean]
+            --ignore-pattern    Specify custom ignore pattern (can be disabled with
+                                --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --help            Show help                                          [boolean]
-            --version         Show version number                                [boolean]"
+            --no-inline-config  Prevent inline configuration comments from changing config
+                                or rules                                         [boolean]
+            --help              Show help                                        [boolean]
+            --version           Show version number                              [boolean]"
         `);
       });
     });

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -329,6 +329,44 @@ describe('base plugin', function () {
       );
       expect(messages).toHaveLength(3);
     });
+
+    describe('allowInlineConfig: false', function () {
+      function processTemplate(template) {
+        let Rule = buildPlugin({
+          MustacheCommentStatement(node) {
+            this.process(node);
+          },
+        });
+
+        Rule.prototype.log = function (result) {
+          messages.push(result.message);
+        };
+        Rule.prototype.process = function (node) {
+          config = this._processInstructionNode(node);
+        };
+
+        runRules(template, [
+          Object.assign({ allowInlineConfig: false }, plugin(Rule, 'fake', 'foo')),
+        ]);
+      }
+
+      it('inline config has no effect', function () {
+        processTemplate('{{! template-lint-disable fake }}');
+
+        expect(config).toEqual(null);
+      });
+
+      it('unknown rules do not throw an error', function () {
+        processTemplate(
+          [
+            '{{! template-lint-enable notarule }}',
+            '{{! template-lint-disable fake norme meneither }}',
+            '{{! template-lint-configure nope false }}',
+          ].join('\n')
+        );
+        expect(messages).toEqual([]);
+      });
+    });
   });
 
   describe('scopes instructions', function () {


### PR DESCRIPTION
This allows gathering the results of a given rule / config (e.g. when using `--rule` along with `--no-config-path`) ignoring inline configuration.

After attempting to run a quick audit of failures in a codebase at work @melsumner and I quickly ran into a few issues:

* running with `--no-config-path` and `--rule` will throws errors if the codebase is using inline configuration to enable/disable custom rules that are added by plugins in the `.template-lintrc.js`
* the ability to disable the rule inline, meant that I had to audit **both** the results of running `--rule` + `--no-config-path` **and** check for all inline comments mentioning the specific rule name in question

After this change, running the following does the trick:

```
ember-template-lint  \n
  --no-config-path   \n
  --no-inline-config \n
  --rule 'no-implicit-this:error'
```