### PR TITLE
Update `require-input-label` rule to detect duplicate labels

### DIFF
--- a/lib/rules/require-input-label.js
+++ b/lib/rules/require-input-label.js
@@ -3,7 +3,8 @@
 const AstNodeInfo = require('../helpers/ast-node-info');
 const Rule = require('./base');
 
-const ERROR_MESSAGE = 'Input elements require a valid associated label.';
+const ERROR_MESSAGE_NO_LABEL = 'Input elements require a valid associated label.';
+const ERROR_MESSAGE_MULTIPLE_LABEL = 'Input elements should not have multiple valid labels.';
 
 function hasValidLabelParent(path) {
   // Parental validation (descriptive elements)
@@ -27,20 +28,28 @@ module.exports = class RequireInputLabel extends Rule {
           return;
         }
 
-        if (hasValidLabelParent(path)) {
+        if (AstNodeInfo.hasAttribute(node, '...attributes')) {
           return;
+        }
+
+        let labelCount = 0;
+
+        if (hasValidLabelParent(path)) {
+          labelCount++;
         }
 
         // An input can be validated by either:
         // Self-validation (descriptive attributes)
-        let validAttributesList = ['id', 'aria-label', 'aria-labelledby', '...attributes'];
-        let hasValidAttributes = AstNodeInfo.hasAnyAttribute(node, validAttributesList);
-        if (hasValidAttributes) {
+        let validAttributesList = ['id', 'aria-label', 'aria-labelledby'];
+        let attributes = validAttributesList.filter((name) => AstNodeInfo.hasAttribute(node, name));
+        labelCount += attributes.length;
+        if (labelCount === 1) {
           return;
         }
 
+        let message = labelCount === 0 ? ERROR_MESSAGE_NO_LABEL : ERROR_MESSAGE_MULTIPLE_LABEL;
         this.log({
-          message: ERROR_MESSAGE,
+          message,
           line: node.loc && node.loc.start.line,
           column: node.loc && node.loc.start.column,
           source: this.sourceForNode(node),
@@ -61,7 +70,7 @@ module.exports = class RequireInputLabel extends Rule {
         }
 
         this.log({
-          message: ERROR_MESSAGE,
+          message: ERROR_MESSAGE_NO_LABEL,
           line: node.loc && node.loc.start.line,
           column: node.loc && node.loc.start.column,
           source: this.sourceForNode(node),
@@ -71,4 +80,5 @@ module.exports = class RequireInputLabel extends Rule {
   }
 };
 
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE_NO_LABEL;
+module.exports.ERROR_MESSAGE_MULTIPLE_LABEL = ERROR_MESSAGE_MULTIPLE_LABEL;

--- a/test/unit/rules/require-input-label-test.js
+++ b/test/unit/rules/require-input-label-test.js
@@ -1,6 +1,9 @@
 'use strict';
 
-const { ERROR_MESSAGE, ERROR_MESSAGE_MULTIPLE_LABEL } = require('../../../lib/rules/require-input-label');
+const { 
+  ERROR_MESSAGE,
+  ERROR_MESSAGE_MULTIPLE_LABEL
+} = require('../../../lib/rules/require-input-label');
 const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({

--- a/test/unit/rules/require-input-label-test.js
+++ b/test/unit/rules/require-input-label-test.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const { 
+const {
   ERROR_MESSAGE,
-  ERROR_MESSAGE_MULTIPLE_LABEL
+  ERROR_MESSAGE_MULTIPLE_LABEL,
 } = require('../../../lib/rules/require-input-label');
 const generateRuleTests = require('../../helpers/rule-test-harness');
 

--- a/test/unit/rules/require-input-label-test.js
+++ b/test/unit/rules/require-input-label-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { ERROR_MESSAGE } = require('../../../lib/rules/require-input-label');
+const { ERROR_MESSAGE, ERROR_MESSAGE_MULTIPLE_LABEL } = require('../../../lib/rules/require-input-label');
 const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
@@ -24,6 +24,7 @@ generateRuleTests({
     '{{input id="foo"}}',
     '<label>Text here<Input /></label>',
     '<label>Text here {{input}}</label>',
+    '<input id="label-input" ...attributes>',
   ],
 
   bad: [
@@ -79,6 +80,33 @@ generateRuleTests({
         line: 1,
         column: 0,
         source: '<Input/>',
+      },
+    },
+    {
+      template: '<input aria-label="first label" aria-labelledby="second label">',
+      result: {
+        message: ERROR_MESSAGE_MULTIPLE_LABEL,
+        line: 1,
+        column: 0,
+        source: '<input aria-label="first label" aria-labelledby="second label">',
+      },
+    },
+    {
+      template: '<input id="label-input" aria-label="second label">',
+      result: {
+        message: ERROR_MESSAGE_MULTIPLE_LABEL,
+        line: 1,
+        column: 0,
+        source: '<input id="label-input" aria-label="second label">',
+      },
+    },
+    {
+      template: '<label>Input label<input aria-label="Custom label"></label>',
+      result: {
+        message: ERROR_MESSAGE_MULTIPLE_LABEL,
+        line: 1,
+        column: 18,
+        source: '<input aria-label="Custom label">',
       },
     },
   ],


### PR DESCRIPTION
This PR is related to [this issue](https://github.com/ember-template-lint/ember-template-lint/issues/1256) reported by @MelSumner.

The idea is to update the rule `require-input-label` to report errors if an input has multiple labels attached.
The rule will report an error if the input is invoked with more than one attribute that can be used to attach a label.

For example, the following patterns are considered invalid :

```html
<label>
  Input label
  <input type="text" aria-label="Custom label"/>
</label>
```

```html
<input type="text" aria-label="Custom label" aria-labelledby="input-label"/>
```
