### PR TITLE
Implement `no-redundant-fn` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Each rule has emojis denoting:
 |                            | [no-passed-in-event-handlers](./docs/rule/no-passed-in-event-handlers.md)                  |
 | :white_check_mark:         | [no-positive-tabindex](./docs/rule/no-positive-tabindex.md)                                |
 | :white_check_mark:         | [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md)                          |
+| :wrench:                   | [no-redundant-fn](./docs/rule/no-redundant-fn.md)                                          |
 |                            | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)                    |
 |                            | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md)                      |
 | :white_check_mark:         | [no-shadowed-elements](./docs/rule/no-shadowed-elements.md)                                |

--- a/docs/rule/no-redundant-fn.md
+++ b/docs/rule/no-redundant-fn.md
@@ -1,0 +1,35 @@
+# no-redundant-fn
+
+The `fn` helper can be used to bind arguments to another function. Using it
+without any arguments is redundant because then the inner function could just
+be used directly.
+
+This rule is looking for `fn` helper usages that don't provide any additional
+arguments to the inner function and warns about them.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<button {{on "click" (fn this.handleClick)}}>Click Me</button>
+```
+
+This rule **allows** the following:
+
+```hbs
+<button {{on "click" this.handleClick}}>Click Me</button>
+```
+
+```hbs
+<button {{on "click" (fn this.handleClick "foo")}}>Click Me</button>
+```
+
+## Migration
+
+:wrench: The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
+## References
+
+- [Ember Guides](https://guides.emberjs.com/release/components/component-state-and-actions/#toc_passing-arguments-to-actions)
+- [`fn` API documentation](https://api.emberjs.com/ember/3.20/classes/Ember.Templates.helpers/methods/fn?anchor=fn)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -74,4 +74,5 @@ module.exports = {
   'style-concatenation': require('./style-concatenation'),
   'table-groups': require('./table-groups'),
   'template-length': require('./template-length'),
+  'no-redundant-fn': require('./no-redundant-fn'),
 };

--- a/lib/rules/no-redundant-fn.js
+++ b/lib/rules/no-redundant-fn.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const Rule = require('./base');
+
+const ERROR_MESSAGE = '`fn` helpers without additional arguments are not allowed';
+
+module.exports = class NoRedundantFn extends Rule {
+  visitor() {
+    return {
+      MustacheStatement(node, path) {
+        return this.process(node, path);
+      },
+      SubExpression(node, path) {
+        return this.process(node, path);
+      },
+    };
+  }
+
+  process(node, { parentNode, parentKey }) {
+    let { path, params } = node;
+    if (
+      path.type !== 'PathExpression' ||
+      path.original !== 'fn' ||
+      params.length !== 1 ||
+      params[0].type !== 'PathExpression'
+    ) {
+      return;
+    }
+
+    if (this.mode === 'fix') {
+      if (node.type === 'MustacheStatement') {
+        node.params = [];
+        node.path = params[0];
+      } else {
+        if (Array.isArray(parentNode[parentKey])) {
+          let index = parentNode[parentKey].indexOf(node);
+          parentNode[parentKey][index] = params[0];
+        } else {
+          parentNode[parentKey] = params[0];
+        }
+      }
+    } else {
+      this.log({
+        message: ERROR_MESSAGE,
+        line: node.loc && node.loc.start.line,
+        column: node.loc && node.loc.start.column,
+        source: this.sourceForNode(node),
+        isFixable: true,
+      });
+    }
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/no-redundant-fn-test.js
+++ b/test/unit/rules/no-redundant-fn-test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+const ERROR_MESSAGE = require('../../../lib/rules/no-redundant-fn').ERROR_MESSAGE;
+
+generateRuleTests({
+  name: 'no-redundant-fn',
+
+  config: true,
+
+  good: [
+    '<button {{on "click" this.handleClick}}>Click Me</button>',
+    '<button {{on "click" (fn this.handleClick "foo")}}>Click Me</button>',
+    '<SomeComponent @onClick={{this.handleClick}} />',
+    '<SomeComponent @onClick={{fn this.handleClick "foo"}} />',
+    '{{foo bar=this.handleClick}}>',
+    '{{foo bar=(fn this.handleClick "foo")}}>',
+  ],
+
+  bad: [
+    {
+      template: '<button {{on "click" (fn this.handleClick)}}>Click Me</button>',
+      fixedTemplate: '<button {{on "click" this.handleClick}}>Click Me</button>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 21,
+        source: '(fn this.handleClick)',
+        isFixable: true,
+      },
+    },
+    {
+      template: '<SomeComponent @onClick={{fn this.handleClick}} />',
+      fixedTemplate: '<SomeComponent @onClick={{this.handleClick}} />',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 24,
+        source: '{{fn this.handleClick}}',
+        isFixable: true,
+      },
+    },
+    {
+      template: '{{foo bar=(fn this.handleClick)}}>',
+      fixedTemplate: '{{foo bar=this.handleClick}}>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 10,
+        source: '(fn this.handleClick)',
+        isFixable: true,
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This rule **forbids** the following:

```hbs
<button {{on "click" (fn this.handleClick)}}>Click Me</button>
```

This rule **allows** the following:

```hbs
<button {{on "click" this.handleClick}}>Click Me</button>
```

```hbs
<button {{on "click" (fn this.handleClick "foo")}}>Click Me</button>
```
