### PR TITLE
Drop support for Node 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: Node 12.x - ubuntu
+    name: Node 14.x - ubuntu
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -37,12 +37,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows]
-        node-version: [10.x, 12.x, 13.x, 14.x]
+        node-version: [13.x, 14.x]
 
         # excluded because it is the `test` job above
         exclude:
           - os: ubuntu
-            node-version: 12.x
+            node-version: 14.x
 
     steps:
       - uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
 
       - name: install dependencies
         run: yarn install --no-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: Node 14.x - ubuntu
+    name: Node 12.x - ubuntu
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -42,7 +42,7 @@ jobs:
         # excluded because it is the `test` job above
         exclude:
           - os: ubuntu
-            node-version: 14.x
+            node-version: 12.x
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows]
-        node-version: [13.x, 14.x]
+        node-version: [10.x, 12.x, 14.x]
 
         # excluded because it is the `test` job above
         exclude:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install ember-template-lint
 npm install --save-dev ember-template-lint
 ```
 
-Node.js `10 || >=12` is required.
+Node.js `13 || >=14` is required.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To install ember-template-lint
 npm install --save-dev ember-template-lint
 ```
 
-Node.js `13 || >=14` is required.
+Node.js `10 || 12 || >=14` is required.
 
 ## Usage
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "release-it-lerna-changelog": "^2.3.0"
   },
   "engines": {
-    "node": "10.* || >= 12.*"
+    "node": "12.* || >= 14.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
@@ -93,7 +93,7 @@
     }
   },
   "volta": {
-    "node": "12.16.3",
+    "node": "12.18.3",
     "yarn": "1.22.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "release-it-lerna-changelog": "^2.3.0"
   },
   "engines": {
-    "node": "12.* || >= 14.*"
+    "node": "10.* || 12.* || >= 14.*"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org"


### PR DESCRIPTION
When I updated the Node version in `package.json` for engines, I got this error: 

```bash
error ember-template-lint@2.10.0: The engine "node" is incompatible with this module. Expected version "13.* || >= 14.*". Got "12.18.1"
error Found incompatible module.
```
I also noticed that we historically seem to do the last two versions of Node, but if we drop support for Node 13 then we'd only support one version of Node. So I set the Node versions in `ci.yml` to use both 13 and 14. 
