### PR TITLE
Fix misspelling of `--print-pending`s help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ yarn ember-template-lint "app/templates/application.hbs" --config-path .my-templ
 # read from stdin
 yarn ember-template-lint --filename app/templates/application.hbs < app/templates/application.hbs
 
-# print list of formated rules for use with `pending` in config file
+# print list of formatted rules for use with `pending` in config file
 yarn ember-template-lint "app/templates/application.hbs" --print-pending
 
 # specify custom ignore pattern `['**/dist/**', '**/tmp/**', '**/node_modules/**']` by default

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -132,7 +132,7 @@ function parseArgv(_argv) {
         boolean: true,
       },
       'print-pending': {
-        describe: 'Print list of formated rules for use with `pending` in config file',
+        describe: 'Print list of formatted rules for use with `pending` in config file',
         boolean: true,
       },
       'ignore-pattern': {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -50,7 +50,7 @@ describe('ember-template-lint executable', function () {
             --verbose           Output errors with source description            [boolean]
             --no-config-path    Does not use the local template-lintrc, will use a blank
                                 template-lintrc instead                          [boolean]
-            --print-pending     Print list of formated rules for use with \`pending\` in
+            --print-pending     Print list of formatted rules for use with \`pending\` in
                                 config file                                      [boolean]
             --ignore-pattern    Specify custom ignore pattern (can be disabled with
                                 --no-ignore-pattern)
@@ -88,7 +88,7 @@ describe('ember-template-lint executable', function () {
             --verbose           Output errors with source description            [boolean]
             --no-config-path    Does not use the local template-lintrc, will use a blank
                                 template-lintrc instead                          [boolean]
-            --print-pending     Print list of formated rules for use with \`pending\` in
+            --print-pending     Print list of formatted rules for use with \`pending\` in
                                 config file                                      [boolean]
             --ignore-pattern    Specify custom ignore pattern (can be disabled with
                                 --no-ignore-pattern)
@@ -284,7 +284,7 @@ describe('ember-template-lint executable', function () {
             --verbose           Output errors with source description            [boolean]
             --no-config-path    Does not use the local template-lintrc, will use a blank
                                 template-lintrc instead                          [boolean]
-            --print-pending     Print list of formated rules for use with \`pending\` in
+            --print-pending     Print list of formatted rules for use with \`pending\` in
                                 config file                                      [boolean]
             --ignore-pattern    Specify custom ignore pattern (can be disabled with
                                 --no-ignore-pattern)


### PR DESCRIPTION
Searched the codebase for instances of "formatted" being misspelled and found the rest. 