### PR TITLE
no-arguments-for-html-elements: Remove wrong examples from the documentation

### DIFF
--- a/docs/rule/no-arguments-for-html-elements.md
+++ b/docs/rule/no-arguments-for-html-elements.md
@@ -45,14 +45,6 @@ This rule **forbids** the following:
 ```
 
 ```hbs
-<img src="this.picture" >
-```
-
-```hbs
-<img src="@img" >
-```
-
-```hbs
 <div as |blockName|>
     {{blockName}}
 </div>
@@ -66,14 +58,6 @@ This rule **allows** the following:
 
 ```hbs
 <Img @src="1" />
-```
-
-```hbs
-<img src={{this.picture}} >
-```
-
-```hbs
-<img src={{@img}} >
 ```
 
 ```hbs


### PR DESCRIPTION
These snippets are actually not flagged at all by this rule. 🤷‍♂️ 