### PR TITLE
no-arguments-for-html-elements: Extract `no-block-params-for-html-elements` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Each rule has emojis denoting:
 |                            | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)            |
 | :white_check_mark:         | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                            |
 |                            | [no-bare-strings](./docs/rule/no-bare-strings.md)                                          |
+|                            | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md)      |
 | :car:                      | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md)              |
 | :white_check_mark:         | [no-debugger](./docs/rule/no-debugger.md)                                                  |
 | :white_check_mark:         | [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                          |

--- a/docs/rule/no-arguments-for-html-elements.md
+++ b/docs/rule/no-arguments-for-html-elements.md
@@ -27,11 +27,6 @@ Uncaught (in promise) TypeError: func is not a function
 This is untraceable for end-users.
 This linting rule determines if it is a component or not and emits an error if argument is assigned to a lower-case element without the same block name and without dots in notation.
 
-This rule will also emit an error for these other conditions:
-
-- trying to specify "path-like" string as attribute argument
-- trying to use an HTML element with block params
-
 ## Examples
 
 This rule **forbids** the following:
@@ -44,12 +39,6 @@ This rule **forbids** the following:
 <img @src="1" >
 ```
 
-```hbs
-<div as |blockName|>
-    {{blockName}}
-</div>
-```
-
 This rule **allows** the following:
 
 ```hbs
@@ -58,12 +47,6 @@ This rule **allows** the following:
 
 ```hbs
 <Img @src="1" />
-```
-
-```hbs
-<MyComponent as |blockName|>
-  {{blockName}}
-</MyComponent>
 ```
 
 ```hbs

--- a/docs/rule/no-block-params-for-html-elements.md
+++ b/docs/rule/no-block-params-for-html-elements.md
@@ -1,0 +1,34 @@
+# no-block-params-for-html-elements
+
+Block parameters (`<Checkbox as |checkbox|>`) are only useful when invoking
+components. When they are used on regular HTML elements they are useless and an
+indicator of a potential bug.
+
+This rule warns about all block parameter usages on regular HTML elements
+(angle bracket invocations with lower-case tagnames).
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<div as |blockName|></div>
+```
+
+This rule **allows** the following:
+
+```hbs
+<div></div>
+```
+
+```hbs
+<Checkbox as |blockName|></Checkbox>
+```
+
+## Migration
+
+- Remove the unused block parameters or fix the tag name to refer to a component
+
+## Related Rules
+
+- [no-arguments-for-html-elements](no-arguments-for-html-elements.md)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -19,6 +19,7 @@ module.exports = {
   'no-arguments-for-html-elements': require('./no-arguments-for-html-elements'),
   'no-attrs-in-components': require('./no-attrs-in-components'),
   'no-bare-strings': require('./no-bare-strings'),
+  'no-block-params-for-html-elements': require('./no-block-params-for-html-elements'),
   'no-curly-component-invocation': require('./no-curly-component-invocation'),
   'no-debugger': require('./no-debugger'),
   'no-duplicate-attributes': require('./no-duplicate-attributes'),

--- a/lib/rules/no-arguments-for-html-elements.js
+++ b/lib/rules/no-arguments-for-html-elements.js
@@ -34,7 +34,7 @@ module.exports = class NoArgumentsForHTMLElements extends Rule {
     }
 
     return {
-      ElementNode: (node) => {
+      ElementNode(node) {
         if (looksLikeHTMLElement(this.scope, node)) {
           detectInvalidAttributes(node);
         }

--- a/lib/rules/no-arguments-for-html-elements.js
+++ b/lib/rules/no-arguments-for-html-elements.js
@@ -37,14 +37,6 @@ module.exports = class NoArgumentsForHTMLElements extends Rule {
           });
         }
       });
-      node.blockParams.forEach((param) => {
-        log({
-          message: makeError(2, param),
-          line: node.loc && node.loc.start.line,
-          column: node.loc && node.loc.start.column,
-          source: sourceForNode(node),
-        });
-      });
     }
 
     return {

--- a/lib/rules/no-arguments-for-html-elements.js
+++ b/lib/rules/no-arguments-for-html-elements.js
@@ -20,8 +20,8 @@ module.exports = class NoArgumentsForHTMLElements extends Rule {
       ElementNode(node) {
         if (looksLikeHTMLElement(this.scope, node)) {
           node.attributes.forEach((attr) => {
-            const name = attr.name;
-            if (attr.name.startsWith('@')) {
+            const { name } = attr;
+            if (name.startsWith('@')) {
               this.log({
                 message: makeError(name, node.tag),
                 line: attr.loc && attr.loc.start.line,

--- a/lib/rules/no-arguments-for-html-elements.js
+++ b/lib/rules/no-arguments-for-html-elements.js
@@ -9,9 +9,6 @@ function makeError(attrName, tagName) {
 
 module.exports = class NoArgumentsForHTMLElements extends Rule {
   visitor() {
-    const log = this.log.bind(this);
-    const sourceForNode = this.sourceForNode.bind(this);
-
     function looksLikeHTMLElement(scope, node) {
       const isComponent = isAngleBracketComponent(scope, node);
       const isSlot = node.tag.startsWith(':');
@@ -19,24 +16,20 @@ module.exports = class NoArgumentsForHTMLElements extends Rule {
       return !isComponent && !isSlot && !isPath;
     }
 
-    function detectInvalidAttributes(node) {
-      node.attributes.forEach((attr) => {
-        const name = attr.name;
-        if (attr.name.startsWith('@')) {
-          log({
-            message: makeError(name, node.tag),
-            line: attr.loc && attr.loc.start.line,
-            column: attr.loc && attr.loc.start.column,
-            source: sourceForNode(attr),
-          });
-        }
-      });
-    }
-
     return {
       ElementNode(node) {
         if (looksLikeHTMLElement(this.scope, node)) {
-          detectInvalidAttributes(node);
+          node.attributes.forEach((attr) => {
+            const name = attr.name;
+            if (attr.name.startsWith('@')) {
+              this.log({
+                message: makeError(name, node.tag),
+                line: attr.loc && attr.loc.start.line,
+                column: attr.loc && attr.loc.start.column,
+                source: this.sourceForNode(attr),
+              });
+            }
+          });
         }
       },
     };

--- a/lib/rules/no-arguments-for-html-elements.js
+++ b/lib/rules/no-arguments-for-html-elements.js
@@ -3,16 +3,10 @@
 const Rule = require('./base');
 const isAngleBracketComponent = require('../helpers/is-angle-bracket-component');
 
-const ERROR_MESSAGES = {
-  1: 'Arguments ("%") should not be used on HTML elements ("<%>").',
-  2: 'Block params ("%") should not be used on HTML elements.',
-};
-
-function makeError(msgId, ...args) {
-  return args.reduce((result, value) => {
-    return result.replace('%', value);
-  }, ERROR_MESSAGES[msgId]);
+function makeError(attrName, tagName) {
+  return `Arguments (${attrName}) should not be used on HTML elements (<${tagName}>).`;
 }
+
 module.exports = class NoArgumentsForHTMLElements extends Rule {
   visitor() {
     const log = this.log.bind(this);
@@ -30,7 +24,7 @@ module.exports = class NoArgumentsForHTMLElements extends Rule {
         const name = attr.name;
         if (attr.name.startsWith('@')) {
           log({
-            message: makeError(1, name, node.tag),
+            message: makeError(name, node.tag),
             line: attr.loc && attr.loc.start.line,
             column: attr.loc && attr.loc.start.column,
             source: sourceForNode(attr),
@@ -48,4 +42,5 @@ module.exports = class NoArgumentsForHTMLElements extends Rule {
     };
   }
 };
+
 module.exports.makeError = makeError;

--- a/lib/rules/no-block-params-for-html-elements.js
+++ b/lib/rules/no-block-params-for-html-elements.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const Rule = require('./base');
+const isAngleBracketComponent = require('../helpers/is-angle-bracket-component');
+
+module.exports = class NoBlockParamsForHtmlElements extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        if (node.blockParams.length !== 0 && !isAngleBracketComponent(this.scope, node)) {
+          this.log({
+            message: NoBlockParamsForHtmlElements.generateErrorMessage(node.tag),
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
+        }
+      },
+    };
+  }
+
+  static generateErrorMessage(tagName) {
+    return `Block parameters on <${tagName}> elements are disallowed`;
+  }
+};

--- a/lib/rules/no-block-params-for-html-elements.js
+++ b/lib/rules/no-block-params-for-html-elements.js
@@ -7,7 +7,11 @@ module.exports = class NoBlockParamsForHtmlElements extends Rule {
   visitor() {
     return {
       ElementNode(node) {
-        if (node.blockParams.length !== 0 && !isAngleBracketComponent(this.scope, node)) {
+        if (
+          node.blockParams.length !== 0 &&
+          !isAngleBracketComponent(this.scope, node) &&
+          !node.tag.startsWith(':')
+        ) {
           this.log({
             message: NoBlockParamsForHtmlElements.generateErrorMessage(node.tag),
             line: node.loc && node.loc.start.line,

--- a/test/unit/rules/no-arguments-for-html-elements-test.js
+++ b/test/unit/rules/no-arguments-for-html-elements-test.js
@@ -23,15 +23,6 @@ generateRuleTests({
 
   bad: [
     {
-      template: '<div as |a|></div>',
-      result: {
-        message: makeError(2, 'a'),
-        source: '<div as |a|></div>',
-        line: 1,
-        column: 0,
-      },
-    },
-    {
       template: '<div @value="1"></div>',
       result: {
         message: makeError(1, '@value', 'div'),

--- a/test/unit/rules/no-arguments-for-html-elements-test.js
+++ b/test/unit/rules/no-arguments-for-html-elements-test.js
@@ -25,7 +25,7 @@ generateRuleTests({
     {
       template: '<div @value="1"></div>',
       result: {
-        message: makeError(1, '@value', 'div'),
+        message: makeError('@value', 'div'),
         source: '@value="1"',
         line: 1,
         column: 5,
@@ -34,7 +34,7 @@ generateRuleTests({
     {
       template: '<div @value></div>',
       result: {
-        message: makeError(1, '@value', 'div'),
+        message: makeError('@value', 'div'),
         source: '@value',
         line: 1,
         column: 5,
@@ -43,7 +43,7 @@ generateRuleTests({
     {
       template: '<img @src="12">',
       result: {
-        message: makeError(1, '@src', 'img'),
+        message: makeError('@src', 'img'),
         source: '@src="12"',
         line: 1,
         column: 5,

--- a/test/unit/rules/no-block-params-for-html-elements-test.js
+++ b/test/unit/rules/no-block-params-for-html-elements-test.js
@@ -12,7 +12,9 @@ generateRuleTests({
     '<div></div>',
     '<Checkbox as |blockName|></Checkbox>',
     '<@nav.Link as |blockName|></@nav.Link>',
+    '<this.foo as |blah|></this.foo>',
     '{{#let (component \'foo\') as |bar|}} <bar @name="1" as |n|><n/></bar> {{/let}}',
+    '<Something><:Item as |foo|></:Item></Something>',
   ],
 
   bad: [

--- a/test/unit/rules/no-block-params-for-html-elements-test.js
+++ b/test/unit/rules/no-block-params-for-html-elements-test.js
@@ -1,0 +1,38 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+const { generateErrorMessage } = require('../../../lib/rules/no-block-params-for-html-elements');
+
+generateRuleTests({
+  name: 'no-block-params-for-html-elements',
+
+  config: true,
+
+  good: [
+    '<div></div>',
+    '<Checkbox as |blockName|></Checkbox>',
+    '<@nav.Link as |blockName|></@nav.Link>',
+    '{{#let (component \'foo\') as |bar|}} <bar @name="1" as |n|><n/></bar> {{/let}}',
+  ],
+
+  bad: [
+    {
+      template: '<div as |blockName|></div>',
+      result: {
+        message: generateErrorMessage('div'),
+        line: 1,
+        column: 0,
+        source: '<div as |blockName|></div>',
+      },
+    },
+    {
+      template: '<div as |a b c|></div>',
+      result: {
+        message: generateErrorMessage('div'),
+        line: 1,
+        column: 0,
+        source: '<div as |a b c|></div>',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Resolves https://github.com/ember-template-lint/ember-template-lint/issues/1451

---

# no-block-params-for-html-elements

Block parameters (`<Checkbox as |checkbox|>`) are only useful when invoking
components. When they are used on regular HTML elements they are useless and an
indicator of a potential bug.

This rule warns about all block parameter usages on regular HTML elements
(angle bracket invokations with lower-case tagnames).

## Examples

This rule **forbids** the following:

```hbs
<div as |blockName|></div>
```

This rule **allows** the following:

```hbs
<div></div>
```

```hbs
<Checkbox as |blockName|></Checkbox>
```

> 