### PR TITLE
Implement `no-link-to-tag-name` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Each rule has emojis denoting:
 |                            | [no-invalid-link-title](./docs/rule/no-invalid-link-title.md)                              |
 | :white_check_mark:         | [no-invalid-meta](./docs/rule/no-invalid-meta.md)                                          |
 | :white_check_mark:         | [no-invalid-role](./docs/rule/no-invalid-role.md)                                          |
+|                            | [no-link-to-tag-name](./docs/rule/no-link-to-tag-name.md)                                  |
 | :white_check_mark:         | [no-log](./docs/rule/no-log.md)                                                            |
 | :dress:                    | [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                          |
 | :white_check_mark:         | [no-negated-condition](./docs/rule/no-negated-condition.md)                                |

--- a/docs/rule/no-link-to-tag-name.md
+++ b/docs/rule/no-link-to-tag-name.md
@@ -1,0 +1,45 @@
+# no-link-to-tag-name
+
+The builtin `LinkTo` component generates an `<a>` element. Since it is still
+built on top of `Ember.Component` it is possible to assign a `tagName` from the
+outside to change that `<a>` element into something else. This goes against
+several a11y rules though, because elements that link somewhere should be links,
+which have to be represented by `<a>` elements.
+
+This rule looks for `LinkTo` component invocations where a custom `tagName` is
+assigned and warns about them.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<LinkTo @route="routeName" @tagName="button">Link text</LinkTo>
+```
+
+```hbs
+{{#link-to "routeName" tagName="button"}}Link text{{/link-to}}
+```
+
+```hbs
+{{link-to "Link text" "routeName" tagName="button"}}
+```
+
+This rule **allows** the following:
+
+```hbs
+<LinkTo @route="routeName">Link text</LinkTo>
+```
+
+```hbs
+{{#link-to "routeName"}}Link text{{/link-to}}
+```
+
+```hbs
+{{link-to "Link text" "routeName"}}
+```
+
+## Migration
+
+- Remove the `tagName` overrides and, if you need it, adjust the styling of the
+  `<a>` elements to make them look like buttons

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -39,6 +39,7 @@ module.exports = {
   'no-invalid-link-title': require('./no-invalid-link-title'),
   'no-invalid-meta': require('./no-invalid-meta'),
   'no-invalid-role': require('./no-invalid-role'),
+  'no-link-to-tag-name': require('./no-link-to-tag-name'),
   'no-log': require('./no-log'),
   'no-multiple-empty-lines': require('./no-multiple-empty-lines'),
   'no-negated-condition': require('./no-negated-condition'),

--- a/lib/rules/no-link-to-tag-name.js
+++ b/lib/rules/no-link-to-tag-name.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const Rule = require('./base');
+
+const ERROR_MESSAGE = 'Overriding `tagName` on `LinkTo` components is not allowed';
+
+module.exports = class NoLinkToTagName extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        this.processAngleBracket(node);
+      },
+
+      BlockStatement(node) {
+        this.processCurly(node);
+      },
+
+      MustacheStatement(node) {
+        this.processCurly(node);
+      },
+    };
+  }
+
+  processAngleBracket(node) {
+    let { attributes, tag } = node;
+    if (tag !== 'LinkTo') {
+      return;
+    }
+
+    let tagNameAttr = attributes.find((it) => it.name === '@tagName');
+    if (tagNameAttr) {
+      this.log({
+        message: ERROR_MESSAGE,
+        line: tagNameAttr.loc && tagNameAttr.loc.start.line,
+        column: tagNameAttr.loc && tagNameAttr.loc.start.column,
+        source: this.sourceForNode(tagNameAttr),
+      });
+    }
+  }
+
+  processCurly(node) {
+    let { hash, path } = node;
+    if (path.type !== 'PathExpression' || path.original !== 'link-to') {
+      return;
+    }
+
+    let tagNameHashPair = hash.pairs.find((it) => it.key === 'tagName');
+    if (tagNameHashPair) {
+      this.log({
+        message: ERROR_MESSAGE,
+        line: tagNameHashPair.loc && tagNameHashPair.loc.start.line,
+        column: tagNameHashPair.loc && tagNameHashPair.loc.start.column,
+        source: this.sourceForNode(tagNameHashPair),
+      });
+    }
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/no-link-to-tag-name-test.js
+++ b/test/unit/rules/no-link-to-tag-name-test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+const ERROR_MESSAGE = require('../../../lib/rules/no-link-to-tag-name').ERROR_MESSAGE;
+
+generateRuleTests({
+  name: 'no-link-to-tag-name',
+
+  config: true,
+
+  good: [
+    '<Foo @route="routeName" @tagName="button">Link text</Foo>',
+    '<LinkTo @route="routeName">Link text</LinkTo>',
+    '{{#link-to "routeName"}}Link text{{/link-to}}',
+    '{{#foo "routeName" tagName="button"}}Link text{{/foo}}',
+    '{{link-to "Link text" "routeName"}}',
+    '{{foo "Link text" "routeName" tagName="button"}}',
+  ],
+
+  bad: [
+    {
+      template: '<LinkTo @route="routeName" @tagName="button">Link text</LinkTo>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 27,
+        source: '@tagName="button"',
+      },
+    },
+    {
+      template: '{{#link-to "routeName" tagName="button"}}Link text{{/link-to}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 23,
+        source: 'tagName="button"',
+      },
+    },
+    {
+      template: '{{link-to "Link text" "routeName" tagName="button"}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 34,
+        source: 'tagName="button"',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This should resolve https://github.com/ember-template-lint/ember-template-lint/issues/1231

/cc @MelSumner 