### PR TITLE
ast-node-info: Remove trivial `isElement()` helpers

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -206,14 +206,6 @@ const helpers = require('ember-template-lint').ASTHelpers;
 
   Returns any attributes on the node with a name that matches `attributeName`.
 
-* `function isImgElement(node): boolean`
-
-  Returns true if this node is an `img` element.
-
-* `function isLinkElement(node): boolean`
-
-  Returns true if this node is a link (`a`) element.
-
 * `function childrenFor(node): Object[]`
 
   Returns any child nodes of this node.

--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -131,26 +131,6 @@ function findAttribute(node, attributeName) {
   }
 }
 
-function isInputElement(node) {
-  return node.tag === 'input';
-}
-
-function isImgElement(node) {
-  return node.tag === 'img';
-}
-
-function isLinkElement(node) {
-  return node.tag === 'a';
-}
-
-function isObjectElement(node) {
-  return node.tag === 'object';
-}
-
-function isAreaElement(node) {
-  return node.tag === 'area';
-}
-
 function childrenFor(node) {
   if (node.type === 'Program' || node.type === 'Block' || node.type === 'Template') {
     return node.body;
@@ -197,11 +177,6 @@ module.exports = {
   isComponentNode,
   isConfigurationHtmlComment,
   isElementNode,
-  isInputElement,
-  isObjectElement,
-  isAreaElement,
-  isImgElement,
-  isLinkElement,
   isMustacheStatement,
   isNonConfigurationHtmlComment,
   isTextNode,

--- a/lib/rules/link-href-attributes.js
+++ b/lib/rules/link-href-attributes.js
@@ -22,7 +22,7 @@ module.exports = class LinkHrefAttributes extends Rule {
   visitor() {
     return {
       ElementNode(node) {
-        if (AstNodeInfo.isLinkElement(node) && !AstNodeInfo.hasAttribute(node, 'href')) {
+        if (node.tag === 'a' && !AstNodeInfo.hasAttribute(node, 'href')) {
           this.log({
             message: 'a tags must have an href attribute',
             line: node.loc && node.loc.start.line,

--- a/lib/rules/link-rel-noopener.js
+++ b/lib/rules/link-rel-noopener.js
@@ -66,7 +66,7 @@ module.exports = class LinkRelNoopener extends Rule {
   visitor() {
     return {
       ElementNode(node) {
-        let isLink = AstNodeInfo.isLinkElement(node);
+        let isLink = node.tag === 'a';
         if (!isLink) {
           return;
         }

--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -38,10 +38,10 @@ module.exports = class RequireValidAltText extends Rule {
           return;
         }
 
-        const isImg = AstNodeInfo.isImgElement(node);
-        const isObj = AstNodeInfo.isObjectElement(node);
-        const isInput = AstNodeInfo.isInputElement(node);
-        const isArea = AstNodeInfo.isAreaElement(node);
+        const isImg = node.tag === 'img';
+        const isObj = node.tag === 'object';
+        const isInput = node.tag === 'input';
+        const isArea = node.tag === 'area';
 
         if (isImg) {
           const hasAltAttribute = AstNodeInfo.hasAttribute(node, 'alt');

--- a/test/unit/helpers/ast-node-info-test.js
+++ b/test/unit/helpers/ast-node-info-test.js
@@ -4,16 +4,6 @@ const { parse } = require('ember-template-recast');
 
 const AstNodeInfo = require('../../../lib/helpers/ast-node-info');
 
-describe('isImgElement', function () {
-  it('can detect an image tag', function () {
-    let tableAst = parse('<table></table>');
-    expect(AstNodeInfo.isImgElement(tableAst.body[0])).toBe(false);
-
-    let imgAst = parse('<img />');
-    expect(AstNodeInfo.isImgElement(imgAst.body[0])).toBe(true);
-  });
-});
-
 describe('hasChildren', function () {
   it('functions for empty input', function () {
     expect(AstNodeInfo.hasChildren(parse(''))).toBe(false);


### PR DESCRIPTION
as #1168 suggests, these are too trivial to serve any real purpose and should be replaced by regular `tag` property checks

/cc @MelSumner 