### PR TITLE
no-invalid-interactive: Add `canvas` to the list of interactive tag names

### DIFF
--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -4,6 +4,7 @@ const ast = require('./ast-node-info');
 
 const INTERACTIVE_TAG_NAMES = new Set([
   'button',
+  'canvas',
   'details',
   'embed',
   'iframe',

--- a/test/unit/rules/no-invalid-interactive-test.js
+++ b/test/unit/rules/no-invalid-interactive-test.js
@@ -9,6 +9,7 @@ generateRuleTests({
 
   good: [
     '<button {{action "foo"}}></button>',
+    '<canvas {{on "mousedown"}}></canvas>',
     '<div role="button" {{action "foo"}}></div>',
     '<div randomProperty={{myValue}}></div>',
     '<li><button {{action "foo"}}></button></li>',


### PR DESCRIPTION
This addresses https://github.com/ember-template-lint/ember-template-lint/issues/1113#issuecomment-627396555

/cc @MelSumner 