### PR TITLE
no-invalid-interactive: Only warn about known disallowed DOM events in the `on` modifier

### DIFF
--- a/lib/rules/no-invalid-interactive.js
+++ b/lib/rules/no-invalid-interactive.js
@@ -90,6 +90,19 @@ module.exports = class NoInvalidInteractive extends Rule {
               return;
             }
           }
+
+          // Allow {{on "scroll" this.handleScroll}}
+          if (modifierName === 'on') {
+            let eventNameNode = node.params[0];
+            if (
+              eventNameNode &&
+              eventNameNode.type === 'StringLiteral' &&
+              !DISALLOWED_DOM_EVENTS.has(eventNameNode.value)
+            ) {
+              return;
+            }
+          }
+
           this.log({
             message: 'Interaction added to non-interactive element',
             line: node.loc && node.loc.start.line,

--- a/test/unit/rules/no-invalid-interactive-test.js
+++ b/test/unit/rules/no-invalid-interactive-test.js
@@ -26,6 +26,8 @@ generateRuleTests({
     '<form {{on "submit" this.send}}></form>',
     '<form {{on "reset" this.reset}}></form>',
     '<form {{on "change" this.change}}></form>',
+    '<div {{on "scroll" this.handleScroll}}></div>',
+    '<code {{on "copy" (action @onCopy)}}></code>',
     {
       config: { additionalInteractiveTags: ['div'] },
       template: '<div {{on "click" this.onClick}}></div>',


### PR DESCRIPTION
Resolves #1113

/cc @MelSumner 