### PR TITLE
ast-node-info: Remove trivial `isNode()` helpers

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -170,34 +170,6 @@ const helpers = require('ember-template-lint').ASTHelpers;
 
   Returns true if this node is *not* an HTML comment that is meant to set linter configuration.
 
-* `function isTextNode(node): boolean`
-
-  Returns true if this node is a `TextNode` node.
-
-* `function isCommentStatement(node): boolean`
-
-  Returns true if this node is a `CommentStatement` node.
-
-* `function isMustacheCommentStatement(node): boolean`
-
-  Returns true if this node is a `MustacheCommentStatement` node.
-
-* `function isElementNode(node): boolean`
-
-  Returns true if this node is an `ElementNode` node.
-
-* `function isComponentNode(node): boolean`
-
-  Returns true if this node is a `ComponentNode` node.
-
-* `function isMustacheStatement(node): boolean`
-
-  Returns true if this node is a `MustacheStatement` node.
-
-* `function isBlockStatement(node): boolean`
-
-  Returns true if this node is a `BlockStatement` node.
-
 * `function hasAttribute(node, attributeName): boolean`
 
   Returns true if this node has an attribute whose name matches `attributeName`.

--- a/lib/helpers/ast-node-info.js
+++ b/lib/helpers/ast-node-info.js
@@ -8,54 +8,6 @@ function isNonConfigurationHtmlComment(node) {
   return node.type === 'CommentStatement' && node.value.trim().indexOf('template-lint ') !== 0;
 }
 
-function isTextNode(node) {
-  return node.type === 'TextNode';
-}
-
-function isAttrNode(node) {
-  return node.type === 'AttrNode';
-}
-
-function isCommentStatement(node) {
-  return node.type === 'CommentStatement';
-}
-
-function isConcatStatement(node) {
-  return node.type === 'ConcatStatement';
-}
-
-function isMustacheCommentStatement(node) {
-  return node.type === 'MustacheCommentStatement';
-}
-
-function isPathExpression(node) {
-  return node.type === 'PathExpression';
-}
-
-function isSubExpression(node) {
-  return node.type === 'SubExpression';
-}
-
-function isElementNode(node) {
-  return node && node.type === 'ElementNode';
-}
-
-function isComponentNode(node) {
-  return node && node.type === 'ComponentNode';
-}
-
-function isMustacheStatement(node) {
-  return node.type === 'MustacheStatement';
-}
-
-function isBlockStatement(node) {
-  return node.type === 'BlockStatement';
-}
-
-function isStringLiteral(node) {
-  return node.type === 'StringLiteral';
-}
-
 function isIf(node) {
   return node.path && node.path.original === 'if';
 }
@@ -160,8 +112,6 @@ module.exports = {
   hasAttributeValue,
   attributeValue,
   elementAttributeValue,
-  isBlockStatement,
-  isStringLiteral,
   isIf,
   isUnless,
   isEach,
@@ -169,16 +119,6 @@ module.exports = {
   isLet,
   isWith,
   isControlFlowHelper,
-  isCommentStatement,
-  isConcatStatement,
-  isMustacheCommentStatement,
-  isPathExpression,
-  isSubExpression,
-  isComponentNode,
   isConfigurationHtmlComment,
-  isElementNode,
-  isMustacheStatement,
   isNonConfigurationHtmlComment,
-  isTextNode,
-  isAttrNode,
 };

--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -77,7 +77,7 @@ function reason(node) {
     return `an <${node.tag}> element with the \`controls\` attribute`;
   }
 
-  if (!ast.isElementNode(node) && !ast.isComponentNode(node)) {
+  if (node.type !== 'ElementNode' && node.type !== 'ComponentNode') {
     return null;
   }
 

--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -207,7 +207,7 @@ module.exports = class BlockIndentation extends Rule {
     let startLine = node.loc.start.line;
 
     if (startLine === 1 && startColumn !== 0) {
-      let isElementNode = AstNodeInfo.isElementNode(node);
+      let isElementNode = node && node.type === 'ElementNode';
       let displayName = isElementNode ? node.tag : node.path.original;
       let display = isElementNode ? `<${displayName}>` : `{{#${displayName}}}`;
       let startLocation = `L${node.loc.start.line}:C${node.loc.start.column}`;
@@ -234,7 +234,7 @@ module.exports = class BlockIndentation extends Rule {
       return;
     }
 
-    let isElementNode = AstNodeInfo.isElementNode(node);
+    let isElementNode = node && node.type === 'ElementNode';
     let displayName = isElementNode ? node.tag : node.path.original;
     let display = isElementNode ? `</${displayName}>` : `{{/${displayName}}}`;
     let startColumn = node.loc.start.column;
@@ -289,7 +289,7 @@ module.exports = class BlockIndentation extends Rule {
 
       if (
         this.config.ignoreComments &&
-        (AstNodeInfo.isCommentStatement(child) || AstNodeInfo.isMustacheCommentStatement(child))
+        (child.type === 'CommentStatement' || child.type === 'MustacheCommentStatement')
       ) {
         break;
       }
@@ -300,7 +300,7 @@ module.exports = class BlockIndentation extends Rule {
       let hasLeadingContent = false;
       for (let j = i - 1; j >= 0; j--) {
         let sibling = children[j];
-        if (sibling.loc && !AstNodeInfo.isTextNode(sibling)) {
+        if (sibling.loc && sibling.type !== 'TextNode') {
           // Found an element or statement. If it's on this line, then we
           // have leading content, so set the flag and break. If it's not
           // on this line, then we've scanned back to a previous line, so
@@ -335,7 +335,7 @@ module.exports = class BlockIndentation extends Rule {
       let childStartLine = child.loc.start.line;
 
       // sanitize text node starting column info
-      if (AstNodeInfo.isTextNode(child)) {
+      if (child.type === 'TextNode') {
         // TextNode's include leading newlines, but those newlines do
         // not get used in calculating indentation
         let withoutLeadingNewLines = child.chars.replace(/^(\r\n|\n)*/, '');
@@ -364,20 +364,20 @@ module.exports = class BlockIndentation extends Rule {
       }
 
       if (expectedStartColumn !== childStartColumn) {
-        let isElementNode = AstNodeInfo.isElementNode(child);
+        let isElementNode = child.type === 'ElementNode';
         let display;
 
         if (isElementNode) {
           display = `<${child.tag}>`;
-        } else if (AstNodeInfo.isBlockStatement(child)) {
+        } else if (child.type === 'BlockStatement') {
           display = `{{#${child.path.original}}}`;
-        } else if (AstNodeInfo.isMustacheStatement(child)) {
+        } else if (child.type === 'MustacheStatement') {
           display = `{{${child.path.original}}}`;
-        } else if (AstNodeInfo.isTextNode(child)) {
+        } else if (child.type === 'TextNode') {
           display = child.chars.replace(/^\s*/, '');
-        } else if (AstNodeInfo.isCommentStatement(child)) {
+        } else if (child.type === 'CommentStatement') {
           display = `<!--${child.value}-->`;
-        } else if (AstNodeInfo.isMustacheCommentStatement(child)) {
+        } else if (child.type === 'MustacheCommentStatement') {
           display = `{{!${child.value}}}`;
         } else {
           display = child.path.original;
@@ -400,7 +400,7 @@ module.exports = class BlockIndentation extends Rule {
   }
 
   validateBlockElse(node) {
-    if (!AstNodeInfo.isBlockStatement(node) || !node.inverse) {
+    if (node.type !== 'BlockStatement' || !node.inverse) {
       return;
     }
 
@@ -438,7 +438,7 @@ module.exports = class BlockIndentation extends Rule {
     let firstItem = inverse && inverse.body[0];
 
     // handle `{{else if foo}}`
-    if (inverse && firstItem && AstNodeInfo.isBlockStatement(firstItem)) {
+    if (inverse && firstItem && firstItem.type === 'BlockStatement') {
       return (
         inverse.loc.start.line === firstItem.loc.start.line &&
         // as of glimmer-vm@0.24.0 the firstItem of a nested else if block
@@ -465,7 +465,7 @@ module.exports = class BlockIndentation extends Rule {
     }
 
     // do not validate nodes without children (whitespace will count as TextNodes)
-    if (AstNodeInfo.isElementNode(node)) {
+    if (node && node.type === 'ElementNode') {
       return AstNodeInfo.hasChildren(node);
     }
 
@@ -483,7 +483,7 @@ module.exports = class BlockIndentation extends Rule {
   }
 
   endingControlCharCount(node) {
-    if (AstNodeInfo.isElementNode(node)) {
+    if (node && node.type === 'ElementNode') {
       // </>
       return 3;
     }

--- a/lib/rules/link-rel-noopener.js
+++ b/lib/rules/link-rel-noopener.js
@@ -99,14 +99,14 @@ module.exports = class LinkRelNoopener extends Rule {
 
 function isFixable(elementNode) {
   let oldRel = AstNodeInfo.findAttribute(elementNode, 'rel');
-  return !oldRel || AstNodeInfo.isTextNode(oldRel.value);
+  return !oldRel || oldRel.value.type === 'TextNode';
 }
 
 function fix(node, config) {
   let oldRel = AstNodeInfo.findAttribute(node, 'rel');
 
   let oldRelValue =
-    oldRel && AstNodeInfo.isTextNode(oldRel.value)
+    oldRel && oldRel.value.type === 'TextNode'
       ? // normalize whitespace between values
         oldRel.value.chars.trim().replace(/\s+/g, '')
       : '';

--- a/lib/rules/no-element-event-actions.js
+++ b/lib/rules/no-element-event-actions.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const AstNodeInfo = require('../helpers/ast-node-info');
 const Rule = require('./base');
 
 const ERROR_MESSAGE =
@@ -31,10 +30,10 @@ function isDomEventAttributeName(name) {
 
 function isEventPropertyWithAction(node) {
   return (
-    AstNodeInfo.isAttrNode(node) &&
+    node.type === 'AttrNode' &&
     isDomEventAttributeName(node.name) &&
-    AstNodeInfo.isMustacheStatement(node.value) &&
-    AstNodeInfo.isPathExpression(node.value.path) &&
+    node.value.type === 'MustacheStatement' &&
+    node.value.path.type === 'PathExpression' &&
     node.value.path.original === 'action'
   );
 }

--- a/lib/rules/no-inline-styles.js
+++ b/lib/rules/no-inline-styles.js
@@ -56,7 +56,7 @@ module.exports = class NoInlineStyles extends Rule {
           return;
         }
 
-        const hasDynamicStyle = AstNodeInfo.isMustacheStatement(style.value);
+        const hasDynamicStyle = style.value.type === 'MustacheStatement';
         if (this.config.allowDynamicStyles && hasDynamicStyle) {
           return;
         }

--- a/lib/rules/no-invalid-link-text.js
+++ b/lib/rules/no-invalid-link-text.js
@@ -14,7 +14,7 @@ const DISALLOWED_LINK_TEXT = new Set([
 function hasInvalidLinkText(node) {
   // Extract the text content(s) from the TextNode child(ren)
   const nodeChildren = AstNodeInfo.childrenFor(node);
-  const textChildren = nodeChildren.filter((child) => AstNodeInfo.isTextNode(child));
+  const textChildren = nodeChildren.filter((child) => child.type === 'TextNode');
 
   if (nodeChildren.length !== textChildren.length) {
     // do not flag an error when the link contains additional dynamic (non-text) children

--- a/lib/rules/no-invalid-link-title.js
+++ b/lib/rules/no-invalid-link-title.js
@@ -6,7 +6,7 @@ const Rule = require('./base');
 function hasInvalidLinkTitle(node, titleAttributeValues) {
   // Extract the text content(s) from the TextNode child(ren)
   const nodeChildren = AstNodeInfo.childrenFor(node);
-  const textChildren = nodeChildren.filter((child) => AstNodeInfo.isTextNode(child));
+  const textChildren = nodeChildren.filter((child) => child.type === 'TextNode');
   const linkTexts = textChildren.map((linkText) => linkText.chars.toLowerCase().trim());
 
   // Check to see if the text content is the same as the title attribute value

--- a/lib/rules/no-negated-condition.js
+++ b/lib/rules/no-negated-condition.js
@@ -19,7 +19,7 @@ module.exports = class NoNegatedCondition extends Rule {
         return;
       }
 
-      if (AstNodeInfo.isBlockStatement(node)) {
+      if (node.type === 'BlockStatement') {
         if (this.sourceForNode(node).startsWith('{{else ')) {
           // We only care about the beginning of the overall `if` / `unless` statement so ignore the `else` parts.
           return;
@@ -28,7 +28,7 @@ module.exports = class NoNegatedCondition extends Rule {
         if (
           node.inverse &&
           node.inverse.body.length > 0 &&
-          AstNodeInfo.isBlockStatement(node.inverse.body[0]) &&
+          node.inverse.body[0].type === 'BlockStatement' &&
           isIf &&
           AstNodeInfo.isIf(node.inverse.body[0])
         ) {
@@ -39,24 +39,23 @@ module.exports = class NoNegatedCondition extends Rule {
 
       if (
         node.params.length === 0 ||
-        !AstNodeInfo.isSubExpression(node.params[0]) ||
-        !AstNodeInfo.isPathExpression(node.params[0].path) ||
+        node.params[0].type !== 'SubExpression' ||
+        node.params[0].path.type !== 'PathExpression' ||
         node.params[0].path.original !== 'not'
       ) {
         // No negation present.
         return;
       }
 
-      if (isIf && AstNodeInfo.isSubExpression(node.params[0].params[0])) {
+      if (isIf && node.params[0].params[0].type === 'SubExpression') {
         // We don't want to suggest converting to `unless` when there are helpers
         // in the condition, as the `simple-unless` rule does not permit that.
         return;
       }
 
       // Determine what error message to show:
-      const isIfElseBlockStatement = AstNodeInfo.isBlockStatement(node) && node.inverse;
-      const isIfElseNonBlockStatement =
-        !AstNodeInfo.isBlockStatement(node) && node.params.length === 3;
+      const isIfElseBlockStatement = node.type === 'BlockStatement' && node.inverse;
+      const isIfElseNonBlockStatement = node.type !== 'BlockStatement' && node.params.length === 3;
       const shouldFlipCondition = isIfElseBlockStatement || isIfElseNonBlockStatement;
       const message = isUnless
         ? ERROR_MESSAGE_USE_IF

--- a/lib/rules/no-unnecessary-component-helper.js
+++ b/lib/rules/no-unnecessary-component-helper.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const AstNodeInfo = require('../helpers/ast-node-info');
 const Rule = require('./base');
 
 const ERROR_MESSAGE = 'Invoke component directly instead of using `component` helper';
@@ -19,7 +18,7 @@ module.exports = class NoUnnecessaryComponentHelper extends Rule {
 
     function isComponentHelper(node) {
       return (
-        AstNodeInfo.isPathExpression(node.path) &&
+        node.path.type === 'PathExpression' &&
         node.path.original === 'component' &&
         node.params.length > 0
       );
@@ -28,7 +27,7 @@ module.exports = class NoUnnecessaryComponentHelper extends Rule {
     function checkNode(node) {
       if (
         isComponentHelper(node) &&
-        AstNodeInfo.isStringLiteral(node.params[0]) &&
+        node.params[0].type === 'StringLiteral' &&
         !node.params[0].value.includes('@') &&
         !inSafeNamespace
       ) {

--- a/lib/rules/style-concatenation.js
+++ b/lib/rules/style-concatenation.js
@@ -12,8 +12,8 @@ module.exports = class StyleConcatenation extends Rule {
         let style = AstNodeInfo.findAttribute(node, 'style');
         if (
           style &&
-          (AstNodeInfo.isConcatStatement(style.value) ||
-            (AstNodeInfo.isMustacheStatement(style.value) && isConcatHelper(style.value.path)))
+          (style.value.type === 'ConcatStatement' ||
+            (style.value.type === 'MustacheStatement' && isConcatHelper(style.value.path)))
         ) {
           this.log({
             message: ERROR_MESSAGE,
@@ -28,7 +28,7 @@ module.exports = class StyleConcatenation extends Rule {
 };
 
 function isConcatHelper(node) {
-  return node && AstNodeInfo.isPathExpression(node) && node.original === 'concat';
+  return node && node.type === 'PathExpression' && node.original === 'concat';
 }
 
 module.exports.ERROR_MESSAGE = ERROR_MESSAGE;


### PR DESCRIPTION
This addresses https://github.com/ember-template-lint/ember-template-lint/pull/1460#issuecomment-673594609