### PR TITLE
fix: cache pending/ignore config lookups for faster perf/less memory

### DIFF
--- a/lib/-private/module-status-cache.js
+++ b/lib/-private/module-status-cache.js
@@ -1,0 +1,97 @@
+const path = require('path');
+
+const micromatch = require('micromatch');
+
+class ModuleStatusCache {
+  constructor(config, configPath) {
+    this.config = config;
+    this.configPath = configPath || '';
+    this.cache = {
+      pending: {},
+      ignore: {},
+    };
+  }
+
+  get processCWD() {
+    if (!this._processCWD) {
+      this._processCWD = process.cwd();
+    }
+    return this._processCWD;
+  }
+
+  lookupPending(moduleId) {
+    if (!moduleId || !this.config.pending) {
+      return false;
+    }
+    if (!this.cache.pendingLookup) {
+      this.cache.pendingLookup = this._extractPendingCache();
+    }
+    if (!(moduleId in this.cache.pending)) {
+      const fullPathModuleId = path.resolve(this.processCWD, moduleId);
+      this.cache.pending[moduleId] = this.cache.pendingLookup[fullPathModuleId];
+    }
+    return this.cache.pending[moduleId];
+  }
+
+  lookupIgnore(moduleId) {
+    if (!(moduleId in this.cache.ignore)) {
+      const ignores = this.config['ignore'] || [];
+      this.cache.ignore[moduleId] = ignores.find((match) => match(moduleId));
+    }
+    return Boolean(this.cache.ignore[moduleId]);
+  }
+
+  _extractPendingCache() {
+    const list = this.config.pending;
+    const byFullModuleId = {};
+
+    if (!list) {
+      return byFullModuleId;
+    }
+
+    for (const item of list) {
+      if (typeof item === 'string') {
+        const fullPath = this.resolveFullModuleId(item);
+        byFullModuleId[fullPath] = true;
+      } else if (item.moduleId) {
+        const fullPath = this.resolveFullModuleId(item.moduleId);
+        byFullModuleId[fullPath] = item;
+      }
+    }
+
+    return byFullModuleId;
+  }
+
+  resolveFullModuleId(moduleId) {
+    if (!this._baseDirBasedOnConfigPath) {
+      this._baseDirBasedOnConfigPath = path.resolve(this.processCWD, path.dirname(this.configPath));
+    }
+    return path.resolve(this._baseDirBasedOnConfigPath, moduleId);
+  }
+
+  getConfigForFile(options) {
+    let filePath = options.filePath;
+    let configuredRules = this.config.rules;
+    let overrides = this.config.overrides;
+
+    let fileConfig = Object.assign({}, this.config, {
+      pendingStatus: this.lookupPending(options.moduleId),
+      shouldIgnore: this.lookupIgnore(options.moduleId),
+    });
+
+    if (filePath && overrides) {
+      let overridesRules = {};
+      overrides.forEach((override) => {
+        const isFileMatch = override.files && micromatch.isMatch(filePath, override.files);
+        if (isFileMatch) {
+          overridesRules = Object.assign(overridesRules, override.rules);
+        }
+      });
+      // If there is an override present, then the overridden ruleset takes precedence.
+      fileConfig.rules = Object.assign({}, configuredRules, overridesRules);
+    }
+    return fileConfig;
+  }
+}
+
+module.exports = ModuleStatusCache;

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -364,103 +364,6 @@ function _determineConfigForSeverity(config) {
   }
 }
 
-class ModuleStatusCache {
-  constructor(config, configPath) {
-    this.config = config;
-    this.configPath = configPath || '';
-    this.cache = {
-      pending: {},
-      ignore: {},
-    };
-    this.processCWD = process.cwd();
-  }
-
-  lookupPending(moduleId) {
-    if (!moduleId || !this.config.pending) {
-      return false;
-    }
-    if (!this.cache.pendingLookup) {
-      this.cache.pendingLookup = this._extractPendingCache();
-    }
-    if (!(moduleId in this.cache.pending)) {
-      const fullPathModuleId = path.resolve(this.processCWD, moduleId);
-      this.cache.pending[moduleId] = this.cache.pendingLookup[fullPathModuleId];
-    }
-    return this.cache.pending[moduleId];
-  }
-
-  lookupIgnore(moduleId) {
-    if (!(moduleId in this.cache.ignore)) {
-      const ignores = this.config['ignore'] || [];
-      this.cache.ignore[moduleId] = ignores.find((match) => match(moduleId));
-    }
-    return Boolean(this.cache.ignore[moduleId]);
-  }
-
-  _extractPendingCache() {
-    const list = this.config.pending;
-    const byFullModuleId = {};
-
-    if (!list) {
-      return byFullModuleId;
-    }
-
-    for (const item of list) {
-      if (typeof item === 'string') {
-        const fullPath = this.resolveFullModuleId(item);
-        byFullModuleId[fullPath] = true;
-      } else if (item.moduleId) {
-        const fullPath = this.resolveFullModuleId(item.moduleId);
-        byFullModuleId[fullPath] = item;
-      }
-    }
-
-    return byFullModuleId;
-  }
-
-  resolveFullModuleId(moduleId) {
-    if (!this._baseDirBasedOnConfigPath) {
-      this._baseDirBasedOnConfigPath = path.resolve(this.processCWD, path.dirname(this.configPath));
-    }
-    return path.resolve(this._baseDirBasedOnConfigPath, moduleId);
-  }
-}
-
-let configModuleCacheMap = new WeakMap();
-
-/**
- * Returns the config in conjunction with overrides configuration.
- * @param {*} config
- * @param {*} filePath
- */
-function getConfigForFile(config, options) {
-  if (!configModuleCacheMap.has(config)) {
-    configModuleCacheMap.set(config, new ModuleStatusCache(config, options.configPath));
-  }
-  let moduleStatusCache = configModuleCacheMap.get(config);
-  let filePath = options.filePath;
-  let configuredRules = config.rules;
-  let overrides = config.overrides;
-
-  let fileConfig = Object.assign({}, config, {
-    pendingStatus: moduleStatusCache.lookupPending(options.moduleId),
-    shouldIgnore: moduleStatusCache.lookupIgnore(options.moduleId),
-  });
-
-  if (filePath && overrides) {
-    let overridesRules = {};
-    overrides.forEach((override) => {
-      const isFileMatch = override.files && micromatch.isMatch(filePath, override.files);
-      if (isFileMatch) {
-        overridesRules = Object.assign(overridesRules, override.rules);
-      }
-    });
-    // If there is an override present, then the overridden ruleset takes precedence.
-    fileConfig.rules = Object.assign({}, configuredRules, overridesRules);
-  }
-  return fileConfig;
-}
-
 function determineRuleConfig(ruleData) {
   let ruleConfig = {
     severity: ruleData === false ? IGNORE_SEVERITY : ERROR_SEVERITY,
@@ -542,7 +445,6 @@ module.exports = {
   ERROR_SEVERITY,
   IGNORE_SEVERITY,
   WARNING_SEVERITY,
-  getConfigForFile,
   getProjectConfig,
   getRuleFromString,
   resolveProjectConfig,

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -364,47 +364,87 @@ function _determineConfigForSeverity(config) {
   }
 }
 
-function statusForModule(type, config, options) {
-  let moduleId = options.moduleId;
-  let list = config[type];
-  let configPath = options.configPath || '';
-  if (!list) {
-    return false;
+class ModuleStatusCache {
+  constructor(config, configPath) {
+    this.config = config;
+    this.configPath = configPath || '';
+    this.cache = {
+      pending: {},
+      ignore: {},
+    };
+    this.processCWD = process.cwd();
   }
 
-  for (const item of list) {
-    let fullPathModuleId = path.resolve(process.cwd(), moduleId);
+  lookupPending(moduleId) {
+    if (!moduleId || !this.config.pending) {
+      return false;
+    }
+    if (!this.cache.pendingLookup) {
+      this.cache.pendingLookup = this._extractPendingCache();
+    }
+    if (!(moduleId in this.cache.pending)) {
+      const fullPathModuleId = path.resolve(this.processCWD, moduleId);
+      this.cache.pending[moduleId] = this.cache.pendingLookup[fullPathModuleId];
+    }
+    return this.cache.pending[moduleId];
+  }
 
-    if (typeof item === 'function' && item(moduleId)) {
-      return true;
-    } else if (typeof item === 'string') {
-      let fullPathItem = path.resolve(process.cwd(), path.dirname(configPath), item);
-      if (fullPathModuleId === fullPathItem) {
-        return true;
-      }
-    } else if (item.moduleId) {
-      let fullPathItem = path.resolve(process.cwd(), path.dirname(configPath), item.moduleId);
-      if (fullPathModuleId === fullPathItem) {
-        return item;
+  lookupIgnore(moduleId) {
+    if (!(moduleId in this.cache.ignore)) {
+      const ignores = this.config['ignore'] || [];
+      this.cache.ignore[moduleId] = ignores.find((match) => match(moduleId));
+    }
+    return Boolean(this.cache.ignore[moduleId]);
+  }
+
+  _extractPendingCache() {
+    const list = this.config.pending;
+    const byFullModuleId = {};
+
+    if (!list) {
+      return byFullModuleId;
+    }
+
+    for (const item of list) {
+      if (typeof item === 'string') {
+        const fullPath = this.resolveFullModuleId(item);
+        byFullModuleId[fullPath] = true;
+      } else if (item.moduleId) {
+        const fullPath = this.resolveFullModuleId(item.moduleId);
+        byFullModuleId[fullPath] = item;
       }
     }
+
+    return byFullModuleId;
   }
 
-  return false;
+  resolveFullModuleId(moduleId) {
+    if (!this._baseDirBasedOnConfigPath) {
+      this._baseDirBasedOnConfigPath = path.resolve(this.processCWD, path.dirname(this.configPath));
+    }
+    return path.resolve(this._baseDirBasedOnConfigPath, moduleId);
+  }
 }
+
+let configModuleCacheMap = new WeakMap();
+
 /**
  * Returns the config in conjunction with overrides configuration.
  * @param {*} config
  * @param {*} filePath
  */
 function getConfigForFile(config, options) {
+  if (!configModuleCacheMap.has(config)) {
+    configModuleCacheMap.set(config, new ModuleStatusCache(config, options.configPath));
+  }
+  let moduleStatusCache = configModuleCacheMap.get(config);
   let filePath = options.filePath;
   let configuredRules = config.rules;
   let overrides = config.overrides;
 
   let fileConfig = Object.assign({}, config, {
-    pendingStatus: statusForModule('pending', config, options),
-    shouldIgnore: statusForModule('ignore', config, options),
+    pendingStatus: moduleStatusCache.lookupPending(options.moduleId),
+    shouldIgnore: moduleStatusCache.lookupIgnore(options.moduleId),
   });
 
   if (filePath && overrides) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,8 +1,8 @@
 const { parse, transform } = require('ember-template-recast');
 
+const ModuleStatusCache = require('./-private/module-status-cache');
 const {
   getProjectConfig,
-  getConfigForFile,
   getRuleFromString,
   WARNING_SEVERITY,
   ERROR_SEVERITY,
@@ -56,6 +56,7 @@ class Linter {
 
       this.config.rules[name] = config;
     }
+    this._moduleStatusCache = new ModuleStatusCache(this.config, this.options.configPath);
   }
 
   /**
@@ -233,7 +234,7 @@ class Linter {
     }
 
     let currentSource = options.source;
-    let fileConfig = getConfigForFile(this.config, options);
+    let fileConfig = this._moduleStatusCache.getConfigForFile(options);
 
     let pending = fileConfig.pending;
     let ruleNames = new Set(fixableIssues.map((r) => r.rule));
@@ -266,7 +267,7 @@ class Linter {
    */
   verify(options) {
     let results = [];
-    let fileConfig = getConfigForFile(this.config, options);
+    let fileConfig = this._moduleStatusCache.getConfigForFile(options);
     let pendingStatus = fileConfig.pendingStatus;
 
     if (fileConfig.shouldIgnore) {

--- a/test/unit/-private/module-status-cache-test.js
+++ b/test/unit/-private/module-status-cache-test.js
@@ -1,0 +1,123 @@
+const ModuleStatusCache = require('../../../lib/-private/module-status-cache');
+
+describe('ModuleStatusCache', function () {
+  it('Merges the overrides rules with existing rules config', function () {
+    let config = {
+      rules: {
+        foo: 'bar',
+        baz: 'derp',
+      },
+      overrides: [
+        {
+          files: ['**/templates/**/*.hbs'],
+          rules: {
+            baz: 'bang',
+          },
+        },
+      ],
+    };
+
+    let expectedRule = {
+      foo: 'bar',
+      baz: 'bang',
+    };
+    let actual = new ModuleStatusCache(config).getConfigForFile({
+      filePath: 'app/templates/foo.hbs',
+    });
+
+    expect(actual.rules).toEqual(expectedRule);
+  });
+
+  it('Returns the correct rules config if overrides is empty/not present', function () {
+    let config = {
+      rules: {
+        foo: 'bar',
+        baz: 'derp',
+      },
+      overrides: [],
+    };
+
+    // clone to ensure we are not mutating
+    let expected = JSON.parse(JSON.stringify(config));
+
+    let actual = new ModuleStatusCache(config).getConfigForFile({
+      filePath: 'app/templates/foo.hbs',
+    });
+
+    expect(actual.rules).toEqual(expected.rules);
+
+    delete config.overrides;
+
+    actual = new ModuleStatusCache(config).getConfigForFile('app/templates/foo.hbs');
+
+    expect(actual.rules).toEqual(expected.rules);
+  });
+
+  it('Merges the overrides rules from multiple overrides with existing rules config', function () {
+    let config = {
+      rules: {
+        qux: 'blobber',
+        foo: 'bar',
+        baz: 'derp',
+      },
+      overrides: [
+        {
+          files: ['**/templates/**/*.hbs'],
+          rules: {
+            baz: 'bang',
+          },
+        },
+        {
+          files: ['**/foo.hbs'],
+          rules: {
+            foo: 'zomg',
+          },
+        },
+      ],
+    };
+
+    let expectedRule = {
+      qux: 'blobber',
+      foo: 'zomg',
+      baz: 'bang',
+    };
+    let actual = new ModuleStatusCache(config).getConfigForFile({
+      filePath: 'app/templates/foo.hbs',
+    });
+
+    expect(actual.rules).toEqual(expectedRule);
+  });
+
+  it('returns the correct pendingStatus when the provided moduleId is listed in `pending`', function () {
+    let config = {
+      pending: ['some/path/here', { moduleId: 'foo/bar/baz', only: ['no-bare-strings'] }],
+    };
+
+    let moduleStatusCache = new ModuleStatusCache(config);
+
+    expect(
+      moduleStatusCache.getConfigForFile({ moduleId: 'some/path/here' }).pendingStatus
+    ).toBeTruthy();
+    expect(
+      moduleStatusCache.getConfigForFile({ moduleId: 'foo/bar/baz' }).pendingStatus
+    ).toBeTruthy();
+    expect(
+      moduleStatusCache.getConfigForFile({ moduleId: 'some/other/path' }).pendingStatus
+    ).toBeFalsy();
+  });
+
+  it('matches with absolute paths for modules', function () {
+    let config = {
+      pending: ['some/path/here', { moduleId: 'foo/bar/baz', only: ['no-bare-strings'] }],
+    };
+
+    let moduleStatusCache = new ModuleStatusCache(config);
+    expect(
+      moduleStatusCache.getConfigForFile({ moduleId: `${process.cwd()}/some/path/here` })
+        .pendingStatus
+    ).toBeTruthy();
+    expect(
+      moduleStatusCache.getConfigForFile({ moduleId: `${process.cwd()}/foo/bar/baz` }).pendingStatus
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
This commit improves the lookups of `ignore` and `pending` configs by reducing the amount of iterations required over those config properties.

tl;dr:

- cached the config lookups for `pending` and `ignore` to reduce the amount of times we have to re-iterate the `pending` or `ignore` arrays provided by the config.
- cache string lookups for normalized moduleId paths since
- runtime on codebase with 668 handlebars files went from ~13 seconds to ~9 seconds

This was done in three steps:

First Step

The normalized `moduleId` was cached. Running ember-template-lint on a big codebase (668 template files) took 12.94 seconds to run. I used this command in the app's codebase directory to profile:

```
node --prof ../ember-template-lint/bin/ember-template-lint.js .
```

Next, I generated a graph with the [flamebearer][flamebearer] npm package:

```
node --prof-process --preprocess -j isolate*.log | flamebearer
```

<img width="1188" alt="Screen_Shot_2020-08-13_at_9_25_14_AM" src="https://user-images.githubusercontent.com/1275021/90181853-f29c8200-dd65-11ea-8163-c2e3f94a5e00.png">

Profiling showed that ~19% of the CPU time was spent inside of the `statusForModule` function. Upon further investigation, I noticed that the [normalized moduleId based on the current working directory was being generated in a loop][3], creating a new string for potentially every item in the `pending` or `ignore` config. Our app has no `ignore` config, but does have a lot of `pending` entries.

Moving the `fullPathModuleId` to a variable outside the loop took the runtime from 12.94 seconds to 11.04 seconds, about ~2 seconds of savings on its own!

An important thing to keep in mind for the next two steps: `statusForModule` is called _at least once per rule_ to determine if the rule should be ignored or allowed to fail (or removed from the pending file if now passing). This means that any functions ran or strings created by `statusForModule` are, in the worst case scenario, calculated `numberOfFiles * pendingRuleConfigItems * ignoreConfigItems` times if the loop doesn't find the config for the file early, as it has to search the entire array of `pending` or `ignore` items for every file.

Rather than rejoining the paths, they are instead generated once and stored in a cache object. This reduces the number of strings generated and time generating the same strings over and over. Caching the result of `process.cwd` (since it seems unlikely to change once the program is started) potentially has a nice performance side effect for users on Node 10 (supported until April 2021) as [process.cwd was not cached until Node 12.2](https://github.com/nodejs/node/pull/27224).

Second Step

Lookups for `ignore` and `pending` were separated out into different caches. This was done because while [`statusForModule` will check for a function to run][1] instead of a string, in practice this is only true for `ignore` rules. The reason `ignore` rules need the function check is that they are always a function due to being converted from [strings to functions via the micromatch module][2]. Caching the lookup of `ignore` rules reduced the need to run the functions for every rule/file.

Third Step

Last, but not least: `pending` rules always seem to be a list of `object`s or `string`s (as generated by `--print-pending`) and having a list that potentially has a function in it doesn't seem likely given that the recommendation from ember-template-lint is to copy/paste the output of `--print-pending`.

After re-profiling, the runtime went from 12.94 seconds to 9.04 seconds on my machine. The `get-config` file no longer showed up in the profile.

<img width="1116" alt="Screen Shot 2020-08-13 at 12 07 40 PM" src="https://user-images.githubusercontent.com/1275021/90181902-0647e880-dd66-11ea-9cd4-cc2778198139.png">

[1]: https://github.com/ember-template-lint/ember-template-lint/blob/5937b63bed30380b4bce0f96b19061658a176840/lib/get-config.js#L376-L377
[2]: https://github.com/ember-template-lint/ember-template-lint/blob/5937b63bed30380b4bce0f96b19061658a176840/lib/get-config.js#L280
[3]: https://github.com/ember-template-lint/ember-template-lint/blob/5937b63bed30380b4bce0f96b19061658a176840/lib/get-config.js#L374
[flamebearer]: https://github.com/mapbox/flamebearer
