### PR TITLE
Use `eslint-plugin-import-helpers` to sort imports alphabetically

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,15 @@ module.exports = {
   env: {
     node: true,
   },
-  plugins: ['eslint-comments', 'filenames', 'import', 'node', 'prettier', 'unicorn'],
+  plugins: [
+    'eslint-comments',
+    'filenames',
+    'import',
+    'import-helpers',
+    'node',
+    'prettier',
+    'unicorn',
+  ],
   extends: [
     'eslint:recommended',
     'plugin:eslint-comments/recommended',
@@ -91,6 +99,19 @@ module.exports = {
     'import/no-useless-path-segments': 'error',
     'import/no-webpack-loader-syntax': 'error',
     'import/unambiguous': 'error',
+
+    'import-helpers/order-imports': [
+      'error',
+      {
+        newlinesBetween: 'always',
+        groups: [
+          '/^(assert|async_hooks|buffer|child_process|cluster|console|constants|crypto|dgram|dns|domain|events|fs|http|http2|https|inspector|module|net|os|path|perf_hooks|process|punycode|querystring|readline|repl|stream|string_decoder|timers|tls|trace_events|tty|url|util|v8|vm|zli)/',
+          ['module'],
+          ['parent', 'sibling', 'index'],
+        ],
+        alphabetize: { order: 'asc', ignoreCase: true },
+      },
+    ],
 
     'prettier/prettier': 'error',
 

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -7,14 +7,17 @@ require('v8-compile-cache'); // eslint-disable-line import/no-unassigned-import
 
 const fs = require('fs');
 const path = require('path');
-const micromatch = require('micromatch');
-const isValidGlob = require('is-valid-glob');
+const util = require('util');
+
 const getStdin = require('get-stdin');
 const globby = require('globby');
+const isValidGlob = require('is-valid-glob');
+const micromatch = require('micromatch');
+
 const Linter = require('../lib');
 const processResults = require('../lib/helpers/process-results');
 
-const readFile = require('util').promisify(fs.readFile);
+const readFile = util.promisify(fs.readFile);
 
 const STDIN = '/dev/stdin';
 

--- a/dev/new-rule/index.js
+++ b/dev/new-rule/index.js
@@ -3,7 +3,9 @@
 
 const fs = require('fs');
 const path = require('path');
+
 const chalk = require('chalk');
+
 const toTitleCase = require('./helpers/to-title-case');
 
 function usage() {

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -1,13 +1,15 @@
 'use strict';
 
 const path = require('path');
-const resolve = require('resolve');
+
 const chalk = require('chalk');
-const micromatch = require('micromatch');
 const findUp = require('find-up');
-const defaultRules = require('./rules');
+const micromatch = require('micromatch');
+const resolve = require('resolve');
+
 const defaultConfigurations = require('./config');
 const DEPRECATED_RULES = require('./helpers/deprecated-rules');
+const defaultRules = require('./rules');
 
 const KNOWN_ROOT_PROPERTIES = new Set([
   'extends',

--- a/lib/get-editor-config.js
+++ b/lib/get-editor-config.js
@@ -1,9 +1,10 @@
 // main code parts copypasted from https://github.com/editorconfig/editorconfig-core-js and and rewritten as Class.
 
 'use strict';
-const micromatch = require('micromatch');
-const path = require('path');
 const fs = require('fs');
+const path = require('path');
+
+const micromatch = require('micromatch');
 
 class EditorConfigResolver {
   constructor() {

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const assert = require('assert');
+
 const Linter = require('..');
+
 const { processRules } = require('../get-config');
 
 function parseMeta(item) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,4 +1,5 @@
 const { parse, transform } = require('ember-template-recast');
+
 const {
   getProjectConfig,
   getConfigForFile,

--- a/lib/printers/pretty.js
+++ b/lib/printers/pretty.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk');
+
 const Linter = require('../linter');
 
 class PrettyPrinter {

--- a/lib/rules/attribute-indentation.js
+++ b/lib/rules/attribute-indentation.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 function getWhiteSpaceLength(statement) {
   let whiteSpace = statement.match(/^\s+/) || [];

--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -50,10 +50,11 @@
       `ignoreComments: <boolean>` - skip indentation for comments (defaults to `false`)',
  */
 
-const AstNodeInfo = require('../helpers/ast-node-info');
-const Rule = require('./base');
-const createErrorMessage = require('../helpers/create-error-message');
 const assert = require('assert');
+
+const AstNodeInfo = require('../helpers/ast-node-info');
+const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 const VALID_FOLLOWING_CHARS = new Set([' ', '>', '}', '~']);
 const VOID_TAGS = {

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 module.exports = class EolLast extends Rule {
   parseConfig(config) {

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -10,8 +10,9 @@
  */
 
 const os = require('os');
-const Rule = require('./base');
+
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 const reLineEnds = /(\r\n?|\n)/g;
 const reLines = /(.*?(?:\r\n?|\n|$))/gm;

--- a/lib/rules/link-rel-noopener.js
+++ b/lib/rules/link-rel-noopener.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const AstNodeInfo = require('../helpers/ast-node-info');
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 /**
  Disallow usage of `<a target="_blank">` without an `rel="noopener"` attribute.

--- a/lib/rules/modifier-name-case.js
+++ b/lib/rules/modifier-name-case.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const dasherize = require('../helpers/dasherize-component-name');
+const Rule = require('./base');
 
 function generateErrorMessage(modifierName) {
   let dasherizeModifierName = dasherize(modifierName);

--- a/lib/rules/no-action-modifiers.js
+++ b/lib/rules/no-action-modifiers.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 const ERROR_MESSAGE = 'Do not use the `action` modifier. Instead, use the `on` modifier.';
 

--- a/lib/rules/no-arguments-for-html-elements.js
+++ b/lib/rules/no-arguments-for-html-elements.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const isAngleBracketComponent = require('../helpers/is-angle-bracket-component');
+const Rule = require('./base');
 
 function makeError(attrName, tagName) {
   return `Arguments (${attrName}) should not be used on HTML elements (<${tagName}>).`;

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -22,8 +22,8 @@
      * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
  */
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 const GLOBAL_ATTRIBUTES = [
   'title',

--- a/lib/rules/no-block-params-for-html-elements.js
+++ b/lib/rules/no-block-params-for-html-elements.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const isAngleBracketComponent = require('../helpers/is-angle-bracket-component');
+const Rule = require('./base');
 
 module.exports = class NoBlockParamsForHtmlElements extends Rule {
   visitor() {

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -1,6 +1,6 @@
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
 const { transformTagName } = require('../helpers/curly-component-invocation');
+const Rule = require('./base');
 
 const DEFAULT_CONFIG = {
   allow: [],

--- a/lib/rules/no-element-event-actions.js
+++ b/lib/rules/no-element-event-actions.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
 
 const ERROR_MESSAGE =
   'Do not use HTML element event properties like `onclick`. Instead, use the `on` modifier.';

--- a/lib/rules/no-forbidden-elements.js
+++ b/lib/rules/no-forbidden-elements.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 function ERROR_MESSAGE_FORBIDDEN_ELEMENTS(element) {
   return `Use of <${element}> detected. Do not use forbidden elements.`;

--- a/lib/rules/no-heading-inside-button.js
+++ b/lib/rules/no-heading-inside-button.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
 
 const ERROR_MESSAGE = 'Buttons should not contain heading elements';
 const HEADING_ELEMENTS = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);

--- a/lib/rules/no-html-comments.js
+++ b/lib/rules/no-html-comments.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const AstNodeInfo = require('../helpers/ast-node-info');
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 module.exports = class NoHtmlComments extends Rule {
   parseConfig(config) {

--- a/lib/rules/no-implicit-this.js
+++ b/lib/rules/no-implicit-this.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 function message(original) {
   return (

--- a/lib/rules/no-inline-styles.js
+++ b/lib/rules/no-inline-styles.js
@@ -1,8 +1,8 @@
 'use strict';
 
 const AstNodeInfo = require('../helpers/ast-node-info');
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 /**
  Disallow usage of elements with inline styles

--- a/lib/rules/no-invalid-interactive.js
+++ b/lib/rules/no-invalid-interactive.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Rule = require('./base');
-const isInteractiveElement = require('../helpers/is-interactive-element');
 const isAngleBracketComponent = require('../helpers/is-angle-bracket-component');
+const isInteractiveElement = require('../helpers/is-interactive-element');
 const parseConfig = require('../helpers/parse-interactive-element-config');
+const Rule = require('./base');
 
 const DISALLOWED_DOM_EVENTS = new Set([
   // Mouse events:

--- a/lib/rules/no-invalid-link-text.js
+++ b/lib/rules/no-invalid-link-text.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
 
 const DISALLOWED_LINK_TEXT = new Set([
   // WCAG F84-Provided Examples

--- a/lib/rules/no-invalid-link-title.js
+++ b/lib/rules/no-invalid-link-title.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
 
 function hasInvalidLinkTitle(node, titleAttributeValues) {
   // Extract the text content(s) from the TextNode child(ren)

--- a/lib/rules/no-invalid-role.js
+++ b/lib/rules/no-invalid-role.js
@@ -1,9 +1,8 @@
 'use strict';
 
 const AstNodeInfo = require('../helpers/ast-node-info');
-const Rule = require('./base');
-
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 function createErrorMessageDisallowedRoleForElement(element) {
   return `Use of presentation role on <${element}> detected. Semantic elements should not be used for presentation.`;

--- a/lib/rules/no-negated-condition.js
+++ b/lib/rules/no-negated-condition.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
 
 const ERROR_MESSAGE_FLIP_IF =
   'Change `{{if (not condition)}} {{prop1}} {{else}} {{prop2}} {{/if}}` to `{{if condition}} {{prop2}} {{else}} {{prop1}} {{/if}}`.';

--- a/lib/rules/no-nested-interactive.js
+++ b/lib/rules/no-nested-interactive.js
@@ -16,9 +16,9 @@
    * boolean -- `true` for enabled / `false` for disabled
  */
 
-const Rule = require('./base');
 const isInteractiveElement = require('../helpers/is-interactive-element');
 const parseConfig = require('../helpers/parse-interactive-element-config');
+const Rule = require('./base');
 
 module.exports = class NoNestedInteractive extends Rule {
   parseConfig(config) {

--- a/lib/rules/no-nested-landmark.js
+++ b/lib/rules/no-nested-landmark.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
 
 function createErrorMessage(element) {
   return `Nested landmark elements on <${element}> detected. Landmark elements should not be nested within landmark elements of the same name.`;

--- a/lib/rules/no-outlet-outside-routes.js
+++ b/lib/rules/no-outlet-outside-routes.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const isRouteTemplate = require('../helpers/is-route-template');
+const Rule = require('./base');
 
 const message = 'Unexpected {{outlet}} usage. Only use {{outlet}} within a route template.';
 

--- a/lib/rules/no-positional-data-test-selectors.js
+++ b/lib/rules/no-positional-data-test-selectors.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const Rule = require('./base');
 const { builders: b } = require('ember-template-recast');
+
+const Rule = require('./base');
 
 const BUILT_INS = new Set([
   'action',

--- a/lib/rules/no-redundant-landmark-role.js
+++ b/lib/rules/no-redundant-landmark-role.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
 
 function createErrorMessage(element, role) {
   return `Use of redundant or invalid role: ${role} on <${element}> detected. If a landmark element is used, any role provided will either be redundant or incorrect.`;

--- a/lib/rules/no-restricted-invocations.js
+++ b/lib/rules/no-restricted-invocations.js
@@ -1,9 +1,9 @@
 'use strict';
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
 const dasherize = require('../helpers/dasherize-component-name');
 const isDasherizedComponentOrHelperName = require('../helpers/is-dasherized-component-or-helper-name');
+const Rule = require('./base');
 
 function isValidCustomErrorMessage(str) {
   return typeof str === 'string' && str.length > 0;

--- a/lib/rules/no-shadowed-elements.js
+++ b/lib/rules/no-shadowed-elements.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const isAngleBracketComponent = require('../helpers/is-angle-bracket-component');
+const Rule = require('./base');
 
 module.exports = class NoShadowedElements extends Rule {
   visitor() {

--- a/lib/rules/no-triple-curlies.js
+++ b/lib/rules/no-triple-curlies.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 module.exports = class NoTripleCurlies extends Rule {
   parseConfig(config) {

--- a/lib/rules/no-unnecessary-component-helper.js
+++ b/lib/rules/no-unnecessary-component-helper.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
 
 const ERROR_MESSAGE = 'Invoke component directly instead of using `component` helper';
 

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 module.exports = class Quotes extends Rule {
   parseConfig(config) {

--- a/lib/rules/require-form-method.js
+++ b/lib/rules/require-form-method.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 // Form `method` attribute keywords:
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fs-method

--- a/lib/rules/require-input-label.js
+++ b/lib/rules/require-input-label.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
 
 const ERROR_MESSAGE = 'Input elements require a valid associated label.';
 

--- a/lib/rules/require-lang-attribute.js
+++ b/lib/rules/require-lang-attribute.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./base');
 
 const ERROR_MESSAGE = 'The `<html>` element must have the `lang` attribute with a non-null value';
 

--- a/lib/rules/self-closing-void-elements.js
+++ b/lib/rules/self-closing-void-elements.js
@@ -16,8 +16,8 @@
    * boolean -- `true` for enabled / `false` for disabled
  */
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 /**
  * [Specs of Void Elements]{@link https://www.w3.org/TR/html-markup/syntax.html#void-element}

--- a/lib/rules/simple-unless.js
+++ b/lib/rules/simple-unless.js
@@ -1,8 +1,8 @@
 'use strict';
 
-const Rule = require('./base');
 const AstNodeInfo = require('../helpers/ast-node-info');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 const messages = {
   followingElseBlock: 'Using an {{else}} block with {{unless}} should be avoided.',

--- a/lib/rules/table-groups.js
+++ b/lib/rules/table-groups.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const AstNodeInfo = require('../helpers/ast-node-info');
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
 const dasherizeComponentName = require('../helpers/dasherize-component-name');
 const isDasherizedComponentOrHelperName = require('../helpers/is-dasherized-component-or-helper-name');
 const { flatMap } = require('../helpers/javascript');
+const Rule = require('./base');
 
 const message = 'Tables must have a table group (thead, tbody or tfoot).';
 const orderingMessage =

--- a/lib/rules/template-length.js
+++ b/lib/rules/template-length.js
@@ -13,8 +13,8 @@
        right thing to do would be to inline the template).
  */
 
-const Rule = require('./base');
 const createErrorMessage = require('../helpers/create-error-message');
+const Rule = require('./base');
 
 const DEFAULT_MAX_LENGTH = 200;
 const DEFAULT_MIN_LENGTH = 5;

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.22.0",
+    "eslint-plugin-import-helpers": "^1.1.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-unicorn": "^21.0.0",

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -2,11 +2,13 @@
 
 const fs = require('fs');
 const path = require('path');
+
 const prettier = require('prettier');
-const rules = require('../lib/rules');
-const { rules: recommendedRules } = require('../lib/config/recommended');
+
 const { rules: octaneRules } = require('../lib/config/octane');
+const { rules: recommendedRules } = require('../lib/config/recommended');
 const { rules: stylisticRules } = require('../lib/config/stylistic');
+const rules = require('../lib/rules');
 const isRuleFixable = require('../test/helpers/is-rule-fixable');
 
 const prettierConfig = {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1,9 +1,9 @@
 'use strict';
 const { readFileSync } = require('fs');
-
-const execa = require('execa');
 const fs = require('fs');
 const path = require('path');
+
+const execa = require('execa');
 
 const Project = require('../helpers/fake-project');
 const setupEnvVar = require('../helpers/setup-env-var');

--- a/test/acceptance/editors-integration-test.js
+++ b/test/acceptance/editors-integration-test.js
@@ -1,9 +1,11 @@
 'use strict';
-const execa = require('execa');
-const Project = require('../helpers/fake-project');
-const setupEnvVar = require('../helpers/setup-env-var');
 const fs = require('fs');
 const path = require('path');
+
+const execa = require('execa');
+
+const Project = require('../helpers/fake-project');
+const setupEnvVar = require('../helpers/setup-env-var');
 
 function run(project, args, options = {}) {
   options.reject = false;

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -1,11 +1,13 @@
 'use strict';
 
-const path = require('path');
 const fs = require('fs');
-const Linter = require('../../lib');
-const buildFakeConsole = require('./../helpers/console');
-const Project = require('../helpers/fake-project');
+const path = require('path');
+
 const chalk = require('chalk');
+
+const Linter = require('../../lib');
+const Project = require('../helpers/fake-project');
+const buildFakeConsole = require('./../helpers/console');
 
 const fixturePath = path.join(__dirname, '..', '/fixtures');
 

--- a/test/acceptance/stdin-by-platform-test.js
+++ b/test/acceptance/stdin-by-platform-test.js
@@ -2,7 +2,9 @@
 
 const fs = require('fs');
 const path = require('path');
+
 const execa = require('execa');
+
 const Project = require('../helpers/fake-project');
 const setupEnvVar = require('../helpers/setup-env-var');
 

--- a/test/helpers/fake-project.js
+++ b/test/helpers/fake-project.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('path');
+
 const FixturifyProject = require('fixturify-project');
 
 const ROOT = process.cwd();

--- a/test/helpers/is-rule-fixable.js
+++ b/test/helpers/is-rule-fixable.js
@@ -1,7 +1,8 @@
-const { parse } = require('@babel/parser');
-const { default: traverse } = require('@babel/traverse');
 const fs = require('fs');
 const path = require('path');
+
+const { parse } = require('@babel/parser');
+const { default: traverse } = require('@babel/traverse');
 
 function isRuleFixable(ruleName) {
   const relativePath = ruleName.startsWith('deprecated-')

--- a/test/printers/pretty-test.js
+++ b/test/printers/pretty-test.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk');
+
 const Printer = require('../../lib/printers/pretty');
 
 describe('Linter.errorsToMessages', function () {

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -1,13 +1,15 @@
 'use strict';
 
-const { parse, transform } = require('ember-template-recast');
-const Rule = require('./../../lib/rules/base');
-const { determineRuleConfig } = require('./../../lib/get-config');
 const { readdirSync } = require('fs');
 const { join, parse: parsePath } = require('path');
+
+const { parse, transform } = require('ember-template-recast');
+
+const EditorConfigResolver = require('../../lib/get-editor-config');
 const ruleNames = Object.keys(require('../../lib/rules'));
 const Project = require('../helpers/fake-project');
-const EditorConfigResolver = require('../../lib/get-editor-config');
+const { determineRuleConfig } = require('./../../lib/get-config');
+const Rule = require('./../../lib/rules/base');
 
 describe('base plugin', function () {
   let project, editorConfigResolver;

--- a/test/unit/default-config-test.js
+++ b/test/unit/default-config-test.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+
 const rules = require('../../lib/rules');
 
 const DEFAULT_CONFIG_PATH = path.join(__dirname, '..', '..', 'lib', 'config');

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const { stripIndent } = require('common-tags');
+
+const recommendedConfig = require('../../lib/config/recommended');
 const {
   getProjectConfig,
   getConfigForFile,
@@ -7,10 +10,8 @@ const {
   resolveProjectConfig,
   getRuleFromString,
 } = require('../../lib/get-config');
-const recommendedConfig = require('../../lib/config/recommended');
 const buildFakeConsole = require('../helpers/console');
 const Project = require('../helpers/fake-project');
-const { stripIndent } = require('common-tags');
 
 describe('get-config', function () {
   let project = null;

--- a/test/unit/github-actions-test.js
+++ b/test/unit/github-actions-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const Printer = require('../../lib/printers/github-actions');
 const Linter = require('../../lib');
+const Printer = require('../../lib/printers/github-actions');
 
 describe('GitHub Actions Annotations', function () {
   describe('_formatGitHubActionAnnotation', () => {

--- a/test/unit/helpers/ast-node-info-test.js
+++ b/test/unit/helpers/ast-node-info-test.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const AstNodeInfo = require('../../../lib/helpers/ast-node-info');
 const { parse } = require('ember-template-recast');
+
+const AstNodeInfo = require('../../../lib/helpers/ast-node-info');
 
 describe('isImgElement', function () {
   it('can detect an image tag', function () {

--- a/test/unit/helpers/is-interactive-element-test.js
+++ b/test/unit/helpers/is-interactive-element-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { parse } = require('ember-template-recast');
+
 const isInteractiveElement = require('../../../lib/helpers/is-interactive-element');
 
 describe('isInteractiveElement', function () {

--- a/test/unit/recommended-config-test.js
+++ b/test/unit/recommended-config-test.js
@@ -1,7 +1,8 @@
 'use strict';
 
-const Linter = require('../../lib');
 const stripIndent = require('common-tags').stripIndent;
+
+const Linter = require('../../lib');
 
 describe('recommended config', function () {
   function buildFakeConsole() {

--- a/test/unit/rule-setup-test.js
+++ b/test/unit/rule-setup-test.js
@@ -1,7 +1,8 @@
 const { readdirSync, existsSync, readFileSync } = require('fs');
 const { join } = require('path');
-const configRecommended = require('../../lib/config/recommended');
+
 const configOctane = require('../../lib/config/octane');
+const configRecommended = require('../../lib/config/recommended');
 const configStylistic = require('../../lib/config/stylistic');
 const isRuleFixable = require('../helpers/is-rule-fixable');
 

--- a/test/unit/rules/deprecations/deprecated-each-syntax-test.js
+++ b/test/unit/rules/deprecations/deprecated-each-syntax-test.js
@@ -1,8 +1,7 @@
 'use strict';
 
+const { DEPRECATION_URL } = require('../../../../lib/rules/deprecations/deprecated-each-syntax');
 const generateRuleTests = require('../../../helpers/rule-test-harness');
-const DEPRECATION_URL = require('../../../../lib/rules/deprecations/deprecated-each-syntax')
-  .DEPRECATION_URL;
 
 const message = `Deprecated {{#each}} usage. See the deprecation guide at ${DEPRECATION_URL}`;
 

--- a/test/unit/rules/deprecations/deprecated-inline-view-helper-test.js
+++ b/test/unit/rules/deprecations/deprecated-inline-view-helper-test.js
@@ -1,8 +1,9 @@
 'use strict';
 
+const {
+  DEPRECATION_URL,
+} = require('../../../../lib/rules/deprecations/deprecated-inline-view-helper');
 const generateRuleTests = require('../../../helpers/rule-test-harness');
-const DEPRECATION_URL = require('../../../../lib/rules/deprecations/deprecated-inline-view-helper')
-  .DEPRECATION_URL;
 
 const message =
   // eslint-disable-next-line prefer-template

--- a/test/unit/rules/deprecations/deprecated-render-helper-test.js
+++ b/test/unit/rules/deprecations/deprecated-render-helper-test.js
@@ -1,8 +1,7 @@
 'use strict';
 
+const { message } = require('../../../../lib/rules/deprecations/deprecated-render-helper');
 const generateRuleTests = require('../../../helpers/rule-test-harness');
-
-const message = require('../../../../lib/rules/deprecations/deprecated-render-helper').message;
 
 generateRuleTests({
   name: 'deprecated-render-helper',

--- a/test/unit/rules/inline-link-to-test.js
+++ b/test/unit/rules/inline-link-to-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { message } = require('../../../lib/rules/inline-link-to');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const message = require('../../../lib/rules/inline-link-to').message;
 
 generateRuleTests({
   name: 'inline-link-to',

--- a/test/unit/rules/linebreak-style-test.js
+++ b/test/unit/rules/linebreak-style-test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const os = require('os');
+
 const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({

--- a/test/unit/rules/no-action-modifiers-test.js
+++ b/test/unit/rules/no-action-modifiers-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-action-modifiers');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ERROR_MESSAGE = require('../../../lib/rules/no-action-modifiers').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-action-modifiers',

--- a/test/unit/rules/no-action-test.js
+++ b/test/unit/rules/no-action-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-action');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ERROR_MESSAGE = require('../../../lib/rules/no-action').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-action',

--- a/test/unit/rules/no-arguments-for-html-elements-test.js
+++ b/test/unit/rules/no-arguments-for-html-elements-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const { makeError } = require('../../../lib/rules/no-arguments-for-html-elements');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
   name: 'no-arguments-for-html-elements',

--- a/test/unit/rules/no-block-params-for-html-elements-test.js
+++ b/test/unit/rules/no-block-params-for-html-elements-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const { generateErrorMessage } = require('../../../lib/rules/no-block-params-for-html-elements');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
   name: 'no-block-params-for-html-elements',

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -1,6 +1,6 @@
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const { transformTagName } = require('../../../lib/helpers/curly-component-invocation');
 const { parseConfig } = require('../../../lib/rules/no-curly-component-invocation');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 function generateError(name) {
   let angleBracketName = transformTagName(name);

--- a/test/unit/rules/no-debugger-test.js
+++ b/test/unit/rules/no-debugger-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { message } = require('../../../lib/rules/no-debugger');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const message = require('../../../lib/rules/no-debugger').message;
 
 generateRuleTests({
   name: 'no-debugger',

--- a/test/unit/rules/no-element-event-actions-test.js
+++ b/test/unit/rules/no-element-event-actions-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-element-event-actions');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ERROR_MESSAGE = require('../../../lib/rules/no-element-event-actions').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-element-event-actions',

--- a/test/unit/rules/no-extra-mut-helper-argument-test.js
+++ b/test/unit/rules/no-extra-mut-helper-argument-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-extra-mut-helper-argument');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ERROR_MESSAGE = require('../../../lib/rules/no-extra-mut-helper-argument').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-extra-mut-helper-argument',

--- a/test/unit/rules/no-forbidden-elements-test.js
+++ b/test/unit/rules/no-forbidden-elements-test.js
@@ -1,9 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE_FORBIDDEN_ELEMENTS } = require('../../../lib/rules/no-forbidden-elements');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-
-const ERROR_MESSAGE_FORBIDDEN_ELEMENTS = require('../../../lib/rules/no-forbidden-elements')
-  .ERROR_MESSAGE_FORBIDDEN_ELEMENTS;
 
 generateRuleTests({
   name: 'no-forbidden-elements',

--- a/test/unit/rules/no-heading-inside-button-test.js
+++ b/test/unit/rules/no-heading-inside-button-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-heading-inside-button');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ERROR_MESSAGE = require('../../../lib/rules/no-heading-inside-button').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-heading-inside-button',

--- a/test/unit/rules/no-implicit-this-test.js
+++ b/test/unit/rules/no-implicit-this-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const { ARGLESS_BUILTIN_HELPERS, message } = require('../../../lib/rules/no-implicit-this');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 let statements = [
   (path) => `{{${path}}}`,

--- a/test/unit/rules/no-input-block-test.js
+++ b/test/unit/rules/no-input-block-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { message } = require('../../../lib/rules/no-input-block');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const message = require('../../../lib/rules/no-input-block').message;
 
 generateRuleTests({
   name: 'no-input-block',

--- a/test/unit/rules/no-input-tagname-test.js
+++ b/test/unit/rules/no-input-tagname-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { message } = require('../../../lib/rules/no-input-tagname');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const message = require('../../../lib/rules/no-input-tagname').message;
 
 generateRuleTests({
   name: 'no-input-tagname',

--- a/test/unit/rules/no-invalid-role-test.js
+++ b/test/unit/rules/no-invalid-role-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const rule = require('../../../lib/rules/no-invalid-role');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 const { createErrorMessageDisallowedRoleForElement, createNonexistentRoleErrorMessage } = rule;
 

--- a/test/unit/rules/no-link-to-tag-name-test.js
+++ b/test/unit/rules/no-link-to-tag-name-test.js
@@ -1,8 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-link-to-tag-name');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-
-const ERROR_MESSAGE = require('../../../lib/rules/no-link-to-tag-name').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-link-to-tag-name',

--- a/test/unit/rules/no-log-test.js
+++ b/test/unit/rules/no-log-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { message } = require('../../../lib/rules/no-log');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const message = require('../../../lib/rules/no-log').message;
 
 generateRuleTests({
   name: 'no-log',

--- a/test/unit/rules/no-multiple-empty-lines-test.js
+++ b/test/unit/rules/no-multiple-empty-lines-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const { parseConfig, CONFIG_ERROR_MESSAGE } = require('../../../lib/rules/no-multiple-empty-lines');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
   name: 'no-multiple-empty-lines',

--- a/test/unit/rules/no-negated-condition-test.js
+++ b/test/unit/rules/no-negated-condition-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const rule = require('../../../lib/rules/no-negated-condition');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 const { ERROR_MESSAGE_FLIP_IF, ERROR_MESSAGE_USE_IF, ERROR_MESSAGE_USE_UNLESS } = rule;
 

--- a/test/unit/rules/no-nested-landmark-test.js
+++ b/test/unit/rules/no-nested-landmark-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const rule = require('../../../lib/rules/no-nested-landmark');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 const { createErrorMessage } = rule;
 

--- a/test/unit/rules/no-nested-splattributes-test.js
+++ b/test/unit/rules/no-nested-splattributes-test.js
@@ -1,8 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-nested-splattributes');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-
-const ERROR_MESSAGE = require('../../../lib/rules/no-nested-splattributes').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-nested-splattributes',

--- a/test/unit/rules/no-obsolete-elements-test.js
+++ b/test/unit/rules/no-obsolete-elements-test.js
@@ -1,10 +1,10 @@
 'use strict';
 
+const {
+  ERROR_MESSAGE_OBSOLETE_ELEMENT,
+  OBSOLETE_ELEMENTS,
+} = require('../../../lib/rules/no-obsolete-elements');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const rule = require('../../../lib/rules/no-obsolete-elements');
-
-const ERROR_MESSAGE_OBSOLETE_ELEMENT = rule.ERROR_MESSAGE_OBSOLETE_ELEMENT;
-const OBSOLETE_ELEMENTS = rule.OBSOLETE_ELEMENTS;
 
 generateRuleTests({
   name: 'no-obsolete-elements',

--- a/test/unit/rules/no-outlet-outside-routes-test.js
+++ b/test/unit/rules/no-outlet-outside-routes-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { message } = require('../../../lib/rules/no-outlet-outside-routes');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const message = require('../../../lib/rules/no-outlet-outside-routes').message;
 
 generateRuleTests({
   name: 'no-outlet-outside-routes',

--- a/test/unit/rules/no-partial-test.js
+++ b/test/unit/rules/no-partial-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { message } = require('../../../lib/rules/no-partial');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const message = require('../../../lib/rules/no-partial').message;
 
 generateRuleTests({
   name: 'no-partial',

--- a/test/unit/rules/no-passed-in-event-handlers-test.js
+++ b/test/unit/rules/no-passed-in-event-handlers-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const { makeErrorMessage } = require('../../../lib/rules/no-passed-in-event-handlers');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
   name: 'no-passed-in-event-handlers',

--- a/test/unit/rules/no-potential-path-strings-test.js
+++ b/test/unit/rules/no-potential-path-strings-test.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
-
 const { generateErrorMessage } = require('../../../lib/rules/no-potential-path-strings');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
   name: 'no-potential-path-strings',

--- a/test/unit/rules/no-redundant-fn-test.js
+++ b/test/unit/rules/no-redundant-fn-test.js
@@ -1,8 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-redundant-fn');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-
-const ERROR_MESSAGE = require('../../../lib/rules/no-redundant-fn').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-redundant-fn',

--- a/test/unit/rules/no-redundant-landmark-role-test.js
+++ b/test/unit/rules/no-redundant-landmark-role-test.js
@@ -1,9 +1,7 @@
 'use strict';
 
+const { createErrorMessage } = require('../../../lib/rules/no-redundant-landmark-role');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const rule = require('../../../lib/rules/no-redundant-landmark-role');
-
-const { createErrorMessage } = rule;
 
 generateRuleTests({
   name: 'no-redundant-landmark-role',

--- a/test/unit/rules/no-unbalanced-curlies-test.js
+++ b/test/unit/rules/no-unbalanced-curlies-test.js
@@ -1,8 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-unbalanced-curlies');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-
-const ERROR_MESSAGE = require('../../../lib/rules/no-unbalanced-curlies').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-unbalanced-curlies',

--- a/test/unit/rules/no-unbound-test.js
+++ b/test/unit/rules/no-unbound-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { message } = require('../../../lib/rules/no-unbound');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const message = require('../../../lib/rules/no-unbound').message;
 
 generateRuleTests({
   name: 'no-unbound',

--- a/test/unit/rules/no-unnecessary-component-helper-test.js
+++ b/test/unit/rules/no-unnecessary-component-helper-test.js
@@ -1,9 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-unnecessary-component-helper');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const rule = require('../../../lib/rules/no-unnecessary-component-helper');
-
-const { ERROR_MESSAGE } = rule;
 
 generateRuleTests({
   name: 'no-unnecessary-component-helper',

--- a/test/unit/rules/no-whitespace-for-layout-test.js
+++ b/test/unit/rules/no-whitespace-for-layout-test.js
@@ -2,8 +2,8 @@
 
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-whitespace-for-layout');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ERROR_MESSAGE = require('../../../lib/rules/no-whitespace-for-layout').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-whitespace-for-layout',

--- a/test/unit/rules/no-whitespace-within-word-test.js
+++ b/test/unit/rules/no-whitespace-within-word-test.js
@@ -2,8 +2,8 @@
 
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-whitespace-within-word');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ERROR_MESSAGE = require('../../../lib/rules/no-whitespace-within-word').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'no-whitespace-within-word',

--- a/test/unit/rules/no-yield-only-test.js
+++ b/test/unit/rules/no-yield-only-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const { ERROR_MESSAGE } = require('../../../lib/rules/no-yield-only');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
   name: 'no-yield-only',

--- a/test/unit/rules/require-button-type-test.js
+++ b/test/unit/rules/require-button-type-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const { ERROR_MESSAGE } = require('../../../lib/rules/require-button-type');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
   name: 'require-button-type',

--- a/test/unit/rules/require-form-method-test.js
+++ b/test/unit/rules/require-form-method-test.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
-
 const { makeErrorMessage } = require('../../../lib/rules/require-form-method');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
   name: 'require-form-method',

--- a/test/unit/rules/require-input-label-test.js
+++ b/test/unit/rules/require-input-label-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/require-input-label');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ERROR_MESSAGE = require('../../../lib/rules/require-input-label').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'require-input-label',

--- a/test/unit/rules/require-lang-attribute-test.js
+++ b/test/unit/rules/require-lang-attribute-test.js
@@ -1,8 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/require-lang-attribute');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-
-const ERROR_MESSAGE = require('../../../lib/rules/require-lang-attribute').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'require-lang-attribute',

--- a/test/unit/rules/require-valid-alt-text-test.js
+++ b/test/unit/rules/require-valid-alt-text-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/require-valid-alt-text');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ERROR_MESSAGE = require('../../../lib/rules/require-valid-alt-text').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'require-valid-alt-text',

--- a/test/unit/rules/simple-unless-test.js
+++ b/test/unit/rules/simple-unless-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { messages } = require('../../../lib/rules/simple-unless');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const messages = require('../../../lib/rules/simple-unless').messages;
 
 generateRuleTests({
   name: 'simple-unless',

--- a/test/unit/rules/style-concatenation-test.js
+++ b/test/unit/rules/style-concatenation-test.js
@@ -1,7 +1,7 @@
 'use strict';
 
+const { ERROR_MESSAGE } = require('../../../lib/rules/style-concatenation');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-const ERROR_MESSAGE = require('../../../lib/rules/style-concatenation').ERROR_MESSAGE;
 
 generateRuleTests({
   name: 'style-concatenation',

--- a/test/unit/rules/table-groups-test.js
+++ b/test/unit/rules/table-groups-test.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const {
   message,
   orderingMessage,
   createTableGroupsErrorMessage,
 } = require('../../../lib/rules/table-groups');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
   name: 'table-groups',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,6 +2094,11 @@ eslint-plugin-filenames@^1.3.2:
     lodash.snakecase "4.1.1"
     lodash.upperfirst "4.3.1"
 
+eslint-plugin-import-helpers@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import-helpers/-/eslint-plugin-import-helpers-1.1.0.tgz#ab5c3f33de2a2f461061e8a13b143e8499c3baa0"
+  integrity sha512-a7l1Sj6hZybVHVkxVRVWm1WaAyk9yDjWvSVhUfnDR23i0vQ8RS1wv9k617qGIWPqkttzg299aEtx+bCHA2EoqQ==
+
 eslint-plugin-import@^2.22.0:
   version "2.22.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz#92f7736fe1fde3e2de77623c838dd992ff5ffb7e"


### PR DESCRIPTION
This ensures that the module imports are sorted and grouped a little more consistently.