### PR TITLE
added meta info for `block-indentation` rule

### DIFF
--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -82,6 +82,16 @@ function isControlChar(char) {
 }
 
 module.exports = class BlockIndentation extends Rule {
+  static get meta() {
+    return {
+      description: 'requires blocks to be indented and aligned',
+      category: 'Stylistic Issues', // 'Deprecated Rules', 'Possible Error', 'Best Practices',
+      presets: { recommended: true },
+      url:
+        'https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rules/block-indentation.md',
+      fixable: false,
+    };
+  }
   parseConfig(config) {
     let configType = typeof config;
 


### PR DESCRIPTION
If this is how we want to add the meta info for each rule, I'll do this for each rule. 

The idea is that adding meta info to each rule will make it easier to break out the documentation in a more automated fashion. 