### PR TITLE
Ensure all rule docs have a references section

### DIFF
--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -133,3 +133,9 @@ Block form (HTML)
 ## Related Rules
 
 * [block-indentation](block-indentation.md)
+* [eslint/max-len](https://eslint.org/docs/rules/max-len)
+* [eslint/indent](https://eslint.org/docs/rules/indent)
+
+## References
+
+* [Google style guide/line wrapping](https://google.github.io/styleguide/htmlcssguide.html#HTML_Line-Wrapping)

--- a/docs/rule/block-indentation.md
+++ b/docs/rule/block-indentation.md
@@ -51,3 +51,8 @@ If `.editorconfig` file present, rule configuration will be inherit from it.
 ## Related Rules
 
 * [attribute-indentation](attribute-indentation.md)
+* [eslint/indent](https://eslint.org/docs/rules/indent)
+
+## References
+
+* [Google style guide/formatting](https://google.github.io/styleguide/htmlcssguide.html#General_Formatting)

--- a/docs/rule/eol-last.md
+++ b/docs/rule/eol-last.md
@@ -30,3 +30,8 @@ The following values are valid configuration:
 ## Related Rules
 
 * [eol-last](https://eslint.org/docs/rules/eol-last) from eslint
+
+## References
+
+* [POSIX standard/line](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap03.html#tag_03_206)
+* [Wikipedia/newline](https://en.wikipedia.org/wiki/Newline#Interpretation)

--- a/docs/rule/inline-link-to.md
+++ b/docs/rule/inline-link-to.md
@@ -23,3 +23,8 @@ The block form is a little longer but has advantages over the inline form:
 * It maps closer to the use of HTML anchor tags which wrap their inner content.
 * It provides an obvious way for developers to put nested markup and components inside of their link.
 * The block form's argument order is more direct: "link to route". The inline form's argument order is somewhat ambiguous (link text then link target). This is opposite of the order in HTML (`href` then link text).
+
+## References
+
+* [Ember guides/routing](https://guides.emberjs.com/release/routing/linking-between-routes/#toc_the-linkto--component)
+* [Ember api/LinkTo component](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)

--- a/docs/rule/linebreak-style.md
+++ b/docs/rule/linebreak-style.md
@@ -16,3 +16,11 @@ This rule is configured with a boolean, or a string value:
 * string -- `system` for the current platforms default line ending / `unix` for LF linebreaks / `windows` for CRLF linebreaks
 
 If `.editorconfig` file present, rule configuration will be inherit from it.
+
+## Related Rules
+
+* [eslint/linebreak-style](https://eslint.org/docs/rules/linebreak-style)
+
+## References
+
+* [Git/line endings](https://docs.github.com/en/github/using-git/configuring-git-to-handle-line-endings)

--- a/docs/rule/modifier-name-case.md
+++ b/docs/rule/modifier-name-case.md
@@ -21,3 +21,10 @@ This rule **allows** the following:
 ```hbs
 <div {{did-insert}}></div>
 ```
+
+## References
+
+* [Documentation](https://guides.emberjs.com/release/components/template-lifecycle-dom-and-modifiers/#toc_event-handlers) for modifiers
+* [Polyfill](https://github.com/buschtoens/ember-on-modifier) for the `on` modifier (needed below Ember 3.11)
+* [Spec](http://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/fn?anchor=on) for the `on` modifier
+* [Spec](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/action?anchor=action) for the `action` modifier

--- a/docs/rule/no-arguments-for-html-elements.md
+++ b/docs/rule/no-arguments-for-html-elements.md
@@ -67,6 +67,10 @@ This rule **allows** the following:
 </MyComponent>
 ```
 
+## Related Rules
+
+* [no-potential-path-strings](no-potential-path-strings.md)
+
 ## References
 
-- [Component Arguments and HTML Attributes](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/)
+* [Component Arguments and HTML Attributes](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/)

--- a/docs/rule/no-attrs-in-components.md
+++ b/docs/rule/no-attrs-in-components.md
@@ -23,3 +23,7 @@ or if you using Ember 3.1 and above:
 ```hbs
 {{@foo}}
 ```
+
+## References
+
+* [rfcs/named args](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md#motivation)

--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -33,3 +33,8 @@ When the config value of `true` is used the following configuration is used:
 * `whitelist` - `(),.&+-=*/#%!?:[]{}`
 * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
 * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
+
+## References
+
+* [ECMA/i18n spec](https://tc39.es/ecma402)
+* [ICU message syntax docs](https://formatjs.io/docs/core-concepts/icu-syntax/)

--- a/docs/rule/no-block-params-for-html-elements.md
+++ b/docs/rule/no-block-params-for-html-elements.md
@@ -32,3 +32,7 @@ This rule **allows** the following:
 ## Related Rules
 
 - [no-arguments-for-html-elements](no-arguments-for-html-elements.md)
+
+## References
+
+- [Component Arguments and HTML Attributes](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/)

--- a/docs/rule/no-duplicate-attributes.md
+++ b/docs/rule/no-duplicate-attributes.md
@@ -2,7 +2,9 @@
 
 :white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
 
-This rule forbids multiple attributes passed to a Component, Helper, or an ElementNode with the same name.
+This rule forbids multiple attributes passed to a Component, Helper, or an ElementNode with the same name. According to the [HTML attributes Spec](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2):
+
+> There must never be two or more attributes on the same start tag whose names are an ASCII case-insensitive match for each other.
 
 ## Examples
 
@@ -17,3 +19,7 @@ This rule **allows** the following:
 ```hbs
 {{employee-details name=name age=age}}
 ```
+
+## References
+
+* [HTML attributes spec](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2)

--- a/docs/rule/no-forbidden-elements.md
+++ b/docs/rule/no-forbidden-elements.md
@@ -41,3 +41,7 @@ This rule **allows** the following:
   * array -- an array of strings to forbid, default: ['meta', 'style', 'html', 'style']
   * object -- An object with the following keys:
     * `forbidden` -- An array of forbidden element names
+
+## References
+
+* [Ember guides/template restrictions](https://guides.emberjs.com/release/components/#toc_restrictions)

--- a/docs/rule/no-html-comments.md
+++ b/docs/rule/no-html-comments.md
@@ -17,3 +17,8 @@ This rule **allows** the following:
 ```hbs
 {{!-- comment goes here --}}
 ```
+
+## References
+
+* [Ember guides/template features](https://guides.emberjs.com/release/components/#toc_supported-features)
+* [Handlebars docs/comments](https://handlebarsjs.com/guide/#template-comments)

--- a/docs/rule/no-implicit-this.md
+++ b/docs/rule/no-implicit-this.md
@@ -90,6 +90,12 @@ know about fallback resolution rules. This makes common features like ["Go To
 Definition"](https://code.visualstudio.com/docs/editor/editingevolved#_go-to-definition)
 much easier to implement since we have semantics that mean "property on class".
 
+## Migration
+
+* use [ember-no-implicit-this-codemod](https://github.com/ember-codemods/ember-no-implicit-this-codemod)
+* [upgrade to Glimmer components](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/), which don't allow ambiguous access
+  * classic components have [auto-reflection](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md#motivation), and can use `this.myArgName` or `this.args.myArgNme` or `@myArgName` interchangeably
+
 ## Configuration
 
  The following values are valid configuration:
@@ -98,3 +104,8 @@ much easier to implement since we have semantics that mean "property on class".
 * object -- An object with the following keys:
   * `allow` -- An array of component / helper names for that may be called
     without arguments (string or regular expression)
+
+## References
+
+* [Glimmer components](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/)
+* [rfcs/named args](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md#motivation)

--- a/docs/rule/no-inline-styles.md
+++ b/docs/rule/no-inline-styles.md
@@ -34,3 +34,7 @@ This rule **allows** the following:
 ## Related Rules
 
 * [style-concatenation](style-concatenation.md)
+
+## References
+
+* [Deprecations/binding style attributes](https://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes)

--- a/docs/rule/no-input-block.md
+++ b/docs/rule/no-input-block.md
@@ -17,3 +17,8 @@ This rule **allows** the following:
 ```hbs
 {{input type="text" value=this.firstName disabled=this.entryNotAllowed size="50"}}
 ```
+
+## References
+
+* [Ember api/input component](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input)
+* [rfcs/built in components](https://emberjs.github.io/rfcs/0459-angle-bracket-built-in-components.html)

--- a/docs/rule/no-input-tagname.md
+++ b/docs/rule/no-input-tagname.md
@@ -16,3 +16,12 @@ This rule **forbids** the following:
 {{yield (component "input" tagName="foo")}}
 {{yield (component "input" tagName=X)}}
 ```
+
+## Related rules
+
+* [no-link-to-tagname](no-link-to-tagname.md)
+
+## References
+
+* [Ember api/input component](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input)
+* [rfcs/built in components](https://emberjs.github.io/rfcs/0459-angle-bracket-built-in-components.html)

--- a/docs/rule/no-invalid-block-param-definition.md
+++ b/docs/rule/no-invalid-block-param-definition.md
@@ -31,3 +31,13 @@ This rule **allows** the following:
     {{blockParam}}
 </MyComponent>
 ```
+
+## Related rules
+
+* [no-shadowed-elements](no-shadowed-elements.md)
+
+## References
+
+* [Ember guides/block content](https://guides.emberjs.com/release/components/block-content/)
+* [rfcs/angle bracket invocation](https://emberjs.github.io/rfcs/0311-angle-bracket-invocation.html)
+* [rfcs/named blocks](https://emberjs.github.io/rfcs/0226-named-blocks.html)

--- a/docs/rule/no-invalid-interactive.md
+++ b/docs/rule/no-invalid-interactive.md
@@ -29,3 +29,7 @@ The following values are valid configuration (same as the `no-nested-interactive
   * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
   * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
   * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.
+
+## References
+
+* [MDN docs/ARIA roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles)

--- a/docs/rule/no-link-to-tagname.md
+++ b/docs/rule/no-link-to-tagname.md
@@ -43,3 +43,12 @@ This rule **allows** the following:
 
 - Remove the `tagName` overrides and, if you need it, adjust the styling of the
   `<a>` elements to make them look like buttons
+
+## Related rules
+
+- [no-input-tagname](no-input-tagname.md)
+
+## References
+
+- [Ember guides/LinkTo component](https://guides.emberjs.com/release/routing/linking-between-routes/#toc_the-linkto--component)
+- [Ember api/LinkTo component](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/LinkTo?anchor=LinkTo)

--- a/docs/rule/no-log.md
+++ b/docs/rule/no-log.md
@@ -12,3 +12,11 @@ This rule **forbids** the following:
 {{log}}
 {{log "foo" var}}
 ```
+
+## Related rules
+
+* [eslint/no-console](https://eslint.org/docs/rules/no-console)
+
+## References
+
+* [Ember api/log helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/log?anchor=log)

--- a/docs/rule/no-nested-interactive.md
+++ b/docs/rule/no-nested-interactive.md
@@ -32,3 +32,7 @@ The following values are valid configuration:
   * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
   * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
   * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.
+
+## References
+
+* [MDN docs/ARIA roles](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles)

--- a/docs/rule/no-nested-splattributes.md
+++ b/docs/rule/no-nested-splattributes.md
@@ -28,3 +28,8 @@ This rule **allows** the following:
 ## Migration
 
 - Remove the inner `...attributes` declaration
+
+## References
+
+- [rfcs/angle bracket invocation](https://emberjs.github.io/rfcs/0311-angle-bracket-invocation.html#html-attributes)
+- [rfcs/modifier splattributes](https://emberjs.github.io/rfcs/0435-modifier-splattributes.html)

--- a/docs/rule/no-outlet-outside-routes.md
+++ b/docs/rule/no-outlet-outside-routes.md
@@ -11,3 +11,8 @@ This rule **forbids** the following (except in routes):
 ```hbs
 {{outlet}}
 ```
+
+## References
+
+* [Ember guides/routing](https://guides.emberjs.com/release/routing/rendering-a-template/)
+* [Ember api/outlet helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/outlet?anchor=outlet)

--- a/docs/rule/no-partial.md
+++ b/docs/rule/no-partial.md
@@ -17,6 +17,6 @@ This rule **forbids** the following:
 {{partial "foo"}}
 ```
 
-## RFCs
+## References
 
-* [Deprecate {{partial}}](https://github.com/emberjs/rfcs/blob/master/text/0449-deprecate-partials.md)
+* [rfcs/deprecate partials](https://github.com/emberjs/rfcs/blob/master/text/0449-deprecate-partials.md)

--- a/docs/rule/no-potential-path-strings.md
+++ b/docs/rule/no-potential-path-strings.md
@@ -32,3 +32,11 @@ This rule **allows** the following:
 ## Migration
 
 - Replace the surrounding `"` characters with `{{`/`}}`
+
+## Related Rules
+
+- [no-arguments-for-html-elements](no-arguments-for-html-elements.md)
+
+## References
+
+- [Component Arguments and HTML Attributes](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/)

--- a/docs/rule/no-quoteless-attributes.md
+++ b/docs/rule/no-quoteless-attributes.md
@@ -40,3 +40,7 @@ This rule **allows** the following:
 ```hbs
 <div data-foo={{someValue}}></div>
 ```
+
+## References
+
+* [HTML spec/attributes](https://html.spec.whatwg.org/multipage/dom.html#attributes)

--- a/docs/rule/no-restricted-invocations.md
+++ b/docs/rule/no-restricted-invocations.md
@@ -41,3 +41,7 @@ One of these:
 ## Related Rules
 
 * [ember/no-restricted-service-injections](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-restricted-service-injections.md)
+
+## References
+
+* [ember-cli-deprecation-workflow](https://github.com/mixonic/ember-cli-deprecation-workflow)

--- a/docs/rule/no-shadowed-elements.md
+++ b/docs/rule/no-shadowed-elements.md
@@ -34,3 +34,13 @@ This rule **allows** the following:
   <bar.baz />
 </Foo>
 ```
+
+## Related rules
+
+* [no-invalid-block-param-definition](no-invalid-block-param-definition.md)
+
+## References
+
+* [Ember guides/block content](https://guides.emberjs.com/release/components/block-content/)
+* [rfcs/angle bracket invocation](https://emberjs.github.io/rfcs/0311-angle-bracket-invocation.html)
+* [rfcs/named blocks](https://emberjs.github.io/rfcs/0226-named-blocks.html)

--- a/docs/rule/no-trailing-spaces.md
+++ b/docs/rule/no-trailing-spaces.md
@@ -23,3 +23,7 @@ This rule **allows** the following:
 ## Related Rules
 
 * [no-trailing-spaces](https://eslint.org/docs/rules/no-trailing-spaces) from eslint
+
+## References
+
+* [git/formatting and whitespace](https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration#_formatting_and_whitespace)

--- a/docs/rule/no-unbalanced-curlies.md
+++ b/docs/rule/no-unbalanced-curlies.md
@@ -43,3 +43,7 @@ If you have curlies in your code that you wish to show verbatim, but are flagged
 <p>This is a closing double curly: {{ '}}' }}</p>
 <p>This is a closing triple curly: {{ '}}}' }}</p>
 ```
+
+## References
+
+* [Handlebars docs/expressions](https://handlebarsjs.com/guide/expressions.html)

--- a/docs/rule/no-unbound.md
+++ b/docs/rule/no-unbound.md
@@ -18,3 +18,8 @@ This rule **forbids** the following:
 ```hbs
 {{some-component foo=(unbound aVar)}}
 ```
+
+## References
+
+* [deprecations/unbound block syntax](https://deprecations.emberjs.com/v1.x/#toc_block-and-multi-argument-unbound-helper)
+* [Ember api/unbound helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=unbound)

--- a/docs/rule/no-unnecessary-concat.md
+++ b/docs/rule/no-unnecessary-concat.md
@@ -33,3 +33,8 @@ Use regexp find-and-replace to fix existing violations of this rule:
 | Before | After |
 | --- | --- |
 | `="{{([^}]+)}}"` | `={{$1}}` |
+
+## References
+
+* [Handlebars docs/expressions](https://handlebarsjs.com/guide/expressions.html)
+* [Ember api/concat helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat)

--- a/docs/rule/no-unused-block-params.md
+++ b/docs/rule/no-unused-block-params.md
@@ -37,3 +37,13 @@ Allowed (later parameter used):
   {{index}}
 {{/each}}
 ```
+
+## Related rules
+
+* [eslint/no-unused-vars](https://eslint.org/docs/rules/no-unused-vars)
+
+## References
+
+* [Ember guides/block content](https://guides.emberjs.com/release/components/block-content/)
+* [rfcs/angle bracket invocation](https://emberjs.github.io/rfcs/0311-angle-bracket-invocation.html)
+* [rfcs/named blocks](https://emberjs.github.io/rfcs/0226-named-blocks.html)

--- a/docs/rule/quotes.md
+++ b/docs/rule/quotes.md
@@ -29,3 +29,7 @@ The following values are valid configuration:
 ## Related Rules
 
 * [quotes](https://eslint.org/docs/rules/quotes) from eslint
+
+## References
+
+* [Google style guide/quotes](https://google.github.io/styleguide/htmlcssguide.html#HTML_Quotation_Marks)

--- a/docs/rule/require-button-type.md
+++ b/docs/rule/require-button-type.md
@@ -31,4 +31,4 @@ This rule **allows** the following:
 
 ## References
 
-* Red [HTML spec - the button element](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type)
+* [HTML spec - the button element](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type)

--- a/docs/rule/self-closing-void-elements.md
+++ b/docs/rule/self-closing-void-elements.md
@@ -29,3 +29,7 @@ The following values are valid configuration:
 
 * boolean -- `true` for enabled / `false` for disabled
 * string -- `require` to mandate the use of self closing tags
+
+## References
+
+* [HTML spec/void elements](https://html.spec.whatwg.org/#void-elements)

--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -68,3 +68,7 @@ The following values are valid configuration:
 ## Related Rules
 
 * [no-negated-condition](no-negated-condition.md)
+
+## References
+
+* [Wikipedia/boolean algebra](https://en.wikipedia.org/wiki/Boolean_algebra)

--- a/docs/rule/table-groups.md
+++ b/docs/rule/table-groups.md
@@ -104,3 +104,7 @@ One of these:
   * `allowed-thead-components` - string[] - components to treat as having the thead tag (using kebab-case names like `nested-scope/component-name`)
   * `allowed-tbody-components` - string[] - components to treat as having the tbody tag (using kebab-case names like `nested-scope/component-name`)
   * `allowed-tfoot-components` - string[] - components to treat as having the tfoot tag (using kebab-case names like `nested-scope/component-name`)
+
+## References
+
+* [HTML spec/table element](https://html.spec.whatwg.org/#the-table-element)

--- a/docs/rule/template-length.md
+++ b/docs/rule/template-length.md
@@ -28,3 +28,11 @@ This rule is configured with a boolean, or a string value:
     right thing to do would be to split the template up into pieces).
   - min {number} - the shortest a template should be without failing a test (assuming the
     right thing to do would be to inline the template.
+
+## Related rules
+
+- [eslint/max-lines](https://eslint.org/docs/rules/max-lines)
+
+## References
+
+- [JS Complexity](https://web.archive.org/web/20160808115119/http://jscomplexity.org/complexity)

--- a/test/unit/rule-setup-test.js
+++ b/test/unit/rule-setup-test.js
@@ -55,7 +55,7 @@ describe('rules setup is correct', function () {
     });
   });
 
-  it('All rules has test files', function () {
+  it('All rules have test files', function () {
     const testsPath = join(__dirname, '..', 'unit', 'rules');
     const ruleFiles = new Set(readdirSync(testsPath).filter((name) => name.endsWith('-test.js')));
     const deprecatedRuleFiles = new Set(
@@ -71,7 +71,7 @@ describe('rules setup is correct', function () {
     });
   });
 
-  it('should have the right contents (title, examples, notices) for each rule documentation file', function () {
+  it('should have the right contents (title, examples, notices, references) for each rule documentation file', function () {
     const CONFIG_MSG_RECOMMENDED =
       ":white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.";
     const CONFIG_MSG_OCTANE =
@@ -87,6 +87,7 @@ describe('rules setup is correct', function () {
 
       expect(file).toContain(`# ${ruleName}`); // Title header.
       expect(file).toContain('## Examples'); // Examples section header.
+      expect(file).toContain('## References');
 
       if (RULE_NAMES_RECOMMENDED.has(ruleName)) {
         expect(file).toContain(CONFIG_MSG_RECOMMENDED);
@@ -119,6 +120,7 @@ describe('rules setup is correct', function () {
 
       expect(file).toContain(`# ${ruleName}`); // Title header.
       expect(file).toContain('## Examples'); // Examples section header.
+      expect(file).toContain('## References');
 
       if (RULE_NAMES_RECOMMENDED.has(ruleName)) {
         expect(file).toContain(CONFIG_MSG_RECOMMENDED);


### PR DESCRIPTION
### What
- adds an assertion to `rule-setup-test` to ensure that all rule doc pages have a `## References` header
- add references section to each rule that fails this test

### Why
- Addresses #1368 