### PR TITLE
expose `DEFAULT_CONFIG` export from `no-bare-strings` rule

### DIFF
--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -30,9 +30,24 @@ This rule **allows** the following:
 
 When the config value of `true` is used the following configuration is used:
 
-* `whitelist` - `(),.&+-=*/#%!?:[]{}`
+* `whitelist` - refer to the `DEFAULT_CONFIG.whitelist` property in the [rule](../lib/rules/no-bare-strings.js)
 * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
 * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
+
+The `DEFAULT_CONFIG` is available as an export. Example use in configuration:
+
+```javascript
+const {
+  DEFAULT_CONFIG
+} = require('ember-template-lint/lib/rules/no-bare-strings');
+const additionalCharsToIgnore = ['a', 'b', 'c'];
+
+module.exports = {
+  rules: {
+    'no-bare-strings': [...DEFAULT_CONFIG.whitelist, ...additionalCharsToIgnore]
+  }
+};
+```
 
 ## References
 

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -143,6 +143,7 @@ module.exports = class NoBareStrings extends Rule {
     super(options);
     this._elementStack = [];
   }
+
   isWithinIgnoredElement() {
     return this._elementStack.some((n) => IGNORED_ELEMENTS.has(n.tag));
   }
@@ -287,3 +288,5 @@ module.exports = class NoBareStrings extends Rule {
     }
   }
 };
+
+module.exports.DEFAULT_CONFIG = DEFAULT_CONFIG;

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -1,6 +1,19 @@
 'use strict';
 
+const rule = require('../../../lib/rules/no-bare-strings');
 const generateRuleTests = require('../../helpers/rule-test-harness');
+
+describe('imports', () => {
+  it('should expose the default config', () => {
+    expect(rule.DEFAULT_CONFIG).toEqual(
+      expect.objectContaining({
+        whitelist: expect.arrayContaining(['&lpar;']),
+        globalAttributes: expect.arrayContaining(['title']),
+        elementAttributes: expect.any(Object),
+      })
+    );
+  });
+});
 
 generateRuleTests({
   name: 'no-bare-strings',


### PR DESCRIPTION
### What
- exports the default config from `no-bare-strings` rule
- docs the same
- adds a test

### Why
- fixes #116 
  - this asks for `basically whitelist and additionalWhitelist` config
  - elsewhere have found it easier to expose the default config and let the user use it how they want, with user config overriding default
- inspired by [eslint-plugin-ember/avoid-leaking-state-in-ember-objects.md](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/avoid-leaking-state-in-ember-objects.md#configuration)