### PR TITLE
BREAKING: replace `whitelist`/`blacklist` references

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     curly: 'error',
     eqeqeq: 'error',
     'func-style': ['error', 'declaration'],
+    'id-denylist': ['error', 'whitelist', 'blacklist'],
     'new-parens': 'error',
     'no-async-promise-executor': 'error',
     'no-console': 'error',

--- a/docs/rule/no-action-modifiers.md
+++ b/docs/rule/no-action-modifiers.md
@@ -23,7 +23,7 @@ This rule **allows** the following:
 The following values are valid configuration:
 
 * boolean -- `true` for enabled / `false` for disabled
-* array -- an array of whitelisted element tag names, which will accept action modifiers
+* array -- an allowlist of element tag names, which will accept action modifiers
 
 ## References
 

--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -22,15 +22,15 @@ This rule **allows** the following:
  The following values are valid configuration:
 
 * boolean -- `true` for enabled / `false` for disabled
-* array -- an array of whitelisted strings
+* array -- an array of allowlisted strings
 * object -- An object with the following keys:
-  * `whitelist` -- An array of whitelisted strings
+  * `allowlist` -- An array of allowlisted strings
   * `globalAttributes` -- An array of attributes to check on every element.
   * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
 
 When the config value of `true` is used the following configuration is used:
 
-* `whitelist` - refer to the `DEFAULT_CONFIG.whitelist` property in the [rule](../lib/rules/no-bare-strings.js)
+* `allowlist` - refer to the `DEFAULT_CONFIG.allowlist` property in the [rule](../lib/rules/no-bare-strings.js)
 * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
 * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
 
@@ -44,7 +44,7 @@ const additionalCharsToIgnore = ['a', 'b', 'c'];
 
 module.exports = {
   rules: {
-    'no-bare-strings': [...DEFAULT_CONFIG.whitelist, ...additionalCharsToIgnore]
+    'no-bare-strings': [...DEFAULT_CONFIG.allowlist, ...additionalCharsToIgnore]
   }
 };
 ```

--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -61,8 +61,8 @@ The following values are valid configuration:
 
 * boolean -- `true` for enabled / `false` for disabled
 * object --
-  * `whitelist` -- array - `['or']` for specific helpers / `[]` for wildcard
-  * `blacklist` -- array - `['or']` for specific helpers / `[]` for none
+  * `allowlist` -- array - `['or']` for specific helpers / `[]` for wildcard
+  * `denylist` -- array - `['or']` for specific helpers / `[]` for none
   * `maxHelpers` -- number - use -1 for no limit
 
 ## Related Rules

--- a/lib/rules/no-action-modifiers.js
+++ b/lib/rules/no-action-modifiers.js
@@ -10,13 +10,13 @@ module.exports = class NoActionModifiers extends Rule {
     switch (typeof config) {
       case 'boolean':
         if (config) {
-          return { whitelist: [] };
+          return { allowlist: [] };
         } else {
           return false;
         }
       case 'object':
         if (Array.isArray(config)) {
-          return { whitelist: config };
+          return { allowlist: config };
         }
         break;
       case 'undefined':
@@ -40,7 +40,7 @@ module.exports = class NoActionModifiers extends Rule {
           return;
         }
 
-        if (this.config.whitelist.includes(parentNode.tag)) {
+        if (this.config.allowlist.includes(parentNode.tag)) {
           return;
         }
 

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -15,9 +15,9 @@
  The following values are valid configuration:
 
    * boolean -- `true` for enabled / `false` for disabled
-   * array -- an array of whitelisted strings
+   * array -- an array of allowlisted strings
    * object -- An object with the following keys:
-     * `whitelist` -- An array of whitelisted strings
+     * `allowlist` -- An array of allowlisted strings
      * `globalAttributes` -- An array of attributes to check on every element.
      * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
  */
@@ -42,7 +42,7 @@ const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'template', 'textare
 
 // Character entity reference chart: https://dev.w3.org/html5/html-author/charref
 const DEFAULT_CONFIG = {
-  whitelist: [
+  allowlist: [
     '&lpar;', // (
     '&rpar;', // )
     '&comma;', // ,
@@ -118,7 +118,7 @@ function isValidConfigObjectFormat(config) {
     let valueType = typeof value;
     let valueIsArray = Array.isArray(value);
 
-    if (key === 'whitelist' && !valueIsArray) {
+    if (key === 'allowlist' && !valueIsArray) {
       return false;
     } else if (key === 'globalAttributes' && !valueIsArray) {
       return false;
@@ -134,8 +134,8 @@ function isValidConfigObjectFormat(config) {
   return true;
 }
 
-function sanitizeConfigArray(whitelist = []) {
-  return whitelist.filter((option) => option !== '').sort((a, b) => b.length - a.length);
+function sanitizeConfigArray(allowlist = []) {
+  return allowlist.filter((option) => option !== '').sort((a, b) => b.length - a.length);
 }
 
 module.exports = class NoBareStrings extends Rule {
@@ -157,14 +157,14 @@ module.exports = class NoBareStrings extends Rule {
       case 'object':
         if (Array.isArray(config)) {
           return {
-            whitelist: sanitizeConfigArray(config),
+            allowlist: sanitizeConfigArray(config),
             globalAttributes: GLOBAL_ATTRIBUTES,
             elementAttributes: TAG_ATTRIBUTES,
           };
         } else if (isValidConfigObjectFormat(config)) {
           // default any missing keys to empty values
           return {
-            whitelist: sanitizeConfigArray(config.whitelist || []),
+            allowlist: sanitizeConfigArray(config.allowlist || []),
             globalAttributes: config.globalAttributes || [],
             elementAttributes: config.elementAttributes || {},
           };
@@ -178,9 +178,9 @@ module.exports = class NoBareStrings extends Rule {
       this.ruleName,
       [
         '  * boolean - `true` to enable / `false` to disable',
-        '  * array -- an array of strings to whitelist',
+        '  * array -- an array of strings to allowlist',
         '  * object -- An object with the following keys:',
-        '    * `whitelist` -- An array of whitelisted strings',
+        '    * `allowlist` -- An array of allowlisted strings',
         '    * `globalAttributes` -- An array of attributes to check on every element',
         '    * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name',
       ],
@@ -240,11 +240,11 @@ module.exports = class NoBareStrings extends Rule {
   }
 
   _getBareString(_string) {
-    let whitelist = this.config.whitelist;
+    let allowlist = this.config.allowlist;
     let string = _string;
 
-    if (whitelist) {
-      for (const entry of whitelist) {
+    if (allowlist) {
+      for (const entry of allowlist) {
         while (string.includes(entry)) {
           string = string.replace(entry, '');
         }

--- a/lib/rules/simple-unless.js
+++ b/lib/rules/simple-unless.js
@@ -11,8 +11,8 @@ const messages = {
 };
 
 const DEFAULT_CONFIG = {
-  whitelist: [],
-  blacklist: [],
+  allowlist: [],
+  denylist: [],
   maxHelpers: 0,
 };
 
@@ -23,9 +23,9 @@ function isValidConfigObjectFormat(config) {
 
     if (value === undefined) {
       config[key] = DEFAULT_CONFIG[key];
-    } else if (key === 'whitelist' && !valueIsArray) {
+    } else if (key === 'allowlist' && !valueIsArray) {
       return false;
-    } else if (key === 'blacklist' && !valueIsArray) {
+    } else if (key === 'denylist' && !valueIsArray) {
       return false;
     }
   }
@@ -55,8 +55,8 @@ module.exports = class SimpleUnless extends Rule {
       [
         '  * boolean -- `true` for enabled / `false` for disabled\n' +
           '  * object --\n' +
-          "    *  `whitelist` -- array - `['or']` for specific helpers / `[]` for wildcard\n" +
-          "    *  `blacklist` -- array - `['or']` for specific helpers / `[]` for none\n" +
+          "    *  `allowlist` -- array - `['or']` for specific helpers / `[]` for wildcard\n" +
+          "    *  `denylist` -- array - `['or']` for specific helpers / `[]` for none\n" +
           '    *  `maxHelpers` -- number - use -1 for no limit',
       ],
       config
@@ -118,8 +118,8 @@ module.exports = class SimpleUnless extends Rule {
   }
 
   _withHelper(node) {
-    const whitelist = this.config.whitelist; // let { whitelist, blacklist, maxHelpers } = this.config;
-    const blacklist = this.config.blacklist;
+    const allowlist = this.config.allowlist; // let { allowlist, denylist, maxHelpers } = this.config;
+    const denylist = this.config.denylist;
     const maxHelpers = this.config.maxHelpers;
 
     let params;
@@ -141,22 +141,22 @@ module.exports = class SimpleUnless extends Rule {
             this._logMessage(message, loc.line, loc.column, actual);
           }
 
-          if (whitelist.length > 0 && !whitelist.includes(param.path.original)) {
+          if (allowlist.length > 0 && !allowlist.includes(param.path.original)) {
             let loc = param.loc.start;
             let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
             let message = `${messages.withHelper} Allowed helper${
-              whitelist.length > 1 ? 's' : ''
-            }: ${whitelist.toString()}`;
+              allowlist.length > 1 ? 's' : ''
+            }: ${allowlist.toString()}`;
 
             this._logMessage(message, loc.line, loc.column, actual);
           }
 
-          if (blacklist.length > 0 && blacklist.includes(param.path.original)) {
+          if (denylist.length > 0 && denylist.includes(param.path.original)) {
             let loc = param.loc.start;
             let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
             let message = `${messages.withHelper} Restricted helper${
-              blacklist.length > 1 ? 's' : ''
-            }: ${blacklist.toString()}`;
+              denylist.length > 1 ? 's' : ''
+            }: ${denylist.toString()}`;
 
             this._logMessage(message, loc.line, loc.column, actual);
           }

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -7,7 +7,7 @@ describe('imports', () => {
   it('should expose the default config', () => {
     expect(rule.DEFAULT_CONFIG).toEqual(
       expect.objectContaining({
-        whitelist: expect.arrayContaining(['&lpar;']),
+        allowlist: expect.arrayContaining(['&lpar;']),
         globalAttributes: expect.arrayContaining(['title']),
         elementAttributes: expect.any(Object),
       })
@@ -75,7 +75,7 @@ generateRuleTests({
     '<div placeholder="wat?"></div>',
 
     {
-      // config as array is whitelist of chars
+      // config as array is allowlist of chars
       config: ['/', '"'],
       template: '{{t "foo"}} / "{{name}}"',
     },

--- a/test/unit/rules/simple-unless-test.js
+++ b/test/unit/rules/simple-unless-test.js
@@ -6,7 +6,7 @@ const generateRuleTests = require('../../helpers/rule-test-harness');
 generateRuleTests({
   name: 'simple-unless',
   config: {
-    whitelist: ['or', 'eq', 'not-eq'],
+    allowlist: ['or', 'eq', 'not-eq'],
     maxHelpers: 2,
   },
 
@@ -27,14 +27,14 @@ generateRuleTests({
     },
     {
       config: {
-        whitelist: ['or', 'eq', 'not-eq'],
+        allowlist: ['or', 'eq', 'not-eq'],
         maxHelpers: 2,
       },
       template: '{{unless (eq foo bar) baz}}',
     },
     {
       config: {
-        whitelist: [],
+        allowlist: [],
         maxHelpers: 2,
       },
       template: '{{unless (eq (not foo) bar) baz}}',
@@ -54,14 +54,14 @@ generateRuleTests({
     {
       config: {
         maxHelpers: -1,
-        blacklist: [],
+        denylist: [],
       },
       template: '{{unless (eq (not foo) bar) baz}}',
     },
     {
       config: {
         maxHelpers: -1,
-        blacklist: ['or'],
+        denylist: ['or'],
       },
       template: '{{unless (eq (not foo) bar) baz}}',
     },
@@ -70,7 +70,7 @@ generateRuleTests({
   bad: [
     {
       config: {
-        whitelist: ['or', 'eq', 'not-eq'],
+        allowlist: ['or', 'eq', 'not-eq'],
         maxHelpers: 2,
       },
       template: "{{unless (if (or true))  'Please no'}}",
@@ -284,7 +284,7 @@ generateRuleTests({
     },
     {
       config: {
-        whitelist: ['test'],
+        allowlist: ['test'],
         maxHelpers: 1,
       },
       template: [
@@ -312,7 +312,7 @@ generateRuleTests({
     },
     {
       config: {
-        whitelist: [],
+        allowlist: [],
         maxHelpers: 2,
       },
       template: [
@@ -331,7 +331,7 @@ generateRuleTests({
     },
     {
       config: {
-        blacklist: ['two'],
+        denylist: ['two'],
         maxHelpers: -1,
       },
       template: [
@@ -350,7 +350,7 @@ generateRuleTests({
     },
     {
       config: {
-        blacklist: ['two', 'four'],
+        denylist: ['two', 'four'],
         maxHelpers: -1,
       },
       template: [


### PR DESCRIPTION
### What
- replaces `whitelist` with `allowlist`
- replaces `blacklist` with `denylist`
- adds both terms to [`eslint/id-denylist`](https://eslint.org/docs/rules/id-denylist) config

### Why
- fixes #989 
- dependent on (should follow) #1481 
- `no-action-modifiers` changes are non-breaking, the rest are breaking changes
- second attempt at this PR. #1485 got merged early & reverting b/c it contained breaking changes that should wait for v3.