### PR TITLE
add `allowlist` & `denylist` alternatives to `whitelist` & `blacklist` configs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     curly: 'error',
     eqeqeq: 'error',
     'func-style': ['error', 'declaration'],
+    'id-denylist': ['error', 'whitelist', 'blacklist'],
     'new-parens': 'error',
     'no-async-promise-executor': 'error',
     'no-console': 'error',
@@ -145,6 +146,17 @@ module.exports = {
       },
       rules: {
         'import/no-dynamic-require': 'off',
+      },
+    },
+    {
+      files: [
+        'lib/rules/no-bare-strings.js',
+        'lib/rules/simple-unless.js',
+        'test/unit/rules/no-bare-strings-test.js',
+        'test/unit/rules/simple-unless-test.js',
+      ],
+      rules: {
+        'id-denylist': 'off',
       },
     },
   ],

--- a/docs/rule/no-action-modifiers.md
+++ b/docs/rule/no-action-modifiers.md
@@ -23,7 +23,7 @@ This rule **allows** the following:
 The following values are valid configuration:
 
 * boolean -- `true` for enabled / `false` for disabled
-* array -- an array of whitelisted element tag names, which will accept action modifiers
+* array -- an allowlist of element tag names, which will accept action modifiers
 
 ## References
 

--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -22,15 +22,16 @@ This rule **allows** the following:
  The following values are valid configuration:
 
 * boolean -- `true` for enabled / `false` for disabled
-* array -- an array of whitelisted strings
+* array -- an array of allowlisted strings
 * object -- An object with the following keys:
-  * `whitelist` -- An array of whitelisted strings
+  * `allowlist` -- An array of allowlisted strings
+  * `whitelist` -- Deprecated, use `allowlist`. If both are provided, `whitelist` will be ignored.
   * `globalAttributes` -- An array of attributes to check on every element.
   * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
 
 When the config value of `true` is used the following configuration is used:
 
-* `whitelist` - refer to the `DEFAULT_CONFIG.whitelist` property in the [rule](../lib/rules/no-bare-strings.js)
+* `allowlist` - refer to the `DEFAULT_CONFIG.allowlist` property in the [rule](../lib/rules/no-bare-strings.js)
 * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
 * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
 
@@ -44,7 +45,7 @@ const additionalCharsToIgnore = ['a', 'b', 'c'];
 
 module.exports = {
   rules: {
-    'no-bare-strings': [...DEFAULT_CONFIG.whitelist, ...additionalCharsToIgnore]
+    'no-bare-strings': [...DEFAULT_CONFIG.allowlist, ...additionalCharsToIgnore]
   }
 };
 ```

--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -61,8 +61,10 @@ The following values are valid configuration:
 
 * boolean -- `true` for enabled / `false` for disabled
 * object --
-  * `whitelist` -- array - `['or']` for specific helpers / `[]` for wildcard
-  * `blacklist` -- array - `['or']` for specific helpers / `[]` for none
+  * `allowlist` -- array - `['or']` for specific helpers / `[]` for wildcard
+  * `whitelist` -- deprecated, use `allowlist`. If both are provided, `whitelist` will be ignored.
+  * `denylist` -- array - `['or']` for specific helpers / `[]` for none
+  * `blacklist` -- deprecated, use `denylist`. If both are provided, `blacklist` will be ignored.
   * `maxHelpers` -- number - use -1 for no limit
 
 ## Related Rules

--- a/lib/rules/no-action-modifiers.js
+++ b/lib/rules/no-action-modifiers.js
@@ -10,13 +10,13 @@ module.exports = class NoActionModifiers extends Rule {
     switch (typeof config) {
       case 'boolean':
         if (config) {
-          return { whitelist: [] };
+          return { allowlist: [] };
         } else {
           return false;
         }
       case 'object':
         if (Array.isArray(config)) {
-          return { whitelist: config };
+          return { allowlist: config };
         }
         break;
       case 'undefined':
@@ -40,7 +40,7 @@ module.exports = class NoActionModifiers extends Rule {
           return;
         }
 
-        if (this.config.whitelist.includes(parentNode.tag)) {
+        if (this.config.allowlist.includes(parentNode.tag)) {
           return;
         }
 

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -15,9 +15,10 @@
  The following values are valid configuration:
 
    * boolean -- `true` for enabled / `false` for disabled
-   * array -- an array of whitelisted strings
+   * array -- an array of allowlisted strings
    * object -- An object with the following keys:
-     * `whitelist` -- An array of whitelisted strings
+     * `allowlist` -- An array of allowlisted strings
+     * `whitelist` -- Deprecated, use `allowlist`. If both are provided, `whitelist` will be ignored.
      * `globalAttributes` -- An array of attributes to check on every element.
      * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
  */
@@ -38,76 +39,79 @@ const TAG_ATTRIBUTES = {
   img: ['alt'],
 };
 
+const DEFAULT_ALLOWLIST = [
+  '&lpar;', // (
+  '&rpar;', // )
+  '&comma;', // ,
+  '&period;', // .
+  '&amp;', // &
+  '&AMP;', // &
+  '&plus;', // +
+  '&minus;', // -
+  '&equals;', // =
+  '&ast;', // *
+  '&midast;', // *
+  '&sol;', // /
+  '&num;', // #
+  '&percnt;', // %
+  '&excl;', // !
+  '&quest;', // ?
+  '&colon;', // :
+  '&lsqb;', // [
+  '&lbrack;', // [
+  '&rsqb;', // ]
+  '&rbrack;', // ]
+  '&lcub;', // {
+  '&lbrace;', // {
+  '&rcub;', // }
+  '&rbrace;', // }
+  '&lt;', // <
+  '&LT;', // <
+  '&gt;', // >
+  '&GT;', // >
+  '&bull;', // •
+  '&bullet;', // •
+  '&mdash;', // —
+  '&ndash;', // –
+  '&nbsp;', // non-breaking space
+  '&Tab;',
+  '&NewLine;',
+  '&verbar;', // |
+  '&vert;', // |
+  '&VerticalLine;', // |
+  '(',
+  ')',
+  ',',
+  '.',
+  '&',
+  '+',
+  '-',
+  '=',
+  '*',
+  '/',
+  '#',
+  '%',
+  '!',
+  '?',
+  ':',
+  '[',
+  ']',
+  '{',
+  '}',
+  '<',
+  '>',
+  '•',
+  '—',
+  ' ',
+  '|',
+];
+
 const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'template', 'textarea']);
 
 // Character entity reference chart: https://dev.w3.org/html5/html-author/charref
 const DEFAULT_CONFIG = {
-  whitelist: [
-    '&lpar;', // (
-    '&rpar;', // )
-    '&comma;', // ,
-    '&period;', // .
-    '&amp;', // &
-    '&AMP;', // &
-    '&plus;', // +
-    '&minus;', // -
-    '&equals;', // =
-    '&ast;', // *
-    '&midast;', // *
-    '&sol;', // /
-    '&num;', // #
-    '&percnt;', // %
-    '&excl;', // !
-    '&quest;', // ?
-    '&colon;', // :
-    '&lsqb;', // [
-    '&lbrack;', // [
-    '&rsqb;', // ]
-    '&rbrack;', // ]
-    '&lcub;', // {
-    '&lbrace;', // {
-    '&rcub;', // }
-    '&rbrace;', // }
-    '&lt;', // <
-    '&LT;', // <
-    '&gt;', // >
-    '&GT;', // >
-    '&bull;', // •
-    '&bullet;', // •
-    '&mdash;', // —
-    '&ndash;', // –
-    '&nbsp;', // non-breaking space
-    '&Tab;',
-    '&NewLine;',
-    '&verbar;', // |
-    '&vert;', // |
-    '&VerticalLine;', // |
-    '(',
-    ')',
-    ',',
-    '.',
-    '&',
-    '+',
-    '-',
-    '=',
-    '*',
-    '/',
-    '#',
-    '%',
-    '!',
-    '?',
-    ':',
-    '[',
-    ']',
-    '{',
-    '}',
-    '<',
-    '>',
-    '•',
-    '—',
-    ' ',
-    '|',
-  ],
+  allowlist: DEFAULT_ALLOWLIST,
+  whitelist: DEFAULT_ALLOWLIST,
   globalAttributes: GLOBAL_ATTRIBUTES,
   elementAttributes: TAG_ATTRIBUTES,
 };
@@ -118,7 +122,7 @@ function isValidConfigObjectFormat(config) {
     let valueType = typeof value;
     let valueIsArray = Array.isArray(value);
 
-    if (key === 'whitelist' && !valueIsArray) {
+    if ((key === 'allowlist' || key === 'whitelist') && !valueIsArray) {
       return false;
     } else if (key === 'globalAttributes' && !valueIsArray) {
       return false;
@@ -134,8 +138,8 @@ function isValidConfigObjectFormat(config) {
   return true;
 }
 
-function sanitizeConfigArray(whitelist = []) {
-  return whitelist.filter((option) => option !== '').sort((a, b) => b.length - a.length);
+function sanitizeConfigArray(allowlist = []) {
+  return allowlist.filter((option) => option !== '').sort((a, b) => b.length - a.length);
 }
 
 module.exports = class NoBareStrings extends Rule {
@@ -157,14 +161,19 @@ module.exports = class NoBareStrings extends Rule {
       case 'object':
         if (Array.isArray(config)) {
           return {
-            whitelist: sanitizeConfigArray(config),
+            allowlist: sanitizeConfigArray(config),
             globalAttributes: GLOBAL_ATTRIBUTES,
             elementAttributes: TAG_ATTRIBUTES,
           };
         } else if (isValidConfigObjectFormat(config)) {
           // default any missing keys to empty values
+          let { allowlist = [], whitelist = [] } = config;
+          let allowlistToUse =
+            [allowlist, whitelist].find((list) => {
+              return Array.isArray(list) && list.length;
+            }) || [];
           return {
-            whitelist: sanitizeConfigArray(config.whitelist || []),
+            allowlist: sanitizeConfigArray(allowlistToUse),
             globalAttributes: config.globalAttributes || [],
             elementAttributes: config.elementAttributes || {},
           };
@@ -178,9 +187,9 @@ module.exports = class NoBareStrings extends Rule {
       this.ruleName,
       [
         '  * boolean - `true` to enable / `false` to disable',
-        '  * array -- an array of strings to whitelist',
+        '  * array -- an array of allowlisted strings',
         '  * object -- An object with the following keys:',
-        '    * `whitelist` -- An array of whitelisted strings',
+        '    * `allowlist` -- An array of allowlisted strings',
         '    * `globalAttributes` -- An array of attributes to check on every element',
         '    * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name',
       ],
@@ -240,11 +249,11 @@ module.exports = class NoBareStrings extends Rule {
   }
 
   _getBareString(_string) {
-    let whitelist = this.config.whitelist;
+    let allowlist = this.config.allowlist;
     let string = _string;
 
-    if (whitelist) {
-      for (const entry of whitelist) {
+    if (allowlist) {
+      for (const entry of allowlist) {
         while (string.includes(entry)) {
           string = string.replace(entry, '');
         }

--- a/lib/rules/simple-unless.js
+++ b/lib/rules/simple-unless.js
@@ -11,6 +11,8 @@ const messages = {
 };
 
 const DEFAULT_CONFIG = {
+  allowlist: [],
+  denylist: [],
   whitelist: [],
   blacklist: [],
   maxHelpers: 0,
@@ -23,9 +25,7 @@ function isValidConfigObjectFormat(config) {
 
     if (value === undefined) {
       config[key] = DEFAULT_CONFIG[key];
-    } else if (key === 'whitelist' && !valueIsArray) {
-      return false;
-    } else if (key === 'blacklist' && !valueIsArray) {
+    } else if (['whitelist', 'blacklist', 'allowlist', 'denylist'].includes(key) && !valueIsArray) {
       return false;
     }
   }
@@ -55,8 +55,8 @@ module.exports = class SimpleUnless extends Rule {
       [
         '  * boolean -- `true` for enabled / `false` for disabled\n' +
           '  * object --\n' +
-          "    *  `whitelist` -- array - `['or']` for specific helpers / `[]` for wildcard\n" +
-          "    *  `blacklist` -- array - `['or']` for specific helpers / `[]` for none\n" +
+          "    *  `allowlist` -- array - `['or']` for specific helpers / `[]` for wildcard\n" +
+          "    *  `denylist` -- array - `['or']` for specific helpers / `[]` for none\n" +
           '    *  `maxHelpers` -- number - use -1 for no limit',
       ],
       config
@@ -118,14 +118,21 @@ module.exports = class SimpleUnless extends Rule {
   }
 
   _withHelper(node) {
-    const whitelist = this.config.whitelist; // let { whitelist, blacklist, maxHelpers } = this.config;
-    const blacklist = this.config.blacklist;
-    const maxHelpers = this.config.maxHelpers;
-
+    let { whitelist, blacklist, allowlist: allow, denylist: deny, maxHelpers } = this.config;
     let params;
     let nextParams = node.params;
     let helperCount = 0;
     let containsSubExpression = false;
+
+    let allowlist =
+      [allow, whitelist].find((list) => {
+        return Array.isArray(list) && list.length;
+      }) || [];
+
+    let denylist =
+      [deny, blacklist].find((list) => {
+        return Array.isArray(list) && list.length;
+      }) || [];
 
     do {
       params = nextParams;
@@ -141,22 +148,22 @@ module.exports = class SimpleUnless extends Rule {
             this._logMessage(message, loc.line, loc.column, actual);
           }
 
-          if (whitelist.length > 0 && !whitelist.includes(param.path.original)) {
+          if (allowlist.length > 0 && !allowlist.includes(param.path.original)) {
             let loc = param.loc.start;
             let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
             let message = `${messages.withHelper} Allowed helper${
-              whitelist.length > 1 ? 's' : ''
-            }: ${whitelist.toString()}`;
+              allowlist.length > 1 ? 's' : ''
+            }: ${allowlist.toString()}`;
 
             this._logMessage(message, loc.line, loc.column, actual);
           }
 
-          if (blacklist.length > 0 && blacklist.includes(param.path.original)) {
+          if (denylist.length > 0 && denylist.includes(param.path.original)) {
             let loc = param.loc.start;
             let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
             let message = `${messages.withHelper} Restricted helper${
-              blacklist.length > 1 ? 's' : ''
-            }: ${blacklist.toString()}`;
+              denylist.length > 1 ? 's' : ''
+            }: ${denylist.toString()}`;
 
             this._logMessage(message, loc.line, loc.column, actual);
           }

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -7,6 +7,7 @@ describe('imports', () => {
   it('should expose the default config', () => {
     expect(rule.DEFAULT_CONFIG).toEqual(
       expect.objectContaining({
+        allowlist: expect.arrayContaining(['&lpar;']),
         whitelist: expect.arrayContaining(['&lpar;']),
         globalAttributes: expect.arrayContaining(['title']),
         elementAttributes: expect.any(Object),
@@ -107,16 +108,26 @@ generateRuleTests({
       template: '<input placeholder="hahaha">',
     },
 
-    '<foo-bar>\n</foo-bar>',
-
     {
       // combine bare string with a variable
       config: ['X'],
       template: '<input placeholder="{{foo}}X">',
     },
 
-    '{{! template-lint-disable no-bare-strings}}LOL{{! template-lint-enable no-bare-strings}}',
+    {
+      // deprecated `whitelist` config
+      config: { whitelist: ['Z'] },
+      template: '<p>Z</p>',
+    },
 
+    {
+      // `allowlist` supercedes deprecated `whitelist` config
+      config: { allowlist: ['Y'], whitelist: ['Z'] },
+      template: '<p>Y</p>',
+    },
+
+    '<foo-bar>\n</foo-bar>',
+    '{{! template-lint-disable no-bare-strings}}LOL{{! template-lint-enable no-bare-strings}}',
     `{{!-- template-lint-disable no-bare-strings --}}
 <i class="material-icons">folder_open</i>
 {{!-- template-lint-enable no-bare-strings --}}`,
@@ -271,6 +282,34 @@ generateRuleTests({
           line: 2,
           column: 9,
           source: 'trolol',
+        },
+      ],
+    },
+
+    {
+      // deprecated `whitelist` config - rule still logs normally
+      config: { whitelist: ['Z'] },
+      template: '<p>Y</p>',
+      results: [
+        {
+          message: 'Non-translated string used',
+          line: 1,
+          column: 3,
+          source: 'Y',
+        },
+      ],
+    },
+
+    {
+      // `allowlist` supercedes deprecated `whitelist` config
+      config: { allowlist: ['Y'], whitelist: ['Z'] },
+      template: '<p>Z</p>',
+      results: [
+        {
+          message: 'Non-translated string used',
+          line: 1,
+          column: 3,
+          source: 'Z',
         },
       ],
     },

--- a/test/unit/rules/simple-unless-test.js
+++ b/test/unit/rules/simple-unless-test.js
@@ -6,7 +6,7 @@ const generateRuleTests = require('../../helpers/rule-test-harness');
 generateRuleTests({
   name: 'simple-unless',
   config: {
-    whitelist: ['or', 'eq', 'not-eq'],
+    allowlist: ['or', 'eq', 'not-eq'],
     maxHelpers: 2,
   },
 
@@ -27,14 +27,14 @@ generateRuleTests({
     },
     {
       config: {
-        whitelist: ['or', 'eq', 'not-eq'],
+        allowlist: ['or', 'eq', 'not-eq'],
         maxHelpers: 2,
       },
       template: '{{unless (eq foo bar) baz}}',
     },
     {
       config: {
-        whitelist: [],
+        allowlist: [],
         maxHelpers: 2,
       },
       template: '{{unless (eq (not foo) bar) baz}}',
@@ -54,23 +54,42 @@ generateRuleTests({
     {
       config: {
         maxHelpers: -1,
-        blacklist: [],
+        denylist: [],
       },
       template: '{{unless (eq (not foo) bar) baz}}',
     },
     {
       config: {
         maxHelpers: -1,
-        blacklist: ['or'],
+        denylist: ['or'],
       },
       template: '{{unless (eq (not foo) bar) baz}}',
+    },
+
+    {
+      // deprecated `whitelist` config
+      config: {
+        maxHelpers: 1,
+        whitelist: ['or'],
+      },
+      template: '{{unless (or foo bar)}}',
+    },
+
+    {
+      // `allowlist` supercedes deprecated `whitelist` config
+      config: {
+        maxHelpers: 1,
+        allowlist: ['and'],
+        whitelist: ['or'],
+      },
+      template: '{{unless (and foo bar)}}',
     },
   ],
 
   bad: [
     {
       config: {
-        whitelist: ['or', 'eq', 'not-eq'],
+        allowlist: ['or', 'eq', 'not-eq'],
         maxHelpers: 2,
       },
       template: "{{unless (if (or true))  'Please no'}}",
@@ -284,7 +303,7 @@ generateRuleTests({
     },
     {
       config: {
-        whitelist: ['test'],
+        allowlist: ['test'],
         maxHelpers: 1,
       },
       template: [
@@ -312,7 +331,7 @@ generateRuleTests({
     },
     {
       config: {
-        whitelist: [],
+        allowlist: [],
         maxHelpers: 2,
       },
       template: [
@@ -331,7 +350,7 @@ generateRuleTests({
     },
     {
       config: {
-        blacklist: ['two'],
+        denylist: ['two'],
         maxHelpers: -1,
       },
       template: [
@@ -350,7 +369,7 @@ generateRuleTests({
     },
     {
       config: {
-        blacklist: ['two', 'four'],
+        denylist: ['two', 'four'],
         maxHelpers: -1,
       },
       template: [
@@ -373,6 +392,43 @@ generateRuleTests({
           source: '{{unless (... (four ...',
           line: 1,
           column: 27,
+        },
+      ],
+    },
+
+    {
+      // deprecated `whitelist` config
+      config: {
+        maxHelpers: 1,
+        whitelist: ['or'],
+      },
+      template: '{{unless (and foo bar)}}',
+      results: [
+        {
+          message:
+            'Using {{unless}} in combination with other helpers should be avoided. Allowed helper: or',
+          line: 1,
+          column: 9,
+          source: '{{unless (and ...',
+        },
+      ],
+    },
+
+    {
+      // `allowlist` supercedes deprecated `whitelist` config
+      config: {
+        maxHelpers: 1,
+        allowlist: ['and'],
+        whitelist: ['or'],
+      },
+      template: '{{unless (or foo bar)}}',
+      results: [
+        {
+          message:
+            'Using {{unless}} in combination with other helpers should be avoided. Allowed helper: and',
+          line: 1,
+          column: 9,
+          source: '{{unless (or ...',
         },
       ],
     },


### PR DESCRIPTION
### What
- renames `whitelist` -> `allowlist` in `no-action-modifiers` docs. this is an array config so we can rename it safely
- adds `allowlist` & `denylist` alternatives to `whitelist` & `blacklist` in rules `no-bare-strings` & `simple-unless`.
  - this introduces the new config values in a backwards compatible way
  - if both are provided, the deprecated configs' values always get clobbered by the new ones
- adds test cases for same
- adds both terms to [`eslint/id-denylist`](https://eslint.org/docs/rules/id-denylist) config
  - ignores the `no-bare-strings` & `simple-unless` rules for now

### Why
- addresses #989 in a backwards-compatible way as suggested on #1487 