### PR TITLE
remove deprecated `whitelist` & `blacklist` configurations

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = {
     curly: 'error',
     eqeqeq: 'error',
     'func-style': ['error', 'declaration'],
-    'id-denylist': ['error', 'whitelist', 'blacklist'],
+    'id-denylist': ['error', 'whitelist', 'whiteList', 'blacklist', 'blackList'],
     'new-parens': 'error',
     'no-async-promise-executor': 'error',
     'no-console': 'error',
@@ -146,17 +146,6 @@ module.exports = {
       },
       rules: {
         'import/no-dynamic-require': 'off',
-      },
-    },
-    {
-      files: [
-        'lib/rules/no-bare-strings.js',
-        'lib/rules/simple-unless.js',
-        'test/unit/rules/no-bare-strings-test.js',
-        'test/unit/rules/simple-unless-test.js',
-      ],
-      rules: {
-        'id-denylist': 'off',
       },
     },
   ],

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ and to configure rules in the template:
 ```hbs
 {{!-- template-lint-configure no-bare-strings ["ZOMG THIS IS ALLOWED!!!!"]  --}}
 
-{{!-- template-lint-configure no-bare-strings {"whitelist": "(),.", "globalAttributes": ["title"]}  --}}
+{{!-- template-lint-configure no-bare-strings {"allowlist": "(),.", "globalAttributes": ["title"]}  --}}
 
 {{!-- template-lint-configure no-bare-strings ["warn", ["ZOMG THIS IS ALLOWED!!!!"]]  --}}
 

--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -25,7 +25,6 @@ This rule **allows** the following:
 * array -- an array of allowlisted strings
 * object -- An object with the following keys:
   * `allowlist` -- An array of allowlisted strings
-  * `whitelist` -- Deprecated, use `allowlist`. If both are provided, `whitelist` will be ignored.
   * `globalAttributes` -- An array of attributes to check on every element.
   * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
 

--- a/docs/rule/no-invalid-interactive.md
+++ b/docs/rule/no-invalid-interactive.md
@@ -23,9 +23,9 @@ This rule **allows** the following:
 
 The following values are valid configuration (same as the `no-nested-interactive` rule above):
 
-* boolean -- `true` indicates all whitelist test will run, `false` indicates that the rule is disabled.
+* boolean -- `true` indicates all allowlisted tests will run, `false` indicates that the rule is disabled.
 * object - Containing the following values:
-  * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.
+  * `ignoredTags` - An array of element tag names that should be allowlisted. Default to `[]`.
   * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
   * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
   * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.

--- a/docs/rule/no-nested-interactive.md
+++ b/docs/rule/no-nested-interactive.md
@@ -26,9 +26,9 @@ This rule **allows** the following (link with button styling):
 
 The following values are valid configuration:
 
-* boolean -- `true` indicates all whitelist test will run, `false` indicates that the rule is disabled.
+* boolean -- `true` indicates all allowlisted tests will run, `false` indicates that the rule is disabled.
 * object - Containing the following values:
-  * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.
+  * `ignoredTags` - An array of element tag names that should be allowlisted. Default to `[]`.
   * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.
   * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.
   * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.

--- a/docs/rule/simple-unless.md
+++ b/docs/rule/simple-unless.md
@@ -62,9 +62,7 @@ The following values are valid configuration:
 * boolean -- `true` for enabled / `false` for disabled
 * object --
   * `allowlist` -- array - `['or']` for specific helpers / `[]` for wildcard
-  * `whitelist` -- deprecated, use `allowlist`. If both are provided, `whitelist` will be ignored.
   * `denylist` -- array - `['or']` for specific helpers / `[]` for none
-  * `blacklist` -- deprecated, use `denylist`. If both are provided, `blacklist` will be ignored.
   * `maxHelpers` -- number - use -1 for no limit
 
 ## Related Rules

--- a/lib/helpers/parse-interactive-element-config.js
+++ b/lib/helpers/parse-interactive-element-config.js
@@ -47,7 +47,7 @@ module.exports = function (ruleName, config) {
     [
       '  * boolean - `true` to enable / `false` to disable',
       '  * object - Containing the following values:',
-      '    * `ignoredTags` - An array of element tag names that should be whitelisted. Default to `[]`.',
+      '    * `ignoredTags` - An array of element tag names that should be allowlisted. Default to `[]`.',
       '    * `ignoreTabindex` - When `true` tabindex will be ignored. Defaults to `false`.',
       '    * `ignoreUsemapAttribute` - When `true` ignores the `usemap` attribute on `img` and `object` elements. Defaults `false`.',
       '    * `additionalInteractiveTags` - An array of element tag names that should also be considered as interactive. Defaults to `[]`.',

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -18,7 +18,6 @@
    * array -- an array of allowlisted strings
    * object -- An object with the following keys:
      * `allowlist` -- An array of allowlisted strings
-     * `whitelist` -- Deprecated, use `allowlist`. If both are provided, `whitelist` will be ignored.
      * `globalAttributes` -- An array of attributes to check on every element.
      * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
  */
@@ -111,7 +110,6 @@ const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'template', 'textare
 // Character entity reference chart: https://dev.w3.org/html5/html-author/charref
 const DEFAULT_CONFIG = {
   allowlist: DEFAULT_ALLOWLIST,
-  whitelist: DEFAULT_ALLOWLIST,
   globalAttributes: GLOBAL_ATTRIBUTES,
   elementAttributes: TAG_ATTRIBUTES,
 };
@@ -122,7 +120,7 @@ function isValidConfigObjectFormat(config) {
     let valueType = typeof value;
     let valueIsArray = Array.isArray(value);
 
-    if ((key === 'allowlist' || key === 'whitelist') && !valueIsArray) {
+    if (key === 'allowlist' && !valueIsArray) {
       return false;
     } else if (key === 'globalAttributes' && !valueIsArray) {
       return false;
@@ -167,13 +165,9 @@ module.exports = class NoBareStrings extends Rule {
           };
         } else if (isValidConfigObjectFormat(config)) {
           // default any missing keys to empty values
-          let { allowlist = [], whitelist = [] } = config;
-          let allowlistToUse =
-            [allowlist, whitelist].find((list) => {
-              return Array.isArray(list) && list.length;
-            }) || [];
+          let { allowlist = [] } = config;
           return {
-            allowlist: sanitizeConfigArray(allowlistToUse),
+            allowlist: sanitizeConfigArray(allowlist),
             globalAttributes: config.globalAttributes || [],
             elementAttributes: config.elementAttributes || {},
           };

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -232,7 +232,7 @@ function parseConfig(config) {
     [
       '  * boolean - `true` to enable / `false` to disable',
       '  * object -- An object with the following keys:',
-      '    * `allow` -- array: A list of whitelisted helpers to be allowed used with curly component syntax',
+      '    * `allow` -- array: A list of allowlisted helpers to be allowed used with curly component syntax',
       '    * `disallow` -- array: A list of component names to not allow use with curly component syntax',
       '    * `requireDash` -- boolean: The codemod assumes that all components have a dash in their name. `true` to enable (default) / `false` to disable',
     ],

--- a/lib/rules/no-whitespace-within-word.js
+++ b/lib/rules/no-whitespace-within-word.js
@@ -3,7 +3,7 @@ const Rule = require('./base');
 
 const ERROR_MESSAGE = 'Excess whitespace in layout detected.';
 
-const blackList = new Set([
+const denylist = new Set([
   '&#32;',
   ' ',
   '&#160;',
@@ -59,7 +59,7 @@ const blackList = new Set([
 ]);
 
 function isWhitespace(char) {
-  return blackList.has(char);
+  return denylist.has(char);
 }
 
 function splitTextByEntity(input) {
@@ -78,7 +78,7 @@ function splitTextByEntity(input) {
 
       // now we know we have an "entity like thing"
       let possibleEntity = input.slice(i, possibleEndIndex + 1);
-      if (blackList.has(possibleEntity)) {
+      if (denylist.has(possibleEntity)) {
         result.push(possibleEntity);
         i += possibleEntity.length - 1;
       } else {

--- a/lib/rules/simple-unless.js
+++ b/lib/rules/simple-unless.js
@@ -13,8 +13,6 @@ const messages = {
 const DEFAULT_CONFIG = {
   allowlist: [],
   denylist: [],
-  whitelist: [],
-  blacklist: [],
   maxHelpers: 0,
 };
 
@@ -25,7 +23,7 @@ function isValidConfigObjectFormat(config) {
 
     if (value === undefined) {
       config[key] = DEFAULT_CONFIG[key];
-    } else if (['whitelist', 'blacklist', 'allowlist', 'denylist'].includes(key) && !valueIsArray) {
+    } else if (['allowlist', 'denylist'].includes(key) && !valueIsArray) {
       return false;
     }
   }
@@ -118,21 +116,11 @@ module.exports = class SimpleUnless extends Rule {
   }
 
   _withHelper(node) {
-    let { whitelist, blacklist, allowlist: allow, denylist: deny, maxHelpers } = this.config;
+    let { allowlist = [], denylist = [], maxHelpers } = this.config;
     let params;
     let nextParams = node.params;
     let helperCount = 0;
     let containsSubExpression = false;
-
-    let allowlist =
-      [allow, whitelist].find((list) => {
-        return Array.isArray(list) && list.length;
-      }) || [];
-
-    let denylist =
-      [deny, blacklist].find((list) => {
-        return Array.isArray(list) && list.length;
-      }) || [];
 
     do {
       params = nextParams;

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -8,7 +8,6 @@ describe('imports', () => {
     expect(rule.DEFAULT_CONFIG).toEqual(
       expect.objectContaining({
         allowlist: expect.arrayContaining(['&lpar;']),
-        whitelist: expect.arrayContaining(['&lpar;']),
         globalAttributes: expect.arrayContaining(['title']),
         elementAttributes: expect.any(Object),
       })
@@ -76,7 +75,7 @@ generateRuleTests({
     '<div placeholder="wat?"></div>',
 
     {
-      // config as array is whitelist of chars
+      // config as array is allowlist of chars
       config: ['/', '"'],
       template: '{{t "foo"}} / "{{name}}"',
     },
@@ -112,18 +111,6 @@ generateRuleTests({
       // combine bare string with a variable
       config: ['X'],
       template: '<input placeholder="{{foo}}X">',
-    },
-
-    {
-      // deprecated `whitelist` config
-      config: { whitelist: ['Z'] },
-      template: '<p>Z</p>',
-    },
-
-    {
-      // `allowlist` supercedes deprecated `whitelist` config
-      config: { allowlist: ['Y'], whitelist: ['Z'] },
-      template: '<p>Y</p>',
     },
 
     '<foo-bar>\n</foo-bar>',
@@ -282,34 +269,6 @@ generateRuleTests({
           line: 2,
           column: 9,
           source: 'trolol',
-        },
-      ],
-    },
-
-    {
-      // deprecated `whitelist` config - rule still logs normally
-      config: { whitelist: ['Z'] },
-      template: '<p>Y</p>',
-      results: [
-        {
-          message: 'Non-translated string used',
-          line: 1,
-          column: 3,
-          source: 'Y',
-        },
-      ],
-    },
-
-    {
-      // `allowlist` supercedes deprecated `whitelist` config
-      config: { allowlist: ['Y'], whitelist: ['Z'] },
-      template: '<p>Z</p>',
-      results: [
-        {
-          message: 'Non-translated string used',
-          line: 1,
-          column: 3,
-          source: 'Z',
         },
       ],
     },

--- a/test/unit/rules/simple-unless-test.js
+++ b/test/unit/rules/simple-unless-test.js
@@ -65,25 +65,6 @@ generateRuleTests({
       },
       template: '{{unless (eq (not foo) bar) baz}}',
     },
-
-    {
-      // deprecated `whitelist` config
-      config: {
-        maxHelpers: 1,
-        whitelist: ['or'],
-      },
-      template: '{{unless (or foo bar)}}',
-    },
-
-    {
-      // `allowlist` supercedes deprecated `whitelist` config
-      config: {
-        maxHelpers: 1,
-        allowlist: ['and'],
-        whitelist: ['or'],
-      },
-      template: '{{unless (and foo bar)}}',
-    },
   ],
 
   bad: [
@@ -392,43 +373,6 @@ generateRuleTests({
           source: '{{unless (... (four ...',
           line: 1,
           column: 27,
-        },
-      ],
-    },
-
-    {
-      // deprecated `whitelist` config
-      config: {
-        maxHelpers: 1,
-        whitelist: ['or'],
-      },
-      template: '{{unless (and foo bar)}}',
-      results: [
-        {
-          message:
-            'Using {{unless}} in combination with other helpers should be avoided. Allowed helper: or',
-          line: 1,
-          column: 9,
-          source: '{{unless (and ...',
-        },
-      ],
-    },
-
-    {
-      // `allowlist` supercedes deprecated `whitelist` config
-      config: {
-        maxHelpers: 1,
-        allowlist: ['and'],
-        whitelist: ['or'],
-      },
-      template: '{{unless (or foo bar)}}',
-      results: [
-        {
-          message:
-            'Using {{unless}} in combination with other helpers should be avoided. Allowed helper: and',
-          line: 1,
-          column: 9,
-          source: '{{unless (or ...',
         },
       ],
     },


### PR DESCRIPTION
### What
- removes `whitelist` & `blacklist` configurations deprecated in #1489 
- removes a few instances that my initial pass w/ [`eslint/id-denylist`](https://eslint.org/docs/rules/id-denylist) did not catch.
  - term was only used descriptively in `.md` file or docstring, not as a property name
  - term was used camelcase `blackList`, where previously we only caught `blacklist`

### Why
- completes #989 