### PR TITLE
skip validation of html attributes

### DIFF
--- a/lib/rules/no-whitespace-within-word.js
+++ b/lib/rules/no-whitespace-within-word.js
@@ -105,29 +105,11 @@ function splitTextByEntity(input) {
 module.exports = class NoWhitespaceWithinWord extends Rule {
   visitor() {
     return {
-      Program: {
-        enter() {
-          this.attrNodeCount = 0;
-        },
-        exit() {
-          delete this.attrNodeCount;
-        },
-      },
-
-      AttrNode: {
-        enter() {
-          this.attrNodeCount++;
-        },
-        exit() {
-          this.attrNodeCount--;
-        },
-      },
-
-      TextNode(node) {
-        if (this.attrNodeCount > 0) {
+      TextNode(node, path) {
+        let parents = [...path.parents()];
+        if (parents.find((parent) => parent.node.type === 'AttrNode')) {
           return;
         }
-
         let alternationCount = 0;
         let source = this.sourceForNode(node);
         let characters = splitTextByEntity(source);

--- a/lib/rules/no-whitespace-within-word.js
+++ b/lib/rules/no-whitespace-within-word.js
@@ -105,7 +105,29 @@ function splitTextByEntity(input) {
 module.exports = class NoWhitespaceWithinWord extends Rule {
   visitor() {
     return {
+      Program: {
+        enter() {
+          this.attrNodeCount = 0;
+        },
+        exit() {
+          delete this.attrNodeCount;
+        },
+      },
+
+      AttrNode: {
+        enter() {
+          this.attrNodeCount++;
+        },
+        exit() {
+          this.attrNodeCount--;
+        },
+      },
+
       TextNode(node) {
+        if (this.attrNodeCount > 0) {
+          return;
+        }
+
         let alternationCount = 0;
         let source = this.sourceForNode(node);
         let characters = splitTextByEntity(source);

--- a/test/unit/rules/no-whitespace-within-word-test.js
+++ b/test/unit/rules/no-whitespace-within-word-test.js
@@ -14,6 +14,7 @@ generateRuleTests({
     'It is possible to get some examples of in-word emph a sis past this rule.',
     'However, I do not want a rule that flags annoying false positives for correctly-used single-character words.',
     '<div>Welcome</div>',
+    '<div enable-background="a b c d e f g h i j k l m">We want to ignore values of HTML attributes</div>',
   ],
 
   bad: [


### PR DESCRIPTION
The following HTML used to raise an error with the rule 'no-whitespace-within-word', even though the
whitespace is on an HTML attribute.  Now there are guardrails to skip the rule when underneath an AttrNode.

```hbs
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" id="Layer_1" x="0px" y="0px" width="22px" height="22px" viewBox="5.0 -10.0 100.0 135.0" enable-background="new 0 0 100 100" xml:space="preserve">
  <path d="M78.096,87.006c2.966,2.977,2.966,7.793,0,10.769c-2.956,2.968-7.761,2.968-10.727,0L19.68,49.999L67.369,2.224  c2.966-2.967,7.771-2.967,10.727,0c2.966,2.977,2.966,7.793,0,10.77l-36.92,37.006L78.096,87.006z"/>
</svg>
```