### PR TITLE
Update a11y config file

### DIFF
--- a/lib/config/a11y.js
+++ b/lib/config/a11y.js
@@ -4,6 +4,7 @@ module.exports = {
   rules: {
     'link-href-attributes': 'error',
     'no-abstract-roles': 'error',
+    'no-duplicate-attributes': 'error',
     'no-heading-inside-button': 'error',
     'no-invalid-interactive': 'error',
     'no-invalid-link-text': 'error',


### PR DESCRIPTION
Update a11y.js to include `no-duplicate-attributes` which aligns with WCAG Success Criteria 4.1.1- Parsing.