### PR TITLE
Fix `extends` overriding order

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -264,7 +264,7 @@ function processExtends(config, options) {
           delete configuration.loadedConfigurations;
 
           if (configuration.rules) {
-            config.rules = Object.assign({}, configuration.rules, config.rules);
+            config.rules = Object.assign({}, config.rules, configuration.rules);
           } else {
             logger.log(chalk.yellow(`Missing rules for extends: ${extendName}`));
           }

--- a/test/fixtures/with-multiple-extends/.template-lintrc.js
+++ b/test/fixtures/with-multiple-extends/.template-lintrc.js
@@ -1,9 +1,4 @@
 module.exports = {
-  plugins: [
-    './plugins/plugin1'
-  ],
-  extends: [
-    'recommended',
-    'plugin1:recommended'
-  ]
+  plugins: ['./plugins/plugin1'],
+  extends: ['plugin1:recommended', 'recommended'],
 };

--- a/test/fixtures/with-plugins-overwriting/.template-lintrc.js
+++ b/test/fixtures/with-plugins-overwriting/.template-lintrc.js
@@ -1,13 +1,7 @@
 module.exports = {
-  plugins: [
-    './plugins/plugin1',
-    './plugins/plugin2'
-  ],
-  extends: [
-    'plugin2:disable-inline-component',
-    'plugin1:enable-inline-component',
-  ],
+  plugins: ['./plugins/plugin1', './plugins/plugin2'],
+  extends: ['plugin1:enable-inline-component', 'plugin2:disable-inline-component'],
   rules: {
-    'no-bare-strings': true
-  }
+    'no-bare-strings': true,
+  },
 };


### PR DESCRIPTION
Previously the first `extends` was taking precedence over the following. This commit changes the priority, so that the later `extends` can override the rule definitions from the previous.

This should hopefully unblock us from releasing v3.0.0.

Resolves https://github.com/ember-template-lint/ember-template-lint/issues/1417

/cc @rwjblue 