### PR TITLE
Ensure `bad` test cases **always** have results.

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -180,6 +180,8 @@ module.exports = function generateRuleTests({
         let options = prepare(item, item.config);
         let actual = linter.verify(options);
 
+        assert(actual.length > 0, '`bad` test cases should always emit at least one failure');
+
         if (item.fatal) {
           assert.strictEqual(actual.length, 1); // can't have more than one fatal error
           delete actual[0].source; // remove the source (stack trace is not easy to assert)


### PR DESCRIPTION
Prior to this it was possible to leverage the test harness (either by ourselves, or externally) and make passing tests when no issues were logged by a `bad` test case.

For example:

```js
const generateRuleTests = require('../utils/generate-rule-tests');

generateRuleTests({
  name: 'whatever',

  bad: [
    {
      template: `some template here`,
      verifyResults(results) {
        expect(results).toMatchInlineSnapshot(`Array []`);
      },
    }
  ]
```