### PR TITLE
`no-whitespace-within-word` rule should ignore <style> elements

### DIFF
--- a/lib/rules/no-whitespace-within-word.js
+++ b/lib/rules/no-whitespace-within-word.js
@@ -3,7 +3,7 @@ const Rule = require('./base');
 
 const ERROR_MESSAGE = 'Excess whitespace in layout detected.';
 
-const blackList = new Set([
+const whitespaceCharacterList = new Set([
   '&#32;',
   ' ',
   '&#160;',
@@ -59,7 +59,7 @@ const blackList = new Set([
 ]);
 
 function isWhitespace(char) {
-  return blackList.has(char);
+  return whitespaceCharacterList.has(char);
 }
 
 function splitTextByEntity(input) {
@@ -78,7 +78,7 @@ function splitTextByEntity(input) {
 
       // now we know we have an "entity like thing"
       let possibleEntity = input.slice(i, possibleEndIndex + 1);
-      if (blackList.has(possibleEntity)) {
+      if (whitespaceCharacterList.has(possibleEntity)) {
         result.push(possibleEntity);
         i += possibleEntity.length - 1;
       } else {

--- a/lib/rules/no-whitespace-within-word.js
+++ b/lib/rules/no-whitespace-within-word.js
@@ -107,7 +107,12 @@ module.exports = class NoWhitespaceWithinWord extends Rule {
     return {
       TextNode(node, path) {
         let parents = [...path.parents()];
-        if (parents.find((parent) => parent.node.type === 'AttrNode')) {
+        if (
+          parents.find((parent) => parent.node.type === 'AttrNode') ||
+          parents.find(
+            (parent) => parent.node.type === 'ElementNode' && parent.node.tag === 'style'
+          )
+        ) {
           return;
         }
         let alternationCount = 0;

--- a/test/unit/rules/no-whitespace-within-word-test.js
+++ b/test/unit/rules/no-whitespace-within-word-test.js
@@ -15,6 +15,11 @@ generateRuleTests({
     'However, I do not want a rule that flags annoying false positives for correctly-used single-character words.',
     '<div>Welcome</div>',
     '<div enable-background="a b c d e f g h i j k l m">We want to ignore values of HTML attributes</div>',
+    `<style>
+  .my-custom-class > * {
+    border: 2px dotted red;
+  }
+</style>`,
   ],
 
   bad: [


### PR DESCRIPTION
It is not a major use case, but we have an admin-only component with some generated `<style>` tags, which are flagged by `no-whitespace-within-word`.
This PR adds a (formerly breaking) test for this case and fixes it, by simply ignoring `<style>` elements for this rule.

Example for what was formerly incorrectly flagged:

```html
<style>
  .my-custom-class > * {
    border: 2px dotted red;
  }
</style>
```

While I was working on this rule, I also renamed the internal variable `blackList` to the IMHO more meaningful `whitespaceCharacterList`.