### PR TITLE
Add `as-indentation` option to `attribute-indentation` rule

### DIFF
--- a/docs/rule/attribute-indentation.md
+++ b/docs/rule/attribute-indentation.md
@@ -100,6 +100,20 @@ as |employee|
 {{/employee-details}}
 ```
 
+Block form (as-indentation attribute)
+
+```hbs
+{{#employee-details
+  firstName=firstName
+  lastName=lastName
+  age=age
+  avatarUrl=avatarUrl
+  as |employee|
+}}
+  {{employee.fullName}}
+{{/employee-details}}
+```
+
 Block form (open invocation < 80 characters)
 
 ```hbs
@@ -129,6 +143,7 @@ Block form (HTML)
 * object - { 'process-elements': `true` } - Also validate the indentation of HTML/SVG elements.
 * object - { 'element-open-end': `new-line`|`last-attribute` } - Enforce the position of the closing brace `>` to be on a new line or next to the last attribute (defaults to `new-line`).
 * object - { 'mustache-open-end': `new-line`|`last-attribute` } - Enforce the position of the closing braces `}}` to be on a new line or next to the last attribute (defaults to `new-line`).
+* object - { 'as-indentation': `attribute`|`closing-brace` } - Enforce the position of the `as |param|` to be indented at the same level as closing brace or attribute (defaults to `closing-brace`).
 
 ## Related Rules
 

--- a/lib/rules/attribute-indentation.js
+++ b/lib/rules/attribute-indentation.js
@@ -148,9 +148,10 @@ module.exports = class AttributeIndentation extends Rule {
         paramOrHashPairEndLoc = node.hash.loc.end;
       }
 
+      const indentation = this.config.asIndentation === 'attribute' ? 2 : 0;
       expected = {
         line: paramOrHashPairEndLoc.line + 1,
-        column: node.loc.start.column,
+        column: node.loc.start.column + indentation,
       };
       if (paramOrHashPairEndLoc.line === programStartLoc.line) {
         /*
@@ -476,6 +477,7 @@ module.exports = class AttributeIndentation extends Rule {
   parseConfig(config) {
     let configType = typeof config;
     const OPEN_END_CONFIG_VALUES = new Set(['new-line', 'last-attribute']);
+    const AS_INDENTATION_VALUES = new Set(['attribute', 'closing-brace']);
 
     switch (configType) {
       case 'boolean':
@@ -518,6 +520,12 @@ module.exports = class AttributeIndentation extends Rule {
           // if element-open-end is set, assume process-elements=true
           result.processElements = true;
           result.elementOpenEnd = config['element-open-end'];
+        }
+        if ('as-indentation' in config) {
+          if (!AS_INDENTATION_VALUES.has(config['as-indentation'])) {
+            break;
+          }
+          result.asIndentation = config['as-indentation'];
         }
         return result;
       }

--- a/test/unit/rules/attribute-indentation-test.js
+++ b/test/unit/rules/attribute-indentation-test.js
@@ -12,6 +12,32 @@ generateRuleTests({
       config: {
         'mustache-open-end': 'new-line',
         'element-open-end': 'new-line',
+        'as-indentation': 'attribute',
+      },
+      template: `
+      {{#foo
+        attribute=this.mine
+        as |let|
+      }}
+      {{/foo}}`,
+    },
+    {
+      config: {
+        'mustache-open-end': 'new-line',
+        'element-open-end': 'new-line',
+        'as-indentation': 'closing-brace',
+      },
+      template: `
+      {{#foo
+        attribute=this.mine
+      as |let|
+      }}
+      {{/foo}}`,
+    },
+    {
+      config: {
+        'mustache-open-end': 'new-line',
+        'element-open-end': 'new-line',
       },
       template:
         '<div' +


### PR DESCRIPTION
Should fix this issue: https://github.com/ember-template-lint/ember-template-lint/issues/554