### PR TITLE
Add missing `keygen` element to `no-obsolete-elements` rule elements list

### DIFF
--- a/lib/rules/no-obsolete-elements.js
+++ b/lib/rules/no-obsolete-elements.js
@@ -20,6 +20,7 @@ const OBSOLETE_ELEMENTS = [
   'frame',
   'frameset',
   'isindex',
+  'keygen',
   'listing',
   'marquee',
   'menuitem',

--- a/test/unit/rules/no-obsolete-elements-test.js
+++ b/test/unit/rules/no-obsolete-elements-test.js
@@ -19,11 +19,13 @@ generateRuleTests({
   ],
 
   bad: OBSOLETE_ELEMENTS.map((element) => {
+    const VOID_ELEMENTS = ['keygen'];
+    const html = VOID_ELEMENTS.includes(element) ? `<${element}>` : `<${element}></${element}>`;
     return {
-      template: `<${element}></${element}>`,
+      template: html,
       result: {
         message: ERROR_MESSAGE_OBSOLETE_ELEMENT(element),
-        source: `<${element}></${element}>`,
+        source: html,
         line: 1,
         column: 0,
       },


### PR DESCRIPTION
This is a bug since this element was listed in the rule documentation but not actually included in the rule implementation.

This element can be found in the spec: https://html.spec.whatwg.org/multipage/obsolete.html#non-conforming-features