### PR TITLE
Enable `catchNonexistentRoles` by default on `no-invalid-role` rule

### DIFF
--- a/docs/rule/no-invalid-role.md
+++ b/docs/rule/no-invalid-role.md
@@ -50,8 +50,7 @@ This rule **allows** the following:
 
 * boolean - `true` to enable / `false` to disable
 
-* object - { 'catchNonexistentRoles' : `true|false` } -- Whether invalid role values should be allowed (defaults to `false`)
-(TODO: change default to true in next major release)
+* object - { 'catchNonexistentRoles' : `true|false` } -- Whether invalid role values should be allowed (defaults to `true`)
 
 ## Migration
 

--- a/lib/rules/no-invalid-role.js
+++ b/lib/rules/no-invalid-role.js
@@ -172,7 +172,7 @@ const VALID_ROLES = new Set([
   'treeitem',
 ]);
 
-const DEFAULT_CONFIG = { catchNonexistentRoles: false };
+const DEFAULT_CONFIG = { catchNonexistentRoles: true };
 
 module.exports = class NoInvalidRole extends Rule {
   parseConfig(config) {
@@ -192,7 +192,7 @@ module.exports = class NoInvalidRole extends Rule {
       [
         '  * boolean - `true` to enable / `false` to disable',
         '  * object -- An object with the following keys:',
-        '    * `catchNonexistentRoles` -- Whether invalid role values should be allowed (defaults to `false`)',
+        '    * `catchNonexistentRoles` -- Whether invalid role values should be allowed (defaults to `true`)',
       ],
       config
     );

--- a/test/unit/rules/no-invalid-role-test.js
+++ b/test/unit/rules/no-invalid-role-test.js
@@ -83,6 +83,15 @@ generateRuleTests({
 
     {
       template: '<div role="command interface"></div>',
+      result: {
+        message: createNonexistentRoleErrorMessage('div'),
+        source: '<div role="command interface"></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div role="command interface"></div>',
       config: {
         catchNonexistentRoles: true,
       },
@@ -95,9 +104,6 @@ generateRuleTests({
     },
     {
       template: '<div role="COMMAND INTERFACE"></div>',
-      config: {
-        catchNonexistentRoles: true,
-      },
       result: {
         message: createNonexistentRoleErrorMessage('div'),
         source: '<div role="COMMAND INTERFACE"></div>',


### PR DESCRIPTION
Part of V3 release in #1315.