### PR TITLE
`require-input-label` rule should ignore hidden inputs

### DIFF
--- a/docs/rule/require-input-label.md
+++ b/docs/rule/require-input-label.md
@@ -42,6 +42,10 @@ This rule **allows** the following:
 <input ...attributes />
 ```
 
+```hbs
+<input type="hidden" />
+```
+
 ## Migration
 
 * the recommended fix is to add an associated label element.

--- a/lib/rules/require-input-label.js
+++ b/lib/rules/require-input-label.js
@@ -38,6 +38,11 @@ module.exports = class RequireInputLabel extends Rule {
           labelCount++;
         }
 
+        const typeAttribute = AstNodeInfo.findAttribute(node, 'type');
+        if (typeAttribute && typeAttribute.value.chars === 'hidden') {
+          return;
+        }
+
         // An input can be validated by either:
         // Self-validation (descriptive attributes)
         let validAttributesList = ['id', 'aria-label', 'aria-labelledby'];
@@ -62,6 +67,11 @@ module.exports = class RequireInputLabel extends Rule {
         }
 
         if (hasValidLabelParent(path)) {
+          return;
+        }
+
+        const typeAttribute = node.hash.pairs.find((pair) => pair.key === 'type');
+        if (typeAttribute && typeAttribute.value.value === 'hidden') {
           return;
         }
 

--- a/test/unit/rules/require-input-label-test.js
+++ b/test/unit/rules/require-input-label-test.js
@@ -28,6 +28,11 @@ generateRuleTests({
     '<label>Text here<Input /></label>',
     '<label>Text here {{input}}</label>',
     '<input id="label-input" ...attributes>',
+
+    // Hidden inputs are allowed.
+    '<input type="hidden"/>',
+    '<Input type="hidden" />',
+    '{{input type="hidden"}}',
   ],
 
   bad: [
@@ -110,6 +115,60 @@ generateRuleTests({
         line: 1,
         column: 18,
         source: '<input aria-label="Custom label">',
+      },
+    },
+    {
+      template: '{{input type="button"}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 0,
+        source: '{{input type="button"}}',
+      },
+    },
+    {
+      template: '{{input type=myType}}',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 0,
+        source: '{{input type=myType}}',
+      },
+    },
+    {
+      template: '<input type="button"/>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 0,
+        source: '<input type="button"/>',
+      },
+    },
+    {
+      template: '<input type={{myType}}/>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 0,
+        source: '<input type={{myType}}/>',
+      },
+    },
+    {
+      template: '<Input type="button"/>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 0,
+        source: '<Input type="button"/>',
+      },
+    },
+    {
+      template: '<Input type={{myType}}/>',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 0,
+        source: '<Input type={{myType}}/>',
       },
     },
   ],


### PR DESCRIPTION
Presumably, hidden inputs don't need labels for accessibility.

Fixes #1538.