### PR TITLE
Allow nested landmarks of different types in `no-nested-landmark` rule

### DIFF
--- a/docs/rule/no-nested-landmark.md
+++ b/docs/rule/no-nested-landmark.md
@@ -76,6 +76,13 @@ This rule **allows** the following:
 </div>
 ```
 
+```hbs
+<footer>
+  <nav>
+  </nav>
+</footer>
+```
+
 ## References
 
 - [HTML Sectioning Elements](https://www.w3.org/TR/wai-aria-practices-1.1/#html-sectioning-elements)

--- a/docs/rule/no-nested-landmark.md
+++ b/docs/rule/no-nested-landmark.md
@@ -58,6 +58,13 @@ This rule **forbids** the following:
 </main>
 ```
 
+```hbs
+<header>
+  {{! the "header" tag is equivalent to the "banner" role }}
+  <div role="banner"></div>
+</header>
+```
+
 This rule **allows** the following:
 
 ```hbs

--- a/docs/rule/no-nested-landmark.md
+++ b/docs/rule/no-nested-landmark.md
@@ -84,10 +84,10 @@ This rule **allows** the following:
 ```
 
 ```hbs
-<footer>
+<header>
   <nav>
   </nav>
-</footer>
+</header>
 ```
 
 ## References

--- a/lib/rules/no-nested-landmark.js
+++ b/lib/rules/no-nested-landmark.js
@@ -21,6 +21,15 @@ const ROLES = new Set([
   'contentinfo',
 ]);
 
+const EQUIVALENT_ROLE = {
+  aside: 'complementary',
+  footer: 'contentinfo',
+  header: 'banner',
+  main: 'main',
+  nav: 'navigation',
+  section: 'region',
+};
+
 module.exports = class NoNestedLandmark extends Rule {
   visitor() {
     return {
@@ -46,7 +55,8 @@ module.exports = class NoNestedLandmark extends Rule {
 
   getLandmarkType(node) {
     const roleValue = AstNodeInfo.elementAttributeValue(node, 'role');
-    return roleValue || node.tag;
+    const equivalentRole = EQUIVALENT_ROLE[node.tag];
+    return roleValue || equivalentRole || node.tag;
   }
 
   isLandmarkElement(node) {

--- a/lib/rules/no-nested-landmark.js
+++ b/lib/rules/no-nested-landmark.js
@@ -27,7 +27,10 @@ module.exports = class NoNestedLandmark extends Rule {
       ElementNode(node, path) {
         if (this.isLandmarkElement(node)) {
           for (let parent of path.parents()) {
-            if (this.isLandmarkElement(parent.node)) {
+            if (
+              this.isLandmarkElement(parent.node) &&
+              this.getLandmarkType(parent.node) === this.getLandmarkType(node)
+            ) {
               this.log({
                 message: createErrorMessage(node.tag),
                 line: node.loc && node.loc.start.line,
@@ -39,6 +42,11 @@ module.exports = class NoNestedLandmark extends Rule {
         }
       },
     };
+  }
+
+  getLandmarkType(node) {
+    const roleValue = AstNodeInfo.elementAttributeValue(node, 'role');
+    return roleValue || node.tag;
   }
 
   isLandmarkElement(node) {

--- a/test/unit/rules/no-nested-landmark-test.js
+++ b/test/unit/rules/no-nested-landmark-test.js
@@ -14,9 +14,9 @@ generateRuleTests({
     '<div><main></main></div>',
     '<div role="application"><div role="document"><div role="application"></div></div></div>',
     '<footer><nav></nav></footer>', // nested landmarks of different types are okay
-    '<div role="footer"><nav></nav></div>',
+    '<div role="contentinfo"><nav></nav></div>',
     '<footer><div role="navigation"></div></footer>',
-    '<div role="footer"><div role="navigation"></div></div>',
+    '<div role="contentinfo"><div role="navigation"></div></div>',
   ],
 
   bad: [

--- a/test/unit/rules/no-nested-landmark-test.js
+++ b/test/unit/rules/no-nested-landmark-test.js
@@ -13,10 +13,10 @@ generateRuleTests({
   good: [
     '<div><main></main></div>',
     '<div role="application"><div role="document"><div role="application"></div></div></div>',
-    '<footer><nav></nav></footer>', // nested landmarks of different types are okay
-    '<div role="contentinfo"><nav></nav></div>',
-    '<footer><div role="navigation"></div></footer>',
-    '<div role="contentinfo"><div role="navigation"></div></div>',
+    '<header><nav></nav></header>', // nested landmarks of different types are okay
+    '<div role="banner"><nav></nav></div>',
+    '<header><div role="navigation"></div></header>',
+    '<div role="banner"><div role="navigation"></div></div>',
   ],
 
   bad: [

--- a/test/unit/rules/no-nested-landmark-test.js
+++ b/test/unit/rules/no-nested-landmark-test.js
@@ -15,8 +15,8 @@ generateRuleTests({
     '<div role="application"><div role="document"><div role="application"></div></div></div>',
     '<footer><nav></nav></footer>', // nested landmarks of different types are okay
     '<div role="footer"><nav></nav></div>',
-    '<footer><div role="nav"></div></footer>',
-    '<div role="footer"><div role="nav"></div></div>',
+    '<footer><div role="navigation"></div></footer>',
+    '<div role="footer"><div role="navigation"></div></div>',
   ],
 
   bad: [
@@ -92,6 +92,24 @@ generateRuleTests({
         line: 1,
         column: 8,
         source: '<header></header>',
+      },
+    },
+    {
+      template: '<header><div role="banner"></div></header>',
+      result: {
+        message: createErrorMessage('div'),
+        line: 1,
+        column: 8,
+        source: '<div role="banner"></div>',
+      },
+    },
+    {
+      template: '<div role="contentinfo"><footer></footer></div>',
+      result: {
+        message: createErrorMessage('footer'),
+        line: 1,
+        column: 24,
+        source: '<footer></footer>',
       },
     },
   ],

--- a/test/unit/rules/no-nested-landmark-test.js
+++ b/test/unit/rules/no-nested-landmark-test.js
@@ -13,6 +13,10 @@ generateRuleTests({
   good: [
     '<div><main></main></div>',
     '<div role="application"><div role="document"><div role="application"></div></div></div>',
+    '<footer><nav></nav></footer>', // nested landmarks of different types are okay
+    '<div role="footer"><nav></nav></div>',
+    '<footer><div role="nav"></div></footer>',
+    '<div role="footer"><div role="nav"></div></div>',
   ],
 
   bad: [


### PR DESCRIPTION
The rule `no-nested-landmark` raised a false error in our template when a `<nav>` tag was nested inside of a `<footer>`.  When I looked through the code I realized that the rule checks for ANY landmark inside of any other landmark.  This bugfix makes sure that it checks for landmarks of the same type.  I added a helper method `getLandmarkType` that will return either the role of the element, or the tag name if the role is missing.

Fixes #1542.