### PR TITLE
Ignore comments in `no-invalid-block-param-definition` rule

### DIFF
--- a/lib/rules/no-invalid-block-param-definition.js
+++ b/lib/rules/no-invalid-block-param-definition.js
@@ -33,9 +33,13 @@ module.exports = class NoInvalidBlockParamDefinition extends Rule {
       });
     const modifiers = node.modifiers.map((el) => this.sourceForNode(el));
     const children = node.children.map((el) => this.sourceForNode(el));
-    const pureNodeSource = [...attributes, ...modifiers, ...children].reduce((result, src) => {
-      return result.replace(src, '');
-    }, source);
+    const comments = node.comments.map((el) => this.sourceForNode(el));
+    const pureNodeSource = [...attributes, ...modifiers, ...children, ...comments].reduce(
+      (result, src) => {
+        return result.replace(src, '');
+      },
+      source
+    );
 
     const blockStartIndex = pureNodeSource.indexOf('|');
     const blockEndIndex = pureNodeSource.slice(blockStartIndex + 1).indexOf('|');

--- a/test/unit/rules/no-invalid-block-param-definition-test.js
+++ b/test/unit/rules/no-invalid-block-param-definition-test.js
@@ -43,6 +43,10 @@ as
   </MyComponent>
 </MyComponent>
 `,
+
+    // Ensure comments are ignored:
+    '<div {{! This is needed to serve as a container }}></div>',
+    '<MyComponent {{! This is needed to serve as a container }}></MyComponent>',
   ],
 
   bad: [


### PR DESCRIPTION
Fixes #1539.