### PR TITLE
Convert verify/verifyAndFix to async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ let linter = new TemplateLinter();
 let template = fs.readFileSync('some/path/to/template.hbs', {
   encoding: 'utf8',
 });
-let results = linter.verify({ source: template, moduleId: 'template.hbs' });
+let results = await linter.verify({ source: template, moduleId: 'template.hbs' });
 ```
 
 `results` will be an array of objects which have the following properties:

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -36,9 +36,9 @@ async function buildLinterOptions(filePath, filename = '', isReadingStdin) {
   }
 }
 
-function lintSource(linter, options, shouldFix) {
+async function lintSource(linter, options, shouldFix) {
   if (shouldFix) {
-    let { isFixed, output, messages } = linter.verifyAndFix(options);
+    let { isFixed, output, messages } = await linter.verifyAndFix(options);
     if (isFixed) {
       fs.writeFileSync(options.filePath, output);
     }
@@ -237,7 +237,7 @@ async function run() {
       filePaths.has(STDIN)
     );
 
-    let messages = lintSource(linter, linterOptions, options.fix);
+    let messages = await lintSource(linter, linterOptions, options.fix);
 
     resultsAccumulator.push(...messages);
   }

--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -176,9 +176,9 @@ module.exports = function generateRuleTests({
       let testOrOnly = shouldFocus ? focusMethod : testMethod;
       let testName = item.name ? item.name : template;
 
-      testOrOnly(`${testName}: logs errors`, function () {
+      testOrOnly(`${testName}: logs errors`, async function () {
         let options = prepare(item, item.config);
-        let actual = linter.verify(options);
+        let actual = await linter.verify(options);
 
         assert(actual.length > 0, '`bad` test cases should always emit at least one failure');
 
@@ -197,19 +197,19 @@ module.exports = function generateRuleTests({
       });
 
       if (!skipDisabledTests) {
-        testOrOnly(`${testName}: passes when rule is disabled`, function () {
+        testOrOnly(`${testName}: passes when rule is disabled`, async function () {
           let config = false;
           let options = prepare(item, config);
-          let actual = linter.verify(options);
+          let actual = await linter.verify(options);
 
           assert.deepStrictEqual(actual, []);
         });
 
         testOrOnly(
           `${testName}: passes when disabled via inline comment - single rule`,
-          function () {
+          async function () {
             let options = prepare(`${DISABLE_ONE}\n${template}`);
-            let actual = linter.verify(options);
+            let actual = await linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
           }
@@ -217,33 +217,36 @@ module.exports = function generateRuleTests({
 
         testOrOnly(
           `${testName}: passes when disabled via long-form inline comment - single rule`,
-          function () {
+          async function () {
             let options = prepare(`${DISABLE_ONE_LONG}\n${template}`);
-            let actual = linter.verify(options);
+            let actual = await linter.verify(options);
 
             assert.deepStrictEqual(actual, []);
           }
         );
 
-        testOrOnly(`${testName}: passes when disabled via inline comment - all rules`, function () {
-          let options = prepare(`${DISABLE_ALL}\n${template}`);
-          let actual = linter.verify(options);
+        testOrOnly(
+          `${testName}: passes when disabled via inline comment - all rules`,
+          async function () {
+            let options = prepare(`${DISABLE_ALL}\n${template}`);
+            let actual = await linter.verify(options);
 
-          assert.deepStrictEqual(actual, []);
-        });
+            assert.deepStrictEqual(actual, []);
+          }
+        );
       }
 
       if (item.fixedTemplate) {
-        testOrOnly(`\`${item.template}\` -> ${item.fixedTemplate}\``, function () {
+        testOrOnly(`\`${item.template}\` -> ${item.fixedTemplate}\``, async function () {
           let options = prepare(item.template, item.config);
-          let result = linter.verifyAndFix(options);
+          let result = await linter.verifyAndFix(options);
 
           assert.deepStrictEqual(result.output, item.fixedTemplate);
         });
 
-        testOrOnly(`${item.fixedTemplate}\` is idempotent`, function () {
+        testOrOnly(`${item.fixedTemplate}\` is idempotent`, async function () {
           let options = prepare(item.fixedTemplate, item.config);
-          let result = linter.verifyAndFix(options);
+          let result = await linter.verifyAndFix(options);
 
           assert.deepStrictEqual(result.output, item.fixedTemplate);
         });
@@ -256,9 +259,9 @@ module.exports = function generateRuleTests({
       let testOrOnly = shouldFocus ? focusMethod : testMethod;
       let testName = item.name ? item.name : item.template;
 
-      testOrOnly(`${testName}: passes`, function () {
+      testOrOnly(`${testName}: passes`, async function () {
         let options = prepare(item, item.config);
-        let actual = linter.verify(options);
+        let actual = await linter.verify(options);
 
         assert.deepStrictEqual(actual, []);
       });
@@ -272,12 +275,12 @@ module.exports = function generateRuleTests({
       let friendlyConfig = JSON.stringify(config);
       let testName = name ? name : template;
 
-      testOrOnly(`${testName}: errors with config \`${friendlyConfig}\``, function () {
+      testOrOnly(`${testName}: errors with config \`${friendlyConfig}\``, async function () {
         let expectedResults = item.results || [item.result];
         expectedResults = expectedResults.map(parseResult);
 
         let options = prepare(item, item.config);
-        let actual = linter.verify(options);
+        let actual = await linter.verify(options);
 
         for (const [i, element] of actual.entries()) {
           if (element.fatal) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -181,7 +181,7 @@ class Linter {
    * source has been fixed.
    * @returns {string} result.output - The fixed source.
    */
-  verifyAndFix(options) {
+  async verifyAndFix(options) {
     const originalSource = options.source;
 
     let hasBOM = originalSource.charCodeAt(0) === 0xfeff;
@@ -196,7 +196,7 @@ class Linter {
       iterations++;
 
       options = Object.assign({}, options, { source: currentSource });
-      messages = this.verify(options);
+      messages = await this.verify(options);
       shouldVerify = false;
 
       if (iterations < MAX_AUTOFIX_PASSES) {
@@ -265,7 +265,9 @@ class Linter {
    * @param {string} options.configResolver
    * @returns {Object[]} results - The lint results.
    */
-  verify(options) {
+  // temporary eslint-disable while we're implementing the new pending feature (which requires async/await)
+  // eslint-disable-next-line require-await
+  async verify(options) {
     let results = [];
     let fileConfig = this._moduleStatusCache.getConfigForFile(options);
     let pendingStatus = fileConfig.pendingStatus;

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -285,7 +285,7 @@ describe('public api', function () {
       await project.dispose();
     });
 
-    it('returns whether the source has been fixed + an array of remaining issues with the provided template', function () {
+    it('returns whether the source has been fixed + an array of remaining issues with the provided template', async function () {
       let templatePath = project.path('app/templates/application.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
       let expected = [
@@ -301,7 +301,7 @@ describe('public api', function () {
         },
       ];
 
-      let result = linter.verifyAndFix({
+      let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),
@@ -312,7 +312,7 @@ describe('public api', function () {
       expect(result.isFixed).toEqual(false);
     });
 
-    it('ensures template parsing errors are only reported once (not once per-rule)', function () {
+    it('ensures template parsing errors are only reported once (not once per-rule)', async function () {
       let templateContents = '{{#ach this.foo as |bar|}}{{/each}}';
       project.write({
         app: {
@@ -324,7 +324,7 @@ describe('public api', function () {
 
       let templatePath = project.path('app/templates/other.hbs');
 
-      let result = linter.verifyAndFix({
+      let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),
@@ -335,7 +335,7 @@ describe('public api', function () {
       expect(result.messages[0].fatal).toEqual(true);
     });
 
-    it('includes updated output when fixable', function () {
+    it('includes updated output when fixable', async function () {
       let templateContents = '<button>LOL, Click me!</button>';
 
       project.write({
@@ -348,7 +348,7 @@ describe('public api', function () {
 
       let templatePath = project.path('app/templates/other.hbs');
 
-      let result = linter.verifyAndFix({
+      let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),
@@ -359,7 +359,7 @@ describe('public api', function () {
       expect(result.isFixed).toEqual(true);
     });
 
-    it('updated output includes byte order mark if input source includes it', function () {
+    it('updated output includes byte order mark if input source includes it', async function () {
       let templateContents = '\uFEFF<button>LOL, Click me!</button>';
 
       project.write({
@@ -372,7 +372,7 @@ describe('public api', function () {
 
       let templatePath = project.path('app/templates/other.hbs');
 
-      let result = linter.verifyAndFix({
+      let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),
@@ -422,7 +422,7 @@ describe('public api', function () {
       await project.dispose();
     });
 
-    it('returns an array of issues with the provided template', function () {
+    it('returns an array of issues with the provided template', async function () {
       let templatePath = project.path('app/templates/application.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
       let expected = [
@@ -448,7 +448,7 @@ describe('public api', function () {
         },
       ];
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),
@@ -457,16 +457,16 @@ describe('public api', function () {
       expect(result).toEqual(expected);
     });
 
-    it('returns a "fatal" result object if an error occurs during parsing', function () {
+    it('returns a "fatal" result object if an error occurs during parsing', async function () {
       let template = '<div>';
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
       });
 
       expect(result[0].fatal).toBe(true);
     });
 
-    it('triggers warnings when severity is set to warn', function () {
+    it('triggers warnings when severity is set to warn', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -476,7 +476,7 @@ describe('public api', function () {
 
       let template = ['<div>', '<p></p>', '</div>'].join('\n');
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -497,7 +497,7 @@ describe('public api', function () {
       expect(result).toEqual([expected]);
     });
 
-    it('allows custom severity level for rules along with custom config', function () {
+    it('allows custom severity level for rules along with custom config', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -507,7 +507,7 @@ describe('public api', function () {
 
       let template = ['<div>', '{{fooData}}{{barData}}', '</div>'].join('\n');
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -528,7 +528,7 @@ describe('public api', function () {
       expect(result).toEqual([expected]);
     });
 
-    it('defaults all messages to warning severity level when module listed in pending', function () {
+    it('defaults all messages to warning severity level when module listed in pending', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -538,7 +538,7 @@ describe('public api', function () {
       });
 
       let template = '<div>bare string</div>';
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -558,7 +558,7 @@ describe('public api', function () {
       expect(result).toEqual([expected]);
     });
 
-    it('does not exclude errors when other rules are marked as pending', function () {
+    it('does not exclude errors when other rules are marked as pending', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -568,7 +568,7 @@ describe('public api', function () {
       });
 
       let template = '<div>bare string</div>';
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -598,11 +598,11 @@ describe('public api', function () {
       expect(result).toEqual(expected);
     });
 
-    it('Works with overrides - base case', function () {
+    it('Works with overrides - base case', async function () {
       let templatePath = project.path('app/templates/components/foo.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         moduleId: templatePath.slice(0, -4),
         filePath: templatePath,
@@ -625,7 +625,7 @@ describe('public api', function () {
       expect(result).toEqual(expected);
     });
 
-    it('Works with overrides with custom warning severity', function () {
+    it('Works with overrides with custom warning severity', async function () {
       let templatePath = project.path('app/templates/components/foo.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
 
@@ -643,7 +643,7 @@ describe('public api', function () {
         },
       });
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         moduleId: templatePath.slice(0, -4),
         filePath: templatePath,
@@ -666,7 +666,7 @@ describe('public api', function () {
       expect(result).toEqual(expected);
     });
 
-    it('Works for older syntax without custom severity', function () {
+    it('Works for older syntax without custom severity', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -679,7 +679,7 @@ describe('public api', function () {
       });
 
       let template = '<div>bare string {{foo}} {{baz}}</div>';
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -722,7 +722,7 @@ describe('public api', function () {
       expect(result).toEqual(expected);
     });
 
-    it('Works with overrides with custom warning severity object', function () {
+    it('Works with overrides with custom warning severity object', async function () {
       let templatePath = project.path('app/templates/components/foo.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
 
@@ -740,7 +740,7 @@ describe('public api', function () {
         },
       });
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         moduleId: templatePath.slice(0, -4),
         filePath: templatePath,
@@ -763,7 +763,7 @@ describe('public api', function () {
       expect(result).toEqual(expected);
     });
 
-    it('Should not trigger the lint error over custom overrides', function () {
+    it('Should not trigger the lint error over custom overrides', async function () {
       let templatePath = project.path('app/templates/components/foo.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
 
@@ -784,7 +784,7 @@ describe('public api', function () {
         },
       });
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         moduleId: templatePath.slice(0, -4),
         filePath: templatePath,
@@ -793,7 +793,7 @@ describe('public api', function () {
       expect(result).toEqual([]);
     });
 
-    it('triggers warnings when specific rule is marked as pending', function () {
+    it('triggers warnings when specific rule is marked as pending', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -804,7 +804,7 @@ describe('public api', function () {
 
       let template = ['<div>', '<p></p>', '</div>'].join('\n');
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -825,7 +825,7 @@ describe('public api', function () {
       expect(result).toEqual([expected]);
     });
 
-    it('module listed via moduleId in pending passes an error results', function () {
+    it('module listed via moduleId in pending passes an error results', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -835,7 +835,7 @@ describe('public api', function () {
       });
 
       let template = '<div></div>';
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -853,7 +853,7 @@ describe('public api', function () {
       expect(result).toEqual([expected]);
     });
 
-    it('module listed as object via rule exclusion in pending passes an error results', function () {
+    it('module listed as object via rule exclusion in pending passes an error results', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -863,7 +863,7 @@ describe('public api', function () {
       });
 
       let template = '<div></div>';
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -881,7 +881,7 @@ describe('public api', function () {
       expect(result).toEqual([expected]);
     });
 
-    it('triggers error if pending rule is passing', function () {
+    it('triggers error if pending rule is passing', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -891,7 +891,7 @@ describe('public api', function () {
       });
 
       let template = '<div>Bare strings are bad</div>';
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -921,7 +921,7 @@ describe('public api', function () {
       expect(result).toEqual(expected);
     });
 
-    it('does not include errors when marked as ignored', function () {
+    it('does not include errors when marked as ignored', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -931,7 +931,7 @@ describe('public api', function () {
       });
 
       let template = '<div>bare string</div>';
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -940,7 +940,7 @@ describe('public api', function () {
       expect(result).toEqual([]);
     });
 
-    it('does not include errors when marked as ignored using glob', function () {
+    it('does not include errors when marked as ignored using glob', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -950,7 +950,7 @@ describe('public api', function () {
       });
 
       let template = '<div>bare string</div>';
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -959,7 +959,7 @@ describe('public api', function () {
       expect(result).toEqual([]);
     });
 
-    it('shows a "rule not found" error if a rule definition is not found"', function () {
+    it('shows a "rule not found" error if a rule definition is not found"', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
@@ -968,7 +968,7 @@ describe('public api', function () {
       });
 
       let template = '';
-      let result = linter.verify({
+      let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
         moduleId: 'some/path/here',
@@ -996,7 +996,7 @@ describe('public api', function () {
       });
     });
 
-    it('returns plugin rule issues', function () {
+    it('returns plugin rule issues', async function () {
       let templatePath = path.join(basePath, 'app', 'templates', 'application.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
       let expected = [
@@ -1012,7 +1012,7 @@ describe('public api', function () {
         },
       ];
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),
@@ -1021,12 +1021,12 @@ describe('public api', function () {
       expect(result).toEqual(expected);
     });
 
-    it('allow you to disable plugin rules inline', function () {
+    it('allow you to disable plugin rules inline', async function () {
       let templatePath = path.join(basePath, 'app', 'templates', 'disabled-rule.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
       let expected = [];
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),
@@ -1047,7 +1047,7 @@ describe('public api', function () {
       });
     });
 
-    it('returns plugin rule issues', function () {
+    it('returns plugin rule issues', async function () {
       let templatePath = path.join(basePath, 'app', 'templates', 'application.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
       let expected = [
@@ -1063,7 +1063,7 @@ describe('public api', function () {
         },
       ];
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),
@@ -1083,7 +1083,7 @@ describe('public api', function () {
       });
     });
 
-    it('returns plugin rule issues', function () {
+    it('returns plugin rule issues', async function () {
       let templatePath = path.join(basePath, 'app', 'templates', 'application.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
       let expected = [
@@ -1109,7 +1109,7 @@ describe('public api', function () {
         },
       ];
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),
@@ -1130,7 +1130,7 @@ describe('public api', function () {
       });
     });
 
-    it('returns plugin rule issues', function () {
+    it('returns plugin rule issues', async function () {
       let templatePath = path.join(basePath, 'app', 'templates', 'application.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
       let expected = [
@@ -1146,7 +1146,7 @@ describe('public api', function () {
         },
       ];
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),
@@ -1167,12 +1167,12 @@ describe('public api', function () {
       });
     });
 
-    it('returns plugin rule issues', function () {
+    it('returns plugin rule issues', async function () {
       let templatePath = path.join(basePath, 'app', 'templates', 'application.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
       let expected = [];
 
-      let result = linter.verify({
+      let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
         moduleId: templatePath.slice(0, -4),

--- a/test/unit/recommended-config-test.js
+++ b/test/unit/recommended-config-test.js
@@ -21,7 +21,7 @@ describe('recommended config', function () {
   });
 
   function ensureValid(source) {
-    it(`passes with: \`${source}\``, function () {
+    it(`passes with: \`${source}\``, async function () {
       let config = { extends: 'recommended' };
 
       let linter = new Linter({
@@ -29,7 +29,7 @@ describe('recommended config', function () {
         config,
       });
 
-      expect(linter.verify({ source, moduleId: 'some/thing.hbs' })).toEqual([]);
+      expect(await linter.verify({ source, moduleId: 'some/thing.hbs' })).toEqual([]);
     });
   }
 


### PR DESCRIPTION
Converts `verify` and `verifyAndFix` APIs to async/await. This allows for the addition, or usage of, other async APIs (specifically, the [new `pending` APIs](https://github.com/ember-template-lint/ember-template-lint-pending-utils) that have been build to enable a more robust `pending` system).

Implements #1551 