### PR TITLE
Ensure globbing is only used when using a globlike pattern.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "find-up": "^5.0.0",
     "get-stdin": "^8.0.0",
     "globby": "^11.0.1",
-    "is-valid-glob": "^1.0.0",
+    "is-glob": "^4.0.1",
     "micromatch": "^4.0.2",
     "resolve": "^1.17.0",
     "v8-compile-cache": "^2.1.1",

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -23,15 +23,14 @@ describe('expandFileGlobs', function () {
       project.write({ 'application.hbs': 'almost empty' });
 
       let files = expandFileGlobs(['application.hbs', 'other.hbs'], []);
-      expect(files.has('application.hbs')).toBe(true);
-      expect(files.has('other.hbs')).toBe(false);
+      expect(files).toEqual(new Set(['application.hbs']));
     });
 
     it('respects a basic ignore option', function () {
       project.write({ 'application.hbs': 'almost empty' });
 
       let files = expandFileGlobs(['application.hbs', 'other.hbs'], ['application.hbs']);
-      expect(files.has('application.hbs')).toBe(false);
+      expect(files).toEqual(new Set([]));
     });
   });
 
@@ -45,6 +44,18 @@ describe('expandFileGlobs', function () {
 
       let files = expandFileGlobs(['*'], []);
       expect(files.has('application.hbs')).toBe(true);
+    });
+
+    it('does not fallback to globbing if not passed a globlike string', function () {
+      project.write({ 'application.hbs': 'almost empty' });
+
+      let ignorePatterns = [];
+      function glob() {
+        throw new Error('Should not use globbing for exact file matches');
+      }
+
+      let files = expandFileGlobs(['application.hbs'], ignorePatterns, glob);
+      expect(files).toEqual(new Set(['application.hbs']));
     });
 
     it('respects a glob ignore option', function () {


### PR DESCRIPTION
Within the command line script's `expandFileGlobs` method we were using `is-valid-glob` to determine if a given possible pattern / filename string was in fact a pattern or not. The idea here is that if a possible pattern does not contain any glob related wildcards or matchers **and** it is a literal file (ending with `.hbs`) it should be used directly and we should avoid globbing.

The most common scenario for this is when using built-in editor tooling to lint _just_ the current file. In that scenario we **never** want to waste the overhead of globbing, since we were given an explicit path.

Unfortunately, the previous code used `is-valid-glob` and therefore **always** considered any pattern as "valid" since `isValidGlob` is _basically_ just (see [actual code here](https://github.com/micromatch/is-valid-glob/blob/c18c82999df11133c5946f9a21ef74a0ebf88334/index.js#L3-L11)):

```js
function isValidGlob(pattern) {
  return Boolean(pattern) && (Array.isArray(pattern) || typeof pattern === 'string');
}
```

The package we _should have used_ is [is-glob](https://www.npmjs.com/package/is-glob), which is actually checking the contents of the string to see if it contains globlike matchers.