### PR TITLE
Allow linting individual files with arbitrary extensions.

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -64,15 +64,22 @@ function executeGlobby(pattern, ignore) {
   );
 }
 
+function isFile(possibleFile) {
+  try {
+    let stat = fs.statSync(possibleFile);
+    return stat.isFile();
+  } catch {
+    return false;
+  }
+}
+
 function expandFileGlobs(filePatterns, ignorePattern, glob = executeGlobby) {
-  let supportedExtensions = new Set(['.hbs', '.html', '.handlebars']);
   let result = new Set();
 
   filePatterns.forEach((pattern) => {
-    let isSupported = supportedExtensions.has(path.extname(pattern));
-    let isLiteralPath = !isGlob(pattern) && fs.existsSync(pattern);
+    let isLiteralPath = !isGlob(pattern) && isFile(pattern);
 
-    if (isSupported && isLiteralPath) {
+    if (isLiteralPath) {
       let isIgnored = micromatch.isMatch(pattern, ignorePattern);
 
       if (!isIgnored) {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -155,6 +155,29 @@ describe('ember-template-lint executable', function () {
       });
     });
 
+    describe('given path to single file with custom extension with errors', function () {
+      it('should print errors', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.fizzle': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        let result = await run(['app/templates/application.fizzle']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toBeTruthy();
+        expect(result.stderr).toBeFalsy();
+      });
+    });
+
     describe('given wildcard path resolving to single file', function () {
       it('should print errors', async function () {
         project.setConfig({

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -26,6 +26,18 @@ describe('expandFileGlobs', function () {
       expect(files).toEqual(new Set(['application.hbs']));
     });
 
+    it('resolves arbitrary file extensions', function () {
+      project.write({ 'application.foobarbaz': 'almost empty' });
+
+      let ignorePatterns = [];
+      function glob() {
+        throw new Error('Should not use globbing for exact file matches');
+      }
+
+      let files = expandFileGlobs(['application.foobarbaz'], ignorePatterns, glob);
+      expect(files).toEqual(new Set(['application.foobarbaz']));
+    });
+
     it('respects a basic ignore option', function () {
       project.write({ 'application.hbs': 'almost empty' });
 

--- a/test/unit/bin/get-files-to-lint-test.js
+++ b/test/unit/bin/get-files-to-lint-test.js
@@ -50,13 +50,29 @@ describe('getFilesToLint', function () {
     });
   }
 
-  // cat applications.hbs | yarn ember-template-lint --filename application.hbs STDIN
   describe('when given a pattern', function () {
     it('returns a set including some files', async function () {
       let files = await getFilesToLint(['app*']);
 
       expect(files.size).toBe(1);
       expect(files.values()).toContain('application.hbs');
+    });
+  });
+
+  describe('when given a specific path', function () {
+    it('returns a set including some files', async function () {
+      let files = await getFilesToLint(['application.hbs']);
+
+      expect(files.size).toBe(1);
+      expect(files.values()).toContain('application.hbs');
+    });
+
+    it('supports arbitrary extension when explictly passed', async function () {
+      project.write({ 'foo.frizzle': 'whatever' });
+
+      let files = await getFilesToLint(['foo.frizzle']);
+
+      expect(files).toEqual(new Set(['foo.frizzle']));
     });
   });
 });


### PR DESCRIPTION
This updates the command line script to allow linting any arbitrary file extension as long as:

1) it is provided on the command line explicitly (no glob pattern)
2) it is a "real file on disk"

These changes allow scripts/utilities to explicitly run `ember-template-lint` on arbitrary files without first forcing them to be wihtin a `.hbs`/`.html`/`.handlebars` file extension. For example, some editor plugins copy the highlighted text to a temp file and lint from there; currently these tools must set the extension on that file in order to lint it properly but after these changes those files can be linted without issue.