### PR TITLE
Add `--working-directory` option.

### DIFF
--- a/lib/-private/module-status-cache.js
+++ b/lib/-private/module-status-cache.js
@@ -3,20 +3,14 @@ const path = require('path');
 const micromatch = require('micromatch');
 
 class ModuleStatusCache {
-  constructor(config, configPath) {
+  constructor(workingDir, config, configPath) {
+    this.workingDir = workingDir;
     this.config = config;
     this.configPath = configPath || '';
     this.cache = {
       pending: {},
       ignore: {},
     };
-  }
-
-  get processCWD() {
-    if (!this._processCWD) {
-      this._processCWD = process.cwd();
-    }
-    return this._processCWD;
   }
 
   lookupPending(moduleId) {
@@ -27,7 +21,7 @@ class ModuleStatusCache {
       this.cache.pendingLookup = this._extractPendingCache();
     }
     if (!(moduleId in this.cache.pending)) {
-      const fullPathModuleId = path.resolve(this.processCWD, moduleId);
+      const fullPathModuleId = path.resolve(this.workingDir, moduleId);
       this.cache.pending[moduleId] = this.cache.pendingLookup[fullPathModuleId];
     }
     return this.cache.pending[moduleId];
@@ -64,7 +58,7 @@ class ModuleStatusCache {
 
   resolveFullModuleId(moduleId) {
     if (!this._baseDirBasedOnConfigPath) {
-      this._baseDirBasedOnConfigPath = path.resolve(this.processCWD, path.dirname(this.configPath));
+      this._baseDirBasedOnConfigPath = path.resolve(this.workingDir, path.dirname(this.configPath));
     }
     return path.resolve(this._baseDirBasedOnConfigPath, moduleId);
   }

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -34,8 +34,8 @@ const ALLOWED_ERROR_CODES = new Set([
   'QUALIFIED_PATH_RESOLUTION_FAILED',
 ]);
 
-function requirePlugin(pluginName, fromConfigPath) {
-  let basedir = fromConfigPath === undefined ? process.cwd() : path.dirname(fromConfigPath);
+function requirePlugin(workingDir, pluginName, fromConfigPath) {
+  let basedir = fromConfigPath === undefined ? workingDir : path.dirname(fromConfigPath);
 
   // throws exception if not found
   let pluginPath = resolve.sync(pluginName, { basedir });
@@ -43,11 +43,11 @@ function requirePlugin(pluginName, fromConfigPath) {
   return require(pluginPath); // eslint-disable-line import/no-dynamic-require
 }
 
-function resolveProjectConfig(options) {
+function resolveProjectConfig(workingDir, options) {
   let configPath;
 
   if (options.configPath) {
-    configPath = path.resolve(process.cwd(), options.configPath);
+    configPath = path.resolve(workingDir, options.configPath);
 
     try {
       // Making sure that the filePath exists, before requiring it directly this is
@@ -152,7 +152,7 @@ function migrateRulesFromRoot(config, source, options) {
   }
 }
 
-function processPlugins(plugins = [], options, checkForCircularReference) {
+function processPlugins(workingDir, plugins = [], options, checkForCircularReference) {
   let logger = options.console || console;
 
   let pluginsHash = {};
@@ -165,7 +165,7 @@ function processPlugins(plugins = [], options, checkForCircularReference) {
       // the second argument here should actually be the config file path for
       // the _currently being processed_ config file (not neccesarily the one
       // specified to the bin script)
-      plugin = requirePlugin(pluginName, options.resolvedConfigPath);
+      plugin = requirePlugin(workingDir, pluginName, options.resolvedConfigPath);
     }
 
     let errorMessage;
@@ -192,13 +192,16 @@ function processPlugins(plugins = [], options, checkForCircularReference) {
 
   forEachPluginConfiguration(pluginsHash, (configuration) => {
     // process plugins recursively
-    Object.assign(pluginsHash, processPlugins(configuration.plugins, options, pluginsHash));
+    Object.assign(
+      pluginsHash,
+      processPlugins(workingDir, configuration.plugins, options, pluginsHash)
+    );
   });
 
   return pluginsHash;
 }
 
-function processLoadedRules(config, options) {
+function processLoadedRules(workingDir, config, options) {
   let loadedRules;
   if (config.loadedRules) {
     loadedRules = config.loadedRules;
@@ -216,15 +219,15 @@ function processLoadedRules(config, options) {
   }
 
   forEachPluginConfiguration(config.plugins, (configuration) => {
-    let plugins = processPlugins(configuration.plugins, options, config.plugins);
+    let plugins = processPlugins(workingDir, configuration.plugins, options, config.plugins);
     // process plugins recursively
-    processLoadedRules({ plugins, loadedRules });
+    processLoadedRules(workingDir, { plugins, loadedRules });
   });
 
   return loadedRules;
 }
 
-function processLoadedConfigurations(config, options) {
+function processLoadedConfigurations(workingDir, config, options) {
   let loadedConfigurations;
   if (config.loadedConfigurations) {
     loadedConfigurations = config.loadedConfigurations;
@@ -238,8 +241,8 @@ function processLoadedConfigurations(config, options) {
     loadedConfigurations[name] = configuration;
 
     // load plugins recursively
-    let plugins = processPlugins(configuration.plugins, options, config.plugins);
-    processLoadedConfigurations({ plugins, loadedConfigurations }, options);
+    let plugins = processPlugins(workingDir, configuration.plugins, options, config.plugins);
+    processLoadedConfigurations(workingDir, { plugins, loadedConfigurations }, options);
   });
 
   return loadedConfigurations;
@@ -420,8 +423,8 @@ function processRules(config) {
   return processedRules;
 }
 
-function getProjectConfig(options) {
-  let source = options.config || resolveProjectConfig(options);
+function getProjectConfig(workingDir, options) {
+  let source = options.config || resolveProjectConfig(workingDir, options);
   let config;
 
   if (source._processed) {
@@ -433,9 +436,9 @@ function getProjectConfig(options) {
     ensureRootProperties(config, source);
     migrateRulesFromRoot(config, source, options);
 
-    config.plugins = processPlugins(source.plugins, options);
-    config.loadedRules = processLoadedRules(config, options);
-    config.loadedConfigurations = processLoadedConfigurations(config, options);
+    config.plugins = processPlugins(workingDir, source.plugins, options);
+    config.loadedRules = processLoadedRules(workingDir, config, options);
+    config.loadedConfigurations = processLoadedConfigurations(workingDir, config, options);
     processExtends(config, options);
     processIgnores(config);
 

--- a/lib/get-editor-config.js
+++ b/lib/get-editor-config.js
@@ -7,7 +7,8 @@ const path = require('path');
 const micromatch = require('micromatch');
 
 class EditorConfigResolver {
-  constructor() {
+  constructor(workingDir) {
+    this.workingDir = workingDir;
     this.EDITOR_CONFIG_CACHE = null;
     this.CONFIG_RESOLUTIONS_CACHE = new Map();
     /**
@@ -208,7 +209,7 @@ class EditorConfigResolver {
     dirname(/root/path/this.file.does.not.exist) => /root/path
   */
   resolveEditorConfigFiles(
-    _filepath = path.join(process.cwd(), 'this.file.does.not.exist'),
+    _filepath = path.join(this.workingDir, 'this.file.does.not.exist'),
     _options = {}
   ) {
     const [resolvedFilePath, processedOptions] = this.opts(_filepath, _options);

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -36,16 +36,17 @@ class Linter {
 
     this.options = options;
     this.console = options.console || console;
+    this.workingDir = options.workingDir || process.cwd();
 
     this.loadConfig();
 
     this.constructor = Linter;
-    this.editorConfigResolver = new EditorConfigResolver();
+    this.editorConfigResolver = new EditorConfigResolver(this.workingDir);
     this.editorConfigResolver.resolveEditorConfigFiles();
   }
 
   loadConfig() {
-    this.config = getProjectConfig(this.options);
+    this.config = getProjectConfig(this.workingDir, this.options);
 
     // we were passed a rule, add the rule being passed in, to the config.
     // ex:
@@ -56,7 +57,11 @@ class Linter {
 
       this.config.rules[name] = config;
     }
-    this._moduleStatusCache = new ModuleStatusCache(this.config, this.options.configPath);
+    this._moduleStatusCache = new ModuleStatusCache(
+      this.workingDir,
+      this.config,
+      this.options.configPath
+    );
   }
 
   /**

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -8,6 +8,8 @@ const execa = require('execa');
 const Project = require('../helpers/fake-project');
 const setupEnvVar = require('../helpers/setup-env-var');
 
+const ROOT = process.cwd();
+
 describe('ember-template-lint executable', function () {
   setupEnvVar('GITHUB_ACTIONS', null);
   setupEnvVar('FORCE_COLOR', '0');
@@ -21,6 +23,7 @@ describe('ember-template-lint executable', function () {
   });
 
   afterEach(async function () {
+    process.chdir(ROOT);
     await project.dispose();
   });
 
@@ -34,31 +37,36 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path       Define a custom config path
+            --config-path               Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config            Define a custom configuration to be used - (e.g. '{
-                                \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')      [string]
-            --quiet             Ignore warnings and only show errors             [boolean]
-            --rule              Specify a rule and its severity to add that rule to loaded
-                                rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\",
-                                { \\"allow\\": [\\"some-helper\\"] }]\`)                   [string]
-            --filename          Used to indicate the filename to be assumed for contents
-                                from STDIN                                        [string]
-            --fix               Fix any errors that are reported as fixable
+            --config                    Define a custom configuration to be used - (e.g.
+                                        '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
+                                                                                  [string]
+            --quiet                     Ignore warnings and only show errors     [boolean]
+            --rule                      Specify a rule and its severity to add that rule
+                                        to loaded rules - (e.g. \`no-implicit-this:error\`
+                                        or \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
+                                                                                  [string]
+            --filename                  Used to indicate the filename to be assumed for
+                                        contents from STDIN                       [string]
+            --fix                       Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --json              Format output as json                            [boolean]
-            --verbose           Output errors with source description            [boolean]
-            --no-config-path    Does not use the local template-lintrc, will use a blank
-                                template-lintrc instead                          [boolean]
-            --print-pending     Print list of formatted rules for use with \`pending\` in
-                                config file                                      [boolean]
-            --ignore-pattern    Specify custom ignore pattern (can be disabled with
-                                --no-ignore-pattern)
+            --json                      Format output as json                    [boolean]
+            --verbose                   Output errors with source description    [boolean]
+            --working-directory, --cwd  Path to a directory that should be considered as
+                                        the current working directory.
+                                                                   [string] [default: \\".\\"]
+            --no-config-path            Does not use the local template-lintrc, will use a
+                                        blank template-lintrc instead            [boolean]
+            --print-pending             Print list of formatted rules for use with
+                                        \`pending\` in config file                 [boolean]
+            --ignore-pattern            Specify custom ignore pattern (can be disabled
+                                        with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --no-inline-config  Prevent inline configuration comments from changing config
-                                or rules                                         [boolean]
-            --help              Show help                                        [boolean]
-            --version           Show version number                              [boolean]"
+            --no-inline-config          Prevent inline configuration comments from
+                                        changing config or rules                 [boolean]
+            --help                      Show help                                [boolean]
+            --version                   Show version number                      [boolean]"
         `);
       });
     });
@@ -72,31 +80,36 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path       Define a custom config path
+            --config-path               Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config            Define a custom configuration to be used - (e.g. '{
-                                \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')      [string]
-            --quiet             Ignore warnings and only show errors             [boolean]
-            --rule              Specify a rule and its severity to add that rule to loaded
-                                rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\",
-                                { \\"allow\\": [\\"some-helper\\"] }]\`)                   [string]
-            --filename          Used to indicate the filename to be assumed for contents
-                                from STDIN                                        [string]
-            --fix               Fix any errors that are reported as fixable
+            --config                    Define a custom configuration to be used - (e.g.
+                                        '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
+                                                                                  [string]
+            --quiet                     Ignore warnings and only show errors     [boolean]
+            --rule                      Specify a rule and its severity to add that rule
+                                        to loaded rules - (e.g. \`no-implicit-this:error\`
+                                        or \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
+                                                                                  [string]
+            --filename                  Used to indicate the filename to be assumed for
+                                        contents from STDIN                       [string]
+            --fix                       Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --json              Format output as json                            [boolean]
-            --verbose           Output errors with source description            [boolean]
-            --no-config-path    Does not use the local template-lintrc, will use a blank
-                                template-lintrc instead                          [boolean]
-            --print-pending     Print list of formatted rules for use with \`pending\` in
-                                config file                                      [boolean]
-            --ignore-pattern    Specify custom ignore pattern (can be disabled with
-                                --no-ignore-pattern)
+            --json                      Format output as json                    [boolean]
+            --verbose                   Output errors with source description    [boolean]
+            --working-directory, --cwd  Path to a directory that should be considered as
+                                        the current working directory.
+                                                                   [string] [default: \\".\\"]
+            --no-config-path            Does not use the local template-lintrc, will use a
+                                        blank template-lintrc instead            [boolean]
+            --print-pending             Print list of formatted rules for use with
+                                        \`pending\` in config file                 [boolean]
+            --ignore-pattern            Specify custom ignore pattern (can be disabled
+                                        with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --no-inline-config  Prevent inline configuration comments from changing config
-                                or rules                                         [boolean]
-            --help              Show help                                        [boolean]
-            --version           Show version number                              [boolean]"
+            --no-inline-config          Prevent inline configuration comments from
+                                        changing config or rules                 [boolean]
+            --help                      Show help                                [boolean]
+            --version                   Show version number                      [boolean]"
         `);
       });
     });
@@ -153,6 +166,45 @@ describe('ember-template-lint executable', function () {
         expect(result.stdout).toBeTruthy();
         expect(result.stderr).toBeFalsy();
       });
+
+      it('when using custom working directory', async function () {
+        process.chdir(ROOT);
+
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+              components: {
+                'foo.hbs': '{{fooData}}',
+              },
+            },
+          },
+        });
+
+        let result = await run(
+          ['--working-directory', project.baseDir, 'app/templates/application.hbs'],
+          {
+            // run from ember-template-lint's root (forces `--working-directory` to be used)
+            cwd: ROOT,
+          }
+        );
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "app/templates/application.hbs
+            1:4  error  Non-translated string used  no-bare-strings
+            1:25  error  Non-translated string used  no-bare-strings
+
+          ✖ 2 problems (2 errors, 0 warnings)"
+        `);
+        expect(result.stderr).toMatchInlineSnapshot('""');
+      });
     });
 
     describe('given wildcard path resolving to single file', function () {
@@ -178,6 +230,40 @@ describe('ember-template-lint executable', function () {
         expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeTruthy();
         expect(result.stderr).toBeFalsy();
+      });
+
+      it('when using custom working directory', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+              components: {
+                'foo.hbs': '{{fooData}}',
+              },
+            },
+          },
+        });
+
+        let result = await run(['--working-directory', project.baseDir, 'app/templates/*'], {
+          // run from ember-template-lint's root (forces `--working-directory` to be used)
+          cwd: ROOT,
+        });
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "app/templates/application.hbs
+            1:4  error  Non-translated string used  no-bare-strings
+            1:25  error  Non-translated string used  no-bare-strings
+
+          ✖ 2 problems (2 errors, 0 warnings)"
+        `);
+        expect(result.stderr).toMatchInlineSnapshot('""');
       });
     });
 
@@ -268,31 +354,36 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path       Define a custom config path
+            --config-path               Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config            Define a custom configuration to be used - (e.g. '{
-                                \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')      [string]
-            --quiet             Ignore warnings and only show errors             [boolean]
-            --rule              Specify a rule and its severity to add that rule to loaded
-                                rules - (e.g. \`no-implicit-this:error\` or \`rule:[\\"error\\",
-                                { \\"allow\\": [\\"some-helper\\"] }]\`)                   [string]
-            --filename          Used to indicate the filename to be assumed for contents
-                                from STDIN                                        [string]
-            --fix               Fix any errors that are reported as fixable
+            --config                    Define a custom configuration to be used - (e.g.
+                                        '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
+                                                                                  [string]
+            --quiet                     Ignore warnings and only show errors     [boolean]
+            --rule                      Specify a rule and its severity to add that rule
+                                        to loaded rules - (e.g. \`no-implicit-this:error\`
+                                        or \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
+                                                                                  [string]
+            --filename                  Used to indicate the filename to be assumed for
+                                        contents from STDIN                       [string]
+            --fix                       Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --json              Format output as json                            [boolean]
-            --verbose           Output errors with source description            [boolean]
-            --no-config-path    Does not use the local template-lintrc, will use a blank
-                                template-lintrc instead                          [boolean]
-            --print-pending     Print list of formatted rules for use with \`pending\` in
-                                config file                                      [boolean]
-            --ignore-pattern    Specify custom ignore pattern (can be disabled with
-                                --no-ignore-pattern)
+            --json                      Format output as json                    [boolean]
+            --verbose                   Output errors with source description    [boolean]
+            --working-directory, --cwd  Path to a directory that should be considered as
+                                        the current working directory.
+                                                                   [string] [default: \\".\\"]
+            --no-config-path            Does not use the local template-lintrc, will use a
+                                        blank template-lintrc instead            [boolean]
+            --print-pending             Print list of formatted rules for use with
+                                        \`pending\` in config file                 [boolean]
+            --ignore-pattern            Specify custom ignore pattern (can be disabled
+                                        with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --no-inline-config  Prevent inline configuration comments from changing config
-                                or rules                                         [boolean]
-            --help              Show help                                        [boolean]
-            --version           Show version number                              [boolean]"
+            --no-inline-config          Prevent inline configuration comments from
+                                        changing config or rules                 [boolean]
+            --help                      Show help                                [boolean]
+            --version                   Show version number                      [boolean]"
         `);
       });
     });
@@ -991,6 +1082,49 @@ describe('ember-template-lint executable', function () {
             '  1:23  error  Ambiguous element used (`div`)  no-shadowed-elements',
             '',
             '✖ 1 problems (1 errors, 0 warnings)',
+          ]);
+          expect(result.stderr).toBeFalsy();
+        });
+      });
+
+      describe('given a working-directory with errors and a lintrc with rules', function () {
+        it('should print properly formatted error messages', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': false,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs':
+                  '<h2>Love for bare strings!!!</h2> <div>Bare strings are great!</div>',
+              },
+            },
+            'other-file.js': "module.exports = { rules: { 'no-bare-strings': true } };",
+          });
+
+          let result = await run(
+            [
+              '--working-directory',
+              project.baseDir,
+              '--config-path',
+              project.path('other-file.js'),
+              '.',
+            ],
+            {
+              // run from ember-template-lint's root (forces `--working-directory` to be used)
+              cwd: ROOT,
+            }
+          );
+
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout.split('\n')).toEqual([
+            'app/templates/application.hbs',
+            '  1:4  error  Non-translated string used  no-bare-strings',
+            '  1:39  error  Non-translated string used  no-bare-strings',
+            '',
+            '✖ 2 problems (2 errors, 0 warnings)',
           ]);
           expect(result.stderr).toBeFalsy();
         });

--- a/test/unit/-private/module-status-cache-test.js
+++ b/test/unit/-private/module-status-cache-test.js
@@ -1,6 +1,8 @@
 const ModuleStatusCache = require('../../../lib/-private/module-status-cache');
 
 describe('ModuleStatusCache', function () {
+  const workingDir = process.cwd();
+
   it('Merges the overrides rules with existing rules config', function () {
     let config = {
       rules: {
@@ -21,7 +23,7 @@ describe('ModuleStatusCache', function () {
       foo: 'bar',
       baz: 'bang',
     };
-    let actual = new ModuleStatusCache(config).getConfigForFile({
+    let actual = new ModuleStatusCache(workingDir, config).getConfigForFile({
       filePath: 'app/templates/foo.hbs',
     });
 
@@ -40,7 +42,7 @@ describe('ModuleStatusCache', function () {
     // clone to ensure we are not mutating
     let expected = JSON.parse(JSON.stringify(config));
 
-    let actual = new ModuleStatusCache(config).getConfigForFile({
+    let actual = new ModuleStatusCache(workingDir, config).getConfigForFile({
       filePath: 'app/templates/foo.hbs',
     });
 
@@ -48,7 +50,7 @@ describe('ModuleStatusCache', function () {
 
     delete config.overrides;
 
-    actual = new ModuleStatusCache(config).getConfigForFile('app/templates/foo.hbs');
+    actual = new ModuleStatusCache(workingDir, config).getConfigForFile('app/templates/foo.hbs');
 
     expect(actual.rules).toEqual(expected.rules);
   });
@@ -81,7 +83,7 @@ describe('ModuleStatusCache', function () {
       foo: 'zomg',
       baz: 'bang',
     };
-    let actual = new ModuleStatusCache(config).getConfigForFile({
+    let actual = new ModuleStatusCache(workingDir, config).getConfigForFile({
       filePath: 'app/templates/foo.hbs',
     });
 
@@ -93,7 +95,7 @@ describe('ModuleStatusCache', function () {
       pending: ['some/path/here', { moduleId: 'foo/bar/baz', only: ['no-bare-strings'] }],
     };
 
-    let moduleStatusCache = new ModuleStatusCache(config);
+    let moduleStatusCache = new ModuleStatusCache(workingDir, config);
 
     expect(
       moduleStatusCache.getConfigForFile({ moduleId: 'some/path/here' }).pendingStatus
@@ -111,13 +113,12 @@ describe('ModuleStatusCache', function () {
       pending: ['some/path/here', { moduleId: 'foo/bar/baz', only: ['no-bare-strings'] }],
     };
 
-    let moduleStatusCache = new ModuleStatusCache(config);
+    let moduleStatusCache = new ModuleStatusCache(workingDir, config);
     expect(
-      moduleStatusCache.getConfigForFile({ moduleId: `${process.cwd()}/some/path/here` })
-        .pendingStatus
+      moduleStatusCache.getConfigForFile({ moduleId: `${workingDir}/some/path/here` }).pendingStatus
     ).toBeTruthy();
     expect(
-      moduleStatusCache.getConfigForFile({ moduleId: `${process.cwd()}/foo/bar/baz` }).pendingStatus
+      moduleStatusCache.getConfigForFile({ moduleId: `${workingDir}/foo/bar/baz` }).pendingStatus
     ).toBeTruthy();
   });
 });

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -16,7 +16,7 @@ describe('base plugin', function () {
   beforeEach(() => {
     project = Project.defaultSetup();
 
-    editorConfigResolver = new EditorConfigResolver();
+    editorConfigResolver = new EditorConfigResolver(project.baseDir);
     editorConfigResolver.resolveEditorConfigFiles();
   });
 

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -15,21 +15,41 @@ describe('expandFileGlobs', function () {
   });
 
   describe('basic', function () {
-    beforeEach(function () {
-      project.chdir();
-    });
-
-    it('resolves a basic pattern', function () {
+    it('resolves a basic pattern (different working directory)', function () {
       project.write({ 'application.hbs': 'almost empty' });
 
-      let files = expandFileGlobs(['application.hbs', 'other.hbs'], []);
+      let files = expandFileGlobs(project.baseDir, ['application.hbs', 'other.hbs'], []);
       expect(files).toEqual(new Set(['application.hbs']));
     });
 
-    it('respects a basic ignore option', function () {
+    it('respects a basic ignore option (different working directory)', function () {
       project.write({ 'application.hbs': 'almost empty' });
 
-      let files = expandFileGlobs(['application.hbs', 'other.hbs'], ['application.hbs']);
+      let files = expandFileGlobs(
+        project.baseDir,
+        ['application.hbs', 'other.hbs'],
+        ['application.hbs']
+      );
+      expect(files).toEqual(new Set([]));
+    });
+
+    it('resolves a basic pattern (within working directory)', function () {
+      project.chdir();
+      project.write({ 'application.hbs': 'almost empty' });
+
+      let files = expandFileGlobs(project.baseDir, ['application.hbs', 'other.hbs'], []);
+      expect(files).toEqual(new Set(['application.hbs']));
+    });
+
+    it('respects a basic ignore option (within working directory)', function () {
+      project.chdir();
+      project.write({ 'application.hbs': 'almost empty' });
+
+      let files = expandFileGlobs(
+        project.baseDir,
+        ['application.hbs', 'other.hbs'],
+        ['application.hbs']
+      );
       expect(files).toEqual(new Set([]));
     });
   });
@@ -42,7 +62,7 @@ describe('expandFileGlobs', function () {
     it('resolves a glob pattern', function () {
       project.write({ 'application.hbs': 'almost empty' });
 
-      let files = expandFileGlobs(['*'], []);
+      let files = expandFileGlobs(project.baseDir, ['*'], []);
       expect(files.has('application.hbs')).toBe(true);
     });
 
@@ -54,14 +74,14 @@ describe('expandFileGlobs', function () {
         throw new Error('Should not use globbing for exact file matches');
       }
 
-      let files = expandFileGlobs(['application.hbs'], ignorePatterns, glob);
+      let files = expandFileGlobs(project.baseDir, ['application.hbs'], ignorePatterns, glob);
       expect(files).toEqual(new Set(['application.hbs']));
     });
 
     it('respects a glob ignore option', function () {
       project.write({ 'application.hbs': 'almost empty' });
 
-      let files = expandFileGlobs(['application.hbs'], ['*']);
+      let files = expandFileGlobs(project.baseDir, ['application.hbs'], ['*']);
       expect(files.has('application.hbs')).toBe(false);
     });
   });

--- a/test/unit/bin/get-files-to-lint-test.js
+++ b/test/unit/bin/get-files-to-lint-test.js
@@ -21,7 +21,7 @@ describe('getFilesToLint', function () {
   // yarn ember-template-lint --filename application.hbs < application.hbs
   describe('when given empty array', function () {
     it('returns a set including stdin', async function () {
-      let files = await getFilesToLint([], 'other.hbs');
+      let files = await getFilesToLint(project.baseDir, [], 'other.hbs');
 
       expect(files.size).toBe(1);
       expect(files.values()).toContain(STDIN);
@@ -31,7 +31,7 @@ describe('getFilesToLint', function () {
   // cat applications.hbs | yarn ember-template-lint --filename application.hbs STDIN
   describe('when given stdin', function () {
     it('returns a set including stdin', async function () {
-      let files = await getFilesToLint([STDIN, 'other.hbs']);
+      let files = await getFilesToLint(project.baseDir, [STDIN, 'other.hbs']);
 
       expect(files.size).toBe(1);
       expect(files.values()).toContain(STDIN);
@@ -42,7 +42,7 @@ describe('getFilesToLint', function () {
     describe("when given stdin through unix's dash", function () {
       // cat applications.hbs | yarn ember-template-lint --filename application.hbs -
       it('returns a set including stdin', async function () {
-        let files = await getFilesToLint(['-', 'other.hbs']);
+        let files = await getFilesToLint(project.baseDir, ['-', 'other.hbs']);
 
         expect(files.size).toBe(1);
         expect(files.values()).toContain(STDIN);
@@ -53,7 +53,7 @@ describe('getFilesToLint', function () {
   // cat applications.hbs | yarn ember-template-lint --filename application.hbs STDIN
   describe('when given a pattern', function () {
     it('returns a set including some files', async function () {
-      let files = await getFilesToLint(['app*']);
+      let files = await getFilesToLint(project.baseDir, ['app*']);
 
       expect(files.size).toBe(1);
       expect(files.values()).toContain('application.hbs');

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -31,7 +31,7 @@ describe('get-config', function () {
       },
     };
 
-    let actual = getProjectConfig({ config });
+    let actual = getProjectConfig(project.baseDir, { config });
     expect(actual.rules).toEqual({
       foo: { config: 'bar', severity: 2 },
       baz: { config: 'derp', severity: 2 },
@@ -46,7 +46,7 @@ describe('get-config', function () {
       },
     };
 
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       config: {
         rules: {
           foo: 'warn',
@@ -58,7 +58,7 @@ describe('get-config', function () {
   });
 
   it('shows rules being "upgraded" to the new syntax when the config is in the old syntax', function () {
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       config: {
         rules: {
           foo: true,
@@ -90,7 +90,7 @@ describe('get-config', function () {
       },
     };
 
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       config: {
         rules: {
           foo: ['warn', { allow: [1, 2, 3] }],
@@ -118,7 +118,7 @@ describe('get-config', function () {
     project.setConfig(expected);
     project.chdir();
 
-    let actual = getProjectConfig({});
+    let actual = getProjectConfig(project.baseDir, {});
 
     expect(actual.rules).toEqual({
       foo: { config: 'bar', severity: 2 },
@@ -138,7 +138,7 @@ describe('get-config', function () {
     )};`;
     project.chdir();
 
-    let actual = getProjectConfig({ configPath: 'some-other-path.js' });
+    let actual = getProjectConfig(project.baseDir, { configPath: 'some-other-path.js' });
 
     expect(actual.rules).toEqual({
       foo: { config: 'bar', severity: 2 },
@@ -158,7 +158,9 @@ describe('get-config', function () {
     )};`;
     project.writeSync();
 
-    let actual = getProjectConfig({ configPath: project.path('some-other-path.js') });
+    let actual = getProjectConfig(project.baseDir, {
+      configPath: project.path('some-other-path.js'),
+    });
 
     expect(actual.rules).toEqual({
       foo: { config: 'bar', severity: 2 },
@@ -167,7 +169,7 @@ describe('get-config', function () {
   });
 
   it('can specify that it extends a default configuration', function () {
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       config: {
         extends: 'recommended',
       },
@@ -179,7 +181,7 @@ describe('get-config', function () {
   it('can extend and override a default configuration', function () {
     let expected = recommendedConfig;
 
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       config: {
         extends: 'recommended',
         rules: {
@@ -193,7 +195,7 @@ describe('get-config', function () {
   });
 
   it('migrates rules in the config root into `rules` property', function () {
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       console: buildFakeConsole(),
       config: {
         'no-bare-strings': false,
@@ -206,7 +208,7 @@ describe('get-config', function () {
   it('rules in the config root trigger a deprecation', function () {
     let console = buildFakeConsole();
 
-    getProjectConfig({
+    getProjectConfig(project.baseDir, {
       console,
       config: {
         'no-bare-strings': true,
@@ -219,7 +221,7 @@ describe('get-config', function () {
   it('warns for unknown rules', function () {
     let console = buildFakeConsole();
 
-    getProjectConfig({
+    getProjectConfig(project.baseDir, {
       console,
       config: {
         rules: {
@@ -234,7 +236,7 @@ describe('get-config', function () {
   it('warns for unknown extends', function () {
     let console = buildFakeConsole();
 
-    getProjectConfig({
+    getProjectConfig(project.baseDir, {
       console,
       config: {
         extends: ['recommended', 'plugin1:wrong-extend'],
@@ -270,7 +272,7 @@ describe('get-config', function () {
 
     project.chdir();
 
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       console,
     });
 
@@ -301,7 +303,7 @@ describe('get-config', function () {
 
     project.chdir();
 
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       console,
       config: {
         extends: ['my-awesome-thing:stylistic'],
@@ -314,7 +316,7 @@ describe('get-config', function () {
   });
 
   it('extending multiple configurations allows subsequent configs to override earlier ones', function () {
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       config: {
         extends: ['recommended', 'myplugin:recommended'],
 
@@ -337,7 +339,7 @@ describe('get-config', function () {
   });
 
   it('extending multiple configurations merges all rules', function () {
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       config: {
         extends: ['myplugin:first', 'myplugin:second'],
 
@@ -370,7 +372,7 @@ describe('get-config', function () {
   it('can specify plugin without rules', function () {
     let console = buildFakeConsole();
 
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       console,
       config: {
         extends: 'myplugin:basic-configuration',
@@ -398,7 +400,7 @@ describe('get-config', function () {
     let wrongPluginPath = './bad-plugin-path/incorrect-file-name';
 
     expect(function () {
-      getProjectConfig({
+      getProjectConfig(project.baseDir, {
         config: {
           plugins: [wrongPluginPath],
         },
@@ -409,7 +411,7 @@ describe('get-config', function () {
   it('validates non-default loaded rules', function () {
     let console = buildFakeConsole();
 
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       console,
 
       config: {
@@ -435,7 +437,7 @@ describe('get-config', function () {
   it('can chain extends and load rules across chained plugins', function () {
     let console = buildFakeConsole();
 
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       console,
 
       config: {
@@ -504,7 +506,7 @@ describe('get-config', function () {
     config.plugins[0].configurations.recommended = config;
 
     let console = buildFakeConsole();
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       console,
       config,
     });
@@ -535,7 +537,7 @@ describe('get-config', function () {
     plugin.configurations.recommended.plugins = [plugin];
 
     let console = buildFakeConsole();
-    let actual = getProjectConfig({
+    let actual = getProjectConfig(project.baseDir, {
       console,
 
       config: {
@@ -551,7 +553,7 @@ describe('get-config', function () {
 
   it('getting config is idempotent', function () {
     let console = buildFakeConsole();
-    let firstPass = getProjectConfig({
+    let firstPass = getProjectConfig(project.baseDir, {
       console,
       config: {
         rules: {
@@ -569,7 +571,7 @@ describe('get-config', function () {
       },
     });
     let firstPassJSON = JSON.stringify(firstPass);
-    let secondPass = getProjectConfig({
+    let secondPass = getProjectConfig(project.baseDir, {
       console,
       config: firstPass,
     });
@@ -588,7 +590,7 @@ describe('get-config', function () {
 
     let cloned = JSON.parse(JSON.stringify(config));
 
-    let actual = getProjectConfig(config);
+    let actual = getProjectConfig(project.baseDir, config);
 
     expect(Object.keys(actual.rules).length).toBeTruthy();
     expect(config).toEqual(cloned);
@@ -614,13 +616,29 @@ describe('determineRuleConfig', function () {
 
 describe('resolveProjectConfig', function () {
   it('should return an empty object when options.config is set explicitly false', function () {
-    const config = resolveProjectConfig({ config: false });
+    let project = Project.defaultSetup();
 
-    expect(config).toEqual({});
+    try {
+      const config = resolveProjectConfig(project.baseDir, { config: false });
+
+      expect(config).toEqual({});
+    } finally {
+      project.dispose();
+    }
   });
 });
 
 describe('getProjectConfig', function () {
+  let project = null;
+
+  beforeEach(function () {
+    project = Project.defaultSetup();
+  });
+
+  afterEach(async function () {
+    await project.dispose();
+  });
+
   it('processing config is idempotent', function () {
     let config = {
       plugins: [
@@ -649,10 +667,10 @@ describe('getProjectConfig', function () {
       bar: { config: false, severity: 0 },
     };
 
-    let processedConfig = getProjectConfig({ config });
+    let processedConfig = getProjectConfig(project.baseDir, { config });
     expect(processedConfig.rules).toEqual(expected);
 
-    let reprocessedConfig = getProjectConfig({ config });
+    let reprocessedConfig = getProjectConfig(project.baseDir, { config });
     expect(reprocessedConfig.rules).toEqual(expected);
   });
 });


### PR DESCRIPTION
This refactors all read/write operations to be relative to the specified `--working-directory`. This working directory is threaded through the various internal/private API methods for configuration, and `process.cwd()` is now **only** used to default the working directory (when the command line option is not specified).

Closes #1204