### PR TITLE
Allow `itemprop` use in meta tags in `no-invalid-meta` rule

### DIFF
--- a/lib/rules/no-invalid-meta.js
+++ b/lib/rules/no-invalid-meta.js
@@ -24,22 +24,23 @@ module.exports = class NoInvalidMeta extends Rule {
         const hasContent = AstNodeInfo.hasAttribute(node, 'content');
         const hasName = AstNodeInfo.hasAttribute(node, 'name');
         const hasProperty = AstNodeInfo.hasAttribute(node, 'property');
-        const hasNameOrProperty = hasName || hasProperty;
+        const hasItemprop = AstNodeInfo.hasAttribute(node, 'itemprop');
+        const hasIdentifier = hasName || hasProperty || hasItemprop;
 
         const contentAttrValue = AstNodeInfo.elementAttributeValue(node, 'content');
 
-        if ((hasNameOrProperty || hasHttpEquiv) && !hasContent) {
+        if ((hasIdentifier || hasHttpEquiv) && !hasContent) {
           this.log({
             message:
-              'a meta content attribute must be defined if the name, property or the http-equiv attribute is defined',
+              'a meta content attribute must be defined if the name, property, itemprop or the http-equiv attribute is defined',
             line: node.loc && node.loc.start.line,
             column: node.loc && node.loc.start.column,
             source: this.sourceForNode(node),
           });
-        } else if (hasContent && !hasNameOrProperty && !hasHttpEquiv) {
+        } else if (hasContent && !hasIdentifier && !hasHttpEquiv) {
           this.log({
             message:
-              'a meta content attribute cannot be defined if the name, property nor the http-equiv attributes are defined',
+              'a meta content attribute cannot be defined if the name, property, itemprop nor the http-equiv attributes are defined',
             line: node.loc && node.loc.start.line,
             column: node.loc && node.loc.start.column,
             source: this.sourceForNode(node),

--- a/test/unit/rules/no-invalid-meta-test.js
+++ b/test/unit/rules/no-invalid-meta-test.js
@@ -18,6 +18,7 @@ generateRuleTests({
     '<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable= yes">',
     '<meta name={{name}} content={{content}}>',
     '<meta property="og:type" content="website">',
+    '<meta itemprop="type" content="website">',
 
     // doesn't error on unrelated elements
     '<div></div>',
@@ -92,7 +93,7 @@ generateRuleTests({
 
       result: {
         message:
-          'a meta content attribute must be defined if the name, property or the http-equiv attribute is defined',
+          'a meta content attribute must be defined if the name, property, itemprop or the http-equiv attribute is defined',
         line: 1,
         column: 0,
         source: '<meta name="viewport">',
@@ -103,10 +104,21 @@ generateRuleTests({
 
       result: {
         message:
-          'a meta content attribute must be defined if the name, property or the http-equiv attribute is defined',
+          'a meta content attribute must be defined if the name, property, itemprop or the http-equiv attribute is defined',
         line: 1,
         column: 0,
         source: '<meta property="og:type">',
+      },
+    },
+    {
+      template: '<meta itemprop="type">',
+
+      result: {
+        message:
+          'a meta content attribute must be defined if the name, property, itemprop or the http-equiv attribute is defined',
+        line: 1,
+        column: 0,
+        source: '<meta itemprop="type">',
       },
     },
     {
@@ -114,7 +126,7 @@ generateRuleTests({
 
       result: {
         message:
-          'a meta content attribute must be defined if the name, property or the http-equiv attribute is defined',
+          'a meta content attribute must be defined if the name, property, itemprop or the http-equiv attribute is defined',
         line: 1,
         column: 0,
         source: '<meta http-equiv="refresh">',
@@ -125,7 +137,7 @@ generateRuleTests({
 
       result: {
         message:
-          'a meta content attribute cannot be defined if the name, property nor the http-equiv attributes are defined',
+          'a meta content attribute cannot be defined if the name, property, itemprop nor the http-equiv attributes are defined',
         line: 1,
         column: 0,
         source: '<meta content="72001">',


### PR DESCRIPTION
According to the [microdata specs][1]:

> If a `meta` element has an `itemprop` attribute, the `name`, `http-equiv`, and `charset` attributes must be omitted, and the `content` attribute must be present.

This allows for `<meta itemprop="foobar" content="baz">`

[1]: https://www.w3.org/TR/microdata/#content-models

Fixes #1565