### PR TITLE
Allow passing a top level `meta` property.

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -6,22 +6,6 @@ const Linter = require('..');
 
 const { processRules } = require('../get-config');
 
-function parseMeta(item) {
-  let meta = item !== undefined && typeof item === 'object' && item.meta ? item.meta : {};
-  meta.filePath = meta.filePath || 'layout.hbs';
-  meta.moduleId = meta.moduleId || 'layout';
-  const editorConfig = meta.editorConfig || {};
-
-  if (!('configResolver' in meta)) {
-    meta.configResolver = {
-      editorConfig() {
-        return editorConfig;
-      },
-    };
-  }
-  return meta;
-}
-
 function getVerifyOptions(template, meta) {
   const options = { source: template, filePath: meta.filePath, moduleId: meta.moduleId };
   if ('configResolver' in meta) {
@@ -83,6 +67,7 @@ function getVerifyOptions(template, meta) {
  * @param  {Function} [focusMethod]       - function to call when a specific test is to be run on its own (mocha - it.only, qunit - QUnit.only)
  * @param  {Boolean}  skipDisabledTests   - boolean to skip disabled tests or not
  * @param  {Object}   config
+ * @param  {Object}   [meta]
  * @param  {Array}    plugins             - an array of plugins to load
  */
 module.exports = function generateRuleTests({
@@ -95,7 +80,8 @@ module.exports = function generateRuleTests({
   testMethod,
   focusMethod,
   skipDisabledTests,
-  config: passedConfig,
+  config: defaultConfig,
+  meta: defaultMeta,
   plugins,
 }) {
   groupingMethod(name, function () {
@@ -104,6 +90,27 @@ module.exports = function generateRuleTests({
     let DISABLE_ONE_LONG = `{{!-- template-lint-disable ${name} --}}`;
 
     let linter;
+
+    function parseMeta(item) {
+      let meta =
+        item !== undefined && typeof item === 'object' && item.meta
+          ? item.meta
+          : defaultMeta !== undefined
+          ? JSON.parse(JSON.stringify(defaultMeta))
+          : {};
+      meta.filePath = meta.filePath || 'layout.hbs';
+      meta.moduleId = meta.moduleId || 'layout';
+      const editorConfig = meta.editorConfig || {};
+
+      if (!('configResolver' in meta)) {
+        meta.configResolver = {
+          editorConfig() {
+            return editorConfig;
+          },
+        };
+      }
+      return meta;
+    }
 
     function updateLinterConfig(localConfig) {
       if (localConfig === undefined) {
@@ -138,7 +145,7 @@ module.exports = function generateRuleTests({
         plugins,
         rules: {},
       };
-      initialConfig.rules[name] = passedConfig;
+      initialConfig.rules[name] = defaultConfig;
 
       linter = new Linter({
         config: initialConfig,


### PR DESCRIPTION
This allows defaulting the `filePath`/`moduleId`/`editorConfig` instead of being forced to set them on each test.
