### PR TITLE
Add new rule `no-model-argument-in-route-templates`

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,95 +189,96 @@ Each rule has emojis denoting:
 
 <!--RULES_TABLE_START-->
 
-|                            | Rule ID                                                                               |
-| :------------------------- | :------------------------------------------------------------------------------------ |
-|                            | [attribute-indentation](./docs/rule/attribute-indentation.md)                         |
-| :dress:                    | [block-indentation](./docs/rule/block-indentation.md)                                 |
-|                            | [builtin-component-arguments](./docs/rule/builtin-component-arguments.md)             |
-|                            | [deprecated-each-syntax](./docs/rule/deprecated-each-syntax.md)                       |
-|                            | [deprecated-inline-view-helper](./docs/rule/deprecated-inline-view-helper.md)         |
-| :white_check_mark:         | [deprecated-render-helper](./docs/rule/deprecated-render-helper.md)                   |
-| :dress:                    | [eol-last](./docs/rule/eol-last.md)                                                   |
-| :wrench:                   | [inline-link-to](./docs/rule/inline-link-to.md)                                       |
-| :dress:                    | [linebreak-style](./docs/rule/linebreak-style.md)                                     |
-| :white_check_mark:         | [link-href-attributes](./docs/rule/link-href-attributes.md)                           |
-| :white_check_mark::wrench: | [link-rel-noopener](./docs/rule/link-rel-noopener.md)                                 |
-|                            | [modifier-name-case](./docs/rule/modifier-name-case.md)                               |
-| :white_check_mark:         | [no-abstract-roles](./docs/rule/no-abstract-roles.md)                                 |
-| :wrench:                   | [no-accesskey-attribute](./docs/rule/no-accesskey-attribute.md)                       |
-| :car:                      | [no-action](./docs/rule/no-action.md)                                                 |
-|                            | [no-action-modifiers](./docs/rule/no-action-modifiers.md)                             |
-| :white_check_mark:         | [no-args-paths](./docs/rule/no-args-paths.md)                                         |
-|                            | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)       |
-| :wrench:                   | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                             |
-| :white_check_mark:         | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                       |
-|                            | [no-bare-strings](./docs/rule/no-bare-strings.md)                                     |
-|                            | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md) |
-| :car:                      | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md)         |
-| :white_check_mark:         | [no-debugger](./docs/rule/no-debugger.md)                                             |
-|                            | [no-down-event-binding](./docs/rule/no-down-event-binding.md)                         |
-| :white_check_mark:         | [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                     |
-|                            | [no-duplicate-id](./docs/rule/no-duplicate-id.md)                                     |
-|                            | [no-duplicate-landmark-elements](./docs/rule/no-duplicate-landmark-elements.md)       |
-|                            | [no-element-event-actions](./docs/rule/no-element-event-actions.md)                   |
-| :white_check_mark:         | [no-extra-mut-helper-argument](./docs/rule/no-extra-mut-helper-argument.md)           |
-|                            | [no-forbidden-elements](./docs/rule/no-forbidden-elements.md)                         |
-|                            | [no-heading-inside-button](./docs/rule/no-heading-inside-button.md)                   |
-| :white_check_mark:         | [no-html-comments](./docs/rule/no-html-comments.md)                                   |
-| :car:                      | [no-implicit-this](./docs/rule/no-implicit-this.md)                                   |
-| :white_check_mark:         | [no-index-component-invocation](./docs/rule/no-index-component-invocation.md)         |
-| :white_check_mark:         | [no-inline-styles](./docs/rule/no-inline-styles.md)                                   |
-| :white_check_mark:         | [no-input-block](./docs/rule/no-input-block.md)                                       |
-| :white_check_mark:         | [no-input-tagname](./docs/rule/no-input-tagname.md)                                   |
-|                            | [no-invalid-block-param-definition](./docs/rule/no-invalid-block-param-definition.md) |
-| :white_check_mark:         | [no-invalid-interactive](./docs/rule/no-invalid-interactive.md)                       |
-| :white_check_mark:         | [no-invalid-link-text](./docs/rule/no-invalid-link-text.md)                           |
-|                            | [no-invalid-link-title](./docs/rule/no-invalid-link-title.md)                         |
-| :white_check_mark:         | [no-invalid-meta](./docs/rule/no-invalid-meta.md)                                     |
-| :white_check_mark:         | [no-invalid-role](./docs/rule/no-invalid-role.md)                                     |
-|                            | [no-link-to-tagname](./docs/rule/no-link-to-tagname.md)                               |
-| :white_check_mark:         | [no-log](./docs/rule/no-log.md)                                                       |
-| :dress:                    | [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                     |
-| :white_check_mark:         | [no-negated-condition](./docs/rule/no-negated-condition.md)                           |
-| :white_check_mark:         | [no-nested-interactive](./docs/rule/no-nested-interactive.md)                         |
-|                            | [no-nested-landmark](./docs/rule/no-nested-landmark.md)                               |
-|                            | [no-nested-splattributes](./docs/rule/no-nested-splattributes.md)                     |
-| :white_check_mark:         | [no-obsolete-elements](./docs/rule/no-obsolete-elements.md)                           |
-| :white_check_mark:         | [no-outlet-outside-routes](./docs/rule/no-outlet-outside-routes.md)                   |
-| :white_check_mark:         | [no-partial](./docs/rule/no-partial.md)                                               |
-|                            | [no-passed-in-event-handlers](./docs/rule/no-passed-in-event-handlers.md)             |
-| :wrench:                   | [no-positional-data-test-selectors](./docs/rule/no-positional-data-test-selectors.md) |
-| :white_check_mark:         | [no-positive-tabindex](./docs/rule/no-positive-tabindex.md)                           |
-|                            | [no-potential-path-strings](./docs/rule/no-potential-path-strings.md)                 |
-| :white_check_mark:         | [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md)                     |
-| :wrench:                   | [no-redundant-fn](./docs/rule/no-redundant-fn.md)                                     |
-|                            | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)               |
-|                            | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md)                 |
-| :white_check_mark:         | [no-shadowed-elements](./docs/rule/no-shadowed-elements.md)                           |
-| :dress:                    | [no-trailing-spaces](./docs/rule/no-trailing-spaces.md)                               |
-| :white_check_mark:         | [no-triple-curlies](./docs/rule/no-triple-curlies.md)                                 |
-|                            | [no-unbalanced-curlies](./docs/rule/no-unbalanced-curlies.md)                         |
-| :white_check_mark:         | [no-unbound](./docs/rule/no-unbound.md)                                               |
-| :white_check_mark:         | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)     |
-| :dress:                    | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                         |
-| :white_check_mark:         | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                       |
-|                            | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                   |
-|                            | [no-whitespace-within-word](./docs/rule/no-whitespace-within-word.md)                 |
-|                            | [no-yield-only](./docs/rule/no-yield-only.md)                                         |
-| :dress:                    | [quotes](./docs/rule/quotes.md)                                                       |
-| :white_check_mark::wrench: | [require-button-type](./docs/rule/require-button-type.md)                             |
-|                            | [require-each-key](./docs/rule/require-each-key.md)                                   |
-|                            | [require-form-method](./docs/rule/require-form-method.md)                             |
-| :white_check_mark:         | [require-iframe-title](./docs/rule/require-iframe-title.md)                           |
-|                            | [require-input-label](./docs/rule/require-input-label.md)                             |
-|                            | [require-lang-attribute](./docs/rule/require-lang-attribute.md)                       |
-| :white_check_mark:         | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                       |
-| :dress:                    | [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)               |
-| :white_check_mark:         | [simple-unless](./docs/rule/simple-unless.md)                                         |
-|                            | [splat-attributes-only](./docs/rule/splat-attributes-only.md)                         |
-| :white_check_mark:         | [style-concatenation](./docs/rule/style-concatenation.md)                             |
-| :white_check_mark:         | [table-groups](./docs/rule/table-groups.md)                                           |
-|                            | [template-length](./docs/rule/template-length.md)                                     |
+|                            | Rule ID                                                                                     |
+| :------------------------- | :------------------------------------------------------------------------------------------ |
+|                            | [attribute-indentation](./docs/rule/attribute-indentation.md)                               |
+| :dress:                    | [block-indentation](./docs/rule/block-indentation.md)                                       |
+|                            | [builtin-component-arguments](./docs/rule/builtin-component-arguments.md)                   |
+|                            | [deprecated-each-syntax](./docs/rule/deprecated-each-syntax.md)                             |
+|                            | [deprecated-inline-view-helper](./docs/rule/deprecated-inline-view-helper.md)               |
+| :white_check_mark:         | [deprecated-render-helper](./docs/rule/deprecated-render-helper.md)                         |
+| :dress:                    | [eol-last](./docs/rule/eol-last.md)                                                         |
+| :wrench:                   | [inline-link-to](./docs/rule/inline-link-to.md)                                             |
+| :dress:                    | [linebreak-style](./docs/rule/linebreak-style.md)                                           |
+| :white_check_mark:         | [link-href-attributes](./docs/rule/link-href-attributes.md)                                 |
+| :white_check_mark::wrench: | [link-rel-noopener](./docs/rule/link-rel-noopener.md)                                       |
+|                            | [modifier-name-case](./docs/rule/modifier-name-case.md)                                     |
+| :white_check_mark:         | [no-abstract-roles](./docs/rule/no-abstract-roles.md)                                       |
+| :wrench:                   | [no-accesskey-attribute](./docs/rule/no-accesskey-attribute.md)                             |
+| :car:                      | [no-action](./docs/rule/no-action.md)                                                       |
+|                            | [no-action-modifiers](./docs/rule/no-action-modifiers.md)                                   |
+| :white_check_mark:         | [no-args-paths](./docs/rule/no-args-paths.md)                                               |
+|                            | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)             |
+| :wrench:                   | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                                   |
+| :white_check_mark:         | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                             |
+|                            | [no-bare-strings](./docs/rule/no-bare-strings.md)                                           |
+|                            | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md)       |
+| :car:                      | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md)               |
+| :white_check_mark:         | [no-debugger](./docs/rule/no-debugger.md)                                                   |
+|                            | [no-down-event-binding](./docs/rule/no-down-event-binding.md)                               |
+| :white_check_mark:         | [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                           |
+|                            | [no-duplicate-id](./docs/rule/no-duplicate-id.md)                                           |
+|                            | [no-duplicate-landmark-elements](./docs/rule/no-duplicate-landmark-elements.md)             |
+|                            | [no-element-event-actions](./docs/rule/no-element-event-actions.md)                         |
+| :white_check_mark:         | [no-extra-mut-helper-argument](./docs/rule/no-extra-mut-helper-argument.md)                 |
+|                            | [no-forbidden-elements](./docs/rule/no-forbidden-elements.md)                               |
+|                            | [no-heading-inside-button](./docs/rule/no-heading-inside-button.md)                         |
+| :white_check_mark:         | [no-html-comments](./docs/rule/no-html-comments.md)                                         |
+| :car:                      | [no-implicit-this](./docs/rule/no-implicit-this.md)                                         |
+| :white_check_mark:         | [no-index-component-invocation](./docs/rule/no-index-component-invocation.md)               |
+| :white_check_mark:         | [no-inline-styles](./docs/rule/no-inline-styles.md)                                         |
+| :white_check_mark:         | [no-input-block](./docs/rule/no-input-block.md)                                             |
+| :white_check_mark:         | [no-input-tagname](./docs/rule/no-input-tagname.md)                                         |
+|                            | [no-invalid-block-param-definition](./docs/rule/no-invalid-block-param-definition.md)       |
+| :white_check_mark:         | [no-invalid-interactive](./docs/rule/no-invalid-interactive.md)                             |
+| :white_check_mark:         | [no-invalid-link-text](./docs/rule/no-invalid-link-text.md)                                 |
+|                            | [no-invalid-link-title](./docs/rule/no-invalid-link-title.md)                               |
+| :white_check_mark:         | [no-invalid-meta](./docs/rule/no-invalid-meta.md)                                           |
+| :white_check_mark:         | [no-invalid-role](./docs/rule/no-invalid-role.md)                                           |
+|                            | [no-link-to-tagname](./docs/rule/no-link-to-tagname.md)                                     |
+| :white_check_mark:         | [no-log](./docs/rule/no-log.md)                                                             |
+| :wrench:                   | [no-model-argument-in-route-templates](./docs/rule/no-model-argument-in-route-templates.md) |
+| :dress:                    | [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                           |
+| :white_check_mark:         | [no-negated-condition](./docs/rule/no-negated-condition.md)                                 |
+| :white_check_mark:         | [no-nested-interactive](./docs/rule/no-nested-interactive.md)                               |
+|                            | [no-nested-landmark](./docs/rule/no-nested-landmark.md)                                     |
+|                            | [no-nested-splattributes](./docs/rule/no-nested-splattributes.md)                           |
+| :white_check_mark:         | [no-obsolete-elements](./docs/rule/no-obsolete-elements.md)                                 |
+| :white_check_mark:         | [no-outlet-outside-routes](./docs/rule/no-outlet-outside-routes.md)                         |
+| :white_check_mark:         | [no-partial](./docs/rule/no-partial.md)                                                     |
+|                            | [no-passed-in-event-handlers](./docs/rule/no-passed-in-event-handlers.md)                   |
+| :wrench:                   | [no-positional-data-test-selectors](./docs/rule/no-positional-data-test-selectors.md)       |
+| :white_check_mark:         | [no-positive-tabindex](./docs/rule/no-positive-tabindex.md)                                 |
+|                            | [no-potential-path-strings](./docs/rule/no-potential-path-strings.md)                       |
+| :white_check_mark:         | [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md)                           |
+| :wrench:                   | [no-redundant-fn](./docs/rule/no-redundant-fn.md)                                           |
+|                            | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)                     |
+|                            | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md)                       |
+| :white_check_mark:         | [no-shadowed-elements](./docs/rule/no-shadowed-elements.md)                                 |
+| :dress:                    | [no-trailing-spaces](./docs/rule/no-trailing-spaces.md)                                     |
+| :white_check_mark:         | [no-triple-curlies](./docs/rule/no-triple-curlies.md)                                       |
+|                            | [no-unbalanced-curlies](./docs/rule/no-unbalanced-curlies.md)                               |
+| :white_check_mark:         | [no-unbound](./docs/rule/no-unbound.md)                                                     |
+| :white_check_mark:         | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)           |
+| :dress:                    | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                               |
+| :white_check_mark:         | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                             |
+|                            | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                         |
+|                            | [no-whitespace-within-word](./docs/rule/no-whitespace-within-word.md)                       |
+|                            | [no-yield-only](./docs/rule/no-yield-only.md)                                               |
+| :dress:                    | [quotes](./docs/rule/quotes.md)                                                             |
+| :white_check_mark::wrench: | [require-button-type](./docs/rule/require-button-type.md)                                   |
+|                            | [require-each-key](./docs/rule/require-each-key.md)                                         |
+|                            | [require-form-method](./docs/rule/require-form-method.md)                                   |
+| :white_check_mark:         | [require-iframe-title](./docs/rule/require-iframe-title.md)                                 |
+|                            | [require-input-label](./docs/rule/require-input-label.md)                                   |
+|                            | [require-lang-attribute](./docs/rule/require-lang-attribute.md)                             |
+| :white_check_mark:         | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                             |
+| :dress:                    | [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)                     |
+| :white_check_mark:         | [simple-unless](./docs/rule/simple-unless.md)                                               |
+|                            | [splat-attributes-only](./docs/rule/splat-attributes-only.md)                               |
+| :white_check_mark:         | [style-concatenation](./docs/rule/style-concatenation.md)                                   |
+| :white_check_mark:         | [table-groups](./docs/rule/table-groups.md)                                                 |
+|                            | [template-length](./docs/rule/template-length.md)                                           |
 
 <!--RULES_TABLE_END-->
 

--- a/docs/rule/no-model-argument-in-route-templates.md
+++ b/docs/rule/no-model-argument-in-route-templates.md
@@ -1,0 +1,82 @@
+# no-model-argument-in-route-templates
+
+:wrench: The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
+Usage of `{{@model}}` in route templates was introduced to simplify the mental
+model in Ember Octane. Unfortunately, there is a known problem where usage of
+`{{@model}}` can introduce difficult to diagnose failures when transitioning
+within the same route (with different params, e.g. `/posts/1` -> `/posts/2`).
+
+Given this route:
+
+```js
+// app/routes/post.js
+export default class extends Route {
+  model(params) {
+    return this.store.findRecord('post', params.post_id);
+  }
+}
+```
+
+With the following template:
+
+```hbs
+{{! app/templates/post.hbs }}
+{{some-helper @model}}
+```
+
+And a simple `some-helper` implementation like:
+
+```js
+// app/helpers/some-helper.js
+export default helper(function(params) {
+  console.log('some-helper:', ...params);
+});
+```
+
+You'll notice that when transitioning into `/post/1` initially `some-helper`
+will be invoked once (with the resolved model value), at this point things are
+working as expected (the router did its job of absorbing the asynchrony in the
+model hook).  However if you transition from `/posts/1` to `/posts/2`, you will
+notice that `some-helper` is invoked **two** times:
+
+* first with its argument as `undefined`
+* second with its argument as the expected fully resolved model value
+
+This demonstrates the problem clearly: you **never** expect for `{{@model}}` to
+have been `undefined` and in a number of cases this will actually cause errors
+(e.g. if your helper assumed an argument was an object and throw an error).
+
+## Examples
+
+This rule **forbids** usage of `{{@model}}` in route templates:
+
+```hbs
+{{@model}}
+```
+
+```hbs
+{{@model.foo.bar}}
+```
+
+This rule **allows** the following:
+
+```hbs
+{{this.model}}
+```
+
+```hbs
+{{this.model.foo}}
+```
+
+```hbs
+{{this.model.foo.bar}}
+```
+
+## Migration
+
+This rule includes a fixer in order to handle the migration for you automatically.
+
+## References
+
+* TODO: link to Ember issue folks can follow to know when this is fixed

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -47,6 +47,7 @@ module.exports = {
   'no-invalid-role': require('./no-invalid-role'),
   'no-link-to-tagname': require('./no-link-to-tagname'),
   'no-log': require('./no-log'),
+  'no-model-argument-in-route-templates': require('./no-model-argument-in-route-templates'),
   'no-multiple-empty-lines': require('./no-multiple-empty-lines'),
   'no-negated-condition': require('./no-negated-condition'),
   'no-nested-interactive': require('./no-nested-interactive'),

--- a/lib/rules/no-model-argument-in-route-templates.js
+++ b/lib/rules/no-model-argument-in-route-templates.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const { builders } = require('ember-template-recast');
+
+const isRouteTemplate = require('../helpers/is-route-template');
+const Rule = require('./base');
+
+const ERROR_MESSAGE = 'Do not use `{{@model}}` in route templates, use `{{this.model}}` instead.';
+
+module.exports = class NoModelArgumentInRouteTemplates extends Rule {
+  constructor(options) {
+    super(options);
+
+    this.isRouteTemplate = isRouteTemplate(options.filePath);
+  }
+
+  visitor() {
+    if (!this.isRouteTemplate) {
+      // do nothing for component templates
+      return {};
+    }
+
+    return {
+      PathExpression(node, path) {
+        if (node.data && node.parts[0] === 'model') {
+          if (this.mode === 'fix') {
+            path.parentNode[path.parentKey] = builders.path(
+              ['this', 'model', ...node.parts.slice(1)].join('.'),
+              node.loc
+            );
+            return;
+          }
+
+          this.log({
+            message: ERROR_MESSAGE,
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+            isFixable: true,
+          });
+        }
+      },
+    };
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/no-model-argument-in-route-templates-test.js
+++ b/test/unit/rules/no-model-argument-in-route-templates-test.js
@@ -1,0 +1,99 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'no-model-argument-in-route-templates',
+
+  config: true,
+  meta: {
+    filePath: 'app/templates/foo.hbs',
+    moduleId: 'app/templates/foo',
+  },
+
+  good: [
+    '{{model}}',
+    '{{this.model}}',
+    '{{@modelythingy}}',
+    {
+      template: '{{@model}}',
+      meta: {
+        filePath: 'app/components/foo.hbs',
+        moduleId: 'app/components/foo',
+      },
+    },
+    {
+      template: '{{@model}}',
+      meta: {
+        filePath: 'app/templates/components/foo.hbs',
+        moduleId: 'app/templates/components/foo',
+      },
+    },
+  ],
+
+  bad: [
+    {
+      template: '{{@model}}',
+      fixedTemplate: '{{this.model}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 2,
+              "filePath": "app/templates/foo.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Do not use \`{{@model}}\` in route templates, use \`{{this.model}}\` instead.",
+              "moduleId": "app/templates/foo",
+              "rule": "no-model-argument-in-route-templates",
+              "severity": 2,
+              "source": "@model",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '{{@model.foo}}',
+      fixedTemplate: '{{this.model.foo}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 2,
+              "filePath": "app/templates/foo.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Do not use \`{{@model}}\` in route templates, use \`{{this.model}}\` instead.",
+              "moduleId": "app/templates/foo",
+              "rule": "no-model-argument-in-route-templates",
+              "severity": 2,
+              "source": "@model.foo",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '{{@model.foo.bar}}',
+      fixedTemplate: '{{this.model.foo.bar}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 2,
+              "filePath": "app/templates/foo.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Do not use \`{{@model}}\` in route templates, use \`{{this.model}}\` instead.",
+              "moduleId": "app/templates/foo",
+              "rule": "no-model-argument-in-route-templates",
+              "severity": 2,
+              "source": "@model.foo.bar",
+            },
+          ]
+        `);
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Usage of `{{@model}}` in route templates was introduced to simplify the mental model in Ember Octane. Unfortunately, there is a known problem where usage of `{{@model}}` can introduce difficult to diagnose failures when transitioning within the same route (with different params, e.g. `/posts/1` -> `/posts/2`).

You'll notice that when transitioning into `/post/1` initially `{{@model}}` will be the resolved model value. However if you transition from `/posts/1` to `/posts/2`, you will notice that `{{@model}}` updates from that original model value to `undefined` (while the model hook for `/post/2` is still pending) then once that model hook resolves for the second time `{{@model}}` is updated with the final resolved model hook value.

This demonstrates the problem clearly: you **never** expect for `{{@model}}` to have been `undefined` and in a number of cases this will actually cause errors (e.g. if your helper assumed an argument was an object and throw an error).