### PR TITLE
Fix false positive in `no-invalid-link-title` when using a dynamic value surrounded by whitespace.

### DIFF
--- a/lib/rules/no-invalid-link-title.js
+++ b/lib/rules/no-invalid-link-title.js
@@ -7,7 +7,9 @@ function hasInvalidLinkTitle(node, titleAttributeValues) {
   // Extract the text content(s) from the TextNode child(ren)
   const nodeChildren = AstNodeInfo.childrenFor(node);
   const textChildren = nodeChildren.filter((child) => AstNodeInfo.isTextNode(child));
-  const linkTexts = textChildren.map((linkText) => linkText.chars.toLowerCase().trim());
+  const linkTexts = textChildren
+    .map((linkText) => linkText.chars.toLowerCase().trim())
+    .filter((text) => text.length > 0);
 
   // Check to see if the text content is the same as the title attribute value
   const hasMatchingLinkAndTitleText = linkTexts.some((linkText) =>

--- a/test/unit/rules/no-invalid-link-title-test.js
+++ b/test/unit/rules/no-invalid-link-title-test.js
@@ -17,6 +17,11 @@ generateRuleTests({
     '<a href="https://myurl.com" title="New to Ember? Read the full tutorial for the best experience">Read the Tutorial</a>',
     '<a href="./whatever" title={{foo}}>Hello!</a>',
     '{{#link-to "blah.route.here" title="awesome title"}}Some thing else here{{/link-to}}',
+    `
+      <LinkTo @query={{hash page=@pagination.prevPage}} local-class="prev" @rel="prev" @title="previous page" data-test-pagination-prev>
+        {{svg-jar "left-pag"}}
+      </LinkTo>
+    `,
   ],
 
   bad: [


### PR DESCRIPTION
@Turbo87 @MelSumner 

Related issue: #1604

If merged, this PR updates the helper function that processes the link text. Specifically, it adds a filter to remove empty Strings from the Array for comparison against the `title` attribute. This prevents false-positives generated by whitespace appearing before or after the real (non-TextNode) link text.