### PR TITLE
Fix false positive with content within `{{#if}}`/`{{else}}` blocks in `no-duplicate-id` rule

### DIFF
--- a/lib/rules/no-duplicate-id.js
+++ b/lib/rules/no-duplicate-id.js
@@ -1,16 +1,67 @@
 'use strict';
 
+const AstNodeInfo = require('../helpers/ast-node-info');
 const NodeMatcher = require('../helpers/node-matcher');
 const Rule = require('./base');
+
+class ConditionalScope {
+  constructor() {
+    this.frames = [new Set()];
+
+    this.conditionals = [];
+  }
+
+  pushConditional() {
+    this.conditionals.push(new Set());
+  }
+
+  popConditional() {
+    let idsWithinConditional = this.conditionals.pop();
+
+    if (this.conditionals.length > 0) {
+      let parentConditional = this.conditionals[this.conditionals.length - 1];
+      idsWithinConditional.forEach((idValue) => {
+        parentConditional.add(idValue);
+      });
+    } else {
+      this.frames.push(idsWithinConditional);
+    }
+  }
+
+  pushBranch() {
+    this.frames.push(new Set());
+  }
+
+  popBranch() {
+    this.frames.pop();
+  }
+
+  isDuplicateId(idValue) {
+    for (let frame of this.frames) {
+      if (frame.has(idValue)) {
+        return true;
+      }
+    }
+  }
+
+  addId(idValue) {
+    this.frames[this.frames.length - 1].add(idValue);
+
+    if (this.conditionals.length > 0) {
+      let currentConditional = this.conditionals[this.conditionals.length - 1];
+      currentConditional.add(idValue);
+    }
+  }
+}
 
 const ERROR_MESSAGE = 'ID attribute values must be unique';
 module.exports = class NoDuplicateId extends Rule {
   // Handles the primary logic for the rule:
-  // - if `idValue` is unique / not in the existing `idValueSet`; add it and carry on
+  // - if `idValue` is unique / not in the existing `ConditionalScope`; add it and carry on
   // - if it is a duplicate value; log the error
   logIfDuplicate(node, idValue) {
-    if (!this.idValueSet.has(idValue)) {
-      this.idValueSet.add(idValue);
+    if (!this.conditionalScope.isDuplicateId(idValue)) {
+      this.conditionalScope.addId(idValue);
     } else {
       this.log({
         message: ERROR_MESSAGE,
@@ -94,7 +145,8 @@ module.exports = class NoDuplicateId extends Rule {
     }
 
     // Store the idValues collected; reference to look for duplicates
-    this.idValueSet = new Set();
+
+    this.conditionalScope = new ConditionalScope();
 
     return {
       AttrNode(node) {
@@ -133,7 +185,38 @@ module.exports = class NoDuplicateId extends Rule {
         this.logIfDuplicate(node, idValue);
       },
 
-      BlockStatement: handleCurlyNode,
+      BlockStatement: {
+        enter(node) {
+          if (AstNodeInfo.isControlFlowHelper(node)) {
+            this.conditionalScope.pushConditional();
+          } else {
+            handleCurlyNode.call(this, node);
+          }
+        },
+
+        exit(node) {
+          if (AstNodeInfo.isControlFlowHelper(node)) {
+            this.conditionalScope.popConditional();
+          }
+        },
+      },
+
+      Block: {
+        enter(_node, path) {
+          let parent = path.parent;
+          if (AstNodeInfo.isControlFlowHelper(parent.node)) {
+            this.conditionalScope.pushBranch();
+          }
+        },
+
+        exit(_node, path) {
+          let parent = path.parent;
+          if (AstNodeInfo.isControlFlowHelper(parent.node)) {
+            this.conditionalScope.popBranch();
+          }
+        },
+      },
+
       MustacheStatement: handleCurlyNode,
     };
   }

--- a/lib/rules/no-duplicate-id.js
+++ b/lib/rules/no-duplicate-id.js
@@ -11,11 +11,11 @@ class ConditionalScope {
     this.conditionals = [];
   }
 
-  pushConditional() {
+  enterConditional() {
     this.conditionals.push(new Set());
   }
 
-  popConditional() {
+  exitConditional() {
     let idsWithinConditional = this.conditionals.pop();
 
     if (this.conditionals.length > 0) {
@@ -28,11 +28,11 @@ class ConditionalScope {
     }
   }
 
-  pushBranch() {
+  enterConditionalBranch() {
     this.seenIdStack.push(new Set());
   }
 
-  popBranch() {
+  exitConditionalBranch() {
     this.seenIdStack.pop();
   }
 
@@ -188,7 +188,7 @@ module.exports = class NoDuplicateId extends Rule {
       BlockStatement: {
         enter(node) {
           if (AstNodeInfo.isControlFlowHelper(node)) {
-            this.conditionalScope.pushConditional();
+            this.conditionalScope.enterConditional();
           } else {
             handleCurlyNode.call(this, node);
           }
@@ -196,7 +196,7 @@ module.exports = class NoDuplicateId extends Rule {
 
         exit(node) {
           if (AstNodeInfo.isControlFlowHelper(node)) {
-            this.conditionalScope.popConditional();
+            this.conditionalScope.exitConditional();
           }
         },
       },
@@ -205,14 +205,14 @@ module.exports = class NoDuplicateId extends Rule {
         enter(_node, path) {
           let parent = path.parent;
           if (AstNodeInfo.isControlFlowHelper(parent.node)) {
-            this.conditionalScope.pushBranch();
+            this.conditionalScope.enterConditionalBranch();
           }
         },
 
         exit(_node, path) {
           let parent = path.parent;
           if (AstNodeInfo.isControlFlowHelper(parent.node)) {
-            this.conditionalScope.popBranch();
+            this.conditionalScope.exitConditionalBranch();
           }
         },
       },

--- a/lib/rules/no-duplicate-id.js
+++ b/lib/rules/no-duplicate-id.js
@@ -6,7 +6,7 @@ const Rule = require('./base');
 
 class ConditionalScope {
   constructor() {
-    this.frames = [new Set()];
+    this.seenIdStack = [new Set()];
 
     this.conditionals = [];
   }
@@ -20,36 +20,36 @@ class ConditionalScope {
 
     if (this.conditionals.length > 0) {
       let parentConditional = this.conditionals[this.conditionals.length - 1];
-      idsWithinConditional.forEach((idValue) => {
-        parentConditional.add(idValue);
+      idsWithinConditional.forEach((id) => {
+        parentConditional.add(id);
       });
     } else {
-      this.frames.push(idsWithinConditional);
+      this.seenIdStack.push(idsWithinConditional);
     }
   }
 
   pushBranch() {
-    this.frames.push(new Set());
+    this.seenIdStack.push(new Set());
   }
 
   popBranch() {
-    this.frames.pop();
+    this.seenIdStack.pop();
   }
 
-  isDuplicateId(idValue) {
-    for (let frame of this.frames) {
-      if (frame.has(idValue)) {
+  isDuplicateId(id) {
+    for (let seenIds of this.seenIdStack) {
+      if (seenIds.has(id)) {
         return true;
       }
     }
   }
 
-  addId(idValue) {
-    this.frames[this.frames.length - 1].add(idValue);
+  addId(id) {
+    this.seenIdStack[this.seenIdStack.length - 1].add(id);
 
     if (this.conditionals.length > 0) {
       let currentConditional = this.conditionals[this.conditionals.length - 1];
-      currentConditional.add(idValue);
+      currentConditional.add(id);
     }
   }
 }
@@ -57,11 +57,11 @@ class ConditionalScope {
 const ERROR_MESSAGE = 'ID attribute values must be unique';
 module.exports = class NoDuplicateId extends Rule {
   // Handles the primary logic for the rule:
-  // - if `idValue` is unique / not in the existing `ConditionalScope`; add it and carry on
+  // - if `id` is unique / not in the existing `ConditionalScope`; add it and carry on
   // - if it is a duplicate value; log the error
-  logIfDuplicate(node, idValue) {
-    if (!this.conditionalScope.isDuplicateId(idValue)) {
-      this.conditionalScope.addId(idValue);
+  logIfDuplicate(node, id) {
+    if (!this.conditionalScope.isDuplicateId(id)) {
+      this.conditionalScope.addId(id);
     } else {
       this.log({
         message: ERROR_MESSAGE,
@@ -76,13 +76,13 @@ module.exports = class NoDuplicateId extends Rule {
   // that store their attributes as an Array of HashPairs -- in this case,
   // MustacheStatements and BlockStatements
   getHashArgIdValue(node, idAttrName) {
-    let idValue;
+    let id;
     let refPair = { key: idAttrName, value: { type: 'StringLiteral' } };
     let idHashArg = node.hash.pairs.find((testPair) => NodeMatcher.match(testPair, refPair));
     if (idHashArg) {
-      idValue = idHashArg.value.value;
+      id = idHashArg.value.value;
     }
-    return idValue;
+    return id;
   }
 
   visitor() {
@@ -132,19 +132,19 @@ module.exports = class NoDuplicateId extends Rule {
     }
 
     function handleCurlyNode(node) {
-      let idValue = this.getHashArgIdValue(node, 'elementId');
-      if (idValue) {
-        this.logIfDuplicate(node, idValue);
+      let id = this.getHashArgIdValue(node, 'elementId');
+      if (id) {
+        this.logIfDuplicate(node, id);
         return;
       }
 
-      idValue = this.getHashArgIdValue(node, 'id');
-      if (idValue) {
-        this.logIfDuplicate(node, idValue);
+      id = this.getHashArgIdValue(node, 'id');
+      if (id) {
+        this.logIfDuplicate(node, id);
       }
     }
 
-    // Store the idValues collected; reference to look for duplicates
+    // Store the id values collected; reference to look for duplicates
 
     this.conditionalScope = new ConditionalScope();
 
@@ -155,34 +155,34 @@ module.exports = class NoDuplicateId extends Rule {
           return;
         }
 
-        let idValue;
+        let id;
         switch (node.value.type) {
           // ConcatStatement: try to resolve parts to StringLiteral where possible
           // ex. id="id-{{"value"}}" becomes "id-value"
           // ex. id="id-{{value}}-{{"number"}}" becomes "id-{{value}}-number"
           case 'ConcatStatement':
-            idValue = getJoinedConcatParts(node, this);
+            id = getJoinedConcatParts(node, this);
             break;
 
           // TextNode: unwrap
           // ex. id="id-value" becomes "id-value"
           case 'TextNode':
-            idValue = node.value.chars;
+            id = node.value.chars;
             break;
 
           // MustacheStatement: try to resolve
           // ex. id={{"id-value"}} becomes "id-value"
           // ex. id={{idValue}} becomes "{{idValue}}"
           case 'MustacheStatement':
-            idValue = getMustacheValue(node.value, this);
+            id = getMustacheValue(node.value, this);
             break;
 
           default:
-            // If idValue is not assigned by this point, use the raw source
-            idValue = this.sourceForNode(node.value);
+            // If id is not assigned by this point, use the raw source
+            id = this.sourceForNode(node.value);
         }
 
-        this.logIfDuplicate(node, idValue);
+        this.logIfDuplicate(node, id);
       },
 
       BlockStatement: {


### PR DESCRIPTION
`no-duplicate-id` was returning false positives for content within `{{#if}}`/`{{else}}` blocks. 

If merged, this PR will:
- add a test to allow duplicate ids within control flow helper block statements 
`'{{#if}}<div id="id-00"></div>{{else}}<span id="id-00"></span>{{/if}}',`
- add a helper function to check for control flow helper block statements and ignore them

Fixes #1511