### PR TITLE
Implements new todo functionality (replaces pending)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,7 +49,6 @@ module.exports = {
     'no-new-wrappers': 'error',
     'no-octal-escape': 'error',
     'no-return-assign': 'error',
-    'no-return-await': 'error',
     'no-self-compare': 'error',
     'no-sequences': 'error',
     'no-shadow-restricted-names': 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -49,6 +49,7 @@ module.exports = {
     'no-new-wrappers': 'error',
     'no-octal-escape': 'error',
     'no-return-assign': 'error',
+    'no-return-await': 'error',
     'no-self-compare': 'error',
     'no-sequences': 'error',
     'no-shadow-restricted-names': 'error',

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -164,7 +164,7 @@ function parseArgv(_argv) {
         boolean: true,
       },
       'include-todo': {
-        describe: 'Include todos in the results (todos are hidden by default)',
+        describe: 'Include todos in the results',
         default: false,
         boolean: true,
       },

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -312,7 +312,7 @@ async function run() {
     }
 
     if (!filePaths.has(STDIN)) {
-      fileResults = await linter.processTodos(linterOptions, fileResults);
+      fileResults = await linter.processTodos(linterOptions, fileResults, options.fix);
     }
 
     resultsAccumulator.push(...fileResults);

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -160,10 +160,12 @@ function parseArgv(_argv) {
       },
       'update-todo': {
         describe: 'Update list of linting todos by transforming lint errors to todos',
+        default: false,
         boolean: true,
       },
       'include-todo': {
         describe: 'Include todos in the results (todos are hidden by default)',
+        default: false,
         boolean: true,
       },
       'ignore-pattern': {

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -10,6 +10,7 @@ const path = require('path');
 const { promisify } = require('util');
 
 const { getTodoStorageDirPath } = require('@ember-template-lint/todo-utils');
+const chalk = require('chalk');
 const getStdin = require('get-stdin');
 const globby = require('globby');
 const isGlob = require('is-glob');
@@ -39,22 +40,6 @@ async function buildLinterOptions(workingDir, filePath, filename = '', isReading
     let source = await readFile(resolvedFilePath, { encoding: 'utf8' });
 
     return { source, filePath, moduleId };
-  }
-}
-
-// TODO: inline this function
-async function lintSource(linter, linterOptions, options) {
-  if (options.updateTodo || linter.todosEnabled) {
-    return linter.verifyAndUpdateTodos(linterOptions, options);
-  } else if (options.fix) {
-    let { isFixed, output, messages } = await linter.verifyAndFix(linterOptions);
-    if (isFixed) {
-      fs.writeFileSync(linterOptions.filePath, output);
-    }
-
-    return messages;
-  } else {
-    return linter.verify(linterOptions);
   }
 }
 
@@ -174,7 +159,11 @@ function parseArgv(_argv) {
         boolean: true,
       },
       'update-todo': {
-        describe: 'Update list of linting todos',
+        describe: 'Update list of linting todos by transforming lint errors to todos',
+        boolean: true,
+      },
+      'include-todo': {
+        describe: 'Show list of todos',
         boolean: true,
       },
       'ignore-pattern': {
@@ -230,6 +219,8 @@ function printPending(results, options) {
   if (options.json) {
     console.log(pendingListString);
   } else {
+    console.log(chalk.yellow('WARNING: Print pending is deprecated. Use --update-todo instead.\n'));
+
     console.log(
       'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n'
     );
@@ -302,26 +293,39 @@ async function run() {
       filePaths.has(STDIN)
     );
 
-    let messages = await lintSource(linter, linterOptions, options);
+    let fileResults;
 
-    resultsAccumulator.push(...messages);
+    if (options.fix) {
+      let { isFixed, output, messages } = await linter.verifyAndFix(linterOptions);
+      if (isFixed) {
+        fs.writeFileSync(linterOptions.filePath, output);
+      }
+      fileResults = messages;
+    } else {
+      fileResults = await linter.verify(linterOptions);
+    }
+
+    if (options.updateTodo) {
+      await linter.updateTodo(linterOptions, fileResults);
+    }
+
+    if (!filePaths.has(STDIN)) {
+      fileResults = await linter.processTodos(linterOptions, fileResults);
+    }
+
+    resultsAccumulator.push(...fileResults);
   }
 
   let results = processResults(resultsAccumulator);
+
   if (results.errorCount > 0) {
     process.exitCode = 1;
   }
 
-  // TODO: add --update-pending flag
-  // TODO: add new --list-pending feature for new system
-  // TODO: error if using --print-pending and new pending system
-  // TODO: error if we have old config.pending and new pending dir
-  // TODO: migrate to new pending system if using old pending system
-
   if (options.printPending) {
     return printPending(results, options);
   } else {
-    if (results.errorCount || results.warningCount) {
+    if (results.errorCount || results.warningCount || (results.todoCount && options.includeTodo)) {
       let Printer = require('../lib/printers/default');
       let printer = new Printer(options);
       printer.print(results);

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -325,7 +325,7 @@ async function run() {
   if (options.printPending) {
     return printPending(results, options);
   } else {
-    if (results.errorCount || results.warningCount || (results.todoCount && options.includeTodo)) {
+    if (results.errorCount || results.warningCount || (options.includeTodo && results.todoCount)) {
       let Printer = require('../lib/printers/default');
       let printer = new Printer(options);
       printer.print(results);

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 
+const { getTodoStorageDirPath } = require('@ember-template-lint/todo-utils');
 const getStdin = require('get-stdin');
 const globby = require('globby');
 const isGlob = require('is-glob');
@@ -16,8 +17,6 @@ const micromatch = require('micromatch');
 
 const Linter = require('../lib');
 const processResults = require('../lib/helpers/process-results');
-
-const { getTodoStorageDirPath } = require('@ember-template-lint/todo-utils');
 
 const readFile = promisify(fs.readFile);
 
@@ -44,18 +43,18 @@ async function buildLinterOptions(workingDir, filePath, filename = '', isReading
 }
 
 // TODO: inline this function
-async function lintSource(linter, options, shouldFix) {
-  if (options.updateTodos) {
-    return linter.verifyAndUpdateTodos(options);
-  } else if (shouldFix) {
-    let { isFixed, output, messages } = await linter.verifyAndFix(options);
+async function lintSource(linter, linterOptions, options) {
+  if (options.updateTodo || linter.todosEnabled) {
+    return linter.verifyAndUpdateTodos(linterOptions, options);
+  } else if (options.fix) {
+    let { isFixed, output, messages } = await linter.verifyAndFix(linterOptions);
     if (isFixed) {
-      fs.writeFileSync(options.filePath, output);
+      fs.writeFileSync(linterOptions.filePath, output);
     }
 
     return messages;
   } else {
-    return linter.verify(options);
+    return linter.verify(linterOptions);
   }
 }
 
@@ -174,7 +173,7 @@ function parseArgv(_argv) {
           'Print list of formatted rules for use with `pending` in config file (deprecated)',
         boolean: true,
       },
-      'update-todos': {
+      'update-todo': {
         describe: 'Update list of linting todos',
         boolean: true,
       },
@@ -273,7 +272,10 @@ async function run() {
     return;
   }
 
-  if (fs.existsSync(getTodoStorageDirPath(process.cwd())) && linter.config.pending) {
+  if (
+    fs.existsSync(getTodoStorageDirPath(options.workingDirectory)) &&
+    linter.config.pending.length > 0
+  ) {
     console.error(
       'Cannot use the `pending` config option in conjunction with lint todos. Please run with `--update-pending` to migrate to the new todos functionality.'
     );
@@ -281,8 +283,15 @@ async function run() {
     return;
   }
 
-  let filePaths = getFilesToLint(options.workingDirectory, positional, options.ignorePattern);
+  if (options.updateTodo && linter.config.pending.length > 0) {
+    console.error(
+      'Cannot use the `pending` config option in conjunction with `--update-todo`. Please remove the `pending` option from your config and re-run the command.'
+    );
+    process.exitCode = 1;
+    return;
+  }
 
+  let filePaths = getFilesToLint(options.workingDirectory, positional, options.ignorePattern);
 
   let resultsAccumulator = [];
   for (let relativeFilePath of filePaths) {
@@ -293,7 +302,7 @@ async function run() {
       filePaths.has(STDIN)
     );
 
-    let messages = await lintSource(linter, linterOptions, options.fix);
+    let messages = await lintSource(linter, linterOptions, options);
 
     resultsAccumulator.push(...messages);
   }

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -266,8 +266,8 @@ async function run() {
   }
 
   if (
-    fs.existsSync(getTodoStorageDirPath(options.workingDirectory)) &&
-    linter.config.pending.length > 0
+    linter.config.pending.length > 0 &&
+    fs.existsSync(getTodoStorageDirPath(options.workingDirectory))
   ) {
     console.error(
       'Cannot use the `pending` config option in conjunction with lint todos. Please run with `--update-pending` to migrate to the new todos functionality.'
@@ -276,7 +276,7 @@ async function run() {
     return;
   }
 
-  if (options.updateTodo && linter.config.pending.length > 0) {
+  if (linter.config.pending.length > 0 && options.updateTodo) {
     console.error(
       'Cannot use the `pending` config option in conjunction with `--update-todo`. Please remove the `pending` option from your config and re-run the command.'
     );
@@ -300,7 +300,7 @@ async function run() {
     if (options.fix) {
       let { isFixed, output, messages } = await linter.verifyAndFix(linterOptions);
       if (isFixed) {
-        fs.writeFileSync(linterOptions.filePath, output);
+        fs.writeFileSync(linterOptions.filePath, output, { encoding: 'utf-8' });
       }
       fileResults = messages;
     } else {

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -163,7 +163,7 @@ function parseArgv(_argv) {
         boolean: true,
       },
       'include-todo': {
-        describe: 'Show list of todos',
+        describe: 'Include todos in the results (todos are hidden by default)',
         boolean: true,
       },
       'ignore-pattern': {

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -14,10 +14,6 @@ module.exports = class TodoHandler {
     this._processedResults = [];
   }
 
-  get todosEnabled() {
-    return todoStorageDirExists(this._workingDir);
-  }
-
   async update(filePath, results) {
     this._processedResults = this._buildResult(results);
 

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -4,6 +4,8 @@ const {
   todoStorageDirExists,
   writeTodos,
   readTodosForFilePath,
+  applyTodoChanges,
+  getTodoStorageDirPath,
 } = require('@ember-template-lint/todo-utils');
 
 const { TODO_SEVERITY } = require('../get-config');
@@ -20,7 +22,7 @@ module.exports = class TodoHandler {
     await writeTodos(this._workingDir, this._processedResults, filePath);
   }
 
-  async processResults(filePath, results) {
+  async processResults(filePath, results, shouldFix) {
     if (!todoStorageDirExists(this._workingDir)) {
       return results;
     }
@@ -33,16 +35,20 @@ module.exports = class TodoHandler {
     );
 
     if (itemsToRemoveFromTodos.size > 0) {
-      itemsToRemoveFromTodos.forEach((todo) => {
-        results.push({
-          rule: 'invalid-todo-violation-rule',
-          message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`--update-todo\` to remove this todo from the todo list.`,
-          filePath: todo.filePath,
-          moduleId: todo.moduleId,
-          severity: 2,
-          isFixable: true,
+      if (shouldFix) {
+        applyTodoChanges(getTodoStorageDirPath(this._workingDir), [], itemsToRemoveFromTodos);
+      } else {
+        itemsToRemoveFromTodos.forEach((todo) => {
+          results.push({
+            rule: 'invalid-todo-violation-rule',
+            message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`--update-todo\` to remove this todo from the todo list.`,
+            filePath: todo.filePath,
+            moduleId: todo.moduleId,
+            severity: 2,
+            isFixable: true,
+          });
         });
-      });
+      }
     }
 
     [...existingTodos.values()].forEach((todo) => {

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -44,7 +44,7 @@ module.exports = class TodoHandler {
           filePath: todo.filePath,
           moduleId: todo.moduleId,
           severity: 2,
-          isFixable: false,
+          isFixable: true,
         });
       });
     }

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -67,28 +67,16 @@ module.exports = class TodoHandler {
   _buildResult(results) {
     let builtResults = [];
 
-    function buildMessage(result) {
-      return {
-        rule: result.rule,
-        severity: result.severity,
-        moduleId: result.moduleId,
-        message: result.message,
-        line: result.line,
-        column: result.column,
-        source: result.source,
-      };
-    }
-
     for (const result of results) {
       let resultForFile = builtResults.find((r) => r.filePath === result.filePath);
 
       if (resultForFile) {
-        resultForFile.messages.push(buildMessage(result));
+        resultForFile.messages.push({ ...result });
         resultForFile.errorCount += 1;
       } else {
         builtResults.push({
           filePath: result.filePath,
-          messages: [buildMessage(result)],
+          messages: [{ ...result }],
           errorCount: 1,
           source: result.source,
         });

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -71,24 +71,25 @@ module.exports = class TodoHandler {
   }
 
   _buildResult(results) {
-    let builtResults = [];
+    let builtResults = new Map();
 
     for (const result of results) {
-      let resultForFile = builtResults.find((r) => r.filePath === result.filePath);
+      let resultForFile = builtResults.get(result.filePath);
 
-      if (resultForFile) {
-        resultForFile.messages.push({ ...result });
-        resultForFile.errorCount += 1;
-      } else {
-        builtResults.push({
+      if (resultForFile === undefined) {
+        resultForFile = {
           filePath: result.filePath,
-          messages: [{ ...result }],
-          errorCount: 1,
+          messages: [],
+          errorCount: 0,
           source: result.source,
-        });
-      }
-    }
+        };
 
-    return builtResults;
+        builtResults.set(result.filePath, resultForFile);
+      }
+
+      resultForFile.messages.push({ ...result });
+      resultForFile.errorCount += 1;
+    }
+    return [...builtResults.values()];
   }
 };

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -58,7 +58,6 @@ module.exports = class TodoHandler {
           result.column === todo.column
       );
 
-      // set result to -1 so we don't fail linting for todo violations
       result.severity = TODO_SEVERITY;
     });
 

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -1,42 +1,93 @@
-const { buildTodoData, readTodos, getTodoBatches } = require('@ember-template-lint/todo-utils');
+const {
+  buildTodoData,
+  readTodos,
+  getTodoBatches,
+  todoStorageDirExists,
+  writeTodos,
+} = require('@ember-template-lint/todo-utils');
 
 module.exports = class TodoHandler {
-  constructor(todoStorageDir) {
-    this._todoStorageDir = todoStorageDir;
+  constructor(workingDir) {
+    this._workingDir = workingDir;
+    this._processedResults = [];
   }
 
-  async processTodos(filePath, results) {
-    let existingTodoFiles = readTodos(this._todoStorageDir, filePath);
+  get todosEnabled() {
+    return todoStorageDirExists(this._workingDir);
+  }
+
+  async update(filePath, results) {
+    this._processedResults = this._buildResult(results);
+
+    await writeTodos(this._workingDir, this._processedResults);
+  }
+
+  async processResults(filePath, results) {
+    let existingTodoFiles = await readTodos(this._workingDir, filePath);
 
     let [, itemsToRemoveFromTodos, existingTodos] = await getTodoBatches(
-      buildTodoData(results),
+      buildTodoData(this._workingDir, this._buildResult(results)),
       existingTodoFiles
     );
 
     if (itemsToRemoveFromTodos.size > 0) {
-      itemsToRemoveFromTodos.forEach((todoRule) => {
+      itemsToRemoveFromTodos.forEach((todo) => {
         results.push({
           rule: 'invalid-todo-violation-rule',
-          message: `Todo violation passes \`${todoRule}\` rule. Please run \`--fix\` to update todo list.`,
-          filePath: todoRule.filePath,
-          moduleId: todoRule.moduleId,
+          message: `Todo violation passes \`${todo}\` rule. Please run \`--fix\` to update todo list.`,
+          filePath: todo.filePath,
+          moduleId: todo.moduleId,
           severity: 2,
           isFixable: true,
         });
       });
     }
 
-    [...existingTodos.values()].forEach((todoLintMessage) => {
+    [...existingTodos.values()].forEach((todo) => {
       let result = results.find(
         (result) =>
-          result.filePath === todoLintMessage.filePath &&
-          result.ruleId === todoLintMessage.ruleId &&
-          result.line === todoLintMessage.line &&
-          result.column === todoLintMessage.column
+          result.filePath === todo.filePath &&
+          result.ruleId === todo.ruleId &&
+          result.line === todo.line &&
+          result.column === todo.column
       );
 
       // set result to -1 so we don't failing linting for todo violations
       result.severity = -1;
     });
+  }
+
+  _buildResult(results) {
+    let builtResults = [];
+
+    function buildMessage(result) {
+      return {
+        rule: result.rule,
+        severity: result.severity,
+        moduleId: result.moduleId,
+        message: result.message,
+        line: result.line,
+        column: result.column,
+        source: result.source,
+      };
+    }
+
+    for (const result of results) {
+      let resultForFile = builtResults.find((r) => r.filePath === result.filePath);
+
+      if (resultForFile) {
+        resultForFile.messages.push(buildMessage(result));
+        resultForFile.errorCount += 1;
+      } else {
+        builtResults.push({
+          filePath: result.filePath,
+          messages: [buildMessage(result)],
+          errorCount: 1,
+          source: result.source,
+        });
+      }
+    }
+
+    return builtResults;
   }
 };

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -36,7 +36,11 @@ module.exports = class TodoHandler {
 
     if (itemsToRemoveFromTodos.size > 0) {
       if (shouldFix) {
-        applyTodoChanges(getTodoStorageDirPath(this._workingDir), [], itemsToRemoveFromTodos);
+        applyTodoChanges(
+          getTodoStorageDirPath(this._workingDir),
+          new Map(),
+          itemsToRemoveFromTodos
+        );
       } else {
         itemsToRemoveFromTodos.forEach((todo) => {
           results.push({

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -1,0 +1,42 @@
+const { buildTodoData, readTodos, getTodoBatches } = require('@ember-template-lint/todo-utils');
+
+module.exports = class TodoHandler {
+  constructor(todoStorageDir) {
+    this._todoStorageDir = todoStorageDir;
+  }
+
+  async processTodos(filePath, results) {
+    let existingTodoFiles = readTodos(this._todoStorageDir, filePath);
+
+    let [, itemsToRemoveFromTodos, existingTodos] = await getTodoBatches(
+      buildTodoData(results),
+      existingTodoFiles
+    );
+
+    if (itemsToRemoveFromTodos.size > 0) {
+      itemsToRemoveFromTodos.forEach((todoRule) => {
+        results.push({
+          rule: 'invalid-todo-violation-rule',
+          message: `Todo violation passes \`${todoRule}\` rule. Please run \`--fix\` to update todo list.`,
+          filePath: todoRule.filePath,
+          moduleId: todoRule.moduleId,
+          severity: 2,
+          isFixable: true,
+        });
+      });
+    }
+
+    [...existingTodos.values()].forEach((todoLintMessage) => {
+      let result = results.find(
+        (result) =>
+          result.filePath === todoLintMessage.filePath &&
+          result.ruleId === todoLintMessage.ruleId &&
+          result.line === todoLintMessage.line &&
+          result.column === todoLintMessage.column
+      );
+
+      // set result to -1 so we don't failing linting for todo violations
+      result.severity = -1;
+    });
+  }
+};

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -1,10 +1,12 @@
 const {
   buildTodoData,
-  readTodos,
   getTodoBatches,
   todoStorageDirExists,
   writeTodos,
+  readTodosForFilePath,
 } = require('@ember-template-lint/todo-utils');
+
+const { TODO_SEVERITY } = require('../get-config');
 
 module.exports = class TodoHandler {
   constructor(workingDir) {
@@ -19,11 +21,15 @@ module.exports = class TodoHandler {
   async update(filePath, results) {
     this._processedResults = this._buildResult(results);
 
-    await writeTodos(this._workingDir, this._processedResults);
+    await writeTodos(this._workingDir, this._processedResults, filePath);
   }
 
   async processResults(filePath, results) {
-    let existingTodoFiles = await readTodos(this._workingDir, filePath);
+    if (!todoStorageDirExists(this._workingDir)) {
+      return results;
+    }
+
+    let existingTodoFiles = await readTodosForFilePath(this._workingDir, filePath);
 
     let [, itemsToRemoveFromTodos, existingTodos] = await getTodoBatches(
       buildTodoData(this._workingDir, this._buildResult(results)),
@@ -34,11 +40,11 @@ module.exports = class TodoHandler {
       itemsToRemoveFromTodos.forEach((todo) => {
         results.push({
           rule: 'invalid-todo-violation-rule',
-          message: `Todo violation passes \`${todo}\` rule. Please run \`--fix\` to update todo list.`,
+          message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`--update-todo\` to remove this todo from the todo list.`,
           filePath: todo.filePath,
           moduleId: todo.moduleId,
           severity: 2,
-          isFixable: true,
+          isFixable: false,
         });
       });
     }
@@ -47,14 +53,16 @@ module.exports = class TodoHandler {
       let result = results.find(
         (result) =>
           result.filePath === todo.filePath &&
-          result.ruleId === todo.ruleId &&
+          result.rule === todo.ruleId &&
           result.line === todo.line &&
           result.column === todo.column
       );
 
-      // set result to -1 so we don't failing linting for todo violations
-      result.severity = -1;
+      // set result to -1 so we don't fail linting for todo violations
+      result.severity = TODO_SEVERITY;
     });
+
+    return results;
   }
 
   _buildResult(results) {

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -21,6 +21,7 @@ const KNOWN_ROOT_PROPERTIES = new Set([
 ]);
 const SUPPORTED_OVERRIDE_KEYS = new Set(['files', 'rules']);
 // Severity level definitions
+const TODO_SEVERITY = -1;
 const IGNORE_SEVERITY = 0;
 const WARNING_SEVERITY = 1;
 const ERROR_SEVERITY = 2;
@@ -456,6 +457,7 @@ module.exports = {
   ERROR_SEVERITY,
   IGNORE_SEVERITY,
   WARNING_SEVERITY,
+  TODO_SEVERITY,
   getProjectConfig,
   getRuleFromString,
   resolveProjectConfig,

--- a/lib/helpers/process-results.js
+++ b/lib/helpers/process-results.js
@@ -8,7 +8,7 @@ const Linter = require('../linter');
 
   interface Message {
     rule: string;
-    severity: 0 | 1 | 2;
+    severity: -1 | 0 | 1 | 2;
     filePath?: string;
     moduleId?: string;
     message: string;
@@ -23,8 +23,10 @@ const Linter = require('../linter');
     messages: Message[];
     errorCount: number;
     warningCount: number;
+    todoCount: number;
     fixableErrorCount: number;
     fixableWarningCount: number;
+    fixableTodoCount: number;
   }
 
   interface TemplateLintResult {
@@ -34,8 +36,10 @@ const Linter = require('../linter');
 
     errorCount: number;
     warningCount: number;
+    todoCount: number;
     fixableErrorCount: number;
     fixableWarningCount: number;
+    fixableTodoCount: number;
   }
  */
 module.exports = function (messages) {
@@ -43,6 +47,8 @@ module.exports = function (messages) {
   let fixableErrorCount = 0;
   let warningCount = 0;
   let fixableWarningCount = 0;
+  let todoCount = 0;
+  let fixableTodoCount = 0;
   let files = {};
 
   for (let item of messages) {
@@ -54,8 +60,10 @@ module.exports = function (messages) {
         messages: [],
         errorCount: 0,
         warningCount: 0,
+        todoCount: 0,
         fixableErrorCount: 0,
         fixableWarningCount: 0,
+        fixableTodoCount: 0,
       };
     }
 
@@ -80,6 +88,13 @@ module.exports = function (messages) {
           fileResults.fixableWarningCount++;
         }
         break;
+      case Linter.TODO_SEVERITY:
+        todoCount++;
+        fileResults.todoCount++;
+        if (item.isFixable) {
+          fixableTodoCount++;
+          fileResults.fixableTodoCount++;
+        }
     }
 
     files[filePath] = fileResults;
@@ -89,8 +104,10 @@ module.exports = function (messages) {
     files,
     errorCount,
     warningCount,
+    todoCount,
     fixableErrorCount,
     fixableWarningCount,
+    fixableTodoCount,
   };
 
   return output;

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -1,6 +1,7 @@
 const { parse, transform } = require('ember-template-recast');
 
 const ModuleStatusCache = require('./-private/module-status-cache');
+const TodoHandler = require('./-private/todo-handler');
 const {
   getProjectConfig,
   getRuleFromString,
@@ -45,6 +46,10 @@ class Linter {
     this.editorConfigResolver.resolveEditorConfigFiles();
   }
 
+  get _usesLegacyPending() {
+    return typeof this.config.pending === 'undefined';
+  }
+
   loadConfig() {
     this.config = getProjectConfig(this.workingDir, this.options);
 
@@ -62,6 +67,7 @@ class Linter {
       this.config,
       this.options.configPath
     );
+    this._todoHandler = new TodoHandler(process.cwd());
   }
 
   /**
@@ -257,6 +263,14 @@ class Linter {
     }
 
     return currentSource;
+  }
+
+  async verifyAndUpdateTodos(options) {
+    let messages = await this.verify(options);
+
+    this._todoHandler.processTodos(options.filePath, messages);
+
+    return messages;
   }
 
   /**

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -266,8 +266,8 @@ class Linter {
     await this._todoHandler.update(linterOptions.filePath, results);
   }
 
-  processTodos(linterOptions, results) {
-    return this._todoHandler.processResults(linterOptions.filePath, results);
+  processTodos(linterOptions, results, shouldFix) {
+    return this._todoHandler.processResults(linterOptions.filePath, results, shouldFix);
   }
 
   /**

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -8,6 +8,7 @@ const {
   WARNING_SEVERITY,
   ERROR_SEVERITY,
   IGNORE_SEVERITY,
+  TODO_SEVERITY,
 } = require('./get-config');
 const EditorConfigResolver = require('./get-editor-config');
 
@@ -269,18 +270,12 @@ class Linter {
     return currentSource;
   }
 
-  async verifyAndUpdateTodos(linterOptions, options) {
-    let results = await this.verify(linterOptions);
+  async updateTodo(linterOptions, results) {
+    await this._todoHandler.update(linterOptions.filePath, results);
+  }
 
-    if (options.updateTodo) {
-      this._todoHandler.update(linterOptions.filePath, results);
-    }
-
-    if (this.todosEnabled) {
-      this._todoHandler.processResults(linterOptions.filePath, results);
-    }
-
-    return results;
+  async processTodos(linterOptions, results) {
+    return await this._todoHandler.processResults(linterOptions.filePath, results);
   }
 
   /**
@@ -382,6 +377,10 @@ class Linter {
 
     let PrettyPrinter = require('./printers/pretty');
     return PrettyPrinter.errorsToMessages(filePath, errors, options);
+  }
+
+  static get TODO_SEVERITY() {
+    return TODO_SEVERITY;
   }
 
   static get WARNING_SEVERITY() {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -50,6 +50,10 @@ class Linter {
     return typeof this.config.pending === 'undefined';
   }
 
+  get todosEnabled() {
+    return this._todoHandler.todosEnabled;
+  }
+
   loadConfig() {
     this.config = getProjectConfig(this.workingDir, this.options);
 
@@ -67,7 +71,7 @@ class Linter {
       this.config,
       this.options.configPath
     );
-    this._todoHandler = new TodoHandler(process.cwd());
+    this._todoHandler = new TodoHandler(this.workingDir);
   }
 
   /**
@@ -265,12 +269,18 @@ class Linter {
     return currentSource;
   }
 
-  async verifyAndUpdateTodos(options) {
-    let messages = await this.verify(options);
+  async verifyAndUpdateTodos(linterOptions, options) {
+    let results = await this.verify(linterOptions);
 
-    this._todoHandler.processTodos(options.filePath, messages);
+    if (options.updateTodo) {
+      this._todoHandler.update(linterOptions.filePath, results);
+    }
 
-    return messages;
+    if (this.todosEnabled) {
+      this._todoHandler.processResults(linterOptions.filePath, results);
+    }
+
+    return results;
   }
 
   /**

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -47,14 +47,6 @@ class Linter {
     this.editorConfigResolver.resolveEditorConfigFiles();
   }
 
-  get _usesLegacyPending() {
-    return typeof this.config.pending === 'undefined';
-  }
-
-  get todosEnabled() {
-    return this._todoHandler.todosEnabled;
-  }
-
   loadConfig() {
     this.config = getProjectConfig(this.workingDir, this.options);
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -274,8 +274,8 @@ class Linter {
     await this._todoHandler.update(linterOptions.filePath, results);
   }
 
-  async processTodos(linterOptions, results) {
-    return await this._todoHandler.processResults(linterOptions.filePath, results);
+  processTodos(linterOptions, results) {
+    return this._todoHandler.processResults(linterOptions.filePath, results);
   }
 
   /**

--- a/lib/printers/json.js
+++ b/lib/printers/json.js
@@ -15,8 +15,12 @@ class JsonPrinter {
       let warnings = this.options.quiet
         ? []
         : fileErrors.filter((error) => error.severity === Linter.WARNING_SEVERITY);
+      let todos =
+        this.options.quiet || !this.options.includeTodo
+          ? []
+          : fileErrors.filter((error) => error.severity === Linter.TODO_SEVERITY);
 
-      filteredErrors[filePath] = errorsFiltered.concat(warnings);
+      filteredErrors[filePath] = errorsFiltered.concat(warnings, todos);
     }
 
     this.console.log(JSON.stringify(filteredErrors, null, 2));

--- a/lib/printers/pretty.js
+++ b/lib/printers/pretty.js
@@ -12,7 +12,7 @@ class PrettyPrinter {
     for (const filePath of Object.keys(results.files)) {
       let fileResults = results.files[filePath];
       let messages = this.options.quiet
-        ? fileResults.messages.filter((r) => r.severity === Linter.ERROR_SEVERITY)
+        ? fileResults.messages.filter((r) => r.severity > Linter.WARNING_SEVERITY)
         : fileResults.messages;
 
       let output = PrettyPrinter.errorsToMessages(filePath, messages, this.options);
@@ -22,7 +22,8 @@ class PrettyPrinter {
     }
 
     let warningCount = this.options.quiet ? 0 : results.warningCount;
-    let todoCount = this.options.quiet || !this.options.includeTodo ? 0 : results.todoCount;
+    let shouldNotPrintTodos = !this.options.includeTodo;
+    let todoCount = this.options.quiet || shouldNotPrintTodos ? 0 : results.todoCount;
     let count = results.errorCount + warningCount + todoCount;
 
     if (count > 0) {

--- a/lib/printers/pretty.js
+++ b/lib/printers/pretty.js
@@ -12,7 +12,7 @@ class PrettyPrinter {
     for (const filePath of Object.keys(results.files)) {
       let fileResults = results.files[filePath];
       let messages = this.options.quiet
-        ? fileResults.messages.filter((r) => r.severity !== Linter.WARNING_SEVERITY)
+        ? fileResults.messages.filter((r) => r.severity === Linter.ERROR_SEVERITY)
         : fileResults.messages;
 
       let output = PrettyPrinter.errorsToMessages(filePath, messages, this.options);
@@ -22,29 +22,46 @@ class PrettyPrinter {
     }
 
     let warningCount = this.options.quiet ? 0 : results.warningCount;
-    let count = results.errorCount + warningCount;
+    let todoCount = this.options.quiet || !this.options.includeTodo ? 0 : results.todoCount;
+    let count = results.errorCount + warningCount + todoCount;
 
     if (count > 0) {
+      let todoSummary = this.options.includeTodo ? `, ${todoCount} todos` : '';
+
       this.console.log(
         chalk.red(
-          chalk.bold(`✖ ${count} problems (${results.errorCount} errors, ${warningCount} warnings)`)
+          chalk.bold(
+            `✖ ${count} problems (${results.errorCount} errors, ${warningCount} warnings${todoSummary})`
+          )
         )
       );
 
-      if (results.fixableErrorCount > 0 || results.fixableWarningCount > 0) {
-        this.console.log(
-          chalk.red(
-            chalk.bold(
-              `  ${results.fixableErrorCount} errors and ${results.fixableWarningCount} warnings potentially fixable with the \`--fix\` option.`
-            )
-          )
-        );
+      if (
+        results.fixableErrorCount > 0 ||
+        results.fixableWarningCount > 0 ||
+        (this.options.includeTodo && results.fixableTodoCount > 0)
+      ) {
+        let fixableSummary = '  ';
+
+        if (this.options.includeTodo && results.fixableTodoCount > 0) {
+          fixableSummary += `${results.fixableErrorCount} errors, ${results.fixableWarningCount} warnings, and ${results.fixableTodoCount} todos`;
+        } else {
+          fixableSummary += `${results.fixableErrorCount} errors and ${results.fixableWarningCount} warnings`;
+        }
+
+        fixableSummary += ' potentially fixable with the `--fix` option.';
+
+        this.console.log(chalk.red(chalk.bold(fixableSummary)));
       }
     }
   }
 
   static errorsToMessages(filePath, errors, options = {}) {
     errors = errors || [];
+
+    if (!options.includeTodo) {
+      errors = errors.filter((error) => error.severity !== Linter.TODO_SEVERITY);
+    }
 
     if (errors.length === 0) {
       return '';
@@ -67,6 +84,8 @@ class PrettyPrinter {
 
     if (error.severity === Linter.WARNING_SEVERITY) {
       message += `  ${chalk.yellow('warning')}`;
+    } else if (error.severity === Linter.TODO_SEVERITY) {
+      message += `  ${chalk.blueBright('todo')}`;
     } else {
       message += `  ${chalk.red('error')}`;
     }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^3.0.1",
+    "@ember-template-lint/todo-utils": "^3.0.2",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^3.0.2",
+    "@ember-template-lint/todo-utils": "^3.1.0",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     ]
   },
   "dependencies": {
+    "@ember-template-lint/todo-utils": "^2.2.0",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^3.1.0",
+    "@ember-template-lint/todo-utils": "^3.2.0",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^2.2.0",
+    "@ember-template-lint/todo-utils": "^3.0.0",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^3.0.0",
+    "@ember-template-lint/todo-utils": "^3.0.1",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -5,8 +5,9 @@ const path = require('path');
 
 const {
   ensureTodoStorageDir,
-  getTodoStorageDirPath,
+  todoStorageDirExists,
   readTodos,
+  getTodoStorageDirPath,
 } = require('@ember-template-lint/todo-utils');
 const execa = require('execa');
 
@@ -1409,7 +1410,7 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.']);
 
-        expect(fs.existsSync(getTodoStorageDirPath(project.baseDir))).toEqual(false);
+        expect(todoStorageDirExists(project.baseDir)).toEqual(false);
         expect(result.stdout).toBeTruthy();
       });
 
@@ -1498,7 +1499,7 @@ describe('ember-template-lint executable', function () {
         let result = await run(['.', '--update-todo']);
 
         expect(result.exitCode).toEqual(0);
-        expect(fs.existsSync(getTodoStorageDirPath(project.baseDir))).toEqual(true);
+        expect(todoStorageDirExists(project.baseDir)).toEqual(true);
       });
 
       it('errors if a todo item is no longer valid when running without params', async function () {
@@ -1516,10 +1517,10 @@ describe('ember-template-lint executable', function () {
           },
         });
 
-        // first generate a todo
+        // generate todo based on existing error
         await run(['.', '--update-todo']);
 
-        // now fix the rule
+        // mimic fixing the error manually via user interaction
         project.write({
           app: {
             templates: {
@@ -1528,7 +1529,7 @@ describe('ember-template-lint executable', function () {
           },
         });
 
-        // now run normally and expect an error for not running --update-todo again
+        // run normally and expect an error for not running --fix
         let result = await run(['.']);
 
         expect(result.exitCode).toEqual(1);
@@ -1540,7 +1541,20 @@ describe('ember-template-lint executable', function () {
             1 errors and 0 warnings potentially fixable with the \`--fix\` option."
         `);
 
-        // await run(['.', '--fix']);
+        // run fix, and expect that this will delete the outstanding todo item
+        await run(['.', '--fix']);
+
+        // run normally again and expect no error
+        result = await run(['.']);
+
+        let todoStorageDir = getTodoStorageDirPath(project.baseDir);
+        let todos = fs.readdirSync(
+          path.posix.join(todoStorageDir, fs.readdirSync(todoStorageDir)[0])
+        );
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toEqual('');
+        expect(todos).toHaveLength(0);
       });
 
       it('outputs empty summary for no todos or errors', async function () {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -64,7 +64,8 @@ describe('ember-template-lint executable', function () {
             --no-config-path            Does not use the local template-lintrc, will use a
                                         blank template-lintrc instead            [boolean]
             --print-pending             Print list of formatted rules for use with
-                                        \`pending\` in config file                 [boolean]
+                                        \`pending\` in config file (deprecated)    [boolean]
+            --update-todos              Update list of linting todos             [boolean]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -107,7 +108,8 @@ describe('ember-template-lint executable', function () {
             --no-config-path            Does not use the local template-lintrc, will use a
                                         blank template-lintrc instead            [boolean]
             --print-pending             Print list of formatted rules for use with
-                                        \`pending\` in config file                 [boolean]
+                                        \`pending\` in config file (deprecated)    [boolean]
+            --update-todos              Update list of linting todos             [boolean]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -404,7 +406,8 @@ describe('ember-template-lint executable', function () {
             --no-config-path            Does not use the local template-lintrc, will use a
                                         blank template-lintrc instead            [boolean]
             --print-pending             Print list of formatted rules for use with
-                                        \`pending\` in config file                 [boolean]
+                                        \`pending\` in config file (deprecated)    [boolean]
+            --update-todos              Update list of linting todos             [boolean]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -1437,7 +1440,6 @@ describe('ember-template-lint executable', function () {
         });
 
         it('generates todos for existing errors', async function () {
-          it('migrates from config.pending to todos when running for first time', async function () {
           project.setConfig({
             rules: {
               'no-bare-strings': true,
@@ -1446,7 +1448,7 @@ describe('ember-template-lint executable', function () {
           project.write({
             app: {
               templates: {
-                'application.hbs': '<h2>Here too!!</h2><div>Bare strings are bad...</div>',
+                'application.hbs': '<div>Bare strings are bad...</div>',
               },
             },
           });
@@ -1457,11 +1459,41 @@ describe('ember-template-lint executable', function () {
         });
 
         it('and existing todos, outputs todo count in summary', async function () {
-          expect(project.stdout).toContain('✖ 1 problems (0 errors, 0 warnings, 1 todo)');
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
+
+          let result = await run(['.']);
+
+          expect(result.stdout).toContain('✖ 1 problems (0 errors, 0 warnings, 1 todo)');
         });
 
         it('but no todos, outputs 0 for todo count in summary', async function () {
-          expect(project.stdout).toContain('✖ 0 problems (0 errors, 0 warnings, 0 todo)');
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>{{@foo}}</div>',
+              },
+            },
+          });
+
+          let result = await run(['.']);
+
+          expect(result.stdout).toEqual('');
         });
 
         it('with --include-todo param and todos, outputs todos in results', async function () {});

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -68,8 +68,8 @@ describe('ember-template-lint executable', function () {
                                         \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos         [boolean] [default: false]
-            --include-todo              Include todos in the results (todos are hidden by
-                                        default)                [boolean] [default: false]
+            --include-todo              Include todos in the results
+                                                                [boolean] [default: false]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -115,8 +115,8 @@ describe('ember-template-lint executable', function () {
                                         \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos         [boolean] [default: false]
-            --include-todo              Include todos in the results (todos are hidden by
-                                        default)                [boolean] [default: false]
+            --include-todo              Include todos in the results
+                                                                [boolean] [default: false]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -416,8 +416,8 @@ describe('ember-template-lint executable', function () {
                                         \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos         [boolean] [default: false]
-            --include-todo              Include todos in the results (todos are hidden by
-                                        default)                [boolean] [default: false]
+            --include-todo              Include todos in the results
+                                                                [boolean] [default: false]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1530,7 +1530,8 @@ describe('ember-template-lint executable', function () {
           "app/templates/require-button-type.hbs
             -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`--update-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
 
-          ✖ 1 problems (1 errors, 0 warnings)"
+          ✖ 1 problems (1 errors, 0 warnings)
+            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
         `);
       });
 

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -66,9 +66,9 @@ describe('ember-template-lint executable', function () {
             --print-pending             Print list of formatted rules for use with
                                         \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
-                                        errors to todos                          [boolean]
+                                        errors to todos         [boolean] [default: false]
             --include-todo              Include todos in the results (todos are hidden by
-                                        default)                                 [boolean]
+                                        default)                [boolean] [default: false]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -113,9 +113,9 @@ describe('ember-template-lint executable', function () {
             --print-pending             Print list of formatted rules for use with
                                         \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
-                                        errors to todos                          [boolean]
+                                        errors to todos         [boolean] [default: false]
             --include-todo              Include todos in the results (todos are hidden by
-                                        default)                                 [boolean]
+                                        default)                [boolean] [default: false]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -414,9 +414,9 @@ describe('ember-template-lint executable', function () {
             --print-pending             Print list of formatted rules for use with
                                         \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
-                                        errors to todos                          [boolean]
+                                        errors to todos         [boolean] [default: false]
             --include-todo              Include todos in the results (todos are hidden by
-                                        default)                                 [boolean]
+                                        default)                [boolean] [default: false]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -3,6 +3,11 @@ const { readFileSync } = require('fs');
 const fs = require('fs');
 const path = require('path');
 
+const {
+  ensureTodoDir,
+  getTodoStorageDirPath,
+  readTodos,
+} = require('@ember-template-lint/todo-utils');
 const execa = require('execa');
 
 const Project = require('../helpers/fake-project');
@@ -1339,6 +1344,127 @@ describe('ember-template-lint executable', function () {
 
         expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
+      });
+    });
+
+    describe('with todos', function () {
+      it('without --update-todo param does not create `.lint-todo` dir', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+          pending: [
+            {
+              moduleId: 'app/templates/application',
+              only: ['no-html-comments'],
+            },
+          ],
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<h2>Here too!!</h2><div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        let result = await run(['.']);
+
+        expect(fs.existsSync(getTodoStorageDirPath(project.baseDir))).toEqual(false);
+        expect(result.stdout).toBeTruthy();
+      });
+
+      it('errors when config.pending and `.lint-todo` dir coexist', async function () {
+        await ensureTodoDir(project.baseDir);
+
+        project.setConfig({
+          pending: [
+            {
+              moduleId: 'app/templates/application',
+              only: ['no-html-comments'],
+            },
+          ],
+        });
+
+        let result = await run(['.']);
+
+        expect(result.stderr).toBeTruthy();
+      });
+
+      describe('--update-todo param', function () {
+        it('migrates from config.pending to todos when running for first time', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+            pending: [
+              {
+                moduleId: 'app/templates/application',
+                only: ['no-html-comments'],
+              },
+            ],
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<h2>Here too!!</h2><div>Bare strings are bad...</div>',
+              },
+            },
+          });
+
+          await run(['.', '--update-todo']);
+
+          expect(typeof project.getConfig().pending).toBeUndefined();
+        });
+
+        it('generates no todos for no errors', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<h2>{{@notBare}}</h2>',
+              },
+            },
+          });
+
+          await run(['.', '--update-todo']);
+
+          expect((await readTodos(getTodoStorageDirPath(project.baseDir))).size).toEqual(0);
+        });
+
+        it('generates todos for existing errors', async function () {
+          it('migrates from config.pending to todos when running for first time', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<h2>Here too!!</h2><div>Bare strings are bad...</div>',
+              },
+            },
+          });
+
+          await run(['.', '--update-todo']);
+
+          expect((await readTodos(getTodoStorageDirPath(project.baseDir))).size).toEqual(1);
+        });
+
+        it('and existing todos, outputs todo count in summary', async function () {
+          expect(project.stdout).toContain('✖ 1 problems (0 errors, 0 warnings, 1 todo)');
+        });
+
+        it('but no todos, outputs 0 for todo count in summary', async function () {
+          expect(project.stdout).toContain('✖ 0 problems (0 errors, 0 warnings, 0 todo)');
+        });
+
+        it('with --include-todo param and todos, outputs todos in results', async function () {});
       });
     });
 

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1520,7 +1520,13 @@ describe('ember-template-lint executable', function () {
         await run(['.', '--update-todo']);
 
         // now fix the rule
-        await run(['.', '--fix']);
+        project.write({
+          app: {
+            templates: {
+              'require-button-type.hbs': '<button type="submit">Klikk</button>',
+            },
+          },
+        });
 
         // now run normally and expect an error for not running --update-todo again
         let result = await run(['.']);
@@ -1533,6 +1539,8 @@ describe('ember-template-lint executable', function () {
           ✖ 1 problems (1 errors, 0 warnings)
             1 errors and 0 warnings potentially fixable with the \`--fix\` option."
         `);
+
+        // await run(['.', '--fix']);
       });
 
       it('outputs empty summary for no todos or errors', async function () {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -67,7 +67,8 @@ describe('ember-template-lint executable', function () {
                                         \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos                          [boolean]
-            --include-todo              Show list of todos                       [boolean]
+            --include-todo              Include todos in the results (todos are hidden by
+                                        default)                                 [boolean]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -113,7 +114,8 @@ describe('ember-template-lint executable', function () {
                                         \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos                          [boolean]
-            --include-todo              Show list of todos                       [boolean]
+            --include-todo              Include todos in the results (todos are hidden by
+                                        default)                                 [boolean]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -413,7 +415,8 @@ describe('ember-template-lint executable', function () {
                                         \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos                          [boolean]
-            --include-todo              Show list of todos                       [boolean]
+            --include-todo              Include todos in the results (todos are hidden by
+                                        default)                                 [boolean]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -65,7 +65,9 @@ describe('ember-template-lint executable', function () {
                                         blank template-lintrc instead            [boolean]
             --print-pending             Print list of formatted rules for use with
                                         \`pending\` in config file (deprecated)    [boolean]
-            --update-todo               Update list of linting todos             [boolean]
+            --update-todo               Update list of linting todos by transforming lint
+                                        errors to todos                          [boolean]
+            --include-todo              Show list of todos                       [boolean]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -109,7 +111,9 @@ describe('ember-template-lint executable', function () {
                                         blank template-lintrc instead            [boolean]
             --print-pending             Print list of formatted rules for use with
                                         \`pending\` in config file (deprecated)    [boolean]
-            --update-todo               Update list of linting todos             [boolean]
+            --update-todo               Update list of linting todos by transforming lint
+                                        errors to todos                          [boolean]
+            --include-todo              Show list of todos                       [boolean]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -407,7 +411,9 @@ describe('ember-template-lint executable', function () {
                                         blank template-lintrc instead            [boolean]
             --print-pending             Print list of formatted rules for use with
                                         \`pending\` in config file (deprecated)    [boolean]
-            --update-todo               Update list of linting todos             [boolean]
+            --update-todo               Update list of linting todos by transforming lint
+                                        errors to todos                          [boolean]
+            --include-todo              Show list of todos                       [boolean]
             --ignore-pattern            Specify custom ignore pattern (can be disabled
                                         with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
@@ -1245,10 +1251,22 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--print-pending']);
 
-        let expectedOutputData =
-          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings",\n      "no-html-comments"\n    ]\n  }\n]';
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "WARNING: Print pending is deprecated. Use --update-todo instead.
 
-        expect(result.stdout).toEqual(expectedOutputData);
+          Add the following to your \`.template-lintrc.js\` file to mark these files as pending.
+
+
+          pending: [
+            {
+              \\"moduleId\\": \\"app/templates/application\\",
+              \\"only\\": [
+                \\"no-bare-strings\\",
+                \\"no-html-comments\\"
+              ]
+            }
+          ]"
+        `);
         expect(result.stderr).toBeFalsy();
       });
 
@@ -1276,10 +1294,14 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--print-pending']);
 
-        let expectedOutputData =
-          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: []';
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "WARNING: Print pending is deprecated. Use --update-todo instead.
 
-        expect(result.stdout).toEqual(expectedOutputData);
+          Add the following to your \`.template-lintrc.js\` file to mark these files as pending.
+
+
+          pending: []"
+        `);
         expect(result.stderr).toBeFalsy();
       });
 
@@ -1305,10 +1327,21 @@ describe('ember-template-lint executable', function () {
         });
         let result = await run(['.', '--print-pending']);
 
-        let expectedOutputData =
-          'Add the following to your `.template-lintrc.js` file to mark these files as pending.\n\n\npending: [\n  {\n    "moduleId": "app/templates/application",\n    "only": [\n      "no-bare-strings"\n    ]\n  }\n]';
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "WARNING: Print pending is deprecated. Use --update-todo instead.
 
-        expect(result.stdout).toEqual(expectedOutputData);
+          Add the following to your \`.template-lintrc.js\` file to mark these files as pending.
+
+
+          pending: [
+            {
+              \\"moduleId\\": \\"app/templates/application\\",
+              \\"only\\": [
+                \\"no-bare-strings\\"
+              ]
+            }
+          ]"
+        `);
         expect(result.stderr).toBeFalsy();
       });
     });
@@ -1350,8 +1383,8 @@ describe('ember-template-lint executable', function () {
       });
     });
 
-    describe('with todos', function () {
-      it('without --update-todo param does not create `.lint-todo` dir', async function () {
+    describe('with/without --update-todo and --include-todo params', function () {
+      it('does not create `.lint-todo` dir without --update-todo param', async function () {
         project.setConfig({
           rules: {
             'no-bare-strings': true,
@@ -1394,117 +1427,202 @@ describe('ember-template-lint executable', function () {
         expect(result.stderr).toBeTruthy();
       });
 
-      describe('--update-todo param', function () {
-        it('errors if config.pending is present when running with --update-todo', async function () {
-          project.setConfig({
-            rules: {
-              'no-bare-strings': true,
+      it('errors if config.pending is present when running with --update-todo', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+          pending: [
+            {
+              moduleId: 'app/templates/application',
+              only: ['no-html-comments'],
             },
-            pending: [
-              {
-                moduleId: 'app/templates/application',
-                only: ['no-html-comments'],
-              },
-            ],
-          });
-          project.write({
-            app: {
-              templates: {
-                'application.hbs': '<h2>Here too!!</h2><div>Bare strings are bad...</div>',
-              },
+          ],
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<h2>Here too!!</h2><div>Bare strings are bad...</div>',
             },
-          });
-
-          let result = await run(['.', '--update-todo']);
-
-          expect(result.exitCode).toEqual(1);
-          expect(result.stderr).toContain(
-            'Cannot use the `pending` config option in conjunction with `--update-todo`. Please remove the `pending` option from your config and re-run the command.'
-          );
+          },
         });
 
-        it('generates no todos for no errors', async function () {
-          project.setConfig({
-            rules: {
-              'no-bare-strings': true,
-            },
-          });
-          project.write({
-            app: {
-              templates: {
-                'application.hbs': '<h2>{{@notBare}}</h2>',
-              },
-            },
-          });
+        let result = await run(['.', '--update-todo']);
 
-          await run(['.', '--update-todo']);
+        expect(result.exitCode).toEqual(1);
+        expect(result.stderr).toContain(
+          'Cannot use the `pending` config option in conjunction with `--update-todo`. Please remove the `pending` option from your config and re-run the command.'
+        );
+      });
 
-          expect(fs.existsSync(getTodoStorageDirPath(project.baseDir))).toEqual(false);
+      it('generates no todos for no errors', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<h2>{{@notBare}}</h2>',
+            },
+          },
         });
 
-        it('generates todos for existing errors', async function () {
-          project.setConfig({
-            rules: {
-              'no-bare-strings': true,
-              'no-html-comments': true,
-            },
-          });
-          project.write({
-            app: {
-              templates: {
-                'application.hbs':
-                  '<div>Bare strings are bad...</div><span>Very bad</span><!-- bad comment -->',
-              },
-            },
-          });
+        await run(['.', '--update-todo']);
 
-          let result = await run(['.', '--update-todo']);
+        const result = await readTodos(project.baseDir);
 
-          expect(result.exitCode).toEqual(0);
-          expect(fs.existsSync(getTodoStorageDirPath(project.baseDir))).toEqual(true);
+        expect(result.size).toEqual(0);
+      });
+
+      it('generates todos for existing errors', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+            'no-html-comments': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs':
+                '<div>Bare strings are bad...</div><span>Very bad</span><!-- bad comment -->',
+            },
+          },
         });
 
-        it('and existing todos, outputs empty summary', async function () {
-          project.setConfig({
-            rules: {
-              'no-bare-strings': true,
-            },
-          });
-          project.write({
-            app: {
-              templates: {
-                'application.hbs': '<div>Bare strings are bad...</div>',
-              },
-            },
-          });
+        let result = await run(['.', '--update-todo']);
 
-          let result = await run(['.']);
+        expect(result.exitCode).toEqual(0);
+        expect(fs.existsSync(getTodoStorageDirPath(project.baseDir))).toEqual(true);
+      });
 
-          expect(result.stdout).toEqual('');
+      it('errors if a todo item is no longer valid when running without params', async function () {
+        project.setConfig({
+          rules: {
+            'require-button-type': true,
+          },
         });
 
-        it('but no todos, outputs empty summary', async function () {
-          project.setConfig({
-            rules: {
-              'no-bare-strings': true,
+        project.write({
+          app: {
+            templates: {
+              'require-button-type.hbs': '<button>Klikk</button>',
             },
-          });
-          project.write({
-            app: {
-              templates: {
-                'application.hbs': '<div>{{@foo}}</div>',
-              },
-            },
-          });
-
-          let result = await run(['.']);
-
-          expect(result.stdout).toEqual('');
+          },
         });
 
-        it('with --include-todo param and todos, outputs todos in results', async function () {});
+        // first generate a todo
+        await run(['.', '--update-todo']);
 
-        it('with workflow - verify fails, run `--update-todo`, verify passes', async function () {});
+        // now fix the rule
+        await run(['.', '--fix']);
+
+        // now run normally and expect an error for not running --update-todo again
+        let result = await run(['.']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "app/templates/require-button-type.hbs
+            -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`--update-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
+
+          ✖ 1 problems (1 errors, 0 warnings)"
+        `);
+      });
+
+      it('outputs empty summary for no todos or errors', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>{{@foo}}</div>',
+            },
+          },
+        });
+
+        let result = await run(['.', '--update-todo']);
+
+        expect(result.stdout).toEqual('');
+      });
+
+      it('outputs empty summary for existing todos', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        // generate todos
+        await run(['.', '--update-todo']);
+
+        // running again should return no results
+        let result = await run(['.']);
+
+        expect(result.stdout).toEqual('');
+      });
+
+      it('with --include-todo param and --update-todo, outputs todos in results', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        let result = await run(['.', '--update-todo', '--include-todo']);
+
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "app/templates/application.hbs
+            1:5  todo  Non-translated string used  no-bare-strings
+
+          ✖ 1 problems (0 errors, 0 warnings, 1 todos)"
+        `);
+      });
+
+      it('with --include-todo param and existing todos, outputs todos in results', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        // generate todos
+        await run(['.', '--update-todo']);
+
+        // running again with --include-todo should return todo summary
+        let result = await run(['.', '--include-todo']);
+
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "app/templates/application.hbs
+            1:5  todo  Non-translated string used  no-bare-strings
+
+          ✖ 1 problems (0 errors, 0 warnings, 1 todos)"
+        `);
       });
     });
 

--- a/test/helpers/fake-project.js
+++ b/test/helpers/fake-project.js
@@ -67,6 +67,10 @@ module.exports = class FakeProject extends FixturifyProject {
     this.writeSync();
   }
 
+  getConfig() {
+    return require(path.join(this.baseDir, '.template-lintrc'));
+  }
+
   setEditorConfig(value = DEFAULT_EDITOR_CONFIG) {
     this.files['.editorconfig'] = value;
 

--- a/test/printers/pretty-test.js
+++ b/test/printers/pretty-test.js
@@ -1,5 +1,6 @@
 const chalk = require('chalk');
 
+const { TODO_SEVERITY } = require('../../lib');
 const Printer = require('../../lib/printers/pretty');
 
 describe('Linter.errorsToMessages', function () {
@@ -65,5 +66,31 @@ describe('Linter.errorsToMessages', function () {
     let result = Printer.errorsToMessages('file/path', []);
 
     expect(result).toEqual('');
+  });
+
+  it('does not format todos if options to include them are not passed', function () {
+    let result = Printer.errorsToMessages('file/path', [
+      { rule: 'some rule', message: 'some message', line: 11, column: 12, severity: TODO_SEVERITY },
+    ]);
+
+    expect(result).toEqual('');
+  });
+
+  it('format todos if options to include them are passed', function () {
+    let result = Printer.errorsToMessages(
+      'file/path',
+      [
+        {
+          rule: 'some rule',
+          message: 'some message',
+          line: 11,
+          column: 12,
+          severity: TODO_SEVERITY,
+        },
+      ],
+      { includeTodo: true }
+    );
+
+    expect(result).toEqual('file/path\n' + '  11:12  todo  some message  some rule\n');
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,7 +239,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^3.0.0":
+"@ember-template-lint/todo-utils@^3.0.1":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.0.2.tgz#fc74f51b9d9a2a3e922fbe9f700f8b23b7970ee5"
   integrity sha512-hdzylXigm5MctZnp1m4f0+DvteNyvBMA+GAQCng6vGe4zExC8yisS6uc4z5DOgKNLnAiRRpwviXZF6Ik34YW6A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,10 +239,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.1.0.tgz#4273dcf4f9ba5d1929084bdd0b2b1f0ab66f2f30"
-  integrity sha512-sUmKf8kTpqhgKbSyX9pLQ4kAhGA6vWgnpflYCWWMJ9CdtsldGtwUJb5eONMJNhhZOsfRpBpIrYa2SiXJ2b/Wgg==
+"@ember-template-lint/todo-utils@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.2.0.tgz#5d004cf9a8af913e8b9c65c4f941890b6dc31898"
+  integrity sha512-P7IsPIXAdzjsWn6pa9GTIlRyqBp+0KuVDpZhk2TIpX7NsiKMVWZyVdQZne5wZ+6gdonBjBY2hwx/wTZU1Zjj0Q==
   dependencies:
     fs-extra "^9.0.1"
     slash "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,7 +239,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^3.0.1":
+"@ember-template-lint/todo-utils@^3.0.2":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.0.2.tgz#fc74f51b9d9a2a3e922fbe9f700f8b23b7970ee5"
   integrity sha512-hdzylXigm5MctZnp1m4f0+DvteNyvBMA+GAQCng6vGe4zExC8yisS6uc4z5DOgKNLnAiRRpwviXZF6Ik34YW6A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,12 +239,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^2.2.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-2.3.0.tgz#987b8f1d22a4f50e745851c3579e4f2870664c70"
-  integrity sha512-NPjkS4wVAEwxWid8C/T01b5DxQVL6WimvSITtohxDgf68u9N74JnfRuMctIvYHAJDkBIU0CX7wUoohQdRiEwfA==
+"@ember-template-lint/todo-utils@^3.0.0":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.0.2.tgz#fc74f51b9d9a2a3e922fbe9f700f8b23b7970ee5"
+  integrity sha512-hdzylXigm5MctZnp1m4f0+DvteNyvBMA+GAQCng6vGe4zExC8yisS6uc4z5DOgKNLnAiRRpwviXZF6Ik34YW6A==
   dependencies:
     fs-extra "^9.0.1"
+    slash "^3.0.0"
 
 "@eslint/eslintrc@^0.2.2":
   version "0.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,10 +239,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^3.0.2":
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.0.2.tgz#fc74f51b9d9a2a3e922fbe9f700f8b23b7970ee5"
-  integrity sha512-hdzylXigm5MctZnp1m4f0+DvteNyvBMA+GAQCng6vGe4zExC8yisS6uc4z5DOgKNLnAiRRpwviXZF6Ik34YW6A==
+"@ember-template-lint/todo-utils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-3.1.0.tgz#4273dcf4f9ba5d1929084bdd0b2b1f0ab66f2f30"
+  integrity sha512-sUmKf8kTpqhgKbSyX9pLQ4kAhGA6vWgnpflYCWWMJ9CdtsldGtwUJb5eONMJNhhZOsfRpBpIrYa2SiXJ2b/Wgg==
   dependencies:
     fs-extra "^9.0.1"
     slash "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,6 +239,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@ember-template-lint/todo-utils@^2.2.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-2.3.0.tgz#987b8f1d22a4f50e745851c3579e4f2870664c70"
+  integrity sha512-NPjkS4wVAEwxWid8C/T01b5DxQVL6WimvSITtohxDgf68u9N74JnfRuMctIvYHAJDkBIU0CX7wUoohQdRiEwfA==
+  dependencies:
+    fs-extra "^9.0.1"
+
 "@eslint/eslintrc@^0.2.2":
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.2.tgz#d01fc791e2fc33e88a29d6f3dc7e93d0cd784b76"
@@ -1175,6 +1182,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 atob@^2.1.2:
   version "2.1.2"
@@ -2720,6 +2732,16 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.0.1.tgz#910da0062437ba4c39fedd863f1675ccfefcb9fc"
+  integrity sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^1.0.0"
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -4069,6 +4091,15 @@ jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
   integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -6418,6 +6449,16 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-1.0.0.tgz#b61a1da173e8435b2fe3c67d29b9adf8594bd16d"
+  integrity sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unset-value@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Todo functionality is intended to replace the `--print-pending` feature which should have a deprecation warning for now.
Based on spec #1557 and continued the work from PR #1577.

⚠️ this is intended to be a power user feature, ideally for large projects that often have large teams of engineers working on a very large codebase. We do not want this feature to result in people deferring tech debt unnecessarily. For smaller projects, one would expect any and all linting errors would be fixed. 

We'll want to call this out in the README to make it clear we're not advocating hiding your linting errors away.

## Examples

A sneak peek into what this looks like with practical use.

Given a sample project with lint errors, running `ember-template-lint .` predictably results in the expected errors.

<img width="680" alt="Screen Shot 2020-12-03 at 2 12 57 PM" src="https://user-images.githubusercontent.com/180990/101095059-32d07c00-3572-11eb-9778-b498bac76214.png">

To opt-in to the new TODO functionality, you run with the `--update-todo` option.

<img width="698" alt="Screen Shot 2020-12-03 at 2 13 20 PM" src="https://user-images.githubusercontent.com/180990/101095114-47ad0f80-3572-11eb-90ce-675294097d4e.png">

This results in errors being transformed to TODOs. TODOs are not visible by default when running `ember-template-lint`. You can include them as part of the normal output by including the `--include-todo` option.

<img width="703" alt="Screen Shot 2020-12-03 at 2 13 38 PM" src="https://user-images.githubusercontent.com/180990/101095210-762aea80-3572-11eb-96c0-ab5b10b0d0a4.png">

Introducing new errors will not automatically convert them to TODOs. You need to run with `--update-todo` again to opt them in.

<img width="715" alt="Screen Shot 2020-12-03 at 2 14 17 PM" src="https://user-images.githubusercontent.com/180990/101095267-8ba01480-3572-11eb-8237-190f02570f64.png"> 

Fixes #1557 

## Related

There is an [eslint formatter](https://github.com/scalvert/eslint-formatter-todo) that mimics this same behavior. 

TODO:

- [x] Add warning if user is using deprecated `pending` feature
- [x] Ensure fixing errors results in removal of existing todos via `--fix`

- Documentation will be added in a subsequent PR