### PR TITLE
Add new rule `no-down-event-binding`

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Each rule has emojis denoting:
 |                            | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md) |
 | :car:                      | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md)         |
 | :white_check_mark:         | [no-debugger](./docs/rule/no-debugger.md)                                             |
+|                            | [no-down-event-binding](./docs/rule/no-down-event-binding.md)                         |
 | :white_check_mark:         | [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                     |
 |                            | [no-duplicate-id](./docs/rule/no-duplicate-id.md)                                     |
 |                            | [no-duplicate-landmark-elements](./docs/rule/no-duplicate-landmark-elements.md)       |

--- a/docs/rule/no-down-event-binding.md
+++ b/docs/rule/no-down-event-binding.md
@@ -1,0 +1,43 @@
+# no-down-event-binding
+
+Many browser events have both an "up" and a "down" version that can be listened to (`key{up,down}`, `mouse{up,down}`, etc). For accessibility purposes, it's better to bind to the "up" event. This rule helps guide developers in the right direction by calling out binding to the "down" event.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<div {{on 'keydown' this.handleKey}}></div>
+```
+
+```hbs
+<div {{action this.handleKey on='keydown'}}></div>
+```
+
+```hbs
+<input type="text" onkeydown="handleKeyDown()">
+```
+
+This rule **allows** the following:
+
+```hbs
+<div {{on 'keyup' this.handleKey}}></div>
+```
+
+```hbs
+<div {{action this.handleKey on='keyup'}}></div>
+```
+
+```hbs
+<input type="text" onkeyup="handleKeyUp()">
+```
+
+Component arguments are _not_ validated, even if their name looks like the intent might be to register a down event handler.
+
+```hbs
+<MyComponent @onKeyDown={{this.handleKeyDown}} />
+```
+
+## References
+
+- [WCAG guidelines on using the "down"-event](https://www.w3.org/WAI/WCAG21/Techniques/failures/F101)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -25,6 +25,7 @@ module.exports = {
   'no-block-params-for-html-elements': require('./no-block-params-for-html-elements'),
   'no-curly-component-invocation': require('./no-curly-component-invocation'),
   'no-debugger': require('./no-debugger'),
+  'no-down-event-binding': require('./no-down-event-binding'),
   'no-duplicate-attributes': require('./no-duplicate-attributes'),
   'no-duplicate-id': require('./no-duplicate-id'),
   'no-duplicate-landmark-elements': require('./no-duplicate-landmark-elements'),

--- a/lib/rules/no-down-event-binding.js
+++ b/lib/rules/no-down-event-binding.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const { match } = require('../helpers/node-matcher');
+const Rule = require('./base');
+
+const ERROR_MESSAGE = 'Avoid binding to a `down` event; bind to an `up` event instead';
+
+/**
+ * Detects that a Node is an instance of the `{{on}}` modifier with a known event that is being listened to
+ *
+ * @param {object} node
+ * @return {boolean}
+ */
+function isOnModifier(node) {
+  return match(node, { path: { original: 'on' }, params: [{ type: 'StringLiteral' }] });
+}
+
+/**
+ * Detects that a Node is an instance of the `{{action}}` modifier
+ *
+ * @param {object} node
+ * @return {boolean}
+ */
+function isActionModifer(node) {
+  return match(node, { path: { original: 'action' } });
+}
+
+/**
+ * Check if an event name is a "down" event
+ *
+ * @param {string} eventName
+ * @return {boolean}
+ */
+function isDownEvent(eventName) {
+  return eventName.toLowerCase().endsWith('down');
+}
+
+module.exports = class NoDownEventBinding extends Rule {
+  visitor() {
+    return {
+      AttrNode(node) {
+        if (node.name.startsWith('on') && isDownEvent(node.name)) {
+          this.log({
+            message: ERROR_MESSAGE,
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
+        }
+      },
+
+      ElementModifierStatement(node) {
+        if (isOnModifier(node)) {
+          const eventNameNode = node.params[0];
+
+          if (isDownEvent(eventNameNode.value)) {
+            this.log({
+              message: ERROR_MESSAGE,
+              line: eventNameNode.loc && eventNameNode.loc.start.line,
+              column: eventNameNode.loc && eventNameNode.loc.start.column,
+              source: this.sourceForNode(eventNameNode),
+            });
+          }
+        }
+
+        if (isActionModifer(node)) {
+          const onHashPair = node.hash.pairs.find((hashPairNode) =>
+            match(hashPairNode, { key: 'on' })
+          );
+
+          if (onHashPair && isDownEvent(onHashPair.value.value)) {
+            this.log({
+              message: ERROR_MESSAGE,
+              line: onHashPair.value.loc && onHashPair.value.loc.start.line,
+              column: onHashPair.value.loc && onHashPair.value.loc.start.column,
+              source: this.sourceForNode(onHashPair.value),
+            });
+          }
+        }
+      },
+    };
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/no-down-event-binding-test.js
+++ b/test/unit/rules/no-down-event-binding-test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-down-event-binding');
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'no-down-event-binding',
+
+  config: true,
+
+  good: [
+    // Typical event binding
+    "<div {{on 'keyup' this.doSomething}}></div>",
+    "<div {{action this.doSomething on='keyup'}}></div>",
+    // DOM event handling through attributes
+    '<input type="text" onkeyup="myFunction()">',
+    // For now, we're not catching component arguments
+    '{{my-component keyDown=this.doSomething}}',
+    '<MyComponent @keyDown={{this.doSomething}} />',
+  ],
+
+  bad: [
+    {
+      template: "<div {{on 'keydown' this.doSomething}}></div>",
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 10,
+        source: "'keydown'",
+      },
+    },
+    {
+      template: "<div {{action this.doSomething on='keydown'}}></div>",
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 34,
+        source: "'keydown'",
+      },
+    },
+    {
+      // Detecting the `on` param works, even if it's not the first hash param to `{{action}}`
+      template: "<div {{action this.doSomething preventDefault=true on='keydown'}}></div>",
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 54,
+        source: "'keydown'",
+      },
+    },
+    {
+      // DOM event handling through attributes
+      template: '<input type="text" onkeydown="myFunction()">',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 19,
+        source: 'onkeydown="myFunction()"',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds a new lint rule that catches usage of "down" events in the `{{on}}` or `{{action}}` modifier and guides developers to use the "up" versions of them instead. This is not _always_ the right thing to do, but is _almost_ always the right thing to do, so I think it's worth having a lint rule for!

This came up thanks to a Tweet from @MelSumner today, where she linked to the WCAG guideline around not using "down" events. This was a major TIL for me, and since I'd bet most developers just guess which even they should be using, it felt like a lint rule could really help push people into the proverbial "pit of success"!

https://twitter.com/melaniersumner/status/1330905297326649344
