### PR TITLE
Implement `splat-attributes-only` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ Each rule has emojis denoting:
 | :white_check_mark:         | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                       |
 | :dress:                    | [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)               |
 | :white_check_mark:         | [simple-unless](./docs/rule/simple-unless.md)                                         |
+|                            | [splat-attributes-only](./docs/rule/splat-attributes-only.md)                         |
 | :white_check_mark:         | [style-concatenation](./docs/rule/style-concatenation.md)                             |
 | :white_check_mark:         | [table-groups](./docs/rule/table-groups.md)                                           |
 |                            | [template-length](./docs/rule/template-length.md)                                     |

--- a/docs/rule/splat-attributes-only.md
+++ b/docs/rule/splat-attributes-only.md
@@ -1,0 +1,30 @@
+# splat-attributes-only
+
+It is easy to introduce typos when typing out `...attributes` or to use e.g.
+`...arguments` instead. Unfortunately, that leads to a cryptic runtime error,
+but does not fail the build.
+
+This rule warns you when you use an attribute starting with `...` that is **not**
+`...attributes`.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<div ...atributes></div>
+```
+
+```hbs
+<div ...arguments></div>
+```
+
+This rule **allows** the following:
+
+```hbs
+<div ...attributes></div>
+```
+
+## References
+
+* [Ember 3.11 release](https://blog.emberjs.com/2019/07/15/ember-3-11-released.html)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -84,6 +84,7 @@ module.exports = {
   'require-valid-alt-text': require('./require-valid-alt-text'),
   'self-closing-void-elements': require('./self-closing-void-elements'),
   'simple-unless': require('./simple-unless'),
+  'splat-attributes-only': require('./splat-attributes-only'),
   'style-concatenation': require('./style-concatenation'),
   'table-groups': require('./table-groups'),
   'template-length': require('./template-length'),

--- a/lib/rules/splat-attributes-only.js
+++ b/lib/rules/splat-attributes-only.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const Rule = require('./base');
+
+const ERROR_MESSAGE = 'Only `...attributes` can be applied to elements';
+
+module.exports = class SplatAttributesOnly extends Rule {
+  visitor() {
+    return {
+      AttrNode(node) {
+        if (node.name.startsWith('...') && node.name !== '...attributes') {
+          this.log({
+            message: ERROR_MESSAGE,
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
+        }
+      },
+    };
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/splat-attributes-only-test.js
+++ b/test/unit/rules/splat-attributes-only-test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const { ERROR_MESSAGE } = require('../../../lib/rules/splat-attributes-only');
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'splat-attributes-only',
+
+  config: true,
+
+  good: [
+    '<div ...attributes></div>',
+    '<div attributes></div>',
+    '<div arguments></div>',
+    '<div><div ...attributes></div></div>',
+  ],
+
+  bad: [
+    {
+      template: '<div ...arguments></div>',
+
+      result: {
+        message: ERROR_MESSAGE,
+        source: '...arguments',
+        line: 1,
+        column: 5,
+      },
+    },
+  ],
+});


### PR DESCRIPTION
# splat-attributes-only

It is easy to introduce typos when typing out `...attributes` or to use e.g.
`...arguments` instead. Unfortunately, that leads to a cryptic runtime error,
but does not fail the build.

This rule warns you when you use an attribute starting with `...` that is **not**
`...attributes`.

## Examples

This rule **forbids** the following:

```hbs
<div ...atributes></div>
```

```hbs
<div ...arguments></div>
```

This rule **allows** the following:

```hbs
<div ...attributes></div>
```
