### PR TITLE
Add rootURL to ignore list for index.html

### DIFF
--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -43,6 +43,8 @@ const BUILT_INS = new Set([
   'in-element',
   /* from ember-cli-app-version */
   'app-version',
+  /* from app/index.html */
+  'rootURL',
 ]);
 
 const ALWAYS_CURLY = new Set(['yield']);

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -43,7 +43,7 @@ const BUILT_INS = new Set([
   'in-element',
   /* from ember-cli-app-version */
   'app-version',
-  /* from app/index.html */
+  /* from app/index.html and tests/index.html */
   'rootURL',
 ]);
 

--- a/lib/rules/no-implicit-this.js
+++ b/lib/rules/no-implicit-this.js
@@ -44,7 +44,11 @@ const ARGLESS_BUILTIN_HELPERS = [
 ];
 
 // arg'less Components / Helpers in default ember-cli blueprint
-const ARGLESS_DEFAULT_BLUEPRINT = ['welcome-page'];
+const ARGLESS_DEFAULT_BLUEPRINT = [
+  'welcome-page',
+  /* from app/index.html */
+  'rootURL',
+];
 
 module.exports = class NoImplicitThis extends Rule {
   parseConfig(config) {

--- a/lib/rules/no-implicit-this.js
+++ b/lib/rules/no-implicit-this.js
@@ -46,7 +46,7 @@ const ARGLESS_BUILTIN_HELPERS = [
 // arg'less Components / Helpers in default ember-cli blueprint
 const ARGLESS_DEFAULT_BLUEPRINT = [
   'welcome-page',
-  /* from app/index.html */
+  /* from app/index.html and tests/index.html */
   'rootURL',
 ];
 

--- a/lib/rules/no-implicit-this.js
+++ b/lib/rules/no-implicit-this.js
@@ -37,6 +37,7 @@ const ARGLESS_BUILTIN_HELPERS = [
   'hasBlockParams',
   'hash',
   'input',
+  'log',
   'outlet',
   'query-params',
   'textarea',


### PR DESCRIPTION
#1232 expanded linting to include html files (thank you!). There was a knock on effect when running this in the default app blueprint, in that `app/index.html` and `tests/index.html` both trigger linting errors now.

```
❯ ember-template-lint .
app/index.html
  12:46  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  13:46  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  20:17  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  21:17  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  12:48  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this
  13:48  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this
  20:19  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this
  21:19  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this

tests/index.html
  13:33  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  14:33  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  15:33  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  32:17  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  33:17  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  34:17  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  35:17  error  You are using the component {{rootURL}} with curly component syntax. You should use <RootURL> instead. If it is actually a helper you must manually add it to the 'no-curly-component-invocation' rule configuration, e.g. `'no-curly-component-invocation': { allow: ['rootURL'] }`.  no-curly-component-invocation
  13:35  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this
  14:35  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this
  15:35  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this
  32:19  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this
  33:19  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this
  34:19  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this
  35:19  error  Ambiguous path 'rootURL' is not allowed. Use '@rootURL' if it is a named argument or 'this.rootURL' if it is a property on 'this'. If it is a helper or component that has no arguments, you must either convert it to an angle bracket invocation or manually add it to the 'no-implicit-this' rule configuration, e.g. 'no-implicit-this': { allow: ['rootURL'] }.  no-implicit-this

✖ 22 problems (22 errors, 0 warnings)
```

This change adds `rootURL` to the ignore lists in both rules, to effectively exclude this prop from triggering the linting violation.