### PR TITLE
Update `noImplicitThis` option default to true and `requireDash` option default to false in `no-curly-component-invocation` rule

### DIFF
--- a/docs/rule/no-curly-component-invocation.md
+++ b/docs/rule/no-curly-component-invocation.md
@@ -14,11 +14,11 @@ look like they could be component invocations.
 
 ## Examples
 
-- `{{foo}}` ✅
+- `{{foo}}` ❌
   (simple mustache without `-` in the path is likely to be a property; unless
   `noImplicitThis` is set or in `disallow` list and not a scoped variable)
 
-- `{{foo.bar}}` ✅
+- `{{foo.bar}}` ❌
   (simple mustache with nested path is likely to be a nested property; unless
   `noImplicitThis` is set)
 
@@ -75,16 +75,16 @@ look like they could be component invocations.
 ## Configuration
 
 - boolean -- if `true`, default configuration is applied
-  (`noImplicitThis: false`, `requireDash: true`), see below for details
+  (`noImplicitThis: true`, `requireDash: false`), see below for details
 
 - object -- containing the following properties:
   - boolean -- `noImplicitThis` -- if `true`, the rule considers all simple
     curly invocations without positional or named arguments as components unless
     they are prefixed with `this.` or `@`
-    (default: `false`)
+    (default: `true`)
   - boolean -- `requireDash` -- if `true`, the rule only considers curly
     invocations with a `-` character as potential component invocations
-    (default: `true`)
+    (default: `false`)
   - array -- `allow` -- a list of curly invocation paths that are known to
     **not** be component invocations
   - array -- `disallow` -- a list of curly invocation paths that are known to

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -9,13 +9,7 @@ module.exports = {
     'no-action': 'error',
     'no-args-paths': 'error',
     'no-attrs-in-components': 'error',
-    'no-curly-component-invocation': [
-      'error',
-      {
-        noImplicitThis: 'error',
-        requireDash: 'off',
-      },
-    ],
+    'no-curly-component-invocation': 'error',
     'no-debugger': 'error',
     'no-duplicate-attributes': 'error',
     'no-extra-mut-helper-argument': 'error',

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -5,8 +5,8 @@ const Rule = require('./base');
 const DEFAULT_CONFIG = {
   allow: [],
   disallow: [],
-  requireDash: true,
-  noImplicitThis: false,
+  requireDash: false,
+  noImplicitThis: true,
 };
 
 const BUILT_INS = new Set([
@@ -236,7 +236,8 @@ function parseConfig(config) {
       '  * object -- An object with the following keys:',
       '    * `allow` -- array: A list of allowlisted helpers to be allowed used with curly component syntax',
       '    * `disallow` -- array: A list of component names to not allow use with curly component syntax',
-      '    * `requireDash` -- boolean: The codemod assumes that all components have a dash in their name. `true` to enable (default) / `false` to disable',
+      '    * `requireDash` -- boolean: Assume that all components have a dash in their name. `true` to enable / `false` to disable (default)',
+      '    * `noImplicitThis` -- boolean: Consider all simple curly invocations without positional or named arguments as components unless they are prefixed with `this.` or `@`. `true` to enable (default) / `false` to disable',
     ],
     config
   );

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -171,7 +171,10 @@ const SHARED_BAD = [
 generateRuleTests({
   name: 'no-curly-component-invocation',
 
-  config: true,
+  config: {
+    requireDash: true,
+    noImplicitThis: false,
+  },
 
   good: [...SHARED_MOSTLY_GOOD, ...SHARED_GOOD],
   bad: [...SHARED_BAD],
@@ -182,6 +185,7 @@ generateRuleTests({
 
   config: {
     requireDash: false,
+    noImplicitThis: false,
   },
 
   good: [...SHARED_MOSTLY_GOOD, ...SHARED_GOOD],
@@ -194,6 +198,7 @@ generateRuleTests({
   config: {
     disallow: ['disallowed'],
     requireDash: false,
+    noImplicitThis: false,
   },
 
   good: [
@@ -223,6 +228,7 @@ generateRuleTests({
   config: {
     allow: ['aaa-bbb', 'aaa/bbb'],
     requireDash: false,
+    noImplicitThis: false,
   },
 
   good: [
@@ -241,6 +247,7 @@ generateRuleTests({
 
   config: {
     requireDash: true,
+    noImplicitThis: false,
   },
 
   good: [...SHARED_MOSTLY_GOOD, ...SHARED_GOOD, '{{foo bar=baz}}'],
@@ -251,6 +258,7 @@ generateRuleTests({
   name: 'no-curly-component-invocation',
 
   config: {
+    requireDash: false,
     noImplicitThis: true,
   },
 
@@ -285,22 +293,22 @@ generateRuleTests({
 describe('no-curly-component-invocation', () => {
   describe('parseConfig', () => {
     const TESTS = [
-      [true, { allow: [], disallow: [], requireDash: true, noImplicitThis: false }],
+      [true, { allow: [], disallow: [], requireDash: false, noImplicitThis: true }],
       [
         { allow: ['foo'] },
-        { allow: ['foo'], disallow: [], requireDash: true, noImplicitThis: false },
+        { allow: ['foo'], disallow: [], requireDash: false, noImplicitThis: true },
       ],
       [
         { requireDash: false },
-        { allow: [], disallow: [], requireDash: false, noImplicitThis: false },
+        { allow: [], disallow: [], requireDash: false, noImplicitThis: true },
       ],
       [
         { noImplicitThis: true },
-        { allow: [], disallow: [], requireDash: true, noImplicitThis: true },
+        { allow: [], disallow: [], requireDash: false, noImplicitThis: true },
       ],
       [
         { allow: ['foo'], disallow: ['bar', 'baz'], requireDash: false },
-        { allow: ['foo'], disallow: ['bar', 'baz'], requireDash: false, noImplicitThis: false },
+        { allow: ['foo'], disallow: ['bar', 'baz'], requireDash: false, noImplicitThis: true },
       ],
     ];
 


### PR DESCRIPTION
Part of #1315 V3 release.

This adopts the Ember Octane rule config as the default configuration for the rule.