### PR TITLE
Enable `no-model-argument-in-route-templates` as a `recommended` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Each rule has emojis denoting:
 | :white_check_mark:         | [no-invalid-role](./docs/rule/no-invalid-role.md)                                           |
 |                            | [no-link-to-tagname](./docs/rule/no-link-to-tagname.md)                                     |
 | :white_check_mark:         | [no-log](./docs/rule/no-log.md)                                                             |
-| :wrench:                   | [no-model-argument-in-route-templates](./docs/rule/no-model-argument-in-route-templates.md) |
+| :white_check_mark::wrench: | [no-model-argument-in-route-templates](./docs/rule/no-model-argument-in-route-templates.md) |
 | :dress:                    | [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                           |
 | :white_check_mark:         | [no-negated-condition](./docs/rule/no-negated-condition.md)                                 |
 | :white_check_mark:         | [no-nested-interactive](./docs/rule/no-nested-interactive.md)                               |

--- a/docs/rule/no-model-argument-in-route-templates.md
+++ b/docs/rule/no-model-argument-in-route-templates.md
@@ -1,5 +1,7 @@
 # no-model-argument-in-route-templates
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 :wrench: The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
 
 Usage of `{{@model}}` in route templates was introduced to simplify the mental

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -37,6 +37,7 @@ module.exports = {
     'no-invalid-meta': 'error',
     'no-invalid-role': 'error',
     'no-log': 'error',
+    'no-model-argument-in-route-templates': 'error',
     'no-negated-condition': 'error',
     'no-nested-interactive': 'error',
     'no-nested-landmark': 'error',


### PR DESCRIPTION
Part of V3 release #1315.

https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-model-argument-in-route-templates.md