### PR TITLE
Hide pending option from help output

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -157,6 +157,7 @@ function parseArgv(_argv) {
         describe:
           'Print list of formatted rules for use with `pending` in config file (deprecated)',
         boolean: true,
+        hidden: true,
       },
       'update-todo': {
         describe: 'Update list of linting todos by transforming lint errors to todos',

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -64,8 +64,6 @@ describe('ember-template-lint executable', function () {
                                                                    [string] [default: \\".\\"]
             --no-config-path            Does not use the local template-lintrc, will use a
                                         blank template-lintrc instead            [boolean]
-            --print-pending             Print list of formatted rules for use with
-                                        \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos         [boolean] [default: false]
             --include-todo              Include todos in the results
@@ -111,8 +109,6 @@ describe('ember-template-lint executable', function () {
                                                                    [string] [default: \\".\\"]
             --no-config-path            Does not use the local template-lintrc, will use a
                                         blank template-lintrc instead            [boolean]
-            --print-pending             Print list of formatted rules for use with
-                                        \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos         [boolean] [default: false]
             --include-todo              Include todos in the results
@@ -412,8 +408,6 @@ describe('ember-template-lint executable', function () {
                                                                    [string] [default: \\".\\"]
             --no-config-path            Does not use the local template-lintrc, will use a
                                         blank template-lintrc instead            [boolean]
-            --print-pending             Print list of formatted rules for use with
-                                        \`pending\` in config file (deprecated)    [boolean]
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos         [boolean] [default: false]
             --include-todo              Include todos in the results


### PR DESCRIPTION
Sets `pending` to hidden for help output.

Addresses parts of https://github.com/ember-template-lint/ember-template-lint/issues/1557.