### PR TITLE
Add rule: `no-this-in-template-only-components`

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ Each rule has emojis denoting:
 | :wrench:                   | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)                     |
 |                            | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md)                       |
 | :white_check_mark:         | [no-shadowed-elements](./docs/rule/no-shadowed-elements.md)                                 |
+| :wrench:                   | [no-this-in-template-only-components](./docs/rule/no-this-in-template-only-components.md)   |
 | :nail_care:                | [no-trailing-spaces](./docs/rule/no-trailing-spaces.md)                                     |
 | :white_check_mark:         | [no-triple-curlies](./docs/rule/no-triple-curlies.md)                                       |
 |                            | [no-unbalanced-curlies](./docs/rule/no-unbalanced-curlies.md)                               |

--- a/docs/rule/no-this-in-template-only-components.md
+++ b/docs/rule/no-this-in-template-only-components.md
@@ -1,0 +1,44 @@
+# no-this-in-template-only-components
+
+There is no `this` context in template-only components.
+
+:wrench: The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
+## Examples
+
+This rule **forbids** `this` if the template has no corresponding `component.js`:
+
+```hbs
+<h1>Hello {{this.name}}!</h1>
+```
+
+This rule **allows** `this` if the template has a corresponding `component.js`:
+
+```js
+import Component from '@ember/component';
+
+export default Component.extend({
+  name: 'Derek'
+});
+```
+
+```hbs
+<h1>Hello {{this.name}}!</h1>
+```
+
+The `--fix` option will convert to named arguments:
+
+```hbs
+<h1>Hello {{@name}}!</h1>
+```
+
+## Migration
+
+* use [ember-no-implicit-this-codemod](https://github.com/ember-codemods/ember-no-implicit-this-codemod)
+* [upgrade to Glimmer components](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/), which don't allow ambiguous access
+  * classic components have [auto-reflection](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md#motivation), and can use `this.myArgName` or `this.args.myArgNme` or `@myArgName` interchangeably
+
+## References
+
+* [Glimmer components](https://guides.emberjs.com/release/upgrading/current-edition/glimmer-components/)
+* [rfcs/named args](https://github.com/emberjs/rfcs/blob/master/text/0276-named-args.md#motivation)

--- a/docs/rule/no-this-in-template-only-components.md
+++ b/docs/rule/no-this-in-template-only-components.md
@@ -32,6 +32,12 @@ The `--fix` option will convert to named arguments:
 <h1>Hello {{@name}}!</h1>
 ```
 
+## Configuration
+
+* boolean -- `true` for enabled / `false` for disabled
+* object -- An object with the following keys:
+  * `validComponentExtensions` -- An array of component class extensions. Defaults to `[ '.js', '.ts' ]`
+
 ## Migration
 
 * use [ember-no-implicit-this-codemod](https://github.com/ember-codemods/ember-no-implicit-this-codemod)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -66,6 +66,7 @@ module.exports = {
   'no-redundant-landmark-role': require('./no-redundant-landmark-role'),
   'no-restricted-invocations': require('./no-restricted-invocations'),
   'no-shadowed-elements': require('./no-shadowed-elements'),
+  'no-this-in-template-only-components': require('./no-this-in-template-only-components'),
   'no-trailing-spaces': require('./no-trailing-spaces'),
   'no-triple-curlies': require('./no-triple-curlies'),
   'no-unbalanced-curlies': require('./no-unbalanced-curlies'),

--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -37,7 +37,7 @@ function hasContext(hbsFilePath) {
       return fs.existsSync(jsFilePath);
     }
   }
-  // what other types of files?
+  // TODO: handle pods layout
   return false;
 }
 

--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -12,7 +12,7 @@ function message(original, fixed) {
   );
 }
 
-function hasContext(hbsFilePath) {
+function isTemplateOnlyComponent(hbsFilePath) {
   const paths = hbsFilePath.split(path.sep);
   if (paths[0] === 'app' || paths[0] === 'addon') {
     if (paths[1] === 'templates') {
@@ -25,20 +25,20 @@ function hasContext(hbsFilePath) {
           ...paths.slice(3, -1),
           `${moduleName}.js`
         );
-        return fs.existsSync(jsFilePath);
+        return !fs.existsSync(jsFilePath);
       } else {
         // route template always has a context
-        return true;
+        return false;
       }
     } else if (paths[1] === 'components') {
       // co-located structure: /app/components/foo.hbs => /app/components/foo.js
       const moduleName = path.basename(hbsFilePath, '.hbs');
       const jsFilePath = path.join(path.dirname(hbsFilePath), `${moduleName}.js`);
-      return fs.existsSync(jsFilePath);
+      return !fs.existsSync(jsFilePath);
     }
   }
   // TODO: handle pods layout
-  return false;
+  return true;
 }
 
 function isFixable(original) {
@@ -51,7 +51,7 @@ function isFixable(original) {
 
 module.exports = class NoThisInTemplateOnlyComponents extends Rule {
   visitor() {
-    if (hasContext(this._filePath)) {
+    if (!isTemplateOnlyComponent(this._filePath)) {
       // template is allowed to use `this`
       return null;
     }

--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -48,12 +48,32 @@ function isTemplateOnlyComponent(hbsFilePath, validComponentExtensions) {
   return true;
 }
 
+/**
+ * Properties which should be excluded from auto-fix.
+ *
+ * For example, `{{this.elementId}}` in a template-only component is
+ * most likely a bug and should not be converted to `{{@elementId}}`.
+ */
+const builtInProperties = [
+  'action',
+  'actionContext',
+  'actionContextObject',
+  'attributeBindings',
+  'childViews',
+  'classNameBindings',
+  'classNames',
+  'concatenatedProperties',
+  'element',
+  'elementId',
+  'parentView',
+  'tagName',
+  'target',
+];
+
 function isFixable(original) {
-  if (original === 'this.elementId') {
-    // elementId usage in a template-only component can't be auto-fixed
-    return false;
-  }
-  return true;
+  return !builtInProperties.some((property) => {
+    return original === `this.${property}`;
+  });
 }
 
 const DEFAULT_CONFIG = {

--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -12,20 +12,27 @@ function message(original, fixed) {
   );
 }
 
-function isTemplateOnlyComponent(hbsFilePath) {
+/**
+ * Tests whether the template has a corresponding component class file
+ * @param hbsFilePath - path to the template file
+ * @param validComponentExtensions - an array of valid component class extensions
+ * @returns {boolean} true if a component class was found
+ */
+function isTemplateOnlyComponent(hbsFilePath, validComponentExtensions) {
+  /**
+   * Tests whether the component class exists as `component.js`, `component.ts`, etc.
+   */
+  function componentClassExists(pathWithoutExtension) {
+    return validComponentExtensions.some((ext) => fs.existsSync(pathWithoutExtension + ext));
+  }
   const paths = hbsFilePath.split(path.sep);
   if (paths[0] === 'app' || paths[0] === 'addon') {
     if (paths[1] === 'templates') {
       if (paths[2] === 'components') {
         // classic structure: /app/templates/components/foo.hbs => /app/components/foo.js
         const moduleName = path.basename(hbsFilePath, '.hbs');
-        const jsFilePath = path.join(
-          paths[0],
-          'components',
-          ...paths.slice(3, -1),
-          `${moduleName}.js`
-        );
-        return !fs.existsSync(jsFilePath);
+        const classFilePath = path.join(paths[0], 'components', ...paths.slice(3, -1), moduleName);
+        return !componentClassExists(classFilePath);
       } else {
         // route template always has a context
         return false;
@@ -33,8 +40,8 @@ function isTemplateOnlyComponent(hbsFilePath) {
     } else if (paths[1] === 'components') {
       // co-located structure: /app/components/foo.hbs => /app/components/foo.js
       const moduleName = path.basename(hbsFilePath, '.hbs');
-      const jsFilePath = path.join(path.dirname(hbsFilePath), `${moduleName}.js`);
-      return !fs.existsSync(jsFilePath);
+      const classFilePath = path.join(path.dirname(hbsFilePath), moduleName);
+      return !componentClassExists(classFilePath);
     }
   }
   // TODO: handle pods layout
@@ -49,9 +56,26 @@ function isFixable(original) {
   return true;
 }
 
+const DEFAULT_CONFIG = {
+  validComponentExtensions: ['.js', '.ts'],
+};
+
 module.exports = class NoThisInTemplateOnlyComponents extends Rule {
+  parseConfig(config) {
+    let configType = typeof config;
+
+    switch (configType) {
+      case 'boolean':
+        return config ? DEFAULT_CONFIG : false;
+      case 'object':
+        return { validComponentExtensions: config.validComponentExtensions };
+      case 'undefined':
+        return false;
+    }
+  }
+
   visitor() {
-    if (!isTemplateOnlyComponent(this._filePath)) {
+    if (!isTemplateOnlyComponent(this._filePath, this.config.validComponentExtensions)) {
       // template is allowed to use `this`
       return null;
     }

--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -25,7 +25,7 @@ function isTemplateOnlyComponent(hbsFilePath, validComponentExtensions) {
   function componentClassExists(pathWithoutExtension) {
     return validComponentExtensions.some((ext) => fs.existsSync(pathWithoutExtension + ext));
   }
-  const paths = hbsFilePath.split(path.sep);
+  const paths = path.normalize(hbsFilePath).split(path.sep);
   if (paths[0] === 'app' || paths[0] === 'addon') {
     if (paths[1] === 'templates') {
       if (paths[2] === 'components') {

--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const Rule = require('./base');
+
+function message(original, fixed) {
+  return (
+    `Usage of 'this' in path '${original}' is not allowed in a template-only component. ` +
+    `Use '${fixed}' if it is a named argument or create a component.js for this component.`
+  );
+}
+
+function hasContext(hbsFilePath) {
+  const paths = hbsFilePath.split(path.sep);
+  if (paths[0] === 'app' || paths[0] === 'addon') {
+    if (paths[1] === 'templates') {
+      if (paths[2] === 'components') {
+        // classic structure: /app/templates/components/foo.hbs => /app/components/foo.js
+        const moduleName = path.basename(hbsFilePath, '.hbs');
+        const jsFilePath = path.join(
+          paths[0],
+          'components',
+          ...paths.slice(3, -1),
+          `${moduleName}.js`
+        );
+        return fs.existsSync(jsFilePath);
+      } else {
+        // route template always has a context
+        return true;
+      }
+    } else if (paths[1] === 'components') {
+      // co-located structure: /app/components/foo.hbs => /app/components/foo.js
+      const moduleName = path.basename(hbsFilePath, '.hbs');
+      const jsFilePath = path.join(path.dirname(hbsFilePath), `${moduleName}.js`);
+      return fs.existsSync(jsFilePath);
+    }
+  }
+  // what other types of files?
+  return false;
+}
+
+function isFixable(original) {
+  if (original === 'this.elementId') {
+    // elementId usage in a template-only component can't be auto-fixed
+    return false;
+  }
+  return true;
+}
+
+module.exports = class NoThisInTemplateOnlyComponents extends Rule {
+  visitor() {
+    if (hasContext(this._filePath)) {
+      // template is allowed to use `this`
+      return null;
+    }
+
+    return {
+      PathExpression(path) {
+        if (path.this) {
+          const fixed = path.original.replace(/^this\./, '@');
+          if (this.mode === 'fix' && isFixable(path.original)) {
+            path.original = fixed;
+          } else {
+            this.log({
+              message: message(path.original, fixed),
+              line: path.loc && path.loc.start.line,
+              column: path.loc && path.loc.start.column,
+              source: this.sourceForNode(path),
+              isFixable: isFixable(path.original),
+            });
+          }
+        }
+      },
+    };
+  }
+};
+
+module.exports.message = message;

--- a/test/unit/rules/no-this-in-template-only-components-test.js
+++ b/test/unit/rules/no-this-in-template-only-components-test.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { message } = require('../../../lib/rules/no-this-in-template-only-components');
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'no-this-in-template-only-components',
+
+  config: true,
+
+  good: [
+    '{{welcome-page}}',
+    '<WelcomePage />',
+    '<MyComponent @prop={{can "edit" @model}} />',
+    '{{my-component model=model}}',
+  ],
+
+  bad: [
+    {
+      template: '{{my-component model=this.model}}',
+      fixedTemplate: '{{my-component model=@model}}',
+
+      result: {
+        message: message('this.model', '@model'),
+        source: 'this.model',
+        line: 1,
+        column: 21,
+        isFixable: true,
+      },
+    },
+    {
+      template: '{{my-component action=(action this.myAction)}}',
+      fixedTemplate: '{{my-component action=(action @myAction)}}',
+
+      result: {
+        message: message('this.myAction', '@myAction'),
+        source: 'this.myAction',
+        line: 1,
+        column: 30,
+        isFixable: true,
+      },
+    },
+    {
+      template: '<MyComponent @prop={{can "edit" this.model}} />',
+      fixedTemplate: '<MyComponent @prop={{can "edit" @model}} />',
+
+      result: {
+        message: message('this.model', '@model'),
+        source: 'this.model',
+        line: 1,
+        column: 32,
+        isFixable: true,
+      },
+    },
+    {
+      template: '{{input id=(concat this.elementId "-username")}}',
+      result: {
+        message: message('this.elementId', '@elementId'),
+        source: 'this.elementId',
+        line: 1,
+        column: 19,
+        isFixable: false,
+      },
+    },
+  ],
+});

--- a/test/unit/rules/no-this-in-template-only-components-test.js
+++ b/test/unit/rules/no-this-in-template-only-components-test.js
@@ -13,6 +13,12 @@ generateRuleTests({
     '<WelcomePage />',
     '<MyComponent @prop={{can "edit" @model}} />',
     '{{my-component model=model}}',
+    {
+      template: '{{my-component model=this.model}}',
+      meta: {
+        filePath: 'app/templates/route-template.hbs',
+      },
+    },
   ],
 
   bad: [
@@ -60,6 +66,21 @@ generateRuleTests({
         line: 1,
         column: 19,
         isFixable: false,
+      },
+    },
+    {
+      template: '{{my-component model=this.model}}',
+      fixedTemplate: '{{my-component model=@model}}',
+      meta: {
+        filePath: 'app/templates/components/some-component.hbs',
+      },
+      result: {
+        filePath: 'app/templates/components/some-component.hbs',
+        message: message('this.model', '@model'),
+        source: 'this.model',
+        line: 1,
+        column: 21,
+        isFixable: true,
       },
     },
   ],


### PR DESCRIPTION
After running [ember-no-implicit-this-codemod](https://github.com/ember-codemods/ember-no-implicit-this-codemod) I was left with a bunch of template-only components referencing `{{this.prop}}`. I put together this rule to help me finish the conversion. Maybe it would be useful to someone else.

Related to https://github.com/emberjs/ember.js/issues/18132
