### PR TITLE
Implement `require-splattributes` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Each rule has emojis denoting:
 | :white_check_mark:         | [require-iframe-title](./docs/rule/require-iframe-title.md)                                 |
 |                            | [require-input-label](./docs/rule/require-input-label.md)                                   |
 |                            | [require-lang-attribute](./docs/rule/require-lang-attribute.md)                             |
+|                            | [require-splattributes](./docs/rule/require-splattributes.md)                               |
 | :white_check_mark:         | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                             |
 | :nail_care:                | [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)                     |
 | :white_check_mark:         | [simple-unless](./docs/rule/simple-unless.md)                                               |

--- a/docs/rule/require-splattributes.md
+++ b/docs/rule/require-splattributes.md
@@ -1,0 +1,80 @@
+# require-splattributes
+
+Splattributes (`...attributes`) make it possible to use attributes on component
+invocations (e.g. `<SomeComponent class="blue">`). Forgetting to add
+`...attributes` however makes it impossible to apply attributes like `class` to
+a component.
+
+This rule warns about templates that don't have `...attributes` in them.
+
+Please note that this rule is only useful for Glimmer components or tagless
+(`tagName: ''`) classic components, because regular classic components have
+this functionality built into the root element, which is not part of their
+templates.
+
+This rule also should not be used foo route/controller templates, because those
+don't support `...attributes`. Instead of unconditionally enabling this rule in
+your `.template-lintrc.js` file, you might want to consider using
+[`overrides`](../overrides.md) to only enable it for component templates (see
+below).
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<div>
+  component content
+</div>
+```
+
+```hbs
+<SomeOtherComponent>
+  component content
+</SomeOtherComponent>
+```
+
+This rule **allows** the following:
+
+```hbs
+<div ...attributes>
+  component content
+</div>
+```
+
+```hbs
+<div class="foo">
+  <SomeOtherComponent ...attributes />
+</div>
+```
+
+## Example configuration
+
+```javascript
+module.exports = {
+  extends: 'recommended',
+  rules: {
+    // ...
+  },
+  overrides: [
+    {
+      files: ['app/components/**/*.hbs'],
+      rules: { 'require-splattributes': 'error' },
+    },
+  ],
+};
+```
+
+## Migration
+
+* Add `...attributes` on at least one element or component invocation in the template (usually the root element)
+* Use `{{! template-lint-disable require-splattributes }}` where you explicitly don't want or need `...attributes`
+
+## Related Rules
+
+* [no-nested-splattributes](no-nested-splattributes.md)
+* [splat-attributes-only](splat-attributes-only.md)
+
+## References
+
+* [Splattributes](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/#toc_html-attributes) in the Ember.js guides

--- a/docs/rule/require-splattributes.md
+++ b/docs/rule/require-splattributes.md
@@ -12,7 +12,7 @@ Please note that this rule is only useful for Glimmer components or tagless
 this functionality built into the root element, which is not part of their
 templates.
 
-This rule also should not be used foo route/controller templates, because those
+This rule also should not be used for route/controller templates, because those
 don't support `...attributes`. Instead of unconditionally enabling this rule in
 your `.template-lintrc.js` file, you might want to consider using
 [`overrides`](../overrides.md) to only enable it for component templates (see

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -86,6 +86,7 @@ module.exports = {
   'require-iframe-title': require('./require-iframe-title'),
   'require-input-label': require('./require-input-label'),
   'require-lang-attribute': require('./require-lang-attribute'),
+  'require-splattributes': require('./require-splattributes'),
   'require-valid-alt-text': require('./require-valid-alt-text'),
   'self-closing-void-elements': require('./self-closing-void-elements'),
   'simple-unless': require('./simple-unless'),

--- a/lib/rules/require-splattributes.js
+++ b/lib/rules/require-splattributes.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const Rule = require('./base');
+
+module.exports = class RequireSplattributes extends Rule {
+  visitor() {
+    let foundSplattributes = false;
+
+    return {
+      AttrNode(node) {
+        if (node.name === '...attributes') {
+          foundSplattributes = true;
+        }
+      },
+
+      Template: {
+        exit(node) {
+          if (!foundSplattributes) {
+            let { body } = node;
+            let elementNodes = body.filter((it) => it.type === 'ElementNode');
+            let nonEmptyTextNodes = body.filter((it) => it.type === 'TextNode' && it.chars.trim());
+            if (elementNodes.length === 1 && nonEmptyTextNodes.length === 0) {
+              this.report({
+                message: 'The root element in this template should use `...attributes`',
+                node: elementNodes[0],
+              });
+            } else {
+              this.report({
+                message: 'At least one element in this template should use `...attributes`',
+                node,
+              });
+            }
+          }
+        },
+      },
+    };
+  }
+
+  report({ message, node }) {
+    this.log({
+      message,
+      line: node.loc && node.loc.start.line,
+      column: node.loc && node.loc.start.column,
+      source: this.sourceForNode(node),
+    });
+  }
+};

--- a/test/unit/rules/require-splattributes-test.js
+++ b/test/unit/rules/require-splattributes-test.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'require-splattributes',
+
+  config: true,
+
+  good: [
+    '<div ...attributes></div>',
+    '<Foo ...attributes></Foo>',
+    '<div ...attributes />',
+    '<div><Foo ...attributes /></div>',
+    '<div ...attributes></div><div></div>',
+    '<div></div><div ...attributes></div><div></div>',
+  ],
+
+  bad: [
+    {
+      template: '<div></div>',
+      result: {
+        message: 'The root element in this template should use `...attributes`',
+        line: 1,
+        column: 0,
+        source: '<div></div>',
+      },
+    },
+    {
+      template: '<Foo></Foo>',
+      result: {
+        message: 'The root element in this template should use `...attributes`',
+        line: 1,
+        column: 0,
+        source: '<Foo></Foo>',
+      },
+    },
+    {
+      template: '<div></div><div></div>',
+      result: {
+        message: 'At least one element in this template should use `...attributes`',
+        line: 1,
+        column: 0,
+        source: '<div></div><div></div>',
+      },
+    },
+    {
+      template: '<div/>\n\n',
+      result: {
+        message: 'The root element in this template should use `...attributes`',
+        line: 1,
+        column: 0,
+        source: '<div/>',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Resolves https://github.com/ember-template-lint/ember-template-lint/issues/710

---

# require-splattributes

Splattributes (`...attributes`) make it possible to use attributes on component
invocations (e.g. `<SomeComponent class="blue">`). Forgetting to add
`...attributes` however makes it impossible to apply attributes like `class` to
a component.

This rule warns about templates that don't have `...attributes` in them.

Please note that this rule is only useful for Glimmer components or tagless
(`tagName: ''`) classic components, because regular classic components have
this functionality built into the root element, which is not part of their
templates.

## Examples

This rule **forbids** the following:

```hbs
<div>
  component content
</div>
```

```hbs
<SomeOtherComponent>
  component content
</SomeOtherComponent>
```

This rule **allows** the following:

```hbs
<div ...attributes>
  component content
</div>
```

```hbs
<div class="foo">
  <SomeOtherComponent ...attributes />
</div>
```

## Migration

* Add `...attributes` on at least one element or component invocation in the template (usually the root element)
* Use `{{! template-lint-disable require-splattributes }}` where you explicitly don't want or need `...attributes`

## Related Rules

* [no-nested-splattributes](no-nested-splattributes.md)
* [splat-attributes-only](splat-attributes-only.md)

## References

* [Splattributes](https://guides.emberjs.com/release/components/component-arguments-and-html-attributes/#toc_html-attributes) in the Ember.js guides
