### PR TITLE
Updated `is-route-template` helper to add check for template components with absolute paths

### DIFF
--- a/lib/helpers/is-route-template.js
+++ b/lib/helpers/is-route-template.js
@@ -7,8 +7,8 @@ let path = require('path');
   paths that aren't routes. While this approach is lossy, it at least catches most the cases.
 
   An unfortunate consequence of this is that for now you cannot have routes with names that
-   begin with a dash (`-`) or have `components/` in the name that have outlets in them without
-   adding in an override for this rule to the file.
+  begin with a dash (`-`) or have `components/` in the name that have outlets in them without
+  adding in an override for this rule to the file.
  */
 module.exports = function isRouteTemplate(moduleName) {
   if (typeof moduleName !== 'string') {
@@ -23,6 +23,8 @@ module.exports = function isRouteTemplate(moduleName) {
     // check that this is not a component template - [^/]+ is the app's module name
     // which we don't know here
     !/^[^/]+\/templates\/components\//.test(moduleName) && // classic component
-    !/^[^/]+\/components\//.test(moduleName) // co-located component template
+    !/^[^/]+\/components\//.test(moduleName) && // co-located component template
+    !/^([A-Z]:\\)+[^.]+\\+templates\\components\\/.test(moduleName) && // classic component with absolute path
+    !/^([A-Z]:\\)+[^.]+\\components\\/.test(moduleName) // co-located component with absolute path
   );
 };


### PR DESCRIPTION
Resolves #1648 

Updated the `is-route-template` helper by adding two extra checks for classic component templates & co-located component templates whose filenames are absolute paths. 
