### PR TITLE
Respect extends order and rules overrides

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -253,6 +253,7 @@ function processExtends(config, options) {
   let logger = options.console || console;
 
   let extendedList = normalizeExtends(config, options);
+  let extendedRules = {};
 
   if (extendedList) {
     for (const extendName of extendedList) {
@@ -268,7 +269,7 @@ function processExtends(config, options) {
           delete configuration.loadedConfigurations;
 
           if (configuration.rules) {
-            config.rules = Object.assign({}, config.rules, configuration.rules);
+            extendedRules = Object.assign({}, extendedRules, configuration.rules);
           } else {
             logger.log(chalk.yellow(`Missing rules for extends: ${extendName}`));
           }
@@ -279,6 +280,8 @@ function processExtends(config, options) {
 
       delete config.extends;
     }
+
+    config.rules = Object.assign({}, extendedRules, config.rules);
   }
 }
 

--- a/test/unit/-private/module-status-cache-test.js
+++ b/test/unit/-private/module-status-cache-test.js
@@ -1,4 +1,5 @@
 const ModuleStatusCache = require('../../../lib/-private/module-status-cache');
+const { getProjectConfig } = require('../../../lib/get-config');
 
 describe('ModuleStatusCache', function () {
   const workingDir = process.cwd();
@@ -24,6 +25,101 @@ describe('ModuleStatusCache', function () {
       baz: 'bang',
     };
     let actual = new ModuleStatusCache(workingDir, config).getConfigForFile({
+      filePath: 'app/templates/foo.hbs',
+    });
+
+    expect(actual.rules).toEqual(expectedRule);
+  });
+
+  it('Merges the overrides rules with existing rules from plugin', function () {
+    let config = {
+      plugins: [
+        {
+          name: 'foobar',
+          configurations: {
+            recommended: {
+              rules: {
+                foo: 'foo',
+                bar: 'bar',
+              },
+            },
+          },
+          rules: {
+            foo: class Rule {},
+            bar: class Rule {},
+          },
+        },
+      ],
+      extends: ['foobar:recommended'],
+      overrides: [
+        {
+          files: ['**/templates/**/*.hbs'],
+          rules: {
+            bar: 'bar-override',
+          },
+        },
+      ],
+    };
+
+    let expectedRule = {
+      foo: { config: 'foo', severity: 2 },
+      bar: { config: 'bar-override', severity: 2 },
+    };
+
+    const projectConfig = getProjectConfig(workingDir, { config });
+
+    let actual = new ModuleStatusCache(workingDir, projectConfig).getConfigForFile({
+      filePath: 'app/templates/foo.hbs',
+    });
+
+    expect(actual.rules).toEqual(expectedRule);
+  });
+
+  it('Merges the overrides rules with existing rules from plugin and config', function () {
+    let config = {
+      plugins: [
+        {
+          name: 'foobar',
+          configurations: {
+            recommended: {
+              rules: {
+                foo: 'foo',
+                bar: 'bar',
+              },
+            },
+          },
+          rules: {
+            foo: class Rule {},
+            bar: class Rule {},
+          },
+        },
+      ],
+      extends: ['foobar:recommended'],
+      rules: {
+        bar: 'bar-rules',
+        rules: 'rules-only',
+      },
+      overrides: [
+        {
+          files: ['**/templates/**/*.hbs'],
+          rules: {
+            bar: 'bar-overrides',
+            overrides: 'overrides-only',
+          },
+        },
+      ],
+    };
+
+    let expectedRule = {
+      foo: { config: 'foo', severity: 2 },
+      bar: { config: 'bar-overrides', severity: 2 },
+      rules: { config: 'rules-only', severity: 2 },
+      overrides: { config: 'overrides-only', severity: 2 },
+    };
+
+    const projectConfig = getProjectConfig(workingDir, { config });
+
+    let actual = new ModuleStatusCache(workingDir, projectConfig).getConfigForFile({
       filePath: 'app/templates/foo.hbs',
     });
 

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -674,7 +674,7 @@ describe('getProjectConfig', function () {
     expect(reprocessedConfig.rules).toEqual(expected);
   });
 
-  it('rules override extends', function () {
+  it('merges rules from plugins with rules from config', function () {
     let config = {
       plugins: [
         {
@@ -705,7 +705,7 @@ describe('getProjectConfig', function () {
     expect(processedConfig.rules).toEqual(expected);
   });
 
-  it('extends item overrides previous item', function () {
+  it('merges rules from plugins in the order declared in the array', function () {
     let config = {
       plugins: [
         {

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -673,6 +673,78 @@ describe('getProjectConfig', function () {
     let reprocessedConfig = getProjectConfig(project.baseDir, { config });
     expect(reprocessedConfig.rules).toEqual(expected);
   });
+
+  it('rules override extends', function () {
+    let config = {
+      plugins: [
+        {
+          name: 'foo',
+          configurations: {
+            recommended: {
+              rules: {
+                foo: true,
+              },
+            },
+          },
+          rules: {
+            foo: class Rule {},
+          },
+        },
+      ],
+      extends: ['foo:recommended'],
+      rules: {
+        foo: false,
+      },
+    };
+
+    let expected = {
+      foo: { config: false, severity: 0 },
+    };
+
+    let processedConfig = getProjectConfig(project.baseDir, { config });
+    expect(processedConfig.rules).toEqual(expected);
+  });
+
+  it('extends item overrides previous item', function () {
+    let config = {
+      plugins: [
+        {
+          name: 'foo',
+          configurations: {
+            recommended: {
+              rules: {
+                foo: true,
+              },
+            },
+          },
+          rules: {
+            foo: class Rule {},
+          },
+        },
+        {
+          name: 'bar',
+          configurations: {
+            recommended: {
+              rules: {
+                foo: false,
+              },
+            },
+          },
+          rules: {
+            foo: class Rule {},
+          },
+        },
+      ],
+      extends: ['foo:recommended', 'bar:recommended'],
+    };
+
+    let expected = {
+      foo: { config: false, severity: 0 },
+    };
+
+    let processedConfig = getProjectConfig(project.baseDir, { config });
+    expect(processedConfig.rules).toEqual(expected);
+  });
 });
 
 describe('getRuleFromString', function () {


### PR DESCRIPTION
Added tests cases that cover these two cases and fixes the issues reported on both:

-  Rules override is reversed on extends. Fixes #1417 
- Unable to turn rules off in `next` branch. Fixes #1644 