### PR TITLE
Adds output feedback when creating TODOs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,7 @@ module.exports = {
     'prefer-rest-params': 'error',
     'prefer-spread': 'error',
     'prefer-template': 'error',
-    quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: false }], // Disallow unnecessary template literals.
+    quotes: ['error', 'single', { avoidEscape: true, allowTemplateLiterals: true }],
     radix: 'error',
     'require-atomic-updates': 'error',
     'require-await': 'error',

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -345,10 +345,11 @@ async function run() {
         getTodoConfigFromCommandLineOptions(options)
       );
 
-      let [added] = await linter.updateTodo(linterOptions, fileResults, todoConfig);
+      let [added, removed] = await linter.updateTodo(linterOptions, fileResults, todoConfig);
 
       todoInfo = {
         added,
+        removed,
         todoConfig,
       };
     }
@@ -369,12 +370,12 @@ async function run() {
   if (options.printPending) {
     return printPending(results, options);
   } else {
-    if (
-      results.errorCount ||
-      results.warningCount ||
-      (options.includeTodo && results.todoCount) ||
-      (options.updateTodo && todoInfo.added)
-    ) {
+    let hasErrors = results.errorCount > 0;
+    let hasWarnings = results.warningCount > 0;
+    let hasTodos = options.includeTodo && results.todoCount;
+    let hasUpdatedTodos = options.updateTodo && (todoInfo.added || todoInfo.removed);
+
+    if (hasErrors || hasWarnings || hasTodos || hasUpdatedTodos) {
       let Printer = require('../lib/printers/default');
       let printer = new Printer(options);
       printer.print(results, todoInfo);

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -373,7 +373,9 @@ async function run() {
     let hasErrors = results.errorCount > 0;
     let hasWarnings = results.warningCount > 0;
     let hasTodos = options.includeTodo && results.todoCount;
-    let hasUpdatedTodos = options.updateTodo && (todoInfo.added || todoInfo.removed);
+    let hasUpdatedTodos =
+      options.updateTodo &&
+      (Number.isInteger(todoInfo.added) || Number.isInteger(todoInfo.removed));
 
     if (hasErrors || hasWarnings || hasTodos || hasUpdatedTodos) {
       let Printer = require('../lib/printers/default');

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -310,7 +310,7 @@ async function run() {
 
   if ((options.todoDaysToWarn || options.todoDaysToError) && !options.updateTodo) {
     console.error(
-      'You must use `--update-todo` when using any of `--todo-days-to-warn` or `--todo-days-to-error`.'
+      'Using `--todo-days-to-warn` or `--todo-days-to-error` is only valid when the `--update-todo` option is being used.'
     );
     process.exitCode = 1;
     return;

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -17,10 +17,10 @@ module.exports = class TodoHandler {
     this._processedResults = [];
   }
 
-  async update(filePath, results, todoConfig) {
+  update(filePath, results, todoConfig) {
     this._processedResults = this._buildResult(results);
 
-    await writeTodos(this._workingDir, this._processedResults, filePath, todoConfig);
+    return writeTodos(this._workingDir, this._processedResults, filePath, todoConfig);
   }
 
   async processResults(filePath, results, shouldFix) {

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -17,10 +17,17 @@ module.exports = class TodoHandler {
     this._processedResults = [];
   }
 
-  update(filePath, results, todoConfig) {
+  async update(filePath, results, todoConfig) {
     this._processedResults = this._buildResult(results);
 
-    return writeTodos(this._workingDir, this._processedResults, filePath, todoConfig);
+    let todoBatchCounts = await writeTodos(
+      this._workingDir,
+      this._processedResults,
+      filePath,
+      todoConfig
+    );
+
+    return todoBatchCounts;
   }
 
   async processResults(filePath, results, shouldFix) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -262,8 +262,8 @@ class Linter {
     return currentSource;
   }
 
-  async updateTodo(linterOptions, results, todoConfig) {
-    await this._todoHandler.update(linterOptions.filePath, results, todoConfig);
+  updateTodo(linterOptions, results, todoConfig) {
+    return this._todoHandler.update(linterOptions.filePath, results, todoConfig);
   }
 
   processTodos(linterOptions, results, shouldFix) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -262,12 +262,24 @@ class Linter {
     return currentSource;
   }
 
-  updateTodo(linterOptions, results, todoConfig) {
-    return this._todoHandler.update(linterOptions.filePath, results, todoConfig);
+  async updateTodo(linterOptions, results, todoConfig) {
+    let todoBatchCounts = await this._todoHandler.update(
+      linterOptions.filePath,
+      results,
+      todoConfig
+    );
+
+    return todoBatchCounts;
   }
 
-  processTodos(linterOptions, results, shouldFix) {
-    return this._todoHandler.processResults(linterOptions.filePath, results, shouldFix);
+  async processTodos(linterOptions, results, shouldFix) {
+    let fileResults = await this._todoHandler.processResults(
+      linterOptions.filePath,
+      results,
+      shouldFix
+    );
+
+    return fileResults;
   }
 
   /**

--- a/lib/printers/default.js
+++ b/lib/printers/default.js
@@ -18,9 +18,9 @@ class DefaultPrinter {
     }
   }
 
-  print(results) {
+  print(results, todoInfo) {
     for (let delegate of this.delegates) {
-      delegate.print(results);
+      delegate.print(results, todoInfo);
     }
   }
 }

--- a/lib/printers/pretty.js
+++ b/lib/printers/pretty.js
@@ -57,7 +57,7 @@ class PrettyPrinter {
     }
 
     if (this.options.updateTodo && todoInfo) {
-      let todoSummary = `✔ ${todoInfo.added} TODOs created `;
+      let todoSummary = `✔ ${todoInfo.added} todos created `;
 
       if (todoInfo.todoConfig) {
         let todoConfig = todoInfo.todoConfig;

--- a/lib/printers/pretty.js
+++ b/lib/printers/pretty.js
@@ -57,17 +57,26 @@ class PrettyPrinter {
     }
 
     if (this.options.updateTodo && todoInfo) {
-      let todoSummary = `✔ ${todoInfo.added} todos created `;
+      let todoSummary = `✔ ${todoInfo.added} todos created`;
+
+      if (Number.isInteger(todoInfo.removed)) {
+        todoSummary += `, ${todoInfo.removed} todos removed`;
+      }
 
       if (todoInfo.todoConfig) {
         let todoConfig = todoInfo.todoConfig;
+        let todoConfigSummary = [];
 
-        if (todoConfig.warn && todoConfig.error) {
-          todoSummary += `(warn after ${todoConfig.warn} and error after ${todoConfig.error} days)`;
-        } else if (todoConfig.warn) {
-          todoSummary += `(warn after ${todoConfig.warn} days)`;
-        } else if (todoConfig.error) {
-          todoSummary += `(error after ${todoConfig.error} days)`;
+        if (todoConfig.warn) {
+          todoConfigSummary.push(`warn after ${todoConfig.warn}`);
+        }
+
+        if (todoConfig.error) {
+          todoConfigSummary.push(`error after ${todoConfig.error}`);
+        }
+
+        if (todoConfigSummary.length) {
+          todoSummary += ` (${todoConfigSummary.join(', ')} days)`;
         }
       }
 

--- a/lib/printers/pretty.js
+++ b/lib/printers/pretty.js
@@ -8,7 +8,7 @@ class PrettyPrinter {
     this.console = options.console || console;
   }
 
-  print(results) {
+  print(results, todoInfo) {
     for (const filePath of Object.keys(results.files)) {
       let fileResults = results.files[filePath];
       let messages = this.options.quiet
@@ -54,6 +54,24 @@ class PrettyPrinter {
 
         this.console.log(chalk.red(chalk.bold(fixableSummary)));
       }
+    }
+
+    if (this.options.updateTodo && todoInfo) {
+      let todoSummary = `✔ ${todoInfo.added} TODOs created `;
+
+      if (todoInfo.todoConfig) {
+        let todoConfig = todoInfo.todoConfig;
+
+        if (todoConfig.warn && todoConfig.error) {
+          todoSummary += `(warn after ${todoConfig.warn} and error after ${todoConfig.error} days)`;
+        } else if (todoConfig.warn) {
+          todoSummary += `(warn after ${todoConfig.warn} days)`;
+        } else if (todoConfig.error) {
+          todoSummary += `(error after ${todoConfig.error} days)`;
+        }
+      }
+
+      this.console.log(todoSummary);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^5.0.0",
+    "@ember-template-lint/todo-utils": "^6.0.0",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1593,7 +1593,7 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--update-todo']);
 
-        expect(result.stdout).toEqual('');
+        expect(result.stdout).toMatchInlineSnapshot(`"✔ 0 todos created "`);
       });
 
       it('outputs empty summary for existing todos', async function () {
@@ -1617,6 +1617,25 @@ describe('ember-template-lint executable', function () {
         let result = await run(['.']);
 
         expect(result.stdout).toEqual('');
+      });
+
+      it('with --update-todo but no todos, outputs todos created summary', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>{{someString}}</div>',
+            },
+          },
+        });
+
+        let result = await run(['.', '--update-todo']);
+
+        expect(result.stdout).toMatchInlineSnapshot(`"✔ 0 todos created "`);
       });
 
       it('with --update-todo, outputs todos created summary', async function () {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1593,7 +1593,7 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--update-todo']);
 
-        expect(result.stdout).toMatchInlineSnapshot(`"✔ 0 todos created "`);
+        expect(result.stdout).toMatchInlineSnapshot(`"✔ 0 todos created, 0 todos removed"`);
       });
 
       it('outputs empty summary for existing todos', async function () {
@@ -1635,7 +1635,7 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--update-todo']);
 
-        expect(result.stdout).toMatchInlineSnapshot(`"✔ 0 todos created "`);
+        expect(result.stdout).toMatchInlineSnapshot(`"✔ 0 todos created, 0 todos removed"`);
       });
 
       it('with --update-todo, outputs todos created summary', async function () {
@@ -1654,7 +1654,7 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--update-todo']);
 
-        expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 todos created "`);
+        expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 todos created, 0 todos removed"`);
       });
 
       it('with --update-todo, outputs todos created summary with warn info', async function () {
@@ -1673,7 +1673,9 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--update-todo', '--todo-days-to-warn', '10']);
 
-        expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 todos created (warn after 10 days)"`);
+        expect(result.stdout).toMatchInlineSnapshot(
+          `"✔ 1 todos created, 0 todos removed (warn after 10 days)"`
+        );
       });
 
       it('with --update-todo, outputs todos created summary with error info', async function () {
@@ -1692,7 +1694,9 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--update-todo', '--todo-days-to-error', '10']);
 
-        expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 todos created (error after 10 days)"`);
+        expect(result.stdout).toMatchInlineSnapshot(
+          `"✔ 1 todos created, 0 todos removed (error after 10 days)"`
+        );
       });
 
       it('with --update-todo, outputs todos created summary with warn and error info', async function () {
@@ -1719,7 +1723,7 @@ describe('ember-template-lint executable', function () {
         ]);
 
         expect(result.stdout).toMatchInlineSnapshot(
-          `"✔ 1 todos created (warn after 5 and error after 10 days)"`
+          `"✔ 1 todos created, 0 todos removed (warn after 5, error after 10 days)"`
         );
       });
 
@@ -1744,7 +1748,7 @@ describe('ember-template-lint executable', function () {
             1:5  todo  Non-translated string used  no-bare-strings
 
           ✖ 1 problems (0 errors, 0 warnings, 1 todos)
-          ✔ 1 todos created "
+          ✔ 1 todos created, 0 todos removed"
         `);
       });
 

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1471,14 +1471,14 @@ describe('ember-template-lint executable', function () {
 
         expect(result.exitCode).toEqual(1);
         expect(result.stderr).toContain(
-          'You must use `--update-todo` when using any of `--todo-days-to-warn` or `--todo-days-to-error`.'
+          'Using `--todo-days-to-warn` or `--todo-days-to-error` is only valid when the `--update-todo` option is being used.'
         );
 
         result = await run(['.', '--todo-days-to-error', '10']);
 
         expect(result.exitCode).toEqual(1);
         expect(result.stderr).toContain(
-          'You must use `--update-todo` when using any of `--todo-days-to-warn` or `--todo-days-to-error`.'
+          'Using `--todo-days-to-warn` or `--todo-days-to-error` is only valid when the `--update-todo` option is being used.'
         );
       });
 

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1635,7 +1635,7 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--update-todo']);
 
-        expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 TODOs created "`);
+        expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 todos created "`);
       });
 
       it('with --update-todo, outputs todos created summary with warn info', async function () {
@@ -1654,7 +1654,7 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--update-todo', '--todo-days-to-warn', '10']);
 
-        expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 TODOs created (warn after 10 days)"`);
+        expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 todos created (warn after 10 days)"`);
       });
 
       it('with --update-todo, outputs todos created summary with error info', async function () {
@@ -1673,7 +1673,7 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['.', '--update-todo', '--todo-days-to-error', '10']);
 
-        expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 TODOs created (error after 10 days)"`);
+        expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 todos created (error after 10 days)"`);
       });
 
       it('with --update-todo, outputs todos created summary with warn and error info', async function () {
@@ -1700,7 +1700,7 @@ describe('ember-template-lint executable', function () {
         ]);
 
         expect(result.stdout).toMatchInlineSnapshot(
-          `"✔ 1 TODOs created (warn after 5 and error after 10 days)"`
+          `"✔ 1 todos created (warn after 5 and error after 10 days)"`
         );
       });
 
@@ -1725,7 +1725,7 @@ describe('ember-template-lint executable', function () {
             1:5  todo  Non-translated string used  no-bare-strings
 
           ✖ 1 problems (0 errors, 0 warnings, 1 todos)
-          ✔ 1 TODOs created "
+          ✔ 1 todos created "
         `);
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -239,10 +239,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-5.0.0.tgz#f2f71c75a09c815e2e86719844431f8f639f6edb"
-  integrity sha512-lho61ryxiPst56YTmtLKk3BqpFaVU/vtueTFkOhdXwT4/0zgO/AbzgBRd/Pvfcur8v4+Wr4VY3jtdIS6s3otug==
+"@ember-template-lint/todo-utils@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-6.0.0.tgz#0d9ad05c6381ef0b66bac5f389891b73a6a8d5c6"
+  integrity sha512-QGrrucBZCHcRwfwEBQEfn8AMwxkCHiP2kBwrpC4UovHlPUR2z/vh86WFb9wAJMsZgoDcT1ZrURJGGVDszWB5XA==
   dependencies:
     "@types/eslint" "^7.2.3"
     fs-extra "^9.0.1"


### PR DESCRIPTION
Resolves #1685

When using `--todo-days-to-warn` or `--todo-days-to-error` without `--update-todo`, it prints the following error:

```shell
You must use `--update-todo` when using any of `--todo-days-to-warn` or `--todo-days-to-error`.
```

When new todos are created:

```shell
✔ 1 todos created
```

When new todo created with `warn` days:

```shell
✔ 1 todos created (warn after 10 days)
```

When new todo created with `error` days:

```shell
✔ 1 todos created (error after 10 days)
```

When new todo created with `warn` and `error` days:

```shell
✔ 1 todos created (warn after 5 and error after 10 days)
```