### PR TITLE
Removes complexity and no-return-await rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -29,7 +29,6 @@ module.exports = {
     // Optional eslint rules:
     'array-callback-return': 'error',
     'block-scoped-var': 'error',
-    complexity: 'error',
     curly: 'error',
     eqeqeq: 'error',
     'func-style': ['error', 'declaration'],
@@ -49,7 +48,6 @@ module.exports = {
     'no-new-wrappers': 'error',
     'no-octal-escape': 'error',
     'no-return-assign': 'error',
-    'no-return-await': 'error',
     'no-self-compare': 'error',
     'no-sequences': 'error',
     'no-shadow-restricted-names': 'error',

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -367,7 +367,6 @@ module.exports = class Base {
     this.config = last(this._configStack);
   }
 
-  // eslint-disable-next-line complexity
   _processInstructionNode(node) {
     if (!this._allowInlineConfig) {
       // inline configuration is disabled, do nothing

--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -261,7 +261,6 @@ module.exports = class BlockIndentation extends Rule {
     }
   }
 
-  // eslint-disable-next-line complexity
   validateBlockChildren(node) {
     if (this.isWithinIgnoredElement()) {
       return;

--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -70,7 +70,6 @@ module.exports = class NoCurlyComponentInvocation extends Rule {
 
   visitor() {
     return {
-      // eslint-disable-next-line complexity
       MustacheStatement(node, visitorPath) {
         let parents = [...visitorPath.parents()];
 

--- a/lib/rules/no-invalid-meta.js
+++ b/lib/rules/no-invalid-meta.js
@@ -14,7 +14,6 @@ module.exports = class NoInvalidMeta extends Rule {
   }
   visitor() {
     return {
-      // eslint-disable-next-line complexity
       ElementNode(node) {
         if (node.tag !== 'meta') {
           return;

--- a/lib/rules/no-negated-condition.js
+++ b/lib/rules/no-negated-condition.js
@@ -10,7 +10,6 @@ const ERROR_MESSAGE_USE_UNLESS = 'Change `if (not condition)` to `unless conditi
 
 module.exports = class NoNegatedCondition extends Rule {
   visitor() {
-    // eslint-disable-next-line complexity
     function checkNode(node) {
       const isIf = AstNodeInfo.isIf(node);
       const isUnless = AstNodeInfo.isUnless(node);

--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -24,7 +24,6 @@ module.exports = class RequireValidAltText extends Rule {
 
   visitor() {
     return {
-      // eslint-disable-next-line complexity
       ElementNode(node) {
         if (AstNodeInfo.hasAttribute(node, 'hidden')) {
           return;


### PR DESCRIPTION
Removes two rules from .eslintrc.js.

- `complexity` - was being triggered from largely procedural functions within `pretty.js` for some changes I was making. Additionally is disabled for a number of rules inline. 
- `no-return-await` - precludes us from being able to correctly identify 3rd party calls that return promises. 