### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,8 +261,8 @@ Each rule has emojis denoting:
 | :white_check_mark:         | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)           |
 | :dress:                    | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                               |
 | :white_check_mark:         | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                             |
-| :dress:                    | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                         |
-| :dress:                    | [no-whitespace-within-word](./docs/rule/no-whitespace-within-word.md)                       |
+|                            | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                         |
+|                            | [no-whitespace-within-word](./docs/rule/no-whitespace-within-word.md)                       |
 | :white_check_mark:         | [no-yield-only](./docs/rule/no-yield-only.md)                                               |
 | :dress:                    | [quotes](./docs/rule/quotes.md)                                                             |
 | :white_check_mark::wrench: | [require-button-type](./docs/rule/require-button-type.md)                                   |

--- a/docs/rule/no-whitespace-for-layout.md
+++ b/docs/rule/no-whitespace-for-layout.md
@@ -1,7 +1,5 @@
 # no-whitespace-for-layout
 
-:dress: The `extends: 'stylistic'` property in a configuration file enables this rule.
-
 Formatting of text through the use of multiple whitespace is entirely visual, and therefore is incompatible with screen-reading assistive technology tools.
 
 The rule applies to the content of Handlebars AST TextNodes, and performs a RegExp search for two consecutive white space characters that might indicate the use of whitespace used for layout.

--- a/docs/rule/no-whitespace-within-word.md
+++ b/docs/rule/no-whitespace-within-word.md
@@ -1,7 +1,5 @@
 # no-whitespace-within-word
 
-:dress: The `extends: 'stylistic'` property in a configuration file enables this rule.
-
 In practice, the predominant issue raised by inline whitespace styling is that the resultant text 'formatting' is entirely visual in nature; the ability to discern the correct manner in which to read the text, and therefore, to correctly comprehend its meaning, is restricted to sighted users.
 
 Using in-line whitespace word formatting produces results that are explicitly mentioned in [WCAG's list of common sources of web accessibility failures](https://www.w3.org/TR/WCAG20-TECHS/failures.html). Specifically, this common whitespace-within-word-induced web accessibility issue fails to successfully achieve [WCAG Success Criterion 1.3.2: Meaningful Sequence](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-sequence.html).


### PR DESCRIPTION
Removed `:dress:` from `no-whitespace-for-layout` and `no-whitespace-within-word` since these are A11y rules, not stylistic preferences.