### PR TITLE
Add `no-down-event-binding` to A11Y config

### DIFF
--- a/lib/config/a11y.js
+++ b/lib/config/a11y.js
@@ -6,6 +6,7 @@ module.exports = {
     'no-abstract-roles': 'error',
     'no-accesskey-attribute': 'error',
     'no-aria-hidden-body': 'error',
+    'no-down-event-binding': 'error',
     'no-duplicate-attributes': 'error',
     'no-duplicate-id': 'error',
     'no-duplicate-landmark-elements': 'error',


### PR DESCRIPTION
Updates the a11y config to add a missing rule - `no-down-event-binding` (WCAG 2.5.2)