### PR TITLE
todos: Standardize casing for todos

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ ember-template-lint --config '{ "rules": { "no-implicit-this": { "severity": 2, 
 
 :bulb: Ensure you wrap all glob patterns in quotes so that it won't be interpreted by the CLI. `ember-template-lint app/templates/**` (this will expand all paths in app/templates) and `ember-template-lint "app/templates/**"` (this will pass the glob to ember-template-lint and not interpret the glob).
 
-For more information about the TODO functionality, see [the documentation](docs/todo.md).
+For more information about the todo functionality, see [the documentation](docs/todo.md).
 
 ## Configuration
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,6 +152,6 @@ Note that enabling a rule (`{{!-- template-lint-enable --}}`) that has been conf
 
 A [shell script](./count-lint-violations.sh) is available for generating a list of rules and the number of times disable directive comments are used to disable each of them. This can be useful for identifying the largest sources of tech debt in a codebase.
 
-## Configuring TODO `warn` and `error` values
+## Configuring todo `warn` and `error` values
 
-Configuring specific `warn` and `error` values for TODO creation is detailed in the [Configuring Due Dates section in the TODO docs](docs/todos.md).
+Configuring specific `warn` and `error` values for todo creation is detailed in the [Configuring Due Dates section in the todo docs](docs/todos.md).

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -1,4 +1,4 @@
-# TODOs
+# Todos
 
 Linting is a fundamental tool to help ensure the quality of a codebase. Ensuring there are as few linting errors as possible (ideally 0), is a useful measure of a baseline of code hygiene.
 
@@ -26,7 +26,7 @@ If you want to see TODOs as part of `ember-template-lint`'s output, you can incl
 ember-template-lint . --include-todo
 ```
 
-If an error is fixed manually, `ember-template-lint` will let you know that there's an outstanding TODO file. You can remove this file by running `--fix`
+If an error is fixed manually, `ember-template-lint` will let you know that there's an outstanding todo file. You can remove this file by running `--fix`
 
 ```bash
 ember-template-lint . --fix
@@ -36,7 +36,7 @@ ember-template-lint . --fix
 
 TODOs can be created with optional due dates. These due dates allow for TODOs to, over a period of time, 'decay' the severity to a **warning** and/or **error** after a certain date. This helps ensure that TODOs are created but not forgotten, and can allow for better managing incremental roll-outs of large-scale or slow-to-fix rules.
 
-Due dates can be configured in multiple ways, but all specify integers for `warn` and `error` to signify the number of days from the TODO created date to decay the severity.
+Due dates can be configured in multiple ways, but all specify integers for `warn` and `error` to signify the number of days from the todo created date to decay the severity.
 
 :bulb: Both `warn` and `error` are optional. The value for `warn` should be greater than the value of `error`.
 
@@ -93,13 +93,13 @@ ember-template-lint . --update-todo --todo-days-to-warn=2
 
 ### Due Date Workflows
 
-Converting errors to TODOs with `warn` and `error` dates that transition the TODO to `warn` after 10 days and `error` after 20 days:
+Converting errors to TODOs with `warn` and `error` dates that transition the todo to `warn` after 10 days and `error` after 20 days:
 
 ```bash
 ember-template-lint . --update-todo --todo-days-to-warn=10 --todo-days-to-error=20
 ```
 
-Converting errors to TODOs with `warn` and `error` dates that transition the TODO `error` after 20 days, but doesn't include a `warn` date:
+Converting errors to TODOs with `warn` and `error` dates that transition the todo `error` after 20 days, but doesn't include a `warn` date:
 
 ```bash
 ember-template-lint . --update-todo --no-todo-days-to-warn --todo-days-to-error=20

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -99,7 +99,7 @@ Converting errors to todos with `warn` and `error` dates that transition the tod
 ember-template-lint . --update-todo --todo-days-to-warn=10 --todo-days-to-error=20
 ```
 
-Converting errors to TODOs with `warn` and `error` dates that transition the todo `error` after 20 days, but doesn't include a `warn` date:
+Converting errors to todos with `warn` and `error` dates that transition the todo `error` after 20 days, but doesn't include a `warn` date:
 
 ```bash
 ember-template-lint . --update-todo --no-todo-days-to-warn --todo-days-to-error=20

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -93,7 +93,7 @@ ember-template-lint . --update-todo --todo-days-to-warn=2
 
 ### Due Date Workflows
 
-Converting errors to TODOs with `warn` and `error` dates that transition the todo to `warn` after 10 days and `error` after 20 days:
+Converting errors to todos with `warn` and `error` dates that transition the todo to `warn` after 10 days and `error` after 20 days:
 
 ```bash
 ember-template-lint . --update-todo --todo-days-to-warn=10 --todo-days-to-error=20

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^6.0.0",
+    "@ember-template-lint/todo-utils": "^6.0.1",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1800,7 +1800,7 @@ describe('ember-template-lint executable', function () {
         let result = await run(['.', '--update-todo']);
 
         expect(result.stderr).toMatch(
-          'The provided TODO configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
+          'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
         );
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,14 +278,15 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-6.0.0.tgz#0d9ad05c6381ef0b66bac5f389891b73a6a8d5c6"
-  integrity sha512-QGrrucBZCHcRwfwEBQEfn8AMwxkCHiP2kBwrpC4UovHlPUR2z/vh86WFb9wAJMsZgoDcT1ZrURJGGVDszWB5XA==
+"@ember-template-lint/todo-utils@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-6.0.1.tgz#abe4916652b8e052ffc405dad8e265f098b0cb99"
+  integrity sha512-EAZ/9BQoWNcsX3mwpdxqtwNyHskTtpdImE/gEFrzDFfCK0Tho83V3j0ZdPGiW4TEXFP5yFcxOxy1ZQPL+En/5w==
   dependencies:
-    "@types/eslint" "^7.2.3"
+    "@types/eslint" "^7.2.6"
     fs-extra "^9.0.1"
     slash "^3.0.0"
+    tslib "^2.1.0"
 
 "@eslint/eslintrc@^0.2.2":
   version "0.2.2"
@@ -774,7 +775,7 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/eslint@^7.2.3":
+"@types/eslint@^7.2.6":
   version "7.2.6"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.6.tgz#5e9aff555a975596c03a98b59ecd103decc70c3c"
   integrity sha512-I+1sYH+NPQ3/tVqCeUSBwTE/0heyvtXqpIopUUArlBm0Kpocb8FbMa3AZ/ASKIFpN3rnEx932TTXDbt9OXsNDw==
@@ -6396,6 +6397,11 @@ tslib@^1.9.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
We've been using `TODO` and `todo`, depending on the situation. This PR standardizes us using todo.