### PR TITLE
Allow rule visitor to be an async function (remove `env` argument)

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -208,7 +208,7 @@ class Linter {
       shouldVerify = false;
 
       if (iterations < MAX_AUTOFIX_PASSES) {
-        const output = this._applyFixes(options, messages);
+        const output = await this._applyFixes(options, messages);
 
         // let's lint one more time if source was modified
         shouldVerify = output !== currentSource;
@@ -231,9 +231,9 @@ class Linter {
    * @param {string} options.moduleId
    * @param {Object[]} results - The lint messages.
    *
-   * @returns {string} output - The fixed source.
+   * @returns {Promise<string>} output - The fixed source.
    */
-  _applyFixes(options, results) {
+  async _applyFixes(options, results) {
     let fixableIssues = results.filter((r) => r.isFixable);
 
     // nothing to do, bail out
@@ -255,7 +255,8 @@ class Linter {
         fileConfig,
       });
 
-      let { code } = transform(currentSource, (env) => rule.getVisitor(env));
+      let visitor = await rule.getVisitor();
+      let { code } = transform(currentSource, () => visitor);
       currentSource = code;
     }
 
@@ -294,7 +295,6 @@ class Linter {
    * @returns {Object[]} results - The lint results.
    */
   // temporary eslint-disable while we're implementing the new pending feature (which requires async/await)
-  // eslint-disable-next-line require-await
   async verify(options) {
     let results = [];
     let fileConfig = this._moduleStatusCache.getConfigForFile(options);
@@ -333,7 +333,8 @@ class Linter {
 
     for (let rule of rules) {
       try {
-        transform(templateAST, () => rule.getVisitor());
+        let visitor = await rule.getVisitor();
+        transform(templateAST, () => visitor);
         results.push(...rule.results);
       } catch (error) {
         let message = buildErrorMessage(options.filePath, options.moduleId, error);

--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -83,10 +83,10 @@ module.exports = class Base {
     return config;
   }
 
-  getVisitor(env) {
+  async getVisitor() {
     let pluginContext = this;
     let visitor = {};
-    let ruleVisitor = this.visitor(env);
+    let ruleVisitor = await this.visitor();
     // We use this structure to advise/unadvise on AST events. The walkers we
     // set up read this structure every time they get an AST event and call the
     // appropriate functions. Handlers get added to the before/after list

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -24,7 +24,7 @@ describe('base plugin', function () {
     await project.dispose();
   });
 
-  function runRules(template, rules) {
+  async function runRules(template, rules) {
     let ast = parse(template);
 
     for (let ruleConfig of rules) {
@@ -52,8 +52,8 @@ describe('base plugin', function () {
       });
 
       let rule = new Rule(options);
-
-      transform(ast, (env) => rule.getVisitor(env));
+      let visitor = await rule.getVisitor();
+      transform(ast, () => visitor);
     }
   }
 
@@ -106,41 +106,36 @@ describe('base plugin', function () {
   });
 
   describe('rule APIs', function () {
-    it('can access editorConfig', function () {
+    it('can access editorConfig', async function () {
       class AwesomeRule extends Rule {
         visitor() {
           expect(this.editorConfig.insert_final_newline).toBe(false);
         }
       }
 
-      runRules('foo', [plugin(AwesomeRule, 'awesome-rule', true)]);
+      await runRules('foo', [plugin(AwesomeRule, 'awesome-rule', true)]);
     });
 
-    it('does not error when accessing editorConfig when no filePath is passed', function () {
+    it('does not error when accessing editorConfig when no filePath is passed', async function () {
       class AwesomeRule extends Rule {
         visitor() {
           expect(this.editorConfig.insert_final_newline).toBe(undefined);
         }
       }
 
-      runRules('foo', [
+      await runRules('foo', [
         { Rule: AwesomeRule, name: 'awesome-rule', config: true, filePath: undefined },
       ]);
     });
 
-    it('can access template-recast env', function () {
+    it('can access template-recast env', async function () {
       class AwesomeRule extends Rule {
         visitor(env) {
-          let { syntax } = env;
-          expect(syntax).toHaveProperty('parse');
-          expect(syntax).toHaveProperty('builders');
-          expect(syntax).toHaveProperty('print');
-          expect(syntax).toHaveProperty('traverse');
-          expect(syntax).toHaveProperty('Walker');
+          expect(env).toBe(undefined);
         }
       }
 
-      runRules('foo', [plugin(AwesomeRule, 'awesome-rule', true)]);
+      await runRules('foo', [plugin(AwesomeRule, 'awesome-rule', true)]);
     });
   });
 
@@ -163,8 +158,8 @@ describe('base plugin', function () {
       let template = config.template;
       let nodeSources = config.sources;
 
-      it(`can get raw source for \`${template}\``, function () {
-        runRules(template, [plugin(buildPlugin(visitor), 'fake', config)]);
+      it(`can get raw source for \`${template}\``, async function () {
+        await runRules(template, [plugin(buildPlugin(visitor), 'fake', config)]);
 
         expect(messages).toEqual(nodeSources);
       });
@@ -197,15 +192,15 @@ describe('base plugin', function () {
       },
     };
 
-    it('calls the "Template" node type', function () {
-      runRules('<div>Foo</div>', [plugin(buildPlugin(visitor), 'fake', config)]);
+    it('calls the "Template" node type', async function () {
+      await runRules('<div>Foo</div>', [plugin(buildPlugin(visitor), 'fake', config)]);
 
       expect(wasCalled).toBe(true);
     });
   });
 
   describe('parses instructions', function () {
-    function processTemplate(template) {
+    async function processTemplate(template) {
       let Rule = buildPlugin({
         MustacheCommentStatement(node) {
           this.process(node);
@@ -219,12 +214,12 @@ describe('base plugin', function () {
         config = this._processInstructionNode(node);
       };
 
-      runRules(template, [plugin(Rule, 'fake', 'foo')]);
+      await runRules(template, [plugin(Rule, 'fake', 'foo')]);
     }
 
     function expectConfig(instruction, expectedConfig) {
-      it(`can parse \`${instruction}\``, function () {
-        processTemplate(`{{! ${instruction} }}`);
+      it(`can parse \`${instruction}\``, async function () {
+        await processTemplate(`{{! ${instruction} }}`);
         expect(config).toEqual(expectedConfig);
         expect(messages).toEqual([]);
       });
@@ -280,8 +275,8 @@ describe('base plugin', function () {
     expectConfig('', null);
 
     // Errors
-    it('logs an error when it encounters an unknown rule name', function () {
-      processTemplate(
+    it('logs an error when it encounters an unknown rule name', async function () {
+      await processTemplate(
         [
           '{{! template-lint-enable notarule }}',
           '{{! template-lint-disable fake norme meneither }}',
@@ -296,15 +291,15 @@ describe('base plugin', function () {
       ]);
     });
 
-    it("logs an error when it can't parse a configure instruction's JSON", function () {
-      processTemplate('{{! template-lint-configure fake { not: "json" ] }}');
+    it("logs an error when it can't parse a configure instruction's JSON", async function () {
+      await processTemplate('{{! template-lint-configure fake { not: "json" ] }}');
       expect(messages).toEqual([
         'malformed template-lint-configure instruction: `{ not: "json" ]` is not valid JSON',
       ]);
     });
 
-    it('logs an error when it encounters an unrecognized instruction starting with `template-lint`', function () {
-      processTemplate(
+    it('logs an error when it encounters an unrecognized instruction starting with `template-lint`', async function () {
+      await processTemplate(
         [
           '{{! template-lint-bloober fake }}',
           '{{! template-lint- fake }}',
@@ -318,8 +313,8 @@ describe('base plugin', function () {
       ]);
     });
 
-    it('only logs syntax errors once across all rules', function () {
-      runRules(
+    it('only logs syntax errors once across all rules', async function () {
+      await runRules(
         '{{! template-lint-enable notarule }}{{! template-lint-disable meneither }}{{! template-lint-configure norme true }}',
         [
           plugin(buildPlugin({}), 'fake1'),
@@ -333,7 +328,7 @@ describe('base plugin', function () {
     });
 
     describe('allowInlineConfig: false', function () {
-      function processTemplate(template) {
+      async function processTemplate(template) {
         let Rule = buildPlugin({
           MustacheCommentStatement(node) {
             this.process(node);
@@ -347,19 +342,19 @@ describe('base plugin', function () {
           config = this._processInstructionNode(node);
         };
 
-        runRules(template, [
+        await runRules(template, [
           Object.assign({ allowInlineConfig: false }, plugin(Rule, 'fake', 'foo')),
         ]);
       }
 
-      it('inline config has no effect', function () {
-        processTemplate('{{! template-lint-disable fake }}');
+      it('inline config has no effect', async function () {
+        await processTemplate('{{! template-lint-disable fake }}');
 
         expect(config).toEqual(null);
       });
 
-      it('unknown rules do not throw an error', function () {
-        processTemplate(
+      it('unknown rules do not throw an error', async function () {
+        await processTemplate(
           [
             '{{! template-lint-enable notarule }}',
             '{{! template-lint-disable fake norme meneither }}',
@@ -433,12 +428,12 @@ describe('base plugin', function () {
       return FakeRule;
     }
 
-    function processTemplate(template, config) {
+    async function processTemplate(template, config) {
       if (config === undefined) {
         config = true;
       }
 
-      runRules(template, [plugin(buildPlugin(), 'fake', config)]);
+      await runRules(template, [plugin(buildPlugin(), 'fake', config)]);
     }
 
     beforeEach(function () {
@@ -452,8 +447,8 @@ describe('base plugin', function () {
       let expectedEvents = data.events;
       let config = data.config;
 
-      it(description, function () {
-        processTemplate(template, config);
+      it(description, async function () {
+        await processTemplate(template, config);
         expect(events).toEqual(expectedEvents);
         expect(messages).toEqual([]);
       });


### PR DESCRIPTION
tldr: this feature allow us to have async `visitor` function for template-lint plugin

why: async visitor allow us implement side indegrations inside template-lint plugin (language server integration, a11y tooling integration, side process integration)

for example:

```js
class Plugin extends Base {
  async visitor(env) {
    const project = await languageServer.getProject(env.filePath);
    const registry = project.getReferences();
    return {
      ElementNode(node) {
         const componentName = toComponentName(node.tag);
         const usages = registry[componentName] || [];
          if (usages.length === 0) {
             this.logError({
                msg: `Unused component ${componentName}`
              })
          }
      }
    }
  }
}
```

```js
class Plugin extends Base {
  async visitor(env) {
    const component = await a11yTemplateLinter.renderComponent(env.filePath);
    const a11yIssues = await component.getErrors();
    return {
      Template() {
        if (a11yIssues.length) {
          this.logError({
            msg: `A11Y error ${env.filePath}`
          })
        }
      }
    }
  }
}
```

```js
class Plugin extends Base {
  async visitor(env) {
    const project = await languageServer.getProject(env.filePath);
    const relatedFiles = await project.relatedFiles(env.filePath);
    const testFile = relatedFiles.find(file => file.includes('/tests/'));
    if (!testFile) {
        return;
    }
    const testModuleName = getModuleNameForTest(testFile);
    const testResults = await emberCli.runTests({ filter: testModuleName });
    const coverage = await testResults.getCoverageResult(env.filePath);
    return {
      ElementNode(node) {
        if (!coverage.hasCoverageForLoc(node.loc)) {
          this.logError({
            msg: `Is not covered by tests`
          })
        }
      }
    }
  }
}
```

cc @rwjblue, @MelSumner 