### PR TITLE
Fix `lint:docs` syntax on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "bin": "./bin/ember-template-lint.js",
   "scripts": {
     "lint": "npm-run-all lint:* --continue-on-error",
-    "lint:docs": "markdownlint '**/*.md'",
+    "lint:docs": "markdownlint **/*.md",
     "lint:js": "eslint . --cache",
     "lint:package-json": "sort-package-json --check",
     "new": "node dev/new-rule/index.js",


### PR DESCRIPTION
When running `markdownlint '**/*.md'` from bash we need to quote the glob to prevent the shell from expanding it. `yarn run ...` doesn't call out to the shell so there's no need to quote the glob. This fixes `yarn run lint:docs` on Windows.

See also https://github.com/igorshubovych/markdownlint-cli#globbing-examples