### PR TITLE
Fixes todo creation messaging to include correct counts

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -261,11 +261,11 @@ async function run() {
   let todoInfo = {
     added: 0,
     removed: 0,
-    todoConfig: options.updateTodo
-      ? getTodoConfig(options.workingDirectory, getTodoConfigFromCommandLineOptions(options))
-      : {},
+    todoConfig: getTodoConfig(
+      options.workingDirectory,
+      getTodoConfigFromCommandLineOptions(options)
+    ),
   };
-  let todosToAdd = false;
 
   if (options.config) {
     try {
@@ -353,8 +353,6 @@ async function run() {
         todoInfo.todoConfig
       );
 
-      todosToAdd = true;
-
       todoInfo.added += added;
       todoInfo.removed += removed;
     }
@@ -378,7 +376,7 @@ async function run() {
     let hasErrors = results.errorCount > 0;
     let hasWarnings = results.warningCount > 0;
     let hasTodos = options.includeTodo && results.todoCount;
-    let hasUpdatedTodos = options.updateTodo && todosToAdd;
+    let hasUpdatedTodos = options.updateTodo;
 
     if (hasErrors || hasWarnings || hasTodos || hasUpdatedTodos) {
       let Printer = require('../lib/printers/default');

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1656,6 +1656,26 @@ describe('ember-template-lint executable', function () {
         expect(result.stdout).toMatchInlineSnapshot(`"✔ 1 todos created, 0 todos removed"`);
       });
 
+      it('with --update-todo, outputs todos created summary for multiple errors', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+              'foo.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        let result = await run(['.', '--update-todo']);
+
+        expect(result.stdout).toMatchInlineSnapshot(`"✔ 2 todos created, 0 todos removed"`);
+      });
+
       it('with --update-todo, outputs todos created summary with warn info', async function () {
         project.setConfig({
           rules: {


### PR DESCRIPTION
When working on a bulk todo creation script, @MelSumner and I discovered an issue with the todo creation output where the values output were incorrect for todos created/removed. This was due to the fact that we were generating the output via a loop, and that loop only used the last value from the iteration to provide the counts to output. In addition, we also discovered an unnecessary amount of work processing the todo config, which we moved outside the loop.