### PR TITLE
no-this-in-template-only-components: improve app structure detection

### DIFF
--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -13,39 +13,59 @@ function message(original, fixed) {
 }
 
 /**
+ * Gets the path where a component class file might reside
+ * @param hbsFilePath - path to the template file
+ * @returns {string | undefined} - possible path to the component file, not including extension
+ * or undefined if the template does not have a component class
+ */
+function getComponentPath(hbsFilePath) {
+  if (!hbsFilePath) {
+    // possibly a hbs template literal using eslint-plugin-hbs
+    return;
+  }
+  const paths = path.normalize(hbsFilePath).split(path.sep);
+  const moduleName = path.basename(hbsFilePath, '.hbs');
+  if (paths[0] === 'app' || paths[0] === 'addon') {
+    if (paths[1] === 'templates') {
+      if (paths[2] === 'components') {
+        // classic structure: /app/templates/components/foo.hbs => /app/components/foo.js
+        return path.join(paths[0], 'components', ...paths.slice(3, -1), moduleName);
+      }
+      // route template always has a controller as its context, even if no controller.js exists
+      return;
+    }
+    if ((paths[1] === 'components' || paths[2] === 'components') && moduleName === 'template') {
+      // pods structure, possibly with podModulePrefix:
+      //   /app/components/foo/template.hbs => /app/components/foo/component.js
+      //   /app/<prefix>/components/foo/template.hbs => /app/<prefix>/components/foo/component.js
+      return path.join(path.dirname(hbsFilePath), 'component');
+    }
+    if (paths[1] === 'components') {
+      // co-located structure: /app/components/foo.hbs => /app/components/foo.js
+      return path.join(path.dirname(hbsFilePath), moduleName);
+    }
+  } else if (paths[0] === 'tests' && paths[1] === 'dummy') {
+    // search inside addon dummy app
+    const appPath = getComponentPath(path.join(...paths.slice(2)));
+    if (!appPath) {
+      return;
+    }
+    return path.join('tests', 'dummy', appPath);
+  }
+}
+
+/**
  * Tests whether the template has a corresponding component class file
  * @param hbsFilePath - path to the template file
  * @param validComponentExtensions - an array of valid component class extensions
  * @returns {boolean} true if a component class was found
  */
 function isTemplateOnlyComponent(hbsFilePath, validComponentExtensions) {
-  /**
-   * Tests whether the component class exists as `component.js`, `component.ts`, etc.
-   */
-  function componentClassExists(pathWithoutExtension) {
-    return validComponentExtensions.some((ext) => fs.existsSync(pathWithoutExtension + ext));
+  const componentPath = getComponentPath(hbsFilePath);
+  if (!componentPath) {
+    return false;
   }
-  const paths = path.normalize(hbsFilePath).split(path.sep);
-  if (paths[0] === 'app' || paths[0] === 'addon') {
-    if (paths[1] === 'templates') {
-      if (paths[2] === 'components') {
-        // classic structure: /app/templates/components/foo.hbs => /app/components/foo.js
-        const moduleName = path.basename(hbsFilePath, '.hbs');
-        const classFilePath = path.join(paths[0], 'components', ...paths.slice(3, -1), moduleName);
-        return !componentClassExists(classFilePath);
-      } else {
-        // route template always has a context
-        return false;
-      }
-    } else if (paths[1] === 'components') {
-      // co-located structure: /app/components/foo.hbs => /app/components/foo.js
-      const moduleName = path.basename(hbsFilePath, '.hbs');
-      const classFilePath = path.join(path.dirname(hbsFilePath), moduleName);
-      return !componentClassExists(classFilePath);
-    }
-  }
-  // TODO: handle pods layout
-  return true;
+  return !validComponentExtensions.some((ext) => fs.existsSync(componentPath + ext));
 }
 
 /**

--- a/test/unit/rules/no-this-in-template-only-components-test.js
+++ b/test/unit/rules/no-this-in-template-only-components-test.js
@@ -8,6 +8,10 @@ generateRuleTests({
 
   config: true,
 
+  meta: {
+    filePath: 'app/components/foo.hbs',
+  },
+
   good: [
     '{{welcome-page}}',
     '<WelcomePage />',
@@ -27,6 +31,8 @@ generateRuleTests({
       fixedTemplate: '{{my-component model=@model}}',
 
       result: {
+        filePath: 'app/components/foo.hbs',
+        moduleId: 'layout',
         message: message('this.model', '@model'),
         source: 'this.model',
         line: 1,
@@ -39,6 +45,8 @@ generateRuleTests({
       fixedTemplate: '{{my-component action=(action @myAction)}}',
 
       result: {
+        filePath: 'app/components/foo.hbs',
+        moduleId: 'layout',
         message: message('this.myAction', '@myAction'),
         source: 'this.myAction',
         line: 1,
@@ -51,6 +59,8 @@ generateRuleTests({
       fixedTemplate: '<MyComponent @prop={{can "edit" @model}} />',
 
       result: {
+        filePath: 'app/components/foo.hbs',
+        moduleId: 'layout',
         message: message('this.model', '@model'),
         source: 'this.model',
         line: 1,
@@ -61,6 +71,8 @@ generateRuleTests({
     {
       template: '{{input id=(concat this.elementId "-username")}}',
       result: {
+        filePath: 'app/components/foo.hbs',
+        moduleId: 'layout',
         message: message('this.elementId', '@elementId'),
         source: 'this.elementId',
         line: 1,
@@ -76,6 +88,39 @@ generateRuleTests({
       },
       result: {
         filePath: 'app/templates/components/some-component.hbs',
+        moduleId: 'layout',
+        message: message('this.model', '@model'),
+        source: 'this.model',
+        line: 1,
+        column: 21,
+        isFixable: true,
+      },
+    },
+    {
+      template: '{{my-component model=this.model}}',
+      fixedTemplate: '{{my-component model=@model}}',
+      meta: {
+        filePath: 'tests/dummy/app/templates/components/some-component.hbs',
+      },
+      result: {
+        filePath: 'tests/dummy/app/templates/components/some-component.hbs',
+        moduleId: 'layout',
+        message: message('this.model', '@model'),
+        source: 'this.model',
+        line: 1,
+        column: 21,
+        isFixable: true,
+      },
+    },
+    {
+      template: '{{my-component model=this.model}}',
+      fixedTemplate: '{{my-component model=@model}}',
+      meta: {
+        filePath: 'app/pods/components/some-component/template.hbs',
+      },
+      result: {
+        filePath: 'app/pods/components/some-component/template.hbs',
+        moduleId: 'layout',
         message: message('this.model', '@model'),
         source: 'this.model',
         line: 1,


### PR DESCRIPTION
Improves `isTemplateOnlyComponent` to support linting some more file structures:
- adds support for pods layout, using a simple heuristic so we don't need to read the app's `podModulePrefix`
- adds support for linting an addon's dummy app, by recursively detecting the structure inside `tests/dummy/app/`
- adds support for `` hbs`...` `` literals which fixes https://github.com/ember-template-lint/eslint-plugin-hbs/issues/41
