### PR TITLE
Adds `octane` config back as an alias of `recommended`

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -4,6 +4,7 @@ module.exports = {
   '0-8-recommended': require('./0-8-recommended'),
   '1-x-recommended': require('./1-x-recommended'),
   a11y: require('./a11y'),
+  octane: require('./octane'),
   recommended: require('./recommended'),
   stylistic: require('./stylistic'),
 };

--- a/lib/config/octane.js
+++ b/lib/config/octane.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  extends: 'recommended',
+};


### PR DESCRIPTION
Adds back the `octane` config, but as a passthrough to the `recommended` config. This is a change that's aimed to provide backwards compatibility to plugin authors that may have extended the original `octane` config.