### PR TITLE
Prevent todo removal when using `--update-todo` a subset of normal project configuration

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -254,6 +254,10 @@ function getTodoConfigFromCommandLineOptions(options) {
   return todoConfig;
 }
 
+function isOverridingConfig(options) {
+  return options.config || options.rule || options.noInlineConfig || options.noConfigPath;
+}
+
 async function run() {
   let options = parseArgv(process.argv.slice(2));
   let positional = options._;
@@ -350,7 +354,8 @@ async function run() {
       let [added, removed] = await linter.updateTodo(
         linterOptions,
         fileResults,
-        todoInfo.todoConfig
+        todoInfo.todoConfig,
+        isOverridingConfig(options)
       );
 
       todoInfo.added += added;

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -255,7 +255,13 @@ function getTodoConfigFromCommandLineOptions(options) {
 }
 
 function isOverridingConfig(options) {
-  return options.config || options.rule || options.noInlineConfig || options.noConfigPath;
+  return (
+    options.config ||
+    options.rule ||
+    options.noInlineConfig ||
+    options.noConfigPath ||
+    options.configPath !== '.template-lintrc.js'
+  );
 }
 
 async function run() {

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -17,15 +17,15 @@ module.exports = class TodoHandler {
     this._processedResults = [];
   }
 
-  async update(filePath, results, todoConfig) {
+  async update(filePath, results, todoConfig, isOverridingConfig) {
     this._processedResults = this._buildResult(results);
 
-    let todoBatchCounts = await writeTodos(
-      this._workingDir,
-      this._processedResults,
+    let todoBatchCounts = await writeTodos(this._workingDir, this._processedResults, {
       filePath,
-      todoConfig
-    );
+      todoConfig,
+      // skip removing todo files if the config is overridden as this can result in todos being incorrectly removed
+      skipRemoval: isOverridingConfig,
+    });
 
     return todoBatchCounts;
   }

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -263,11 +263,12 @@ class Linter {
     return currentSource;
   }
 
-  async updateTodo(linterOptions, results, todoConfig) {
+  async updateTodo(linterOptions, results, todoConfig, isOverridingConfig) {
     let todoBatchCounts = await this._todoHandler.update(
       linterOptions.filePath,
       results,
-      todoConfig
+      todoConfig,
+      isOverridingConfig
     );
 
     return todoBatchCounts;

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^6.0.1",
+    "@ember-template-lint/todo-utils": "^7.0.0",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1524,6 +1524,50 @@ describe('ember-template-lint executable', function () {
         expect(todoStorageDirExists(project.baseDir)).toEqual(true);
       });
 
+      it('does not removed todos if custom config params are used', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+              'foo.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        await run(['.', '--update-todo']);
+
+        let todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(todos).toHaveLength(2);
+
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+              'foo.hbs': '<div>{{foo}}</div><!-- such comment -->',
+            },
+          },
+        });
+
+        await run([
+          '.',
+          '--rule',
+          'no-html-comments:error',
+          '--update-todo',
+          '--no-inline-config',
+          '--no-config-path',
+        ]);
+
+        todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(todos).toHaveLength(3);
+      });
+
       it('errors if a todo item is no longer valid when running without params', async function () {
         project.setConfig({
           rules: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,10 +278,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-6.0.1.tgz#abe4916652b8e052ffc405dad8e265f098b0cb99"
-  integrity sha512-EAZ/9BQoWNcsX3mwpdxqtwNyHskTtpdImE/gEFrzDFfCK0Tho83V3j0ZdPGiW4TEXFP5yFcxOxy1ZQPL+En/5w==
+"@ember-template-lint/todo-utils@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-7.0.0.tgz#5ec2013e3ad060fff65078fe7b39fb35544cde83"
+  integrity sha512-0CZLCHIBziRFxg9Vq2xqTgSc+I+coVbqraCK3cBUhbMbRo8fl8y+O5toEDC8ze2a/zguB/qTUhqcg96j14xwSQ==
   dependencies:
     "@types/eslint" "^7.2.6"
     fs-extra "^9.0.1"


### PR DESCRIPTION
In cases where any options are provided that modify the project's config, we want to opt out of removing todos.

Prior to this change, the following would occur:

```shell
ember-template-lint app/ --no-config-path --no-inline-config --rule 'no-positive-tabindex:error' --update-todo --todo-days-to-warn=30 --todo-days-to-error=60

✔ 3 todos created, 0 todos removed (warn after 30, error after 60 days)
```

3 todos are successfully created.

```shell
ember-template-lint app/ --no-config-path --no-inline-config --rule 'require-input-label:error' --update-todo --todo-days-to-warn=10 --todo-days-to-error=21

✔ 9 todos created, 3 todos removed (warn after 10, error after 21 days)
```

3 todos that were created have been removed unnecessarily. 

This is due to the way the todo batching/updating works - it operates on the provided results and adds/removes the todo files as necessary. In this case, we're explicitly filtering out other errors, so the system incorrectly assumes there are no more errors in the files that previously had errors converted to todos.

After this change:

```shell
ember-template-lint app/ --no-config-path --no-inline-config --rule 'no-positive-tabindex:error' --update-todo --todo-days-to-warn=30 --todo-days-to-error=60

✔ 3 todos created, 0 todos removed (warn after 30, error after 60 days)
```

3 todos are successfully created.

```shell
ember-template-lint app/ --no-config-path --no-inline-config --rule 'require-input-label:error' --update-todo --todo-days-to-warn=10 --todo-days-to-error=21

✔ 9 todos created, 0 todos removed (warn after 10, error after 21 days)
```

9 todos are successfully created.