### PR TITLE
Allow `meta` in `<head>` contexts

### DIFF
--- a/docs/rule/no-forbidden-elements.md
+++ b/docs/rule/no-forbidden-elements.md
@@ -34,6 +34,12 @@ This rule **allows** the following:
 ```hbs
 <div></div>
 ```
+```hbs
+<head>
+  <meta charset="utf-8">
+</head>
+```
+
 
 ## Configuration
 

--- a/docs/rule/no-forbidden-elements.md
+++ b/docs/rule/no-forbidden-elements.md
@@ -34,17 +34,17 @@ This rule **allows** the following:
 ```hbs
 <div></div>
 ```
+
 ```hbs
 <head>
   <meta charset="utf-8">
 </head>
 ```
 
-
 ## Configuration
 
 * boolean - `true` to enable / `false` to disable
-  * array -- an array of strings to forbid, default: ['meta', 'style', 'html', 'style']
+  * array -- an array of strings to forbid, default: ['meta', 'style', 'html', 'script']
   * object -- An object with the following keys:
     * `forbidden` -- An array of forbidden element names
 

--- a/lib/rules/no-forbidden-elements.js
+++ b/lib/rules/no-forbidden-elements.js
@@ -92,10 +92,7 @@ module.exports = class NoForbiddenElements extends Rule {
   visitor() {
     return {
       ElementNode(node, path) {
-        if (hasHeadParent(path)) {
-          return;
-        }
-        if (this.isInHeadHbsFile(this, node)) {
+        if (hasHeadParent(path) || this.isInHeadHbsFile(this, node)) {
           return;
         }
 

--- a/lib/rules/no-forbidden-elements.js
+++ b/lib/rules/no-forbidden-elements.js
@@ -39,7 +39,7 @@ function hasHeadParent(path) {
     type: 'ElementNode',
     tag: 'head',
   };
-  let hasHeadElementInParentPath = parents.find((parent) =>
+  let hasHeadElementInParentPath = parents.some((parent) =>
     NodeMatcher.match(parent.node, refParentNode)
   );
   return Boolean(hasHeadElementInParentPath);
@@ -89,7 +89,7 @@ module.exports = class NoForbiddenElements extends Rule {
   visitor() {
     return {
       ElementNode(node, path) {
-        if (hasHeadParent(path) || this.isInHeadHbsFile(this, node)) {
+        if ((node.tag === 'meta' && hasHeadParent(path)) || this.isInHeadHbsFile(this, node)) {
           return;
         }
 

--- a/lib/rules/no-forbidden-elements.js
+++ b/lib/rules/no-forbidden-elements.js
@@ -82,14 +82,14 @@ module.exports = class NoForbiddenElements extends Rule {
     throw new Error(errorMessage);
   }
 
-  isInHeadHbsFile(scope, node) {
-    return scope._filePath === 'app/templates/head.hbs' && node.tag === 'meta';
+  isInHeadHbsFile(scope) {
+    return scope._filePath === 'app/templates/head.hbs';
   }
 
   visitor() {
     return {
       ElementNode(node, path) {
-        if ((node.tag === 'meta' && hasHeadParent(path)) || this.isInHeadHbsFile(this, node)) {
+        if (node.tag === 'meta' && (hasHeadParent(path) || this.isInHeadHbsFile(this))) {
           return;
         }
 

--- a/lib/rules/no-forbidden-elements.js
+++ b/lib/rules/no-forbidden-elements.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const createErrorMessage = require('../helpers/create-error-message');
+const NodeMatcher = require('../helpers/node-matcher');
 const Rule = require('./base');
 
 function ERROR_MESSAGE_FORBIDDEN_ELEMENTS(element) {
@@ -34,13 +35,14 @@ function sanitizeConfigArray(forbidden = []) {
 
 function hasHeadParent(path) {
   let parents = [...path.parents()];
-  let headElementInParentPath = parents.find(
-    (parent) => parent.node.type === 'ElementNode' && parent.node.tag === 'head'
+  let refParentNode = {
+    type: 'ElementNode',
+    tag: 'head',
+  };
+  let hasHeadElementInParentPath = parents.find((parent) =>
+    NodeMatcher.match(parent.node, refParentNode)
   );
-  if (headElementInParentPath) {
-    return true;
-  }
-  return false;
+  return Boolean(hasHeadElementInParentPath);
 }
 module.exports = class NoForbiddenElements extends Rule {
   parseConfig(config) {

--- a/lib/rules/no-forbidden-elements.js
+++ b/lib/rules/no-forbidden-elements.js
@@ -83,10 +83,7 @@ module.exports = class NoForbiddenElements extends Rule {
   }
 
   isInHeadHbsFile(scope, node) {
-    if (scope._filePath === 'app/templates/head.hbs' && node.tag === 'meta') {
-      return true;
-    }
-    return false;
+    return scope._filePath === 'app/templates/head.hbs' && node.tag === 'meta';
   }
 
   visitor() {

--- a/lib/rules/no-forbidden-elements.js
+++ b/lib/rules/no-forbidden-elements.js
@@ -32,6 +32,17 @@ function sanitizeConfigArray(forbidden = []) {
   return forbidden.filter(Boolean).sort((a, b) => b.length - a.length);
 }
 
+function hasHeadParent(path) {
+  let parents = [...path.parents()];
+  let headElementInParentPath = parents.find(
+    (parent) => parent.node.type === 'ElementNode' && parent.node.tag === 'head'
+  );
+  if (headElementInParentPath) {
+    return true;
+  }
+  return false;
+}
+
 module.exports = class NoForbiddenElements extends Rule {
   parseConfig(config) {
     let configType = typeof config;
@@ -71,7 +82,10 @@ module.exports = class NoForbiddenElements extends Rule {
   }
   visitor() {
     return {
-      ElementNode(node) {
+      ElementNode(node, path) {
+        if (hasHeadParent(path)) {
+          return;
+        }
         let isForbiddenElement = this.config.forbidden.includes(node.tag);
         if (isForbiddenElement) {
           this.log({

--- a/lib/rules/no-forbidden-elements.js
+++ b/lib/rules/no-forbidden-elements.js
@@ -42,7 +42,6 @@ function hasHeadParent(path) {
   }
   return false;
 }
-
 module.exports = class NoForbiddenElements extends Rule {
   parseConfig(config) {
     let configType = typeof config;
@@ -80,13 +79,26 @@ module.exports = class NoForbiddenElements extends Rule {
 
     throw new Error(errorMessage);
   }
+
+  isInHeadHbsFile(scope, node) {
+    if (scope._filePath === 'app/templates/head.hbs' && node.tag === 'meta') {
+      return true;
+    }
+    return false;
+  }
+
   visitor() {
     return {
       ElementNode(node, path) {
         if (hasHeadParent(path)) {
           return;
         }
+        if (this.isInHeadHbsFile(this, node)) {
+          return;
+        }
+
         let isForbiddenElement = this.config.forbidden.includes(node.tag);
+
         if (isForbiddenElement) {
           this.log({
             message: ERROR_MESSAGE_FORBIDDEN_ELEMENTS(node.tag),

--- a/test/unit/rules/no-forbidden-elements-test.js
+++ b/test/unit/rules/no-forbidden-elements-test.js
@@ -102,5 +102,20 @@ generateRuleTests({
         source: '<Foo />',
       },
     },
+    {
+      template: '<script></script>',
+      meta: {
+        filePath: 'app/templates/head.hbs',
+        moduleId: 'app/templates/head',
+      },
+      result: {
+        filePath: 'app/templates/head.hbs',
+        moduleId: 'app/templates/head',
+        message: ERROR_MESSAGE_FORBIDDEN_ELEMENTS('script'),
+        line: 1,
+        column: 0,
+        source: '<script></script>',
+      },
+    },
   ],
 });

--- a/test/unit/rules/no-forbidden-elements-test.js
+++ b/test/unit/rules/no-forbidden-elements-test.js
@@ -18,6 +18,13 @@ generateRuleTests({
       template: '<script></script>',
       config: ['html', 'meta', 'style'],
     },
+    {
+      template: '<meta>',
+      meta: {
+        filePath: 'app/templates/head.hbs',
+        moduleId: 'app/templates/head',
+      },
+    },
   ],
   bad: [
     {

--- a/test/unit/rules/no-forbidden-elements-test.js
+++ b/test/unit/rules/no-forbidden-elements-test.js
@@ -13,6 +13,7 @@ generateRuleTests({
     '<div></div>',
     '<footer></footer>',
     '<p></p>',
+    '<head><meta charset="utf-8"></head>',
     {
       template: '<script></script>',
       config: ['html', 'meta', 'style'],

--- a/test/unit/rules/no-forbidden-elements-test.js
+++ b/test/unit/rules/no-forbidden-elements-test.js
@@ -117,5 +117,30 @@ generateRuleTests({
         source: '<script></script>',
       },
     },
+    {
+      template: '<html></html>',
+      meta: {
+        filePath: 'app/templates/head.hbs',
+        moduleId: 'app/templates/head',
+      },
+      result: {
+        filePath: 'app/templates/head.hbs',
+        moduleId: 'app/templates/head',
+        message: ERROR_MESSAGE_FORBIDDEN_ELEMENTS('html'),
+        line: 1,
+        column: 0,
+        source: '<html></html>',
+      },
+    },
+    {
+      template: '<head><html></html></head>',
+      result: {
+        moduleId: 'layout',
+        message: ERROR_MESSAGE_FORBIDDEN_ELEMENTS('html'),
+        line: 1,
+        column: 6,
+        source: '<html></html>',
+      },
+    },
   ],
 });


### PR DESCRIPTION
Resolves #1713 

[x] Part 1: allows meta tags if nested inside of a `<head>` element (a necessary addition once .html files are also linted). 
[x] Part 2: allows meta tags if in a `head.hbs` file to accommodate `ember-cli-head`