### PR TITLE
Fixes todo creation/removal when using scoped configurations.

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -254,13 +254,12 @@ function getTodoConfigFromCommandLineOptions(options) {
   return todoConfig;
 }
 
-function isOverridingConfig(options) {
-  return (
+function _isOverridingConfig(options) {
+  return Boolean(
     options.config ||
-    options.rule ||
-    options.noInlineConfig ||
-    options.noConfigPath ||
-    options.configPath !== '.template-lintrc.js'
+      options.rule ||
+      options.inlineConfig === false ||
+      options.configPath !== '.template-lintrc.js'
   );
 }
 
@@ -268,6 +267,7 @@ async function run() {
   let options = parseArgv(process.argv.slice(2));
   let positional = options._;
   let config;
+  let isOverridingConfig = _isOverridingConfig(options);
   let todoInfo = {
     added: 0,
     removed: 0,
@@ -361,7 +361,7 @@ async function run() {
         linterOptions,
         fileResults,
         todoInfo.todoConfig,
-        isOverridingConfig(options)
+        isOverridingConfig
       );
 
       todoInfo.added += added;
@@ -369,7 +369,12 @@ async function run() {
     }
 
     if (!filePaths.has(STDIN)) {
-      fileResults = await linter.processTodos(linterOptions, fileResults, options.fix);
+      fileResults = await linter.processTodos(
+        linterOptions,
+        fileResults,
+        options.fix,
+        isOverridingConfig
+      );
     }
 
     resultsAccumulator.push(...fileResults);

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -17,29 +17,29 @@ module.exports = class TodoHandler {
     this._processedResults = [];
   }
 
-  async update(filePath, results, todoConfig, isOverridingConfig) {
+  async update(results, writeTodoOptions) {
     this._processedResults = this._buildResult(results);
 
-    let todoBatchCounts = await writeTodos(this._workingDir, this._processedResults, {
-      filePath,
-      todoConfig,
-      // skip removing todo files if the config is overridden as this can result in todos being incorrectly removed
-      skipRemoval: isOverridingConfig,
-    });
+    let todoBatchCounts = await writeTodos(
+      this._workingDir,
+      this._processedResults,
+      writeTodoOptions
+    );
 
     return todoBatchCounts;
   }
 
-  async processResults(filePath, results, shouldFix) {
+  async processResults(results, shouldFix, writeTodoOption) {
     if (!todoStorageDirExists(this._workingDir)) {
       return results;
     }
 
-    let existingTodoFiles = await readTodosForFilePath(this._workingDir, filePath);
+    let existingTodoFiles = await readTodosForFilePath(this._workingDir, writeTodoOption.filePath);
 
     let [, itemsToRemoveFromTodos, existingTodos] = await getTodoBatches(
       buildTodoData(this._workingDir, this._buildResult(results)),
-      existingTodoFiles
+      existingTodoFiles,
+      writeTodoOption
     );
 
     if (itemsToRemoveFromTodos.size > 0) {
@@ -78,7 +78,9 @@ module.exports = class TodoHandler {
           result.column === todo.column
       );
 
-      result.severity = severity;
+      if (result) {
+        result.severity = severity;
+      }
     });
 
     return results;

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -29,17 +29,17 @@ module.exports = class TodoHandler {
     return todoBatchCounts;
   }
 
-  async processResults(results, shouldFix, writeTodoOption) {
+  async processResults(results, shouldFix, writeTodoOptions) {
     if (!todoStorageDirExists(this._workingDir)) {
       return results;
     }
 
-    let existingTodoFiles = await readTodosForFilePath(this._workingDir, writeTodoOption.filePath);
+    let existingTodoFiles = await readTodosForFilePath(this._workingDir, writeTodoOptions.filePath);
 
     let [, itemsToRemoveFromTodos, existingTodos] = await getTodoBatches(
       buildTodoData(this._workingDir, this._buildResult(results)),
       existingTodoFiles,
-      writeTodoOption
+      writeTodoOptions
     );
 
     if (itemsToRemoveFromTodos.size > 0) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -263,23 +263,30 @@ class Linter {
     return currentSource;
   }
 
-  async updateTodo(linterOptions, results, todoConfig, isOverridingConfig) {
-    let todoBatchCounts = await this._todoHandler.update(
-      linterOptions.filePath,
-      results,
+  _getShouldRemove(options, isOverridingConfig) {
+    let config = this._moduleStatusCache.getConfigForFile(options);
+    let rules = new Set(Object.keys(config.rules).filter((ruleId) => config.rules[ruleId]));
+
+    return (todoDatum) => !isOverridingConfig && rules.has(todoDatum.ruleId);
+  }
+
+  async updateTodo(options, results, todoConfig, isOverridingConfig) {
+    let todoBatchCounts = await this._todoHandler.update(results, {
+      filePath: options.filePath,
       todoConfig,
-      isOverridingConfig
-    );
+      // skip removing todo files if the config is overridden as this can result in todos being incorrectly removed
+      shouldRemove: this._getShouldRemove(options, isOverridingConfig),
+    });
 
     return todoBatchCounts;
   }
 
-  async processTodos(linterOptions, results, shouldFix) {
-    let fileResults = await this._todoHandler.processResults(
-      linterOptions.filePath,
-      results,
-      shouldFix
-    );
+  async processTodos(options, results, shouldFix, isOverridingConfig) {
+    let fileResults = await this._todoHandler.processResults(results, shouldFix, {
+      filePath: options.filePath,
+      // skip removing todo files if the config is overridden as this can result in todos being incorrectly removed
+      shouldRemove: this._getShouldRemove(options, isOverridingConfig),
+    });
 
     return fileResults;
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^7.0.0",
+    "@ember-template-lint/todo-utils": "^8.0.0-beta.0",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1568,6 +1568,43 @@ describe('ember-template-lint executable', function () {
         expect(todos).toHaveLength(3);
       });
 
+      it('does not remove todos if custom config params are used with subsequent invocations', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+            'no-html-comments': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+              'foo.hbs': '<div>Bare strings are bad...</div><!-- violation -->',
+            },
+          },
+        });
+
+        await run(['.', '--update-todo']);
+
+        let todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(todos).toHaveLength(3);
+
+        let result = await run([
+          '.',
+          '--rule',
+          'no-html-comments:error',
+          '--update-todo',
+          '--no-inline-config',
+          '--no-config-path',
+        ]);
+
+        todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+        expect(todos).toHaveLength(3);
+      });
+
       it('errors if a todo item is no longer valid when running without params', async function () {
         project.setConfig({
           rules: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,10 +278,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-7.0.0.tgz#5ec2013e3ad060fff65078fe7b39fb35544cde83"
-  integrity sha512-0CZLCHIBziRFxg9Vq2xqTgSc+I+coVbqraCK3cBUhbMbRo8fl8y+O5toEDC8ze2a/zguB/qTUhqcg96j14xwSQ==
+"@ember-template-lint/todo-utils@^8.0.0-beta.0":
+  version "8.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-8.0.0-beta.0.tgz#bdb3316738e2a5ed621034a812b4cbd8ae788c02"
+  integrity sha512-Eqz6uhYlHm7cRWsvHkG6iWHjOvPgFSCZOJ+fzY1gCJNR9Hmkt9Ycd836Uke6TZfTYbNCTmxfV3wTn2ef5apjzg==
   dependencies:
     "@types/eslint" "^7.2.6"
     fs-extra "^9.0.1"


### PR DESCRIPTION
Using todos with the happy path workflow (`ember-template-lint . --update-todo`) with a non-overridden config works in a very straightforward manner. When a config override is provided using one of

- `--no-config-path`
- `--no-inline-config`
- `--rule`
- `--config`

this caused a situation where existing todo files would be incorrectly removed. 

This PR fixes this issue by ensuring that when a config is overridden, the todo batch modifications are done in a non-destructive way by operating only within the scope of the configured rules.