### PR TITLE
Auto-writing todoConfig when one doesn't exist

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -9,7 +9,11 @@ const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 
-const { getTodoStorageDirPath, getTodoConfig } = require('@ember-template-lint/todo-utils');
+const {
+  ensureTodoConfig,
+  getTodoStorageDirPath,
+  getTodoConfig,
+} = require('@ember-template-lint/todo-utils');
 const chalk = require('chalk');
 const getStdin = require('get-stdin');
 const globby = require('globby');
@@ -331,6 +335,10 @@ async function run() {
     );
     process.exitCode = 1;
     return;
+  }
+
+  if (options.updateTodo) {
+    ensureTodoConfig(options.workingDirectory);
   }
 
   let filePaths = getFilesToLint(options.workingDirectory, positional, options.ignorePattern);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^8.0.0-beta.0",
+    "@ember-template-lint/todo-utils": "^8.0.0-beta.2",
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1481,6 +1481,37 @@ describe('ember-template-lint executable', function () {
         );
       });
 
+      it('writes todo config to package.json if run the first time and no config exists', async function () {
+        let result = await run(['.', '--update-todo']);
+        let pkg = JSON.parse(
+          readFileSync(path.join(project.baseDir, 'package.json'), {
+            encoding: 'utf8',
+          })
+        );
+
+        expect(result.exitCode).toEqual(0);
+        expect(pkg.lintTodo.daysToDecay).toEqual({
+          warn: 30,
+          error: 60,
+        });
+      });
+
+      it('does not write todo config to package.json if run the first time and config exists', async function () {
+        project.writeSync();
+        project.writeTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        let result = await run(['.', '--update-todo']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(project.pkg.lintTodo.daysToDecay).toEqual({
+          warn: 5,
+          error: 10,
+        });
+      });
+
       it('generates no todos for no errors', async function () {
         project.setConfig({
           rules: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,10 +278,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^8.0.0-beta.0":
-  version "8.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-8.0.0-beta.0.tgz#bdb3316738e2a5ed621034a812b4cbd8ae788c02"
-  integrity sha512-Eqz6uhYlHm7cRWsvHkG6iWHjOvPgFSCZOJ+fzY1gCJNR9Hmkt9Ycd836Uke6TZfTYbNCTmxfV3wTn2ef5apjzg==
+"@ember-template-lint/todo-utils@^8.0.0-beta.2":
+  version "8.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-8.0.0-beta.2.tgz#fd849b4bf2a3fb2ea240ca3594ababc9e8d13f93"
+  integrity sha512-C1Ezt1hVXkPnQ7ndtmpsKc1oMcjBDI1JrEQrxxOAxX+W+0ggB7NNUH3yqdVZvSDsxkzWq6c25hjvITNZI0ROmg==
   dependencies:
     "@types/eslint" "^7.2.6"
     fs-extra "^9.0.1"


### PR DESCRIPTION
While it's possible to use the new todo feature without a `daysToDecay` config, it's not the recommended approach.

In order to ensure that each invocation uses at least the default configuration, this PR adds a call to `ensureTodoConfig`, which writes a default config of

```json
{
  "lintTodo": {
    "daysToDecay": {
      "warn": 30,
      "error": 60
    }
  }
}
```

It writes this default when using `--update-todo` the first time, if a prior `.lint-todo` directory doesn't exist, _and_ if a prior `lintTodo` config doesn't exist.