### PR TITLE
Fix `no-dynamic-subexpression-invocations` handling of `{{1}}`

### DIFF
--- a/lib/rules/no-dynamic-subexpression-invocations.js
+++ b/lib/rules/no-dynamic-subexpression-invocations.js
@@ -4,6 +4,10 @@ const Rule = require('./base');
 
 module.exports = class NoDynamicSubexpressionInvocations extends Rule {
   logDynamicInvocation(node, path) {
+    if (node.path.type !== 'PathExpression') {
+      return;
+    }
+
     let isLocal = this.scope.isLocal(node.path);
     let isPath = node.path.parts.length > 1;
     let isThisPath = node.path.original.startsWith('this.');

--- a/test/unit/rules/no-dynamic-subexpression-invocations-test.js
+++ b/test/unit/rules/no-dynamic-subexpression-invocations-test.js
@@ -13,6 +13,18 @@ generateRuleTests({
     '{{something here="goes"}}',
     '<button onclick={{fn something "here"}}></button>',
     '{{@thing "somearg"}}',
+    '<Foo @bar="asdf" />',
+    '<Foo @bar={{"asdf"}} />',
+    '<Foo @bar={{true}} />',
+    '<Foo @bar={{false}} />',
+    '<Foo @bar={{undefined}} />',
+    '<Foo @bar={{null}} />',
+    '<Foo @bar={{1}} />',
+    '{{1}}',
+    '{{true}}',
+    '{{null}}',
+    '{{undefined}}',
+    '{{"foo"}}',
   ],
 
   bad: [


### PR DESCRIPTION
Previously, we incorrectly assumed that all `MustacheStatement`/`SubExpression` nodes's `.path` property was itself a `PathExpression`. This was incorrect, there are a number of other node types that `.path` can be in those circumstances.
