### PR TITLE
Add `require-has-block-helper` lint rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Each rule has emojis denoting:
 | :white_check_mark::wrench: | [require-button-type](./docs/rule/require-button-type.md)                                   |
 |                            | [require-each-key](./docs/rule/require-each-key.md)                                         |
 |                            | [require-form-method](./docs/rule/require-form-method.md)                                   |
+|                            | [require-has-block-helper](./docs/rule/require-has-block-helper.md)                         |
 | :white_check_mark:         | [require-iframe-title](./docs/rule/require-iframe-title.md)                                 |
 |                            | [require-input-label](./docs/rule/require-input-label.md)                                   |
 |                            | [require-lang-attribute](./docs/rule/require-lang-attribute.md)                             |

--- a/docs/rule/require-has-block-helper.md
+++ b/docs/rule/require-has-block-helper.md
@@ -1,6 +1,6 @@
 # require-has-block-helper
 
-In Ember 3.25 the properties `hasBlock` and `hasBlockParams` were deprecated. Their replacement is to use `has-block` and `has-block-params` helpers instead.
+In Ember 3.26 the properties `hasBlock` and `hasBlockParams` were deprecated. Their replacement is to use `has-block` and `has-block-params` helpers instead.
 
 This rule prevents the usage of `hasBlock` and `hasBlockParams` and suggests using `has-block` or `has-block-params` instead.
 

--- a/docs/rule/require-has-block-helper.md
+++ b/docs/rule/require-has-block-helper.md
@@ -1,0 +1,54 @@
+# require-has-block-helper
+
+In Ember 3.25 the properties `hasBlock` and `hasBlockParams` were deprecated. Their replacement is to use `has-block` and `has-block-params` helpers instead.
+
+This rule prevents the usage of `hasBlock` and `hasBlockParams` and suggests using `has-block` or `has-block-params` instead.
+
+For more information about this deprecation you can view the [RFC](https://github.com/emberjs/rfcs/blob/master/text/0689-deprecate-has-block.md) or its entry on the [Deprecations page](https://deprecations.emberjs.com/v3.x/#toc_has-block-and-has-block-params).
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+{{hasBlock}}
+{{#if hasBlock}}
+
+{{/if}}
+```
+
+```hbs
+{{hasBlockParams}}
+{{#if hasBlockParams}}
+
+{{/if}}
+```
+
+This rule **allows** the following:
+
+```hbs
+{{has-block}}
+{{#if (has-block)}}
+
+{{/if}}
+```
+
+```hbs
+{{has-block-params}}
+{{#if (has-block-params)}}
+
+{{/if}}
+```
+
+## Migration
+
+* `{{hasBlock}}`-> `{{has-block}}
+* `{{hasBlockParams}}`-> `{{has-block-params}}
+* `{{#if hasBlock}} {{/if}}`-> `{{#if (has-block)}} {{/if}}`
+* `{{#if (hasBlock "inverse")}} {{/if}}`-> `{{#if (has-block "inverse")}} {{/if}}`
+* `{{#if hasBlockParams}} {{/if}}`-> `{{#if (has-block-params)}} {{/if}}`
+* `{{#if (hasBlockParams "inverse")}} {{/if}}`-> `{{#if (has-block-params "inverse")}} {{/if}}`
+
+## References
+
+* [RFC](https://github.com/emberjs/rfcs/blob/master/text/0689-deprecate-has-block.md)
+* [Deprecation information](https://deprecations.emberjs.com/v3.x/#toc_has-block-and-has-block-params)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -83,6 +83,7 @@ module.exports = {
   'require-button-type': require('./require-button-type'),
   'require-each-key': require('./require-each-key'),
   'require-form-method': require('./require-form-method'),
+  'require-has-block-helper': require('./require-has-block-helper'),
   'require-iframe-title': require('./require-iframe-title'),
   'require-input-label': require('./require-input-label'),
   'require-lang-attribute': require('./require-lang-attribute'),
@@ -93,5 +94,4 @@ module.exports = {
   'style-concatenation': require('./style-concatenation'),
   'table-groups': require('./table-groups'),
   'template-length': require('./template-length'),
-  'require-has-block-helper': require('./require-has-block-helper'),
 };

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -93,4 +93,5 @@ module.exports = {
   'style-concatenation': require('./style-concatenation'),
   'table-groups': require('./table-groups'),
   'template-length': require('./template-length'),
+  'require-has-block-helper': require('./require-has-block-helper'),
 };

--- a/lib/rules/require-has-block-helper.js
+++ b/lib/rules/require-has-block-helper.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const Rule = require('./base');
+
+const TRANSFORMATIONS = {
+  hasBlock: 'has-block',
+  hasBlockParams: 'has-block-params',
+};
+
+function getErrorMessage(name) {
+  return `\`${name}\` is deprecated. Use the \`${TRANSFORMATIONS[name]}\` helper instead.`;
+}
+
+module.exports = class RequireHasBlockHelper extends Rule {
+  visitor() {
+    return {
+      PathExpression(node) {
+        if (TRANSFORMATIONS[node.original]) {
+          this.log({
+            message: getErrorMessage(node.original),
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column,
+            source: this.sourceForNode(node),
+          });
+        }
+      },
+    };
+  }
+};
+
+module.exports.getErrorMessage = getErrorMessage;

--- a/test/unit/rules/require-has-block-helper-test.js
+++ b/test/unit/rules/require-has-block-helper-test.js
@@ -1,0 +1,205 @@
+'use strict';
+
+const { getErrorMessage } = require('../../../lib/rules/require-has-block-helper');
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'require-has-block-helper',
+
+  config: true,
+
+  good: [
+    '{{has-block}}',
+    '{{has-block-params}}',
+    '{{something-else}}',
+    '{{component test=(if (has-block) "true")}}',
+    '{{component test=(if (has-block-params) "true")}}',
+    '<SomeComponent someProp={{has-block}}',
+    '<SomeComponent someProp={{has-block-params}}',
+    '{{#if (has-block)}}{{/if}}',
+    '{{#if (has-block-params)}}{{/if}}',
+  ],
+
+  bad: [
+    {
+      template: '{{hasBlock}}',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 2,
+        source: 'hasBlock',
+      },
+    },
+    {
+      template: '{{hasBlockParams}}',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 2,
+        source: 'hasBlockParams',
+      },
+    },
+    {
+      template: '{{if hasBlock "true" "false"}}',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 5,
+        source: 'hasBlock',
+      },
+    },
+    {
+      template: '{{if hasBlockParams "true" "false"}}',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 5,
+        source: 'hasBlockParams',
+      },
+    },
+    {
+      template: '{{if (hasBlock) "true" "false"}}',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 6,
+        source: 'hasBlock',
+      },
+    },
+    {
+      template: '{{if (hasBlockParams) "true" "false"}}',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 6,
+        source: 'hasBlockParams',
+      },
+    },
+    {
+      template: '{{if (hasBlock "inverse") "true" "false"}}',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 6,
+        source: 'hasBlock',
+      },
+    },
+    {
+      template: '{{if (hasBlockParams "inverse") "true" "false"}}',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 6,
+        source: 'hasBlockParams',
+      },
+    },
+    {
+      template: '{{component test=(if hasBlock "true")}}',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 21,
+        source: 'hasBlock',
+      },
+    },
+    {
+      template: '{{component test=(if hasBlockParams "true")}}',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 21,
+        source: 'hasBlockParams',
+      },
+    },
+    {
+      template: '{{#if hasBlock}}{{/if}}',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 6,
+        source: 'hasBlock',
+      },
+    },
+    {
+      template: '{{#if hasBlockParams}}{{/if}}',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 6,
+        source: 'hasBlockParams',
+      },
+    },
+    {
+      template: '{{#if (hasBlock)}}{{/if}}',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 7,
+        source: 'hasBlock',
+      },
+    },
+    {
+      template: '{{#if (hasBlockParams)}}{{/if}}',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 7,
+        source: 'hasBlockParams',
+      },
+    },
+    {
+      template: '{{#if (hasBlock "inverse")}}{{/if}}',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 7,
+        source: 'hasBlock',
+      },
+    },
+    {
+      template: '{{#if (hasBlockParams "inverse")}}{{/if}}',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 7,
+        source: 'hasBlockParams',
+      },
+    },
+    {
+      template: '<button name={{hasBlock}}></button>',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 15,
+        source: 'hasBlock',
+      },
+    },
+    {
+      template: '<button name={{hasBlockParams}}></button>',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 15,
+        source: 'hasBlockParams',
+      },
+    },
+    {
+      template: '<button name={{hasBlock "inverse"}}></button>',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 15,
+        source: 'hasBlock',
+      },
+    },
+    {
+      template: '<button name={{hasBlockParams "inverse"}}></button>',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 15,
+        source: 'hasBlockParams',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Follow up to introducing the `hasBlock` and `hasBlockParams` deprecations in https://github.com/emberjs/ember.js/pull/19374/

Adds a new lint rule, `require-has-block-helper` (open to suggestions on the name) to warn about usage of `hasBlock` and `hasBlockParams`. It was also suggested we create a `fixer` for this lint rule but I haven't got around to that yet. I can either introduce it in a follow up PR or if you don't mind waiting another day or two, I can introduce into this PR.

/cc @pzuraq @rwjblue 