### PR TITLE
rule: no-unknown-arguments-for-builtin-components

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,102 +171,103 @@ Each rule has emojis denoting:
 
 <!--RULES_TABLE_START-->
 
-|                            | Rule ID                                                                                     |
-| :------------------------- | :------------------------------------------------------------------------------------------ |
-|                            | [attribute-indentation](./docs/rule/attribute-indentation.md)                               |
-| :nail_care:                | [block-indentation](./docs/rule/block-indentation.md)                                       |
-|                            | [builtin-component-arguments](./docs/rule/builtin-component-arguments.md)                   |
-|                            | [deprecated-each-syntax](./docs/rule/deprecated-each-syntax.md)                             |
-|                            | [deprecated-inline-view-helper](./docs/rule/deprecated-inline-view-helper.md)               |
-| :white_check_mark:         | [deprecated-render-helper](./docs/rule/deprecated-render-helper.md)                         |
-| :nail_care:                | [eol-last](./docs/rule/eol-last.md)                                                         |
-| :wrench:                   | [inline-link-to](./docs/rule/inline-link-to.md)                                             |
-| :nail_care:                | [linebreak-style](./docs/rule/linebreak-style.md)                                           |
-| :white_check_mark:         | [link-href-attributes](./docs/rule/link-href-attributes.md)                                 |
-| :white_check_mark::wrench: | [link-rel-noopener](./docs/rule/link-rel-noopener.md)                                       |
-|                            | [modifier-name-case](./docs/rule/modifier-name-case.md)                                     |
-| :white_check_mark:         | [no-abstract-roles](./docs/rule/no-abstract-roles.md)                                       |
-| :wrench:                   | [no-accesskey-attribute](./docs/rule/no-accesskey-attribute.md)                             |
-| :car:                      | [no-action](./docs/rule/no-action.md)                                                       |
-|                            | [no-action-modifiers](./docs/rule/no-action-modifiers.md)                                   |
-| :white_check_mark:         | [no-args-paths](./docs/rule/no-args-paths.md)                                               |
-|                            | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)             |
-| :wrench:                   | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                                   |
-| :white_check_mark:         | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                             |
-|                            | [no-bare-strings](./docs/rule/no-bare-strings.md)                                           |
-|                            | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md)       |
-| :car:                      | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md)               |
-| :white_check_mark:         | [no-debugger](./docs/rule/no-debugger.md)                                                   |
-|                            | [no-down-event-binding](./docs/rule/no-down-event-binding.md)                               |
-| :white_check_mark:         | [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                           |
-|                            | [no-duplicate-id](./docs/rule/no-duplicate-id.md)                                           |
-|                            | [no-duplicate-landmark-elements](./docs/rule/no-duplicate-landmark-elements.md)             |
-|                            | [no-dynamic-subexpression-invocations](./docs/rule/no-dynamic-subexpression-invocations.md) |
-|                            | [no-element-event-actions](./docs/rule/no-element-event-actions.md)                         |
-| :white_check_mark:         | [no-extra-mut-helper-argument](./docs/rule/no-extra-mut-helper-argument.md)                 |
-|                            | [no-forbidden-elements](./docs/rule/no-forbidden-elements.md)                               |
-|                            | [no-heading-inside-button](./docs/rule/no-heading-inside-button.md)                         |
-| :white_check_mark:         | [no-html-comments](./docs/rule/no-html-comments.md)                                         |
-| :car:                      | [no-implicit-this](./docs/rule/no-implicit-this.md)                                         |
-| :white_check_mark:         | [no-index-component-invocation](./docs/rule/no-index-component-invocation.md)               |
-| :white_check_mark:         | [no-inline-styles](./docs/rule/no-inline-styles.md)                                         |
-| :white_check_mark:         | [no-input-block](./docs/rule/no-input-block.md)                                             |
-| :white_check_mark:         | [no-input-tagname](./docs/rule/no-input-tagname.md)                                         |
-|                            | [no-invalid-block-param-definition](./docs/rule/no-invalid-block-param-definition.md)       |
-| :white_check_mark:         | [no-invalid-interactive](./docs/rule/no-invalid-interactive.md)                             |
-| :white_check_mark:         | [no-invalid-link-text](./docs/rule/no-invalid-link-text.md)                                 |
-|                            | [no-invalid-link-title](./docs/rule/no-invalid-link-title.md)                               |
-| :white_check_mark:         | [no-invalid-meta](./docs/rule/no-invalid-meta.md)                                           |
-| :white_check_mark:         | [no-invalid-role](./docs/rule/no-invalid-role.md)                                           |
-|                            | [no-link-to-tagname](./docs/rule/no-link-to-tagname.md)                                     |
-| :white_check_mark:         | [no-log](./docs/rule/no-log.md)                                                             |
-| :wrench:                   | [no-model-argument-in-route-templates](./docs/rule/no-model-argument-in-route-templates.md) |
-| :nail_care:                | [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                           |
-|                            | [no-mut-helper](./docs/rule/no-mut-helper.md)                                               |
-| :white_check_mark:         | [no-negated-condition](./docs/rule/no-negated-condition.md)                                 |
-| :white_check_mark:         | [no-nested-interactive](./docs/rule/no-nested-interactive.md)                               |
-|                            | [no-nested-landmark](./docs/rule/no-nested-landmark.md)                                     |
-|                            | [no-nested-splattributes](./docs/rule/no-nested-splattributes.md)                           |
-| :white_check_mark:         | [no-obsolete-elements](./docs/rule/no-obsolete-elements.md)                                 |
-| :white_check_mark:         | [no-outlet-outside-routes](./docs/rule/no-outlet-outside-routes.md)                         |
-| :white_check_mark:         | [no-partial](./docs/rule/no-partial.md)                                                     |
-|                            | [no-passed-in-event-handlers](./docs/rule/no-passed-in-event-handlers.md)                   |
-| :wrench:                   | [no-positional-data-test-selectors](./docs/rule/no-positional-data-test-selectors.md)       |
-| :white_check_mark:         | [no-positive-tabindex](./docs/rule/no-positive-tabindex.md)                                 |
-|                            | [no-potential-path-strings](./docs/rule/no-potential-path-strings.md)                       |
-| :white_check_mark:         | [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md)                           |
-| :wrench:                   | [no-redundant-fn](./docs/rule/no-redundant-fn.md)                                           |
-| :wrench:                   | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)                     |
-|                            | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md)                       |
-| :white_check_mark:         | [no-shadowed-elements](./docs/rule/no-shadowed-elements.md)                                 |
-| :wrench:                   | [no-this-in-template-only-components](./docs/rule/no-this-in-template-only-components.md)   |
-| :nail_care:                | [no-trailing-spaces](./docs/rule/no-trailing-spaces.md)                                     |
-| :white_check_mark:         | [no-triple-curlies](./docs/rule/no-triple-curlies.md)                                       |
-|                            | [no-unbalanced-curlies](./docs/rule/no-unbalanced-curlies.md)                               |
-| :white_check_mark:         | [no-unbound](./docs/rule/no-unbound.md)                                                     |
-| :white_check_mark:         | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)           |
-| :nail_care:                | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                               |
-| :white_check_mark:         | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                             |
-|                            | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                         |
-|                            | [no-whitespace-within-word](./docs/rule/no-whitespace-within-word.md)                       |
-|                            | [no-yield-only](./docs/rule/no-yield-only.md)                                               |
-|                            | [no-yield-to-default](./docs/rule/no-yield-to-default.md)                                   |
-| :nail_care:                | [quotes](./docs/rule/quotes.md)                                                             |
-| :white_check_mark::wrench: | [require-button-type](./docs/rule/require-button-type.md)                                   |
-|                            | [require-each-key](./docs/rule/require-each-key.md)                                         |
-|                            | [require-form-method](./docs/rule/require-form-method.md)                                   |
-| :wrench:                   | [require-has-block-helper](./docs/rule/require-has-block-helper.md)                         |
-| :white_check_mark:         | [require-iframe-title](./docs/rule/require-iframe-title.md)                                 |
-|                            | [require-input-label](./docs/rule/require-input-label.md)                                   |
-|                            | [require-lang-attribute](./docs/rule/require-lang-attribute.md)                             |
-|                            | [require-splattributes](./docs/rule/require-splattributes.md)                               |
-| :white_check_mark:         | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                             |
-| :nail_care:                | [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)                     |
-| :white_check_mark:         | [simple-unless](./docs/rule/simple-unless.md)                                               |
-|                            | [splat-attributes-only](./docs/rule/splat-attributes-only.md)                               |
-| :white_check_mark:         | [style-concatenation](./docs/rule/style-concatenation.md)                                   |
-| :white_check_mark:         | [table-groups](./docs/rule/table-groups.md)                                                 |
-|                            | [template-length](./docs/rule/template-length.md)                                           |
+|                            | Rule ID                                                                                                   |
+| :------------------------- | :-------------------------------------------------------------------------------------------------------- |
+|                            | [attribute-indentation](./docs/rule/attribute-indentation.md)                                             |
+| :nail_care:                | [block-indentation](./docs/rule/block-indentation.md)                                                     |
+|                            | [builtin-component-arguments](./docs/rule/builtin-component-arguments.md)                                 |
+|                            | [deprecated-each-syntax](./docs/rule/deprecated-each-syntax.md)                                           |
+|                            | [deprecated-inline-view-helper](./docs/rule/deprecated-inline-view-helper.md)                             |
+| :white_check_mark:         | [deprecated-render-helper](./docs/rule/deprecated-render-helper.md)                                       |
+| :nail_care:                | [eol-last](./docs/rule/eol-last.md)                                                                       |
+| :wrench:                   | [inline-link-to](./docs/rule/inline-link-to.md)                                                           |
+| :nail_care:                | [linebreak-style](./docs/rule/linebreak-style.md)                                                         |
+| :white_check_mark:         | [link-href-attributes](./docs/rule/link-href-attributes.md)                                               |
+| :white_check_mark::wrench: | [link-rel-noopener](./docs/rule/link-rel-noopener.md)                                                     |
+|                            | [modifier-name-case](./docs/rule/modifier-name-case.md)                                                   |
+| :white_check_mark:         | [no-abstract-roles](./docs/rule/no-abstract-roles.md)                                                     |
+| :wrench:                   | [no-accesskey-attribute](./docs/rule/no-accesskey-attribute.md)                                           |
+| :car:                      | [no-action](./docs/rule/no-action.md)                                                                     |
+|                            | [no-action-modifiers](./docs/rule/no-action-modifiers.md)                                                 |
+| :white_check_mark:         | [no-args-paths](./docs/rule/no-args-paths.md)                                                             |
+|                            | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)                           |
+| :wrench:                   | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                                                 |
+| :white_check_mark:         | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                                           |
+|                            | [no-bare-strings](./docs/rule/no-bare-strings.md)                                                         |
+|                            | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md)                     |
+| :car:                      | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md)                             |
+| :white_check_mark:         | [no-debugger](./docs/rule/no-debugger.md)                                                                 |
+|                            | [no-down-event-binding](./docs/rule/no-down-event-binding.md)                                             |
+| :white_check_mark:         | [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                                         |
+|                            | [no-duplicate-id](./docs/rule/no-duplicate-id.md)                                                         |
+|                            | [no-duplicate-landmark-elements](./docs/rule/no-duplicate-landmark-elements.md)                           |
+|                            | [no-dynamic-subexpression-invocations](./docs/rule/no-dynamic-subexpression-invocations.md)               |
+|                            | [no-element-event-actions](./docs/rule/no-element-event-actions.md)                                       |
+| :white_check_mark:         | [no-extra-mut-helper-argument](./docs/rule/no-extra-mut-helper-argument.md)                               |
+|                            | [no-forbidden-elements](./docs/rule/no-forbidden-elements.md)                                             |
+|                            | [no-heading-inside-button](./docs/rule/no-heading-inside-button.md)                                       |
+| :white_check_mark:         | [no-html-comments](./docs/rule/no-html-comments.md)                                                       |
+| :car:                      | [no-implicit-this](./docs/rule/no-implicit-this.md)                                                       |
+| :white_check_mark:         | [no-index-component-invocation](./docs/rule/no-index-component-invocation.md)                             |
+| :white_check_mark:         | [no-inline-styles](./docs/rule/no-inline-styles.md)                                                       |
+| :white_check_mark:         | [no-input-block](./docs/rule/no-input-block.md)                                                           |
+| :white_check_mark:         | [no-input-tagname](./docs/rule/no-input-tagname.md)                                                       |
+|                            | [no-invalid-block-param-definition](./docs/rule/no-invalid-block-param-definition.md)                     |
+| :white_check_mark:         | [no-invalid-interactive](./docs/rule/no-invalid-interactive.md)                                           |
+| :white_check_mark:         | [no-invalid-link-text](./docs/rule/no-invalid-link-text.md)                                               |
+|                            | [no-invalid-link-title](./docs/rule/no-invalid-link-title.md)                                             |
+| :white_check_mark:         | [no-invalid-meta](./docs/rule/no-invalid-meta.md)                                                         |
+| :white_check_mark:         | [no-invalid-role](./docs/rule/no-invalid-role.md)                                                         |
+|                            | [no-link-to-tagname](./docs/rule/no-link-to-tagname.md)                                                   |
+| :white_check_mark:         | [no-log](./docs/rule/no-log.md)                                                                           |
+| :wrench:                   | [no-model-argument-in-route-templates](./docs/rule/no-model-argument-in-route-templates.md)               |
+| :nail_care:                | [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                                         |
+|                            | [no-mut-helper](./docs/rule/no-mut-helper.md)                                                             |
+| :white_check_mark:         | [no-negated-condition](./docs/rule/no-negated-condition.md)                                               |
+| :white_check_mark:         | [no-nested-interactive](./docs/rule/no-nested-interactive.md)                                             |
+|                            | [no-nested-landmark](./docs/rule/no-nested-landmark.md)                                                   |
+|                            | [no-nested-splattributes](./docs/rule/no-nested-splattributes.md)                                         |
+| :white_check_mark:         | [no-obsolete-elements](./docs/rule/no-obsolete-elements.md)                                               |
+| :white_check_mark:         | [no-outlet-outside-routes](./docs/rule/no-outlet-outside-routes.md)                                       |
+| :white_check_mark:         | [no-partial](./docs/rule/no-partial.md)                                                                   |
+|                            | [no-passed-in-event-handlers](./docs/rule/no-passed-in-event-handlers.md)                                 |
+| :wrench:                   | [no-positional-data-test-selectors](./docs/rule/no-positional-data-test-selectors.md)                     |
+| :white_check_mark:         | [no-positive-tabindex](./docs/rule/no-positive-tabindex.md)                                               |
+|                            | [no-potential-path-strings](./docs/rule/no-potential-path-strings.md)                                     |
+| :white_check_mark:         | [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md)                                         |
+| :wrench:                   | [no-redundant-fn](./docs/rule/no-redundant-fn.md)                                                         |
+| :wrench:                   | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)                                   |
+|                            | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md)                                     |
+| :white_check_mark:         | [no-shadowed-elements](./docs/rule/no-shadowed-elements.md)                                               |
+| :wrench:                   | [no-this-in-template-only-components](./docs/rule/no-this-in-template-only-components.md)                 |
+| :nail_care:                | [no-trailing-spaces](./docs/rule/no-trailing-spaces.md)                                                   |
+| :white_check_mark:         | [no-triple-curlies](./docs/rule/no-triple-curlies.md)                                                     |
+|                            | [no-unbalanced-curlies](./docs/rule/no-unbalanced-curlies.md)                                             |
+| :white_check_mark:         | [no-unbound](./docs/rule/no-unbound.md)                                                                   |
+|                            | [no-unknown-arguments-for-builtin-components](./docs/rule/no-unknown-arguments-for-builtin-components.md) |
+| :white_check_mark:         | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)                         |
+| :nail_care:                | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                                             |
+| :white_check_mark:         | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                                           |
+|                            | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                                       |
+|                            | [no-whitespace-within-word](./docs/rule/no-whitespace-within-word.md)                                     |
+|                            | [no-yield-only](./docs/rule/no-yield-only.md)                                                             |
+|                            | [no-yield-to-default](./docs/rule/no-yield-to-default.md)                                                 |
+| :nail_care:                | [quotes](./docs/rule/quotes.md)                                                                           |
+| :white_check_mark::wrench: | [require-button-type](./docs/rule/require-button-type.md)                                                 |
+|                            | [require-each-key](./docs/rule/require-each-key.md)                                                       |
+|                            | [require-form-method](./docs/rule/require-form-method.md)                                                 |
+| :wrench:                   | [require-has-block-helper](./docs/rule/require-has-block-helper.md)                                       |
+| :white_check_mark:         | [require-iframe-title](./docs/rule/require-iframe-title.md)                                               |
+|                            | [require-input-label](./docs/rule/require-input-label.md)                                                 |
+|                            | [require-lang-attribute](./docs/rule/require-lang-attribute.md)                                           |
+|                            | [require-splattributes](./docs/rule/require-splattributes.md)                                             |
+| :white_check_mark:         | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                                           |
+| :nail_care:                | [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)                                   |
+| :white_check_mark:         | [simple-unless](./docs/rule/simple-unless.md)                                                             |
+|                            | [splat-attributes-only](./docs/rule/splat-attributes-only.md)                                             |
+| :white_check_mark:         | [style-concatenation](./docs/rule/style-concatenation.md)                                                 |
+| :white_check_mark:         | [table-groups](./docs/rule/table-groups.md)                                                               |
+|                            | [template-length](./docs/rule/template-length.md)                                                         |
 
 <!--RULES_TABLE_END-->
 

--- a/docs/rule/builtin-component-arguments.md
+++ b/docs/rule/builtin-component-arguments.md
@@ -46,6 +46,10 @@ This rule **allows** the following:
 * Add the `@` character in front of the relevant attributes to convert them
   into component argument
 
+## Related Rules
+
+- [no-unknown-arguments-for-builtin-components](no-unknown-arguments-for-builtin-components.md)
+
 ## References
 
 * [`Input` component API documentation](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input)

--- a/docs/rule/no-input-tagname.md
+++ b/docs/rule/no-input-tagname.md
@@ -20,6 +20,8 @@ This rule **forbids** the following:
 ## Related rules
 
 * [no-link-to-tagname](no-link-to-tagname.md)
+- [no-unknown-arguments-for-builtin-components](no-unknown-arguments-for-builtin-components.md)
+
 
 ## References
 

--- a/docs/rule/no-link-to-tagname.md
+++ b/docs/rule/no-link-to-tagname.md
@@ -47,6 +47,8 @@ This rule **allows** the following:
 ## Related rules
 
 - [no-input-tagname](no-input-tagname.md)
+- [no-unknown-arguments-for-builtin-components](no-unknown-arguments-for-builtin-components.md)
+
 
 ## References
 

--- a/docs/rule/no-unknown-arguments-for-builtin-components.md
+++ b/docs/rule/no-unknown-arguments-for-builtin-components.md
@@ -1,0 +1,52 @@
+# no-unknown-arguments-for-builtin-components
+
+The builtin components `LinkTo`, `Input`, `Textarea` has list of allowed arguments, and some argument names may be mistyped, this rule trying to highlight possible typos, checking for unknown arguments, also, some components has conflicted and required arguments, rule addressing this behavior.
+
+This rule warns about `unknown`, `required` and `conflicted` arguments for `LinkTo`, `Input`, `Textarea` components.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<LinkTo @unsupportedArgument="foo"> some link with unknown argument</LinkTo>
+<LinkTo @route="info" @model="a" @models="b"> info </LinkTo>
+<LinkTo @models="b"> info </LinkTo>
+```
+
+```hbs
+<Input @foo="bar" />
+```
+
+```hbs
+<Textarea @foo="bar" />
+```
+
+This rule **allows** the following:
+
+```hbs
+<LinkTo @route="readme"> readme </LinkTo>
+```
+
+```hbs
+<Input @value="someValue" />
+```
+
+```hbs
+<Textarea @value="someValue" />
+```
+
+## Migration
+
+* Check references section to get allowed arguments list.
+* If argument represents html attribute, remove `@` from name.
+
+## Related Rules
+
+* [no-link-to-tagname](no-link-to-tagname.md)
+* [no-input-tagname](no-input-tagname.md)
+* [builtin-component-arguments](builtin-component-arguments.md)
+
+## References
+
+* [Reduce API Surface of Built-In Components](https://github.com/emberjs/rfcs/blob/master/text/0707-modernize-built-in-components-2.md#summary)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -72,6 +72,7 @@ module.exports = {
   'no-triple-curlies': require('./no-triple-curlies'),
   'no-unbalanced-curlies': require('./no-unbalanced-curlies'),
   'no-unbound': require('./no-unbound'),
+  'no-unknown-arguments-for-builtin-components': require('./no-unknown-arguments-for-builtin-components'),
   'no-unnecessary-component-helper': require('./no-unnecessary-component-helper'),
   'no-unnecessary-concat': require('./no-unnecessary-concat'),
   'no-unused-block-params': require('./no-unused-block-params'),

--- a/lib/rules/no-unknown-arguments-for-builtin-components.js
+++ b/lib/rules/no-unknown-arguments-for-builtin-components.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const Fuse = require('fuse.js');
+
+const Rule = require('./base');
+
+// from https://github.com/emberjs/rfcs/blob/master/text/0707-modernize-built-in-components-2.md#summary
+const KnownArguments = {
+  LinkTo: {
+    arguments: [
+      'route',
+      'model',
+      'models',
+      'query',
+      'replace',
+      'disabled',
+      'current-when',
+      'activeClass',
+      'loadingClass',
+      'disabledClass',
+    ],
+    conflicts: [['model', 'models']],
+    required: ['route'],
+  },
+  Input: {
+    arguments: ['type', 'value', 'checked', 'insert-newline', 'enter', 'escape-press'],
+    conflicts: [['checked', 'value']],
+  },
+  Textarea: {
+    arguments: ['value', 'insert-newline', 'enter', 'escape-press'],
+  },
+};
+
+function ERROR_MESSAGE(tagName, argumentName) {
+  const candidates = KnownArguments[tagName].arguments;
+  const pureQuery = argumentName.replace('@', '');
+  let query = pureQuery;
+  let fuzzyResults = [];
+
+  while (!fuzzyResults.length && query.length) {
+    fuzzyResults = new Fuse(candidates).search(query);
+    query = query.slice(0, -1);
+  }
+
+  const msg = `"${argumentName}" is unknown argument for <${tagName} /> component.`;
+  if (fuzzyResults.length) {
+    return `${msg} Did you mean "@${fuzzyResults[0].item}"?`;
+  } else {
+    return msg;
+  }
+}
+
+function REQUIRED_MESSAGE(tagName, argumentNames) {
+  return `Argument${argumentNames.length > 1 ? 's' : ''} ${argumentNames
+    .map((el) => `"@${el}"`)
+    .join(' or ')} is required for <${tagName} /> component.`;
+}
+
+function CONFLICT_MESSAGE(argumentName, rawList) {
+  const conflictsList = rawList.filter((el) => `@${el}` !== argumentName);
+  return `"${argumentName}" conflicts with ${conflictsList
+    .map((el) => `"@${el}"`)
+    .join(', ')}, only one should exists.`;
+}
+
+function isArgument(attributeNode) {
+  return attributeNode.name.startsWith('@');
+}
+
+function pureName(attributeNode) {
+  return attributeNode.name.replace('@', '');
+}
+
+module.exports = class NoUnknownArgumentsForBuiltinComponents extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        let nodeMeta = KnownArguments[node.tag];
+        if (!nodeMeta) {
+          return;
+        }
+
+        let warns = [];
+        let seen = [];
+
+        const logError = (attr) => {
+          this.log({
+            message: ERROR_MESSAGE(node.tag, attr.name),
+            line: attr.loc && attr.loc.start.line,
+            column: attr.loc && attr.loc.start.column,
+            source: (this.sourceForNode(attr) || '').split('=')[0],
+          });
+        };
+
+        const logConflict = (attr, conflictList) => {
+          this.log({
+            message: CONFLICT_MESSAGE(attr.name, conflictList),
+            line: attr.loc && attr.loc.start.line,
+            column: attr.loc && attr.loc.start.column,
+            source: (this.sourceForNode(attr) || '').split('=')[0],
+          });
+        };
+
+        const logRequired = (variants) => {
+          this.log({
+            message: REQUIRED_MESSAGE(node.tag, variants),
+            line: node.loc && node.loc.start.line,
+            column: node.loc && node.loc.start.column + 1,
+            source: node.tag,
+          });
+        };
+
+        for (let argument of node.attributes) {
+          if (!isArgument(argument)) {
+            continue;
+          }
+          const argumentName = pureName(argument);
+          if (!nodeMeta.arguments.includes(argumentName)) {
+            warns.push(argument);
+          } else {
+            seen.push(argumentName);
+          }
+        }
+
+        for (let warn of warns) {
+          logError(warn);
+        }
+
+        if ('conflicts' in nodeMeta) {
+          for (let conflictList of nodeMeta.conflicts) {
+            if (conflictList.every((item) => seen.includes(item))) {
+              for (let argumentName of conflictList) {
+                const attr = node.attributes.find(({ name }) => `@${argumentName}` === name);
+                if (attr) {
+                  logConflict(attr, conflictList);
+                }
+              }
+            }
+          }
+        }
+
+        if ('required' in nodeMeta) {
+          for (let requiredItems of nodeMeta.required) {
+            let variants = Array.isArray(requiredItems) ? requiredItems : [requiredItems];
+
+            if (!variants.some((el) => seen.includes(el))) {
+              logRequired(variants);
+            }
+          }
+        }
+      },
+    };
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;
+module.exports.CONFLICT_MESSAGE = CONFLICT_MESSAGE;
+module.exports.REQUIRED_MESSAGE = REQUIRED_MESSAGE;

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "chalk": "^4.0.0",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",
+    "fuse.js": "^6.4.6",
     "get-stdin": "^8.0.0",
     "globby": "^11.0.2",
     "is-glob": "^4.0.1",

--- a/test/unit/rules/no-unknown-arguments-for-builtin-components-test.js
+++ b/test/unit/rules/no-unknown-arguments-for-builtin-components-test.js
@@ -1,0 +1,88 @@
+'use strict';
+
+const {
+  ERROR_MESSAGE,
+  REQUIRED_MESSAGE,
+  CONFLICT_MESSAGE,
+} = require('../../../lib/rules/no-unknown-arguments-for-builtin-components');
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'no-unknown-arguments-for-builtin-components',
+
+  config: true,
+
+  good: [
+    '<Input @value="foo" />',
+    '<Textarea @value="hello" />',
+    '<LinkTo @route="info" @model={{this.model}} />',
+  ],
+
+  bad: [
+    {
+      template: '<Input @valuee={{this.content}} />',
+      result: {
+        message: ERROR_MESSAGE('Input', '@valuee'),
+        line: 1,
+        column: 7,
+        source: '@valuee',
+      },
+    },
+    {
+      template: '<Textarea @valuee={{this.content}} />',
+      result: {
+        message: ERROR_MESSAGE('Textarea', '@valuee'),
+        line: 1,
+        column: 10,
+        source: '@valuee',
+      },
+    },
+    {
+      template: '<LinkTo @route="foo" @valuee={{this.content}} />',
+      result: {
+        message: ERROR_MESSAGE('LinkTo', '@valuee'),
+        line: 1,
+        column: 21,
+        source: '@valuee',
+      },
+    },
+
+    {
+      template: '<LinkTo @route="foo" @madel={{this.content}} />',
+      result: {
+        message: '"@madel" is unknown argument for <LinkTo /> component. Did you mean "@model"?',
+        line: 1,
+        column: 21,
+        source: '@madel',
+      },
+    },
+
+    {
+      template: '<LinkTo @model={{this.model}} />',
+      result: {
+        message: REQUIRED_MESSAGE('LinkTo', ['route']),
+        line: 1,
+        column: 1,
+        source: 'LinkTo',
+      },
+    },
+
+    {
+      template: '<LinkTo @route="info" @model={{this.model}} @models={{this.models}} />',
+      results: [
+        {
+          message: CONFLICT_MESSAGE('@model', ['model', 'models']),
+          line: 1,
+          column: 22,
+          source: '@model',
+        },
+        {
+          message: CONFLICT_MESSAGE('@models', ['model', 'models']),
+          line: 1,
+          column: 44,
+          source: '@models',
+        },
+      ],
+    },
+  ],
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2747,6 +2747,11 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
+fuse.js@^6.4.6:
+  version "6.4.6"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.4.6.tgz#62f216c110e5aa22486aff20be7896d19a059b79"
+  integrity sha512-/gYxR/0VpXmWSfZOIPS3rWwU8SHgsRTwWuXhyb2O6s7aRuVtHtxCkR33bNYu3wyLyNx/Wpv0vU7FZy8Vj53VNw==
+
 gensync@^1.0.0-beta.1:
   version "1.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"


### PR DESCRIPTION
MR resolves: https://github.com/ember-template-lint/ember-template-lint/issues/1730

Adding additional checks for builtin component arguments usages. 

Additions:

 `fuse.js` dependency added for fuzzy suggestions