### PR TITLE
Fixes issue where todos were deleted from a different engine

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -267,7 +267,10 @@ class Linter {
     let config = this._moduleStatusCache.getConfigForFile(options);
     let rules = new Set(Object.keys(config.rules).filter((ruleId) => config.rules[ruleId]));
 
-    return (todoDatum) => !isOverridingConfig && rules.has(todoDatum.ruleId);
+    return (todoDatum) =>
+      !isOverridingConfig &&
+      todoDatum.engine === 'ember-template-lint' &&
+      rules.has(todoDatum.ruleId);
   }
 
   async updateTodo(options, results, todoConfig, isOverridingConfig) {

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -161,7 +161,7 @@ describe('todo usage', () => {
       expect(todoStorageDirExists(project.baseDir)).toEqual(true);
     });
 
-    it.only('does not remove todos from another engine', async function () {
+    it('does not remove todos from another engine', async function () {
       project.setConfig({
         rules: {
           'no-bare-strings': true,


### PR DESCRIPTION
Fixes an issue reported in https://github.com/scalvert/eslint-formatter-todo/issues/80.

While this wouldn't directly plague this lib due to the extra file-based scoping we do here, it ensures that we're still applying the same scope filtering, and ensures this with a test.