### PR TITLE
"is-interactive-element" should match to <summary>, not <details>

### DIFF
--- a/lib/helpers/is-interactive-element.js
+++ b/lib/helpers/is-interactive-element.js
@@ -5,7 +5,7 @@ const ast = require('./ast-node-info');
 const INTERACTIVE_TAG_NAMES = new Set([
   'button',
   'canvas',
-  'details',
+  'summary',
   'embed',
   'iframe',
   'input',

--- a/test/unit/helpers/is-interactive-element-test.js
+++ b/test/unit/helpers/is-interactive-element-test.js
@@ -25,12 +25,18 @@ describe('isInteractiveElement', function () {
     });
   }
 
-  let nonInteractive = ['<a></a>', '<input type="hidden">', '<img>', '<div></div>'];
+  let nonInteractive = [
+    '<a></a>',
+    '<input type="hidden">',
+    '<img>',
+    '<div></div>',
+    '<details><summary>Hello</summary>World</details>',
+  ];
 
   let interactive = {
     '<a href="derp">Link</a>': 'an <a> element with the `href` attribute',
     '<button>Derp</button>': '<button>',
-    '<details></details>': '<details>',
+    '<summary></summary>': '<summary>',
     '<embed>': '<embed>',
     '<iframe></iframe>': '<iframe>',
     '<input>': '<input>',

--- a/test/unit/rules/no-nested-interactive-test.js
+++ b/test/unit/rules/no-nested-interactive-test.js
@@ -95,10 +95,10 @@ generateRuleTests({
       template: '<button><details><summary>Some details</summary><p>!</p></details></button>',
 
       result: {
-        message: 'Do not use <details> inside <button>',
-        source: '<details><summary>Some details</summary><p>!</p></details>',
+        message: 'Do not use <summary> inside <button>',
+        source: '<summary>Some details</summary>',
         line: 1,
-        column: 8,
+        column: 17,
       },
     },
     {


### PR DESCRIPTION
# Bug:

- When using the following pattern, the `is-interactive-element` marks the wrong element as interactive.

    ```hbs
    <details> {{!-- <details> is NOT reachable by keyboard --}}
       <summary> {{!-- <summary> is the focusable element --}}
        Foo
      </summary>
      Bar
    </details>
    ```

- I modified the `is-interactive-element` helper so that it skips the `<details>` tag and marks the `<summary>` tag as interactive.  I also had to modify the unit tests surrounding nested interactive elements.