### PR TITLE
Avoid linting `.html` files by default

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -44,7 +44,7 @@ async function buildLinterOptions(workingDir, filePath, filename = '', isReading
 }
 
 function executeGlobby(workingDir, pattern, ignore) {
-  let supportedExtensions = new Set(['.hbs', '.html', '.handlebars']);
+  let supportedExtensions = new Set(['.hbs', '.handlebars']);
 
   // `--no-ignore-pattern` results in `ignorePattern === [false]`
   let options =


### PR DESCRIPTION
In testing the new beta for v3 we discovered some issues with HTML parsing. Specifically, this issue related to doctype, and part of the original fix was done in https://github.com/ember-template-lint/ember-template-lint/pull/1720. 

During that PR, it was decided to attempt to fix the issue at source, which requires https://github.com/tildeio/simple-html-tokenizer/pull/71 and some additional changes in @glimmery/syntax. 

While those fixes above are in progress, we discussed disabling the HTML parsing. If the above PRs get shipped and merged in time for v3, we can re-enable this. If not, we'll roll it out in a follow up post-v3.