### PR TITLE
chore: fix require-has-block-helper readme linting error

### DIFF
--- a/docs/rule/require-has-block-helper.md
+++ b/docs/rule/require-has-block-helper.md
@@ -5,6 +5,7 @@ In Ember 3.26 the properties `hasBlock` and `hasBlockParams` were deprecated. Th
 This rule prevents the usage of `hasBlock` and `hasBlockParams` and suggests using `has-block` or `has-block-params` instead.
 
 For more information about this deprecation you can view the [RFC](https://github.com/emberjs/rfcs/blob/master/text/0689-deprecate-has-block.md) or its entry on the [Deprecations page](https://deprecations.emberjs.com/v3.x/#toc_has-block-and-has-block-params).
+
 ## Examples
 
 This rule **forbids** the following:


### PR DESCRIPTION
```
$ markdownlint **/*.md
docs/rule/require-has-block-helper.md:8 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual:
0; Above] [Context: "## Examples"]
```