### PR TITLE
Added textarea element support to require-input-label rule

### DIFF
--- a/lib/rules/require-input-label.js
+++ b/lib/rules/require-input-label.js
@@ -25,7 +25,9 @@ module.exports = class RequireInputLabel extends Rule {
       ElementNode(node, path) {
         // Only input elements: check rule conditions
         if (node.tag !== 'input' && node.tag !== 'Input') {
-          return;
+          if (node.tag !== 'textarea') {
+            return;
+          }
         }
 
         if (AstNodeInfo.hasAttribute(node, '...attributes')) {

--- a/lib/rules/require-input-label.js
+++ b/lib/rules/require-input-label.js
@@ -24,10 +24,8 @@ module.exports = class RequireInputLabel extends Rule {
     return {
       ElementNode(node, path) {
         // Only input elements: check rule conditions
-        if (node.tag !== 'input' && node.tag !== 'Input') {
-          if (node.tag !== 'textarea') {
-            return;
-          }
+        if (node.tag !== 'input' && node.tag !== 'Input' && node.tag !== 'textarea') {
+          return;
         }
 
         if (AstNodeInfo.hasAttribute(node, '...attributes')) {

--- a/test/unit/rules/require-input-label-test.js
+++ b/test/unit/rules/require-input-label-test.js
@@ -28,6 +28,9 @@ generateRuleTests({
     '<label>Text here<Input /></label>',
     '<label>Text here {{input}}</label>',
     '<input id="label-input" ...attributes>',
+    '<textarea id="foo" />',
+    '<label for="textarea">Textarea Label</label><textarea id="textarea" />',
+    '<label>Textarea <textarea /></label>',
 
     // Hidden inputs are allowed.
     '<input type="hidden"/>',
@@ -169,6 +172,15 @@ generateRuleTests({
         line: 1,
         column: 0,
         source: '<Input type={{myType}}/>',
+      },
+    },
+    {
+      template: '<textarea />',
+      result: {
+        message: ERROR_MESSAGE,
+        line: 1,
+        column: 0,
+        source: '<textarea />',
       },
     },
   ],


### PR DESCRIPTION
If merged, this PR should resolve issue #1761 by adding support for the `<textarea />` element to the `require-input-label` rule. 

- added good and bad tests
- added check for `<textarea />` element