### PR TITLE
Add ability to pass `node` to `this.log`

### DIFF
--- a/lib/rules/base.js
+++ b/lib/rules/base.js
@@ -529,6 +529,16 @@ module.exports = class Base {
     if (this[MODULE_NAME]) {
       defaults.moduleId = this[MODULE_NAME];
     }
+    if (result.node) {
+      let rawResult = { ...result };
+      let inferredResults = {
+        line: rawResult.node.loc && rawResult.node.loc.start.line,
+        column: rawResult.node.loc && rawResult.node.loc.start.column,
+        source: this.sourceForNode(rawResult.node),
+      };
+      delete result.node;
+      result = Object.assign(result, inferredResults);
+    }
     let reportedResult = Object.assign({}, defaults, result);
 
     this.results.push(reportedResult);

--- a/test/acceptance/rule-test.js
+++ b/test/acceptance/rule-test.js
@@ -204,4 +204,82 @@ describe('rule public api', function () {
       ],
     });
   });
+
+  describe('log results', function () {
+    generateRuleTests({
+      plugins: [
+        {
+          name: 'log-test',
+          rules: {
+            'log-result': class extends Rule {
+              visitor() {
+                return {
+                  ElementNode(node) {
+                    if (node.tag === 'MySpecialThingExplicit') {
+                      this.log({
+                        message: 'Do not use MySpecialThingExplicit',
+                        line: node.loc && node.loc.start.line,
+                        column: node.loc && node.loc.start.column,
+                        source: this.sourceForNode(node),
+                      });
+                    }
+
+                    if (node.tag === 'MySpecialThingInferred') {
+                      this.log({
+                        message: 'Do not use MySpecialThingInferred',
+                        node,
+                      });
+                    }
+
+                    if (node.tag === 'MySpecialThingInferredClobbersExplicit') {
+                      this.log({
+                        message: 'Unclobbered error message',
+                        node,
+                        line: 50,
+                        column: 50,
+                        source: '<NotMySpecialThingInferredClobbersExplicit/>',
+                      });
+                    }
+                  },
+                };
+              }
+            },
+          },
+        },
+      ],
+
+      name: 'log-result',
+      config: true,
+
+      bad: [
+        {
+          template: '<MySpecialThingExplicit/>',
+          result: {
+            column: 0,
+            line: 1,
+            message: 'Do not use MySpecialThingExplicit',
+            source: '<MySpecialThingExplicit/>',
+          },
+        },
+        {
+          template: '<MySpecialThingInferred/>',
+          result: {
+            column: 0,
+            line: 1,
+            message: 'Do not use MySpecialThingInferred',
+            source: '<MySpecialThingInferred/>',
+          },
+        },
+        {
+          template: '<MySpecialThingInferredClobbersExplicit/>',
+          result: {
+            column: 0,
+            line: 1,
+            message: 'Unclobbered error message',
+            source: '<MySpecialThingInferredClobbersExplicit/>',
+          },
+        },
+      ],
+    });
+  });
 });


### PR DESCRIPTION
@MelSumner @rwjblue 

Motivation: #1766 

If merged, this PR would allow a base-extending rule to pass the current `node` as part of the `results` object sent to the logger via `this.log(results)`.  The current behavior is for the logger to append the received `results`, as is, to the reported results. The new behavior is that if the `node` is passed directly, then it will be used to infer and set the values for `source`, `line`, and `column` of the result. In the event that `node` is passed **in addition to** any of these values, the value(s) inferred from `node` will be used. Other (collision-free) items passed directly in `results` -- e.g., `message`, `isFixable`, `fixedTemplate` -- would pass through to the reported results unaffected.  The rationale here is that we wouldn't have to immediately break or migrate existing rulesets.