### PR TITLE
Add max-warnings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,12 @@ Ignore warnings / only report errors
 ember-template-lint "app/templates/application.hbs" --quiet
 ```
 
+Number of warnings to trigger nonzero exit code
+
+```bash
+ember-template-lint "app/templates/application.hbs" --max-warnings=2
+```
+
 Define custom config path
 
 ```bash

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -169,6 +169,10 @@ function parseArgv(_argv) {
         describe: 'Prevent inline configuration comments from changing config or rules',
         boolean: true,
       },
+      'max-warnings': {
+        describe: 'Number of warnings to trigger nonzero exit code',
+        type: 'number',
+      },
     })
     .help()
     .version();
@@ -273,7 +277,11 @@ async function run() {
   }
 
   let results = processResults(resultsAccumulator);
-  if (results.errorCount > 0) {
+
+  if (
+    results.errorCount > 0 ||
+    (!options.quiet && options.maxWarnings && results.warningCount > options.maxWarnings)
+  ) {
     process.exitCode = 1;
   }
 

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -64,6 +64,8 @@ describe('ember-template-lint executable', function () {
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
             --no-inline-config          Prevent inline configuration comments from
                                         changing config or rules                 [boolean]
+            --max-warnings              Number of warnings to trigger nonzero exit code
+                                                                                  [number]
             --help                      Show help                                [boolean]
             --version                   Show version number                      [boolean]"
         `);
@@ -107,6 +109,8 @@ describe('ember-template-lint executable', function () {
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
             --no-inline-config          Prevent inline configuration comments from
                                         changing config or rules                 [boolean]
+            --max-warnings              Number of warnings to trigger nonzero exit code
+                                                                                  [number]
             --help                      Show help                                [boolean]
             --version                   Show version number                      [boolean]"
         `);
@@ -381,6 +385,8 @@ describe('ember-template-lint executable', function () {
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
             --no-inline-config          Prevent inline configuration comments from
                                         changing config or rules                 [boolean]
+            --max-warnings              Number of warnings to trigger nonzero exit code
+                                                                                  [number]
             --help                      Show help                                [boolean]
             --version                   Show version number                      [boolean]"
         `);
@@ -1315,6 +1321,105 @@ describe('ember-template-lint executable', function () {
 
         expect(JSON.parse(result.stdout)).toEqual(expectedOutputData);
         expect(result.stderr).toBeFalsy();
+      });
+    });
+
+    describe('with --max-warnings param', function () {
+      it('should exit with error if warning count is greater than max-warnings', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': 'warn',
+            'no-html-comments': 'warn',
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs':
+                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+            },
+          },
+        });
+
+        let result = await run(['.', '--max-warnings=2']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stderr).toBeFalsy();
+      });
+
+      it('should exit without error if warning count is less or equal to max-warnings', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': 'warn',
+            'no-html-comments': 'warn',
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs':
+                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+            },
+          },
+        });
+
+        let result = await run(['.', '--max-warnings=3']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stderr).toBeFalsy();
+        expect(result.stdout.split('\n')).toEqual([
+          'app/templates/application.hbs',
+          '  1:4  warning  Non-translated string used  no-bare-strings',
+          '  1:24  warning  Non-translated string used  no-bare-strings',
+          '  1:53  warning  HTML comment detected  no-html-comments',
+          '',
+          '✖ 3 problems (0 errors, 3 warnings)',
+        ]);
+      });
+
+      it('should exit with error if error count is greater than zero regardless of max-warnings', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': 'warn',
+            'no-html-comments': 'error',
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs':
+                '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+            },
+          },
+        });
+
+        let result = await run(['.', '--max-warnings=1000']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stderr).toMatchInlineSnapshot('""');
+      });
+    });
+
+    describe('with --max-warnings and --quiet param', function () {
+      it('should exit without error if warning count is more than max-warnings', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': 'warn',
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<h2>Here too!!</h2><div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        let result = await run(['.', '--max-warnings=1', '--quiet']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toMatchInlineSnapshot('""');
+        expect(result.stderr).toMatchInlineSnapshot('""');
       });
     });
   });


### PR DESCRIPTION
Adds `--max-warning` option, similar to [eslint](https://eslint.org/docs/2.0.0/user-guide/command-line-interface#-max-warnings) and [sass-lint](https://github.com/sasstools/sass-lint/tree/master/docs/cli).

TODO

- [x] Update README
