### PR TITLE
Adding no-link-to-positional-params

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Each rule has emojis denoting:
 | :white_check_mark:         | [no-invalid-link-title](./docs/rule/no-invalid-link-title.md)                                             |
 | :white_check_mark:         | [no-invalid-meta](./docs/rule/no-invalid-meta.md)                                                         |
 | :white_check_mark:         | [no-invalid-role](./docs/rule/no-invalid-role.md)                                                         |
-|                            | [no-link-to-positional-params](./docs/rule/no-link-to-positional-params.md)                               |
+| :white_check_mark:         | [no-link-to-positional-params](./docs/rule/no-link-to-positional-params.md)                               |
 |                            | [no-link-to-tagname](./docs/rule/no-link-to-tagname.md)                                                   |
 | :white_check_mark:         | [no-log](./docs/rule/no-log.md)                                                                           |
 | :wrench:                   | [no-model-argument-in-route-templates](./docs/rule/no-model-argument-in-route-templates.md)               |

--- a/docs/rule/no-link-to-positional-params.md
+++ b/docs/rule/no-link-to-positional-params.md
@@ -1,5 +1,7 @@
 # no-link-to-positional-params
 
+:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
+
 Disallows passing positional parameters into link-to in favor of named arguments.
 
 ## Examples

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -37,6 +37,7 @@ module.exports = {
     'no-invalid-link-title': 'error',
     'no-invalid-meta': 'error',
     'no-invalid-role': 'error',
+    'no-link-to-positional-params': 'error',
     'no-log': 'error',
     'no-negated-condition': 'error',
     'no-nested-interactive': 'error',


### PR DESCRIPTION
Adds `no-link-to-positional-params` to `recommended` config. 