### PR TITLE
BREAKING CHANGE: default link-rel-noopener config to `strict`

### DIFF
--- a/docs/rule/link-rel-noopener.md
+++ b/docs/rule/link-rel-noopener.md
@@ -32,8 +32,9 @@ This rule **allows** the following:
 
 The following values are valid configuration:
 
-* string -- `strict` for enabled and validating both noopener `and` noreferrer
-* boolean `true` to maintain backwards compatibility with previous versions of `ember-template-lint` that validate noopener `or` noreferrer
+* string - `strict` (default) for enabled and validating both noopener `and` noreferrer
+* string - `loose` for enabled and validating either noopener `or` noreferrer
+* boolean - `true` uses `strict` mode
 
 If you are supporting Firefox, you should use `strict`.
 

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -7,7 +7,7 @@ module.exports = {
     'deprecated-inline-view-helper': 'error',
     'deprecated-render-helper': 'error',
     'link-href-attributes': 'error',
-    'link-rel-noopener': ['error', 'strict'],
+    'link-rel-noopener': 'error',
     'no-abstract-roles': 'error',
     'no-accesskey-attribute': 'error',
     'no-action': 'error',

--- a/lib/rules/link-rel-noopener.js
+++ b/lib/rules/link-rel-noopener.js
@@ -22,10 +22,9 @@ const Rule = require('./base');
  ```
  */
 
-const DEFAULT_CONFIG = {
+const LOOSE_CONFIG = {
   regexp: /no(opener|referrer)/,
   message: 'links with target="_blank" must have rel="noopener"',
-  configType: 'default',
 };
 
 const STRICT_CONFIG = {
@@ -41,10 +40,13 @@ module.exports = class LinkRelNoopener extends Rule {
 
     switch (configType) {
       case 'boolean':
-        return config ? DEFAULT_CONFIG : false;
+        return config ? STRICT_CONFIG : false;
       case 'string':
         if (config === 'strict') {
           return STRICT_CONFIG;
+        }
+        if (config === 'loose') {
+          return LOOSE_CONFIG;
         }
         break;
       case 'undefined':
@@ -54,7 +56,8 @@ module.exports = class LinkRelNoopener extends Rule {
     let errorMessage = createErrorMessage(
       this.ruleName,
       [
-        '  * boolean - `true` to enable / `false` to disable',
+        '  * boolean - `true` to enable (strict mode) / `false` to disable',
+        '  * string -- `loose` to enable validation for either noopener OR noreferrer',
         '  * string -- `strict` to enable validation for both noopener AND noreferrer',
       ],
       config
@@ -115,7 +118,7 @@ function fix(node, config) {
   // the order the rule suggests in the error message
   let newRelValue = oldRelValue.replace(/(noopener|noreferrer)/g, '');
   newRelValue = `${newRelValue} ${
-    config.configType === 'default' ? 'noopener' : 'noopener noreferrer'
+    config.configType === 'strict' ? 'noopener noreferrer' : 'noopener'
   }`;
 
   let oldRelIndex = oldRel ? node.attributes.indexOf(oldRel) : null;

--- a/test/unit/rules/link-rel-noopener-test.js
+++ b/test/unit/rules/link-rel-noopener-test.js
@@ -8,46 +8,43 @@ generateRuleTests({
   config: true,
 
   good: [
-    '<a href="/some/where"></a>',
-    '<a href="/some/where" target="_self"></a>',
-    '<a href="/some/where" target="_blank" rel="noopener"></a>',
-    '<a href="/some/where" target="_blank" rel="noopener noreferrer"></a>',
-    '<a href="/some/where" target="_blank" rel="noreferrer noopener"></a>',
-    '<a href="/some/where" target="_blank" rel="nofollow noreferrer noopener"></a>',
-    '<a href="/some/where" target="_blank" rel="noreferrer"></a>',
     {
-      config: 'strict',
-      template: '<a href="/some/where/ingrid" target="_blank" rel="noopener noreferrer"></a>,',
+      config: 'loose',
+      template: '<a href="/some/where"></a>',
     },
     {
-      config: 'strict',
-      template:
-        '<a href="/some/where/ingrid" target="_blank" rel="nofollow noopener noreferrer"></a>,',
+      config: 'loose',
+      template: '<a href="/some/where" target="_self"></a>',
     },
     {
-      config: 'strict',
-      template:
-        '<a href="/some/where/ingrid" target="_blank" rel="noopener nofollow noreferrer"></a>,',
+      config: 'loose',
+      template: '<a href="/some/where" target="_blank" rel="noopener"></a>',
     },
     {
-      config: 'strict',
-      template:
-        '<a href="/some/where/ingrid" target="_blank" rel="noopener noreferrer nofollow"></a>,',
+      config: 'loose',
+      template: '<a href="/some/where" target="_blank" rel="noopener noreferrer"></a>',
     },
     {
-      config: 'strict',
-      template: '<a href="/some/where/ingrid" target="_blank" rel="noreferrer noopener"></a>,',
+      config: 'loose',
+      template: '<a href="/some/where" target="_blank" rel="noreferrer noopener"></a>',
     },
     {
-      config: 'strict',
-      template:
-        '<a href="/some/where/ingrid" target="_blank" rel="nofollow noreferrer noopener"></a>,',
+      config: 'loose',
+      template: '<a href="/some/where" target="_blank" rel="nofollow noreferrer noopener"></a>',
     },
     {
-      config: 'strict',
-      template:
-        '<a href="/some/where/ingrid" target="_blank" rel="noreferrer nofollow noopener"></a>,',
+      config: 'loose',
+      template: '<a href="/some/where" target="_blank" rel="noreferrer"></a>',
     },
+    '<a href="/some/where/ingrid" target="_blank" rel="noopener noreferrer"></a>,',
+    '<a href="/some/where/ingrid" target="_blank" rel="nofollow noopener noreferrer"></a>,',
+    '<a href="/some/where/ingrid" target="_blank" rel="noopener nofollow noreferrer"></a>,',
+    '<a href="/some/where/ingrid" target="_blank" rel="noopener noreferrer nofollow"></a>,',
+    '<a href="/some/where/ingrid" target="_blank" rel="noreferrer noopener"></a>,',
+    '<a href="/some/where/ingrid" target="_blank" rel="nofollow noreferrer noopener"></a>,',
+    '<a href="/some/where/ingrid" target="_blank" rel="noreferrer nofollow noopener"></a>,',
+    '<a href="/some/where/ingrid" target="_blank" rel="noreferrer noopener nofollow"></a>,',
+    // `config: strict` should act the same as default (`config: true`)
     {
       config: 'strict',
       template:
@@ -57,6 +54,7 @@ generateRuleTests({
 
   bad: [
     {
+      config: 'loose',
       template: '<a href="/some/where" target="_blank"></a>',
       fixedTemplate: '<a href="/some/where" target="_blank" rel="noopener"></a>',
 
@@ -69,6 +67,7 @@ generateRuleTests({
       },
     },
     {
+      config: 'loose',
       template: '<a href="/some/where" target="_blank" rel="nofollow"></a>',
       fixedTemplate: '<a href="/some/where" target="_blank" rel="nofollow noopener"></a>',
 
@@ -81,7 +80,6 @@ generateRuleTests({
       },
     },
     {
-      config: 'strict',
       template: '<a href="/some/where" target="_blank" rel="noopener"></a>',
       fixedTemplate: '<a href="/some/where" target="_blank" rel="noopener noreferrer"></a>',
 
@@ -95,7 +93,6 @@ generateRuleTests({
       },
     },
     {
-      config: 'strict',
       template: '<a href="/some/where" target="_blank" rel="noreferrer"></a>',
       fixedTemplate: '<a href="/some/where" target="_blank" rel="noopener noreferrer"></a>',
 
@@ -108,6 +105,21 @@ generateRuleTests({
         column: 0,
       },
     },
+    {
+      template: '<a href="/some/where" target="_blank" rel="nofollow"></a>',
+      fixedTemplate:
+        '<a href="/some/where" target="_blank" rel="nofollow noopener noreferrer"></a>',
+
+      result: {
+        isFixable: true,
+        message:
+          'links with target="_blank" must have rel="noopener noreferrer" or rel="noreferrer noopener"',
+        source: '<a href="/some/where" target="_blank" rel="nofollow"></a>',
+        line: 1,
+        column: 0,
+      },
+    },
+    // `config: strict` should act the same as default (`config: true`) for fixer
     {
       config: 'strict',
       template: '<a href="/some/where" target="_blank" rel="nofollow"></a>',


### PR DESCRIPTION
### What

- add `loose` string config option (previous default behavior of noopener OR noreferrer)
- invert default config to use `strict` option (noopener AND noreferrer)

### Why

- I saw [discussion in the 3.0 milestone](https://github.com/ember-template-lint/ember-template-lint/issues/1315#issuecomment-786932862), and it seemed like a pretty quick fix.
- completes #1792 