### PR TITLE
Ensure `no-unknown-arguments-for-builtin-components` allows `@query` only `<LinkTo>`'s

### DIFF
--- a/lib/rules/no-unknown-arguments-for-builtin-components.js
+++ b/lib/rules/no-unknown-arguments-for-builtin-components.js
@@ -20,7 +20,7 @@ const KnownArguments = {
       'disabledClass',
     ],
     conflicts: [['model', 'models']],
-    required: ['route'],
+    required: [['route', 'query']],
   },
   Input: {
     arguments: ['type', 'value', 'checked', 'insert-newline', 'enter', 'escape-press'],

--- a/test/unit/rules/no-unknown-arguments-for-builtin-components-test.js
+++ b/test/unit/rules/no-unknown-arguments-for-builtin-components-test.js
@@ -16,6 +16,8 @@ generateRuleTests({
     '<Input @value="foo" />',
     '<Textarea @value="hello" />',
     '<LinkTo @route="info" @model={{this.model}} />',
+    '<LinkTo @route="info" />',
+    '<LinkTo @query={{hash foo=bar}} />',
   ],
 
   bad: [
@@ -60,7 +62,7 @@ generateRuleTests({
     {
       template: '<LinkTo @model={{this.model}} />',
       result: {
-        message: REQUIRED_MESSAGE('LinkTo', ['route']),
+        message: REQUIRED_MESSAGE('LinkTo', ['route', 'query']),
         line: 1,
         column: 1,
         source: 'LinkTo',


### PR DESCRIPTION
resolves https://github.com/ember-template-lint/ember-template-lint/issues/1802