### PR TITLE
Ensure `no-bare-strings` check's `placeholder` attribute for `<Input />` and `<Textarea />`

### DIFF
--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -35,6 +35,8 @@ const GLOBAL_ATTRIBUTES = [
 
 const TAG_ATTRIBUTES = {
   input: ['placeholder'],
+  Input: ['placeholder'],
+  Textarea: ['placeholder'],
   img: ['alt'],
 };
 

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -35,8 +35,8 @@ const GLOBAL_ATTRIBUTES = [
 
 const TAG_ATTRIBUTES = {
   input: ['placeholder'],
-  Input: ['placeholder'],
-  Textarea: ['placeholder'],
+  Input: ['placeholder', '@placeholder'],
+  Textarea: ['placeholder', '@placeholder'],
   img: ['alt'],
 };
 
@@ -233,7 +233,9 @@ module.exports = class NoBareStrings extends Rule {
     let tag = this._currentElementNode.tag;
     let attributeType = attribute.name;
     let attributeValueNode = attribute.value;
-    let additionalDescription = ` in \`${attributeType}\` attribute`;
+    let additionalDescription = ` in \`${attributeType}\` ${
+      attributeType.charAt(0) === '@' ? 'argument' : 'attribute'
+    }`;
     let isGlobalAttribute = this.config.globalAttributes.includes(attributeType);
     let isElementAttribute =
       this.config.elementAttributes[tag] &&

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -208,6 +208,28 @@ generateRuleTests({
     },
 
     {
+      template: '<Input @placeholder="{{foo}}hahaha trolol" />',
+
+      result: {
+        message: 'Non-translated string used in `@placeholder` argument',
+        line: 1,
+        column: 7,
+        source: 'hahaha trolol',
+      },
+    },
+
+    {
+      template: '<Textarea @placeholder="{{foo}}hahaha trolol" />',
+
+      result: {
+        message: 'Non-translated string used in `@placeholder` argument',
+        line: 1,
+        column: 10,
+        source: 'hahaha trolol',
+      },
+    },
+
+    {
       template: '<div role="contentinfo" aria-label="Contact, Policies and Legal"></div>',
 
       result: {

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -186,6 +186,28 @@ generateRuleTests({
     },
 
     {
+      template: '<Input placeholder="{{foo}}hahaha trolol" />',
+
+      result: {
+        message: 'Non-translated string used in `placeholder` attribute',
+        line: 1,
+        column: 7,
+        source: 'hahaha trolol',
+      },
+    },
+
+    {
+      template: '<Textarea placeholder="{{foo}}hahaha trolol" />',
+
+      result: {
+        message: 'Non-translated string used in `placeholder` attribute',
+        line: 1,
+        column: 10,
+        source: 'hahaha trolol',
+      },
+    },
+
+    {
       template: '<div role="contentinfo" aria-label="Contact, Policies and Legal"></div>',
 
       result: {


### PR DESCRIPTION
resolves https://github.com/ember-template-lint/ember-template-lint/issues/1800