### PR TITLE
Remove `deprecated-each-syntax` from `recommended` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Each rule has emojis denoting:
 |                            | [attribute-indentation](./docs/rule/attribute-indentation.md)                                             |
 | :nail_care:                | [block-indentation](./docs/rule/block-indentation.md)                                                     |
 | :white_check_mark:         | [builtin-component-arguments](./docs/rule/builtin-component-arguments.md)                                 |
-| :white_check_mark:         | [deprecated-each-syntax](./docs/rule/deprecated-each-syntax.md)                                           |
+|                            | [deprecated-each-syntax](./docs/rule/deprecated-each-syntax.md)                                           |
 | :white_check_mark:         | [deprecated-inline-view-helper](./docs/rule/deprecated-inline-view-helper.md)                             |
 | :white_check_mark:         | [deprecated-render-helper](./docs/rule/deprecated-render-helper.md)                                       |
 | :nail_care:                | [eol-last](./docs/rule/eol-last.md)                                                                       |

--- a/docs/rule/deprecated-each-syntax.md
+++ b/docs/rule/deprecated-each-syntax.md
@@ -1,7 +1,5 @@
 # deprecated-each-syntax
 
-:white_check_mark: The `extends: 'recommended'` property in a configuration file enables this rule.
-
 In Ember 2.0, support for using the `in` form of the `{{#each}}` helper
 has been removed.
 

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -3,7 +3,6 @@
 module.exports = {
   rules: {
     'builtin-component-arguments': 'error',
-    'deprecated-each-syntax': 'error',
     'deprecated-inline-view-helper': 'error',
     'deprecated-render-helper': 'error',
     'link-href-attributes': 'error',


### PR DESCRIPTION
This rule was written to help folks migrate away from these older `{{#each` syntaxes in the 1.x era. The assumption here is that if you have `{{#each something}}` that you are relying on "context shifting", but that is simply not the case. For example, you may use a `repeat` helper like:

```hbs
{{#each (repeat 3)}}
 do this three times
{{/each}}
```

In that case, you may not _need_ the block param (which would make this not trigger the rule, but would also trigger the "no-unused-block-params" rule).

This rule should be deprecated itself, and slated for removal in ember-template-lint@4.

Closes #185 (again)
