### PR TITLE
docs: for disabling todos decay days

### DIFF
--- a/docs/todos.md
+++ b/docs/todos.md
@@ -91,6 +91,18 @@ ember-template-lint . --update-todo --todo-days-to-warn=2
 
 ...the todos will be created with a `warn` date 2 days from the created date, and an `error` date 10 days from the created date.
 
+### Disabling Due Dates
+
+If you don't want to use the due dates feature, keeping your todos indefinitely, you can disable them by adding the following config to your `package.json`:
+
+```json
+{
+  "lintTodo": {
+    "daysToDecay": null
+  }
+}
+```
+
 ### Due Date Workflows
 
 Converting errors to todos with `warn` and `error` dates that transition the todo to `warn` after 10 days and `error` after 20 days:


### PR DESCRIPTION
This PR adds a new section to the Markdown docs for `todos`, explaining how to turn off the `daysToDecay` feature when desired.

This PR fixes https://github.com/ember-template-lint/ember-template-lint/issues/1811.

AFAICT disabling `daysToDecay` is not currently possible via environment variables or CLI flags. I tried a few combos of `null | undefined | false` for the `--todo-days-to-warn | --todo-days-to-error` flags, to no avail. I'm happy to update this PR if that's possible though, and I was missing the mark.