### PR TITLE
Prevent `no-duplicate-landmark-elements` false positive for non-landmark roles

### DIFF
--- a/lib/rules/no-duplicate-landmark-elements.js
+++ b/lib/rules/no-duplicate-landmark-elements.js
@@ -8,6 +8,17 @@ const ERROR_MESSAGE =
   'If multiple landmark elements (or elements with an equivalent role) of the same type are found on a page, they must each have a unique label.';
 
 // from https://www.w3.org/WAI/PF/aria/roles#landmark_roles
+const LANDMARK_ROLES = new Set([
+  'banner',
+  'complementary',
+  'contentinfo',
+  'form',
+  'main',
+  'navigation',
+  'region',
+  'search',
+]);
+
 const DEFAULT_ROLE_FOR_ELEMENT = new Map([
   ['header', 'banner'],
   ['main', 'main'],
@@ -41,6 +52,11 @@ module.exports = class NoDuplicateLandmarkElements extends Rule {
         const role = roleAttribute
           ? roleAttribute.value.chars
           : DEFAULT_ROLE_FOR_ELEMENT.get(node.tag);
+
+        const isLandmarkRole = LANDMARK_ROLES.has(role);
+        if (!isLandmarkRole) {
+          return;
+        }
 
         // check for accessible label via aria-label or aria-labelledby
         const labelAttribute =

--- a/test/unit/rules/no-duplicate-landmark-elements-test.js
+++ b/test/unit/rules/no-duplicate-landmark-elements-test.js
@@ -18,6 +18,7 @@ generateRuleTests({
     '<form role="search"></form><form></form>',
     '<header></header><main></main><footer></footer>',
     '<nav aria-label="primary navigation"></nav><nav aria-label={{this.something}}></nav>',
+    '<img role="none"><img role="none">',
   ],
 
   bad: [


### PR DESCRIPTION
Fix https://github.com/ember-template-lint/ember-template-lint/issues/1819
