### PR TITLE
Emit full path when emitting output on CI.

### DIFF
--- a/lib/formatters/default.js
+++ b/lib/formatters/default.js
@@ -17,6 +17,7 @@ class DefaultPrinter {
       quiet: options.quiet,
       updateTodo: options.updateTodo,
       verbose: options.verbose,
+      workingDir: options.workingDir,
     };
 
     // TODO: make format json work

--- a/lib/formatters/pretty.js
+++ b/lib/formatters/pretty.js
@@ -1,4 +1,7 @@
+const path = require('path');
+
 const chalk = require('chalk');
+const ciInfo = require('ci-info');
 
 const Linter = require('../linter');
 
@@ -99,7 +102,10 @@ class PrettyPrinter {
       .map((error) => PrettyPrinter._formatError(error, options))
       .join('\n');
 
-    return `${chalk.underline(filePath)}\n${errorsMessages}\n`;
+    let displayFilePath =
+      ciInfo.isCI && options.workingDir ? path.join(options.workingDir, filePath) : filePath;
+
+    return `${chalk.underline(displayFilePath)}\n${errorsMessages}\n`;
   }
 
   static _formatError(error, options = {}) {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@ember-template-lint/todo-utils": "^8.0.0-beta.3",
     "chalk": "^4.0.0",
+    "ci-info": "^3.1.1",
     "ember-template-recast": "^5.0.1",
     "find-up": "^5.0.0",
     "fuse.js": "^6.4.6",


### PR DESCRIPTION
When running in CI environments, it is helpful to emit the full path to the file on disk (instead of the path relative to the specified working directory). For example, in GitHub Actions CI there are a number of matchers (RegExp's on standard out) that they use to add annotations to files.

Prior to this change, those annotations worked properly for applications that were located in the repo root path but failed to properly identify a file when the the application was not in the repo root. Specifically, when linting in a monorepo format (basically when the project's `package.json` is not also the location of `.git`) the annotations would not work properly.

This changes the output to always use the full path in CI conditions.  This should not regress users (seeing the relative path _looks_ better) since they don't often run in CI environments.
