### PR TITLE
Add `--config` example to README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Specify a config object to use instead of what exists locally
 ember-template-lint --config '{ "rules": { "no-implicit-this": { "severity": 2, "config": true } } }' test/fixtures/no-implicit-this-allow-with-regexp/app/templates
 ```
 
-Specify a config file to run a certain set of rules
+Specify a configuration to override the normally loaded config file:
 
 ```bash
 ember-template-lint . --config='{"extends": "a11y"}'

--- a/README.md
+++ b/README.md
@@ -146,6 +146,12 @@ Specify a config object to use instead of what exists locally
 ember-template-lint --config '{ "rules": { "no-implicit-this": { "severity": 2, "config": true } } }' test/fixtures/no-implicit-this-allow-with-regexp/app/templates
 ```
 
+Specify a config file to run a certain set of rules
+
+```bash
+ember-template-lint . --config='{"extends": "a11y"}'
+```
+
 Provide a custom formatter from a relative path
 
 ```bash


### PR DESCRIPTION
Updates the README to show users how to run a specific config file.