### PR TITLE
Make sure newly generated rules don't trigger lint errors

### DIFF
--- a/dev/templates/test.ejs
+++ b/dev/templates/test.ejs
@@ -1,7 +1,7 @@
 'use strict';
 
-const generateRuleTests = require('../../helpers/rule-test-harness');
 const { ERROR_MESSAGE } = require('../../../lib/rules/<%- ruleId %>');
+const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
   name: '<%- ruleId %>',


### PR DESCRIPTION
ESLint complains about the order of the imports.