### PR TITLE
Only catch exact matches of title and link text in `no-invalid-link-title` rule

### DIFF
--- a/lib/rules/no-invalid-link-title.js
+++ b/lib/rules/no-invalid-link-title.js
@@ -13,7 +13,7 @@ function hasInvalidLinkTitle(node, titleAttributeValues) {
 
   // Check to see if the text content is the same as the title attribute value
   const hasMatchingLinkAndTitleText = linkTexts.some((linkText) =>
-    titleAttributeValues.some((titleValue) => titleValue.includes(linkText))
+    titleAttributeValues.includes(linkText)
   );
 
   return hasMatchingLinkAndTitleText;

--- a/test/unit/rules/no-invalid-link-title-test.js
+++ b/test/unit/rules/no-invalid-link-title-test.js
@@ -14,6 +14,7 @@ generateRuleTests({
     '<LinkTo>{{foo}} more</LinkTo>',
     '<LinkTo @title="nice title">Something else</LinkTo>',
     '<LinkTo title="great titles!">Whatever, don\'t judge me</LinkTo>',
+    '<LinkTo title="Download the video">Download</LinkTo>',
     '<a href="https://myurl.com" title="New to Ember? Read the full tutorial for the best experience">Read the Tutorial</a>',
     '<a href="./whatever" title={{foo}}>Hello!</a>',
     '{{#link-to "blah.route.here" title="awesome title"}}Some thing else here{{/link-to}}',


### PR DESCRIPTION
Fixes #1848.

It seems like the original rule intent was to catch exact matches between the link title/text, so I'm not sure it was written with `titleValue.includes(linkText)` originally.