### PR TITLE
Adding ignore option to no-passed-in-event-handlers

### DIFF
--- a/docs/rule/no-passed-in-event-handlers.md
+++ b/docs/rule/no-passed-in-event-handlers.md
@@ -50,14 +50,21 @@ This rule **allows** the following:
 
   - object -- An object with the following keys:
 
-    - `ignore` -- An array of event handler names to ignore. Event handler names should exclude the @ when specifying those intended for named arguments. This rule will ensure both non-named arguments and named arguments are both ignored appropriately.
+    - `ignore` -- An object with the following keys/values:
+
+      - key: string -- The name of the element or mustache statement to ignore event handlers for
+      - value: array -- Event handler names. Event handler names should exclude the @ when specifying those intended for named arguments. This rule will ensure both non-named arguments and named arguments are both ignored appropriately.
 
       eg.
 
       Given the following configuration:
 
       ```json
-      { "ignore": [click] }
+      {
+        "ignore": {
+          "MyButton": ["click"]
+        }
+      }
       ```
 
       Both `click` and `@click` will be ignore as violations of this rule.

--- a/docs/rule/no-passed-in-event-handlers.md
+++ b/docs/rule/no-passed-in-event-handlers.md
@@ -44,6 +44,24 @@ This rule **allows** the following:
 {{foo onClick=this.handleClick}}
 ```
 
+## Configuration
+
+- boolean - `true` to enable / `false` to disable
+
+  - object -- An object with the following keys:
+
+    - `ignore` -- An array of event handler names to ignore. Event handler names should exclude the @ when specifying those intended for named arguments. This rule will ensure both non-named arguments and named arguments are both ignored appropriately.
+
+      eg.
+
+      Given the following configuration:
+
+      ```json
+      { "ignore": [click] }
+      ```
+
+      Both `click` and `@click` will be ignore as violations of this rule.
+
 ## Migration
 
 - create explicit component APIs for these events (e.g. `@click` -> `@onClick`)

--- a/docs/rule/no-passed-in-event-handlers.md
+++ b/docs/rule/no-passed-in-event-handlers.md
@@ -67,8 +67,6 @@ This rule **allows** the following:
       }
       ```
 
-      Both `click` and `@click` will be ignore as violations of this rule.
-
 ## Migration
 
 - create explicit component APIs for these events (e.g. `@click` -> `@onClick`)

--- a/lib/rules/no-passed-in-event-handlers.js
+++ b/lib/rules/no-passed-in-event-handlers.js
@@ -40,7 +40,37 @@ const EVENT_HANDLER_METHODS = new Set([
   'drop',
 ]);
 
+const DEFAULT_CONFIG = {
+  ignore: [],
+};
+
+function isValidConfigObjectFormat(config) {
+  for (let key in config) {
+    let value = config[key];
+    let valueIsArray = Array.isArray(value);
+
+    if (key === 'ignore' && !valueIsArray) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 module.exports = class NoPassedInEventHandlers extends Rule {
+  parseConfig(config) {
+    switch (typeof config) {
+      case 'boolean': {
+        return config ? DEFAULT_CONFIG : false;
+      }
+      case 'object': {
+        return isValidConfigObjectFormat(config) ? config : DEFAULT_CONFIG;
+      }
+      case 'undefined':
+        return false;
+    }
+  }
+
   visitor() {
     return {
       ElementNode(node) {
@@ -57,7 +87,7 @@ module.exports = class NoPassedInEventHandlers extends Rule {
           }
           name = name.slice(1);
 
-          if (EVENT_HANDLER_METHODS.has(name)) {
+          if (EVENT_HANDLER_METHODS.has(name) && !this.config.ignore.includes(name)) {
             this.log({
               message: makeErrorMessage(name),
               line: attribute.loc && attribute.loc.start.line,
@@ -79,7 +109,7 @@ module.exports = class NoPassedInEventHandlers extends Rule {
         for (let pair of pairs) {
           let { key } = pair;
 
-          if (EVENT_HANDLER_METHODS.has(key)) {
+          if (EVENT_HANDLER_METHODS.has(key) && !this.config.ignore.includes(key)) {
             this.log({
               message: makeErrorMessage(key),
               line: pair.loc && pair.loc.start.line,

--- a/lib/rules/no-passed-in-event-handlers.js
+++ b/lib/rules/no-passed-in-event-handlers.js
@@ -56,6 +56,8 @@ function isValidConfigObjectFormat(config) {
         if (!valueIsArray) {
           return false;
         }
+
+        return !ignores[ignore].some((attributeName) => attributeName.startsWith('@'));
       }
     }
   }

--- a/lib/rules/no-passed-in-event-handlers.js
+++ b/lib/rules/no-passed-in-event-handlers.js
@@ -41,7 +41,7 @@ const EVENT_HANDLER_METHODS = new Set([
 ]);
 
 const DEFAULT_CONFIG = {
-  ignore: [],
+  ignore: {},
 };
 
 function isValidConfigObjectFormat(config) {
@@ -70,7 +70,7 @@ module.exports = class NoPassedInEventHandlers extends Rule {
         return config ? DEFAULT_CONFIG : false;
       }
       case 'object': {
-        return isValidConfigObjectFormat(config) ? config : DEFAULT_CONFIG;
+        return isValidConfigObjectFormat(config) ? config : false;
       }
       case 'undefined':
         return false;

--- a/lib/rules/no-passed-in-event-handlers.js
+++ b/lib/rules/no-passed-in-event-handlers.js
@@ -46,11 +46,17 @@ const DEFAULT_CONFIG = {
 
 function isValidConfigObjectFormat(config) {
   for (let key in config) {
-    let value = config[key];
-    let valueIsArray = Array.isArray(value);
+    let ignores = config[key];
+    let ignoresIsObject = typeof ignores === 'object';
 
-    if (key === 'ignore' && !valueIsArray) {
-      return false;
+    if (key === 'ignore' && ignoresIsObject) {
+      for (let ignore in ignores) {
+        let valueIsArray = Array.isArray(ignores[ignore]);
+
+        if (!valueIsArray) {
+          return false;
+        }
+      }
     }
   }
 
@@ -71,6 +77,16 @@ module.exports = class NoPassedInEventHandlers extends Rule {
     }
   }
 
+  isIgnored(name, attributeName) {
+    let ignoresForName = this.config.ignore[name];
+    if (ignoresForName) {
+      if (ignoresForName.includes(attributeName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   visitor() {
     return {
       ElementNode(node) {
@@ -87,7 +103,7 @@ module.exports = class NoPassedInEventHandlers extends Rule {
           }
           name = name.slice(1);
 
-          if (EVENT_HANDLER_METHODS.has(name) && !this.config.ignore.includes(name)) {
+          if (EVENT_HANDLER_METHODS.has(name) && !this.isIgnored(node.tag, name)) {
             this.log({
               message: makeErrorMessage(name),
               line: attribute.loc && attribute.loc.start.line,
@@ -109,7 +125,7 @@ module.exports = class NoPassedInEventHandlers extends Rule {
         for (let pair of pairs) {
           let { key } = pair;
 
-          if (EVENT_HANDLER_METHODS.has(key) && !this.config.ignore.includes(key)) {
+          if (EVENT_HANDLER_METHODS.has(key) && !this.isIgnored(path.original, key)) {
             this.log({
               message: makeErrorMessage(key),
               line: pair.loc && pair.loc.start.line,

--- a/test/unit/rules/no-passed-in-event-handlers-test.js
+++ b/test/unit/rules/no-passed-in-event-handlers-test.js
@@ -30,26 +30,34 @@ generateRuleTests({
 
     {
       config: {
-        ignore: ['click'],
+        ignore: {
+          Foo: ['click'],
+        },
       },
       template: '<Foo @click={{this.handleClick}} />',
     },
     {
       config: {
-        ignore: ['click'],
+        ignore: {
+          foo: ['click'],
+        },
       },
       template: '{{foo click=this.handleClick}}',
     },
     {
       config: {
-        ignore: ['submit'],
+        ignore: {
+          Foo: ['submit'],
+        },
       },
       template: '<Foo @submit={{this.handleClick}} />',
     },
 
     {
       config: {
-        ignore: ['submit'],
+        ignore: {
+          foo: ['submit'],
+        },
       },
       template: '{{foo submit=this.handleClick}}',
     },

--- a/test/unit/rules/no-passed-in-event-handlers-test.js
+++ b/test/unit/rules/no-passed-in-event-handlers-test.js
@@ -6,7 +6,7 @@ const generateRuleTests = require('../../helpers/rule-test-harness');
 generateRuleTests({
   name: 'no-passed-in-event-handlers',
 
-  config: 'true',
+  config: true,
   good: [
     '<Foo />',
     '<Foo @onClick={{this.handleClick}} />',
@@ -27,6 +27,32 @@ generateRuleTests({
     '{{foo random=true}}',
     '{{input click=this.handleClick}}',
     '{{textarea click=this.handleClick}}',
+
+    {
+      config: {
+        ignore: ['click'],
+      },
+      template: '<Foo @click={{this.handleClick}} />',
+    },
+    {
+      config: {
+        ignore: ['click'],
+      },
+      template: '{{foo click=this.handleClick}}',
+    },
+    {
+      config: {
+        ignore: ['submit'],
+      },
+      template: '<Foo @submit={{this.handleClick}} />',
+    },
+
+    {
+      config: {
+        ignore: ['submit'],
+      },
+      template: '{{foo submit=this.handleClick}}',
+    },
   ],
   bad: [
     {


### PR DESCRIPTION
Adds the ability to ignore specific event handlers from triggering this rule. This is largely intended to assist in migration purposes, where the cost of requiring all callers to update existing APIs is high. This option provides an intermediate migration path for consumers that want to enable this rule to prevent most violations, while allowing some violations to be temporarily ignored.