### PR TITLE
Fix false positive with local `log` in `no-log` rule

### DIFF
--- a/lib/rules/no-log.js
+++ b/lib/rules/no-log.js
@@ -2,13 +2,13 @@
 
 const Rule = require('./_base');
 
-const message = 'Unexpected {{log}} usage.';
+const ERROR_MESSAGE = 'Unexpected {{log}} usage.';
 
 module.exports = class NoLog extends Rule {
   _checkForLog(node) {
-    if (node.path.original === 'log') {
+    if (node.path.original === 'log' && !this.isLocal(node)) {
       this.log({
-        message,
+        message: ERROR_MESSAGE,
         node,
       });
     }
@@ -27,4 +27,4 @@ module.exports = class NoLog extends Rule {
   }
 };
 
-module.exports.message = message;
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/no-log-test.js
+++ b/test/unit/rules/no-log-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { message } = require('../../../lib/rules/no-log');
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-log');
 const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
@@ -8,14 +8,22 @@ generateRuleTests({
 
   config: true,
 
-  good: ['{{foo}}', '{{button}}'],
+  good: [
+    '{{foo}}',
+    '{{button}}',
+    '{{#each this.logs as |log|}}{{log}}{{/each}}',
+    '{{#let this.log as |log|}}{{log}}{{/let}}',
+    '{{#let (component "my-log-component") as |log|}}{{#log}}message{{/log}}{{/let}}',
+    '<Logs @logs={{this.logs}} as |log|>{{log}}</Logs>',
+    '<Logs @logs={{this.logs}} as |log|><Log>{{log}}</Log></Logs>',
+  ],
 
   bad: [
     {
       template: '{{log}}',
 
       result: {
-        message,
+        message: ERROR_MESSAGE,
         source: '{{log}}',
         line: 1,
         column: 0,
@@ -25,7 +33,7 @@ generateRuleTests({
       template: '{{log "Logs are best for debugging!"}}',
 
       result: {
-        message,
+        message: ERROR_MESSAGE,
         source: '{{log "Logs are best for debugging!"}}',
         line: 1,
         column: 0,
@@ -35,7 +43,7 @@ generateRuleTests({
       template: '{{#log}}Arrgh!{{/log}}',
 
       result: {
-        message,
+        message: ERROR_MESSAGE,
         source: '{{#log}}Arrgh!{{/log}}',
         line: 1,
         column: 0,
@@ -45,10 +53,41 @@ generateRuleTests({
       template: '{{#log "Foo"}}{{/log}}',
 
       result: {
-        message,
+        message: ERROR_MESSAGE,
         source: '{{#log "Foo"}}{{/log}}',
         line: 1,
         column: 0,
+      },
+    },
+    {
+      template: '{{#each this.messages as |message|}}{{log message}}{{/each}}',
+
+      result: {
+        message: ERROR_MESSAGE,
+        source: '{{log message}}',
+        line: 1,
+        column: 36,
+      },
+    },
+    {
+      template: '{{#let this.message as |message|}}{{log message}}{{/let}}',
+
+      result: {
+        message: ERROR_MESSAGE,
+        source: '{{log message}}',
+        line: 1,
+        column: 34,
+      },
+    },
+    {
+      template:
+        '<Messages @messages={{this.messages}} as |message|>{{#log}}{{message}}{{/log}}</Messages>',
+
+      result: {
+        message: ERROR_MESSAGE,
+        source: '{{#log}}{{message}}{{/log}}',
+        line: 1,
+        column: 51,
       },
     },
   ],


### PR DESCRIPTION
Prevents local `{{log}}`s from being flagged.