### PR TITLE
Fix `require-has-block-helper` rule autofix when multiple parameters present

### DIFF
--- a/lib/rules/require-has-block-helper.js
+++ b/lib/rules/require-has-block-helper.js
@@ -25,7 +25,11 @@ module.exports = class RequireHasBlockHelper extends Rule {
               ['MustacheStatement', 'SubExpression'].includes(parent.node.type) &&
               parent.node.path.original !== node.original;
             if (isBlockStatement || isImplicitInvocation) {
-              parent.node.params[0] = b.sexpr(TRANSFORMATIONS[node.original], []);
+              const paramIndex = parent.node.params.findIndex((param) => {
+                return param.original === node.original;
+              });
+
+              parent.node.params[paramIndex] = b.sexpr(TRANSFORMATIONS[node.original], []);
             } else {
               node.original = TRANSFORMATIONS[node.original];
             }

--- a/test/unit/rules/require-has-block-helper-test.js
+++ b/test/unit/rules/require-has-block-helper-test.js
@@ -241,5 +241,27 @@ generateRuleTests({
         isFixable: true,
       },
     },
+    {
+      template: '{{#if (or isLoading hasLoadFailed hasBlock)}}...{{/if}}',
+      fixedTemplate: '{{#if (or isLoading hasLoadFailed (has-block))}}...{{/if}}',
+      result: {
+        message: getErrorMessage('hasBlock'),
+        line: 1,
+        column: 34,
+        source: 'hasBlock',
+        isFixable: true,
+      },
+    },
+    {
+      template: '{{#if (or isLoading hasLoadFailed hasBlockParams)}}...{{/if}}',
+      fixedTemplate: '{{#if (or isLoading hasLoadFailed (has-block-params))}}...{{/if}}',
+      result: {
+        message: getErrorMessage('hasBlockParams'),
+        line: 1,
+        column: 34,
+        source: 'hasBlockParams',
+        isFixable: true,
+      },
+    },
   ],
 });


### PR DESCRIPTION
Closes #1856.

PR title / commit message probably needs to be something more clear.