### PR TITLE
Fix `undefined` error message for `no-link-to-positional-params` rule

### DIFF
--- a/docs/rule/no-link-to-positional-params.md
+++ b/docs/rule/no-link-to-positional-params.md
@@ -9,10 +9,6 @@ Disallows passing positional parameters into link-to in favor of named arguments
 This rule **forbids** the following:
 
 ```hbs
-{{link-to "about"}}
-```
-
-```hbs
 {{link-to "About Us" "about"}}
 ```
 

--- a/lib/rules/no-link-to-positional-params.js
+++ b/lib/rules/no-link-to-positional-params.js
@@ -6,62 +6,58 @@ module.exports = class NoLinkToPositionalParams extends Rule {
   visitor() {
     return {
       MustacheStatement(node) {
-        this.process(node);
+        this.process(node, { hasRequiredTextParam: true });
       },
 
       BlockStatement(node) {
-        this.process(node);
+        this.process(node, { hasRequiredTextParam: false });
       },
     };
   }
 
-  process(node) {
+  process(node, options) {
     if (node.path.original === 'link-to' && node.params.length > 0) {
-      let message = this.getMessage(node);
+      let message = this.getMessage(node, options);
 
       this.log({ message, node });
     }
   }
 
-  getMessage(node) {
-    function getError(message) {
-      return `Invoking the \`<LinkTo>\` component with positional arguments is deprecated. ${message}`;
+  getMessage(node, { hasRequiredTextParam }) {
+    let requiredParamsCount = hasRequiredTextParam ? 2 : 1; // Route name is always required, text only for inline `{{link-to}}` components.
+    let hasQueryParams = includesQueryParams(node.params);
+    let modelParamsCount = countModelParams(node.params, requiredParamsCount, hasQueryParams);
+    let namedArguments = ['`route`'];
+    let additionalInfo = '';
+
+    if (modelParamsCount === 1) {
+      namedArguments.push('`model`');
+    } else if (modelParamsCount > 1) {
+      namedArguments.push('`models`');
     }
 
-    if (node.params.length === 1 && node.params[0].type === 'StringLiteral') {
-      return getError('Instead, please use the equivalent named arguments (`@route`).');
+    if (hasQueryParams) {
+      namedArguments.push('`query` using the `hash` helper');
     }
 
-    if (node.params.length === 2) {
-      if (node.params.every((param) => param.type === 'StringLiteral')) {
-        return getError(`Instead, please use the equivalent named arguments (\`@route\`) and pass a
-  block for the link's content.`);
-      }
-
-      if (node.params[0].type === 'StringLiteral' && node.params[1].type === 'PathExpression') {
-        return getError('Instead, please use the equivalent named arguments (`@route`, `@model`).');
-      }
-
-      if (
-        node.params[0].type === 'StringLiteral' &&
-        node.params[1].type === 'SubExpression' &&
-        node.params[1].path.original === 'query-params'
-      ) {
-        return getError(`Instead, please use the equivalent named arguments (\`@route\`, \`@query\`) and the
-\`hash\` helper.`);
-      }
+    if (hasRequiredTextParam) {
+      additionalInfo = ' The content should be passed along as a block.';
     }
 
-    if (node.params.length === 3) {
-      if (
-        node.params[0].type === 'StringLiteral' &&
-        node.params[1].type === 'PathExpression' &&
-        node.params[2].type === 'PathExpression'
-      ) {
-        return getError(
-          'Instead, please use the equivalent named arguments (`@route`, `@models`).'
-        );
-      }
-    }
+    return getErrorMessage(namedArguments.join(', '), additionalInfo);
   }
 };
+
+function includesQueryParams(params) {
+  return params.some((param) => {
+    return param.path && param.path.original === 'query-params';
+  });
+}
+
+function countModelParams(params, requiredCount, hasQueryParams) {
+  return Math.max(params.length - (hasQueryParams ? requiredCount + 1 : requiredCount), 0);
+}
+
+function getErrorMessage(namedArguments, additionalInfo) {
+  return `Invoking the \`{{link-to}}\` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (${namedArguments}).${additionalInfo}`;
+}

--- a/test/unit/rules/no-link-to-positional-params-test.js
+++ b/test/unit/rules/no-link-to-positional-params-test.js
@@ -28,40 +28,143 @@ generateRuleTests({
 
   bad: [
     {
-      template: '{{link-to "about"}}',
-      result: {
-        message:
-          'Invoking the `<LinkTo>` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`@route`).',
-        line: 1,
-        column: 0,
-        source: '{{link-to "about"}}',
-      },
-    },
-    {
       template: '{{link-to "About Us" "about"}}',
       result: {
-        message: `Invoking the \`<LinkTo>\` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (\`@route\`) and pass a
-  block for the link's content.`,
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`). The content should be passed along as a block.',
         line: 1,
         column: 0,
         source: '{{link-to "About Us" "about"}}',
       },
     },
     {
+      template: '{{link-to "About Us" (if this.showNewAboutPage "about-us" "about")}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`). The content should be passed along as a block.',
+        line: 1,
+        column: 0,
+        source: '{{link-to "About Us" (if this.showNewAboutPage "about-us" "about")}}',
+      },
+    },
+    {
+      template: '{{link-to (t "about") "about"}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`). The content should be passed along as a block.',
+        line: 1,
+        column: 0,
+        source: '{{link-to (t "about") "about"}}',
+      },
+    },
+    {
+      template: '{{link-to (t "about") this.aboutRoute}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`). The content should be passed along as a block.',
+        line: 1,
+        column: 0,
+        source: '{{link-to (t "about") this.aboutRoute}}',
+      },
+    },
+    {
+      template: '{{link-to (t "about") this.aboutRoute "foo"}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`, `model`). The content should be passed along as a block.',
+        line: 1,
+        column: 0,
+        source: '{{link-to (t "about") this.aboutRoute "foo"}}',
+      },
+    },
+    {
+      template: '{{link-to (t "about") this.aboutRoute "foo" "bar"}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`, `models`). The content should be passed along as a block.',
+        line: 1,
+        column: 0,
+        source: '{{link-to (t "about") this.aboutRoute "foo" "bar"}}',
+      },
+    },
+    {
+      template: '{{link-to (t "about") this.aboutRoute "foo" "bar" (query-params foo="bar")}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`, `models`, `query` using the `hash` helper). The content should be passed along as a block.',
+        line: 1,
+        column: 0,
+        source: '{{link-to (t "about") this.aboutRoute "foo" "bar" (query-params foo="bar")}}',
+      },
+    },
+
+    {
+      template: '{{#link-to (if this.showNewAboutPage "about-us" "about")}}About Us{{/link-to}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`).',
+        line: 1,
+        column: 0,
+        source: '{{#link-to (if this.showNewAboutPage "about-us" "about")}}About Us{{/link-to}}',
+      },
+    },
+    {
       template: '{{#link-to "about"}}About Us{{/link-to}}',
       result: {
         message:
-          'Invoking the `<LinkTo>` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`@route`).',
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`).',
         line: 1,
         column: 0,
         source: '{{#link-to "about"}}About Us{{/link-to}}',
       },
     },
     {
+      template: '{{#link-to this.aboutRoute}}About Us{{/link-to}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`).',
+        line: 1,
+        column: 0,
+        source: '{{#link-to this.aboutRoute}}About Us{{/link-to}}',
+      },
+    },
+    {
+      template: '{{#link-to this.aboutRoute "foo"}}About Us{{/link-to}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`, `model`).',
+        line: 1,
+        column: 0,
+        source: '{{#link-to this.aboutRoute "foo"}}About Us{{/link-to}}',
+      },
+    },
+    {
+      template: '{{#link-to this.aboutRoute "foo" "bar"}}About Us{{/link-to}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`, `models`).',
+        line: 1,
+        column: 0,
+        source: '{{#link-to this.aboutRoute "foo" "bar"}}About Us{{/link-to}}',
+      },
+    },
+    {
+      template:
+        '{{#link-to this.aboutRoute "foo" "bar" (query-params foo="bar")}}About Us{{/link-to}}',
+      result: {
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`, `models`, `query` using the `hash` helper).',
+        line: 1,
+        column: 0,
+        source:
+          '{{#link-to this.aboutRoute "foo" "bar" (query-params foo="bar")}}About Us{{/link-to}}',
+      },
+    },
+    {
       template: '{{#link-to "post" @post}}Read {{@post.title}}...{{/link-to}}',
       result: {
         message:
-          'Invoking the `<LinkTo>` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`@route`, `@model`).',
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`, `model`).',
         line: 1,
         column: 0,
         source: '{{#link-to "post" @post}}Read {{@post.title}}...{{/link-to}}',
@@ -73,7 +176,7 @@ generateRuleTests({
       {{/link-to}}`,
       result: {
         message:
-          'Invoking the `<LinkTo>` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`@route`, `@models`).',
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`, `models`).',
         line: 1,
         column: 0,
         source: `{{#link-to "post.comment" @comment.post @comment}}
@@ -86,8 +189,8 @@ generateRuleTests({
         Recent Posts
       {{/link-to}}`,
       result: {
-        message: `Invoking the \`<LinkTo>\` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (\`@route\`, \`@query\`) and the
-\`hash\` helper.`,
+        message:
+          'Invoking the `{{link-to}}` component with positional arguments is deprecated. Instead, please use the equivalent named arguments (`route`, `query` using the `hash` helper).',
         line: 1,
         column: 0,
         source: `{{#link-to "posts" (query-params direction="desc" showArchived=false)}}


### PR DESCRIPTION
Closes #1854.

Sorry for the large overhaul. Hope that's okay.

- Removes the type checks as a link's route / label / model(s) can be anything (e.g. `StringLiteral`, `PathExpression` or `SubExpression`)
- Takes into account more than 3 params (e.g. label, route, model(s) and query params)
- Removes the `{{link-to "about"}}` bad case as that's not valid usage of the `{{link-to}}` component (it triggers a build error)