### PR TITLE
Add `has-block-params` as built-in helper to `no-implicit-this` rule

### DIFF
--- a/lib/rules/no-implicit-this.js
+++ b/lib/rules/no-implicit-this.js
@@ -34,6 +34,7 @@ const ARGLESS_BUILTIN_HELPERS = [
   'debugger',
   'has-block',
   'hasBlock',
+  'has-block-params',
   'hasBlockParams',
   'hash',
   'input',


### PR DESCRIPTION
It seems this one was forgotten.