### PR TITLE
Check for link title being substring of link text in `no-invalid-link-title` rule

### DIFF
--- a/docs/rule/no-invalid-link-title.md
+++ b/docs/rule/no-invalid-link-title.md
@@ -2,9 +2,9 @@
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
-The `title` attribute is a useful way to give users extra context for a link. However, this content should be complementary content and should not be the exact same value as the link text.
+The `title` attribute is a useful way to give users extra context for a link. However, this content should be complementary content and should not be exactly the same as or part of the link text.
 
-This rule checks links for the presence of a `title` attribute and ensures that it is not the same as the link text.
+This rule checks links for the presence of a `title` attribute and ensures that it is not the same as or part of the link text.
 
 ## Examples
 
@@ -12,6 +12,10 @@ This rule **forbids** the following:
 
 ```hbs
 <a href="https://mytutorial.com" title="read the tutorial">Read the Tutorial</a>
+```
+
+```hbs
+<a href="https://mytutorial.com" title="Tutorial">Read the Tutorial</a>
 ```
 
 This rule **allows** the following:
@@ -22,7 +26,7 @@ This rule **allows** the following:
 
 ## Migration
 
-* If the `title` attribute value is the same as the link text, it's better to leave it out.
+* If the `title` attribute value is the same as or part of the link text, it's better to leave it out.
 
 ## References
 

--- a/lib/rules/no-invalid-link-title.js
+++ b/lib/rules/no-invalid-link-title.js
@@ -11,12 +11,12 @@ function hasInvalidLinkTitle(node, titleAttributeValues) {
     .map((linkText) => linkText.chars.toLowerCase().trim())
     .filter((text) => text.length > 0);
 
-  // Check to see if the text content is the same as the title attribute value
-  const hasMatchingLinkAndTitleText = linkTexts.some((linkText) =>
-    titleAttributeValues.includes(linkText)
+  // Check to see if the text content includes the title attribute value
+  const linkTextIncludesTitle = linkTexts.some((linkText) =>
+    titleAttributeValues.some((title) => linkText.includes(title))
   );
 
-  return hasMatchingLinkAndTitleText;
+  return linkTextIncludesTitle;
 }
 
 module.exports = class NoInvalidLinkTitle extends Rule {
@@ -60,7 +60,7 @@ module.exports = class NoInvalidLinkTitle extends Rule {
 
           if (hasInvalidLinkTitle(node, titleValues)) {
             this.log({
-              message: 'Title attribute values should not be the same as the link text.',
+              message: 'Title attribute values should not be the same as or part of the link text.',
               node,
             });
           }
@@ -74,7 +74,8 @@ module.exports = class NoInvalidLinkTitle extends Rule {
 
             if (hasInvalidLinkTitle(node, [titleValue])) {
               this.log({
-                message: 'Title attribute values should not be the same as the link text.',
+                message:
+                  'Title attribute values should not be the same as or part of the link text.',
                 node,
               });
             }

--- a/test/unit/rules/no-invalid-link-title-test.js
+++ b/test/unit/rules/no-invalid-link-title-test.js
@@ -37,7 +37,7 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "Title attribute values should not be the same as the link text.",
+              "message": "Title attribute values should not be the same as or part of the link text.",
               "rule": "no-invalid-link-title",
               "severity": 2,
               "source": "<a href=\\"https://myurl.com\\" title=\\"read the tutorial\\">Read the Tutorial</a>",
@@ -57,7 +57,7 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "Title attribute values should not be the same as the link text.",
+              "message": "Title attribute values should not be the same as or part of the link text.",
               "rule": "no-invalid-link-title",
               "severity": 2,
               "source": "<LinkTo title=\\"quickstart\\">Quickstart</LinkTo>",
@@ -97,7 +97,7 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "Title attribute values should not be the same as the link text.",
+              "message": "Title attribute values should not be the same as or part of the link text.",
               "rule": "no-invalid-link-title",
               "severity": 2,
               "source": "{{#link-to title=\\"Do the things\\"}}Do the things{{/link-to}}",
@@ -117,10 +117,70 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "Title attribute values should not be the same as the link text.",
+              "message": "Title attribute values should not be the same as or part of the link text.",
               "rule": "no-invalid-link-title",
               "severity": 2,
               "source": "<LinkTo @route=\\"some.route\\" @title=\\"Do the things\\">Do the things</LinkTo>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<a href="https://myurl.com" title="Tutorial">Read the Tutorial</a>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 0,
+              "endColumn": 66,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Title attribute values should not be the same as or part of the link text.",
+              "rule": "no-invalid-link-title",
+              "severity": 2,
+              "source": "<a href=\\"https://myurl.com\\" title=\\"Tutorial\\">Read the Tutorial</a>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<LinkTo title="Tutorial">Read the Tutorial</LinkTo>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 0,
+              "endColumn": 51,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Title attribute values should not be the same as or part of the link text.",
+              "rule": "no-invalid-link-title",
+              "severity": 2,
+              "source": "<LinkTo title=\\"Tutorial\\">Read the Tutorial</LinkTo>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '{{#link-to title="Tutorial"}}Read the Tutorial{{/link-to}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 0,
+              "endColumn": 58,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Title attribute values should not be the same as or part of the link text.",
+              "rule": "no-invalid-link-title",
+              "severity": 2,
+              "source": "{{#link-to title=\\"Tutorial\\"}}Read the Tutorial{{/link-to}}",
             },
           ]
         `);


### PR DESCRIPTION
Makes the rule more strict.

Closes #1162.