### PR TITLE
Updating stale todo message with more targeted --fix instructions

### DIFF
--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -53,7 +53,7 @@ module.exports = class TodoHandler {
         for (const [, todo] of itemsToRemoveFromTodos) {
           results.push({
             rule: 'invalid-todo-violation-rule',
-            message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`--fix\` to remove this todo from the todo list.`,
+            message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`ember-template-lint ${todo.filePath} --fix\` to remove this todo from the todo list.`,
             filePath: todo.filePath,
             moduleId: todo.moduleId,
             severity: 2,

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -320,15 +320,15 @@ describe('todo usage', () => {
 
       expect(result.exitCode).toEqual(1);
       expect(result.stdout).toMatchInlineSnapshot(`
-          "app/templates/require-button-type.hbs
-            -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`--fix\` to remove this todo from the todo list.  invalid-todo-violation-rule
+        "app/templates/require-button-type.hbs
+          -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`ember-template-lint app/templates/require-button-type.hbs --fix\` to remove this todo from the todo list.  invalid-todo-violation-rule
 
-          ✖ 1 problems (1 errors, 0 warnings)
-            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
-        `);
+        ✖ 1 problems (1 errors, 0 warnings)
+          1 errors and 0 warnings potentially fixable with the \`--fix\` option."
+      `);
 
       // run fix, and expect that this will delete the outstanding todo item
-      await run(['.', '--fix']);
+      await run(['app/templates/require-button-type.hbs', '--fix']);
 
       // run normally again and expect no error
       result = await run(['.']);


### PR DESCRIPTION
The original error message when a todo was stale was instructing users to run `--fix`, but without any qualifying file path. This could cause users to run `ember-template-lint . --fix`, which would potentially fix not only the stale todo, but anything else fixable in the app.

While the `--fix` flag should always be considered 'safe', it could be considered jarring to be instructed to run a particular command, and have unrelated files change. This PR updates the message so that it instructs you to run `--fix` only on the file with the stale todo.