### PR TITLE
Allow words containing redundant words for `require-valid-alt-text` rule

### DIFF
--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -143,8 +143,9 @@ module.exports = class RequireValidAltText extends Rule {
                     node,
                   });
                 } else {
+                  const normalizedAltValueWords = normalizedAltValue.split(' ');
                   const existingWords = REDUNDANT_WORDS.filter((word) =>
-                    normalizedAltValue.includes(word)
+                    normalizedAltValueWords.includes(word)
                   );
                   if (existingWords.length) {
                     this.logNode({

--- a/test/unit/rules/require-valid-alt-text-test.js
+++ b/test/unit/rules/require-valid-alt-text-test.js
@@ -25,6 +25,13 @@ generateRuleTests({
     '<img alt="" role="none">',
     '<img alt="" role="presentation">',
 
+    // Valid words containing redundant words.
+    '<img alt="logout">',
+    '<img alt="photography">',
+    '<img alt="picturesque">',
+    '<img alt="pilgrimage">',
+    '<img alt="spacers">',
+
     '<img ...attributes>',
 
     '<input type="image" alt="some-alt">',


### PR DESCRIPTION
Fixes #1896.