### PR TITLE
updated the invalid violation message for visual distinction

### DIFF
--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -53,7 +53,7 @@ module.exports = class TodoHandler {
         for (const [, todo] of itemsToRemoveFromTodos) {
           results.push({
             rule: 'invalid-todo-violation-rule',
-            message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`ember-template-lint ${todo.filePath} --fix\` to remove this todo from the todo list.`,
+            message: `Todo violation passes \`${todo.ruleId}\` rule! 🎉 🎉  Please run \`ember-template-lint ${todo.filePath} --fix\` to remove this todo from the todo list.`,
             filePath: todo.filePath,
             moduleId: todo.moduleId,
             severity: 2,

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -321,7 +321,7 @@ describe('todo usage', () => {
       expect(result.exitCode).toEqual(1);
       expect(result.stdout).toMatchInlineSnapshot(`
         "app/templates/require-button-type.hbs
-          -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`ember-template-lint app/templates/require-button-type.hbs --fix\` to remove this todo from the todo list.  invalid-todo-violation-rule
+          -:-  error  Todo violation passes \`require-button-type\` rule! 🎉 🎉  Please run \`ember-template-lint app/templates/require-button-type.hbs --fix\` to remove this todo from the todo list.  invalid-todo-violation-rule
 
         ✖ 1 problems (1 errors, 0 warnings)
           1 errors and 0 warnings potentially fixable with the \`--fix\` option."


### PR DESCRIPTION
I've tried to update the message for the `invalid-todo-violation-rule` to appear more visually distinct. Since we can't sub-chalk this, I've added some 🎉 . 

What do you think? 