### PR TITLE
Ensures we always emit output file even with empty results

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -420,11 +420,12 @@ async function run() {
     let hasTodos = options.includeTodo && results.todoCount;
     let hasUpdatedTodos = options.updateTodo;
 
-    if (hasErrors || hasWarnings || hasTodos || hasUpdatedTodos) {
-      let Printer = require('../lib/formatters/default');
-      let printer = new Printer(options);
-      printer.print(results, todoInfo);
-    }
+    let Printer = require('../lib/formatters/default');
+    let printer = new Printer({
+      ...options,
+      hasResultData: hasErrors || hasWarnings || hasTodos || hasUpdatedTodos,
+    });
+    printer.print(results, todoInfo);
   }
 }
 

--- a/lib/formatters/default.js
+++ b/lib/formatters/default.js
@@ -43,11 +43,6 @@ class DefaultPrinter {
         this.delegates.push(new SarifPrinter(printOptions));
         break;
       }
-      case 'json': {
-        let JsonPrinter = require('./json');
-        this.delegates.push(new JsonPrinter(printOptions));
-        break;
-      }
       default: {
         try {
           const CustomPrinter = createRequire(

--- a/lib/formatters/default.js
+++ b/lib/formatters/default.js
@@ -14,12 +14,14 @@ class DefaultPrinter {
     let printOptions = {
       console: this.console,
       includeTodo: options.includeTodo,
-      isInteractive: process.stdout.isTTY,
+      // env var is used to test output options via tests
+      isInteractive: process.stdout.isTTY || process.env['IS_TTY'] === '1',
       outputFile: options.outputFile,
       quiet: options.quiet,
       updateTodo: options.updateTodo,
       verbose: options.verbose,
       workingDir: options.workingDirectory,
+      hasResultData: options.hasResultData,
     };
 
     // TODO: add 'json' format to the list of those below. The plan is to
@@ -39,6 +41,11 @@ class DefaultPrinter {
       case 'sarif': {
         let SarifPrinter = require('./sarif');
         this.delegates.push(new SarifPrinter(printOptions));
+        break;
+      }
+      case 'json': {
+        let JsonPrinter = require('./json');
+        this.delegates.push(new JsonPrinter(printOptions));
         break;
       }
       default: {

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -1,4 +1,3 @@
-const writeOutputFile = require('../helpers/write-output-file');
 const Linter = require('../linter');
 
 class JsonPrinter {
@@ -8,7 +7,7 @@ class JsonPrinter {
   }
 
   print(results) {
-    if (!this.options.hasResultData && !this.options.outputFile) {
+    if (!this.options.hasResultData) {
       return;
     }
 
@@ -30,12 +29,7 @@ class JsonPrinter {
 
     let json = JSON.stringify(filteredErrors, null, 2);
 
-    if (this.options.isInteractive && this.options.outputFile) {
-      let outputPath = writeOutputFile(json, 'json', this.options);
-      this.console.log(`Report written to ${outputPath}`);
-    } else {
-      this.console.log(json);
-    }
+    this.console.log(json);
   }
 }
 

--- a/lib/formatters/json.js
+++ b/lib/formatters/json.js
@@ -1,3 +1,4 @@
+const writeOutputFile = require('../helpers/write-output-file');
 const Linter = require('../linter');
 
 class JsonPrinter {
@@ -7,6 +8,10 @@ class JsonPrinter {
   }
 
   print(results) {
+    if (!this.options.hasResultData && !this.options.outputFile) {
+      return;
+    }
+
     let filteredErrors = {};
     for (let filePath of Object.keys(results.files)) {
       let fileErrors = results.files[filePath].messages;
@@ -23,7 +28,14 @@ class JsonPrinter {
       filteredErrors[filePath] = [...errorsFiltered, ...warnings, ...todos];
     }
 
-    this.console.log(JSON.stringify(filteredErrors, null, 2));
+    let json = JSON.stringify(filteredErrors, null, 2);
+
+    if (this.options.isInteractive && this.options.outputFile) {
+      let outputPath = writeOutputFile(json, 'json', this.options);
+      this.console.log(`Report written to ${outputPath}`);
+    } else {
+      this.console.log(json);
+    }
   }
 }
 

--- a/lib/formatters/pretty.js
+++ b/lib/formatters/pretty.js
@@ -9,6 +9,10 @@ class PrettyPrinter {
   }
 
   print(results, todoInfo) {
+    if (!this.options.hasResultData) {
+      return;
+    }
+
     for (const filePath of Object.keys(results.files)) {
       let fileResults = results.files[filePath];
       let messages = this.options.quiet

--- a/lib/formatters/sarif.js
+++ b/lib/formatters/sarif.js
@@ -21,14 +21,17 @@ class SarifPrinter {
   }
 
   print(results) {
-    let sarifLog = this.buildSarifLog(results);
-    let stringifiedLog = JSON.stringify(sarifLog, null, 2);
+    if (!this.options.hasResultData && !this.options.outputFile) {
+      return;
+    }
+
+    let sarifLog = JSON.stringify(this.buildSarifLog(results), null, 2);
 
     if (this.options.isInteractive) {
-      let outputPath = writeOutputFile(stringifiedLog, 'sarif', this.options);
+      let outputPath = writeOutputFile(sarifLog, 'sarif', this.options);
       this.console.log(`Report written to ${outputPath}`);
     } else {
-      this.console.log(JSON.stringify(sarifLog, null, 2));
+      this.console.log(sarifLog);
     }
   }
 

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1508,6 +1508,25 @@ describe('ember-template-lint executable', function () {
     });
 
     describe('with --format options', function () {
+      it('should always emit a SARIF file even when there are no errors/warnings', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+            'no-html-comments': true,
+          },
+        });
+        project.writeSync();
+
+        let result = await run(['.', '--format', 'sarif', '--output-file', 'my-results.sarif'], {
+          env: {
+            IS_TTY: '1',
+          },
+        });
+
+        expect(result.exitCode).toEqual(0);
+        expect(fs.existsSync(path.join(project.baseDir, 'my-results.sarif'))).toEqual(true);
+      });
+
       it('should be able to load relative printer', async function () {
         project.setConfig({
           rules: {


### PR DESCRIPTION
Currently we only emit the output file if we have results, but this causes issues for CI systems that always expect the presence of an output file, regardless of lint violations or not. This PR ensures we always emit a file if one is specified in options.