### PR TITLE
Deprecate `--json` option in favor of `--format=json`.

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -146,6 +146,7 @@ function parseArgv(_argv) {
       },
       json: {
         describe: 'Format output as json',
+        deprecated: 'Use --format=json instead',
         boolean: true,
       },
       'output-file': {

--- a/lib/formatters/default.js
+++ b/lib/formatters/default.js
@@ -24,15 +24,14 @@ class DefaultPrinter {
       hasResultData: options.hasResultData,
     };
 
-    // TODO: add 'json' format to the list of those below. The plan is to
-    // modify the 'json' formatter to write to a file, similar to the 'sarif' formatter.
-    if (options.json) {
-      let JsonPrinter = require('./json');
-      this.delegates.push(new JsonPrinter(printOptions));
-      return;
-    }
+    const format = options.json ? 'json' : options.format;
 
-    switch (options.format) {
+    switch (format) {
+      case 'json': {
+        let JsonPrinter = require('./json');
+        this.delegates.push(new JsonPrinter(printOptions));
+        break;
+      }
       case 'pretty': {
         let PrettyPrinter = require('./pretty');
         this.delegates.push(new PrettyPrinter(printOptions));

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -51,7 +51,8 @@ describe('ember-template-lint executable', function () {
                                                                 [boolean] [default: false]
             --format                    Specify format to be used in printing output
                                                               [string] [default: \\"pretty\\"]
-            --json                      Format output as json                    [boolean]
+            --json                      Format output as json
+                                         [deprecated: Use --format=json instead] [boolean]
             --output-file               Specify file to write report to           [string]
             --verbose                   Output errors with source description    [boolean]
             --working-directory, --cwd  Path to a directory that should be considered as
@@ -105,7 +106,8 @@ describe('ember-template-lint executable', function () {
                                                                 [boolean] [default: false]
             --format                    Specify format to be used in printing output
                                                               [string] [default: \\"pretty\\"]
-            --json                      Format output as json                    [boolean]
+            --json                      Format output as json
+                                         [deprecated: Use --format=json instead] [boolean]
             --output-file               Specify file to write report to           [string]
             --verbose                   Output errors with source description    [boolean]
             --working-directory, --cwd  Path to a directory that should be considered as
@@ -413,7 +415,8 @@ describe('ember-template-lint executable', function () {
                                                                 [boolean] [default: false]
             --format                    Specify format to be used in printing output
                                                               [string] [default: \\"pretty\\"]
-            --json                      Format output as json                    [boolean]
+            --json                      Format output as json
+                                         [deprecated: Use --format=json instead] [boolean]
             --output-file               Specify file to write report to           [string]
             --verbose                   Output errors with source description    [boolean]
             --working-directory, --cwd  Path to a directory that should be considered as
@@ -1508,6 +1511,53 @@ describe('ember-template-lint executable', function () {
     });
 
     describe('with --format options', function () {
+      it('should print valid JSON string with errors', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+              components: {
+                'foo.hbs': '{{fooData}}',
+              },
+            },
+          },
+        });
+
+        let result = await run(['--format', 'json', '.']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(JSON.parse(result.stdout)).toMatchInlineSnapshot(`
+          Object {
+            "app/templates/application.hbs": Array [
+              Object {
+                "column": 4,
+                "filePath": "app/templates/application.hbs",
+                "line": 1,
+                "message": "Non-translated string used",
+                "rule": "no-bare-strings",
+                "severity": 2,
+                "source": "Here too!!",
+              },
+              Object {
+                "column": 25,
+                "filePath": "app/templates/application.hbs",
+                "line": 1,
+                "message": "Non-translated string used",
+                "rule": "no-bare-strings",
+                "severity": 2,
+                "source": "Bare strings are bad...",
+              },
+            ],
+          }
+        `);
+        expect(result.stderr).toBeFalsy();
+      });
+
       it('should always emit a SARIF file even when there are no errors/warnings', async function () {
         project.setConfig({
           rules: {


### PR DESCRIPTION
Deprecate (documentation wise) using `--json` option, in favor of using `--format=json`. Everything else is the same (same format, same console outputting behavior).

Note: A future PR will refactor the formatters to use a unified system for emitting when `--outputFile` is specified.
