### PR TITLE
Add new rule `no-action-on-submit-button`

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Each rule has emojis denoting:
 | [no-accesskey-attribute](./docs/rule/no-accesskey-attribute.md)                                           | ✅  |     | ⌨️  | 🔧  |
 | [no-action](./docs/rule/no-action.md)                                                                     | ✅  |     |     |     |
 | [no-action-modifiers](./docs/rule/no-action-modifiers.md)                                                 |     |     |     |     |
+| [no-action-on-submit-button](./docs/rule/no-action-on-submit-button.md)                                   |     |     |     |     |
 | [no-args-paths](./docs/rule/no-args-paths.md)                                                             | ✅  |     |     |     |
 | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)                           | ✅  |     |     |     |
 | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                                                 | ✅  |     | ⌨️  | 🔧  |

--- a/docs/rule/no-action-on-submit-button.md
+++ b/docs/rule/no-action-on-submit-button.md
@@ -1,0 +1,35 @@
+# no-action-on-submit-button
+
+This rule requires all `<button>` elements with a `type="submit"` attribute to not have any click action.
+
+When the `type` attribute of `<button>` elements is `submit`, the action should be on the `<form>` element instead of directly on the button.
+
+By default, the `type` attribute of `<button>` elements is `submit`.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<button type="submit" {{on "click" this.handleClick}} />
+<button type="submit" {{action "handleClick"}} />
+<button {{on "click" this.handleClick}} />
+<button {{action "handleClick"}} />
+```
+
+This rule **allows** the following:
+
+```hbs
+<button type="button" {{on "click" this.handleClick}} />
+<button type="button" {{action "handleClick"}} />
+<button type="submit" />
+<button />
+```
+
+## Related Rules
+
+- [require-button-type](require-button-type.md)
+
+## References
+
+- [HTML spec - the button element](https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-type)

--- a/docs/rule/no-action-on-submit-button.md
+++ b/docs/rule/no-action-on-submit-button.md
@@ -1,6 +1,6 @@
 # no-action-on-submit-button
 
-This rule requires all `<button>` elements with a `type="submit"` attribute to not have any click action.
+In a `<form>`, this rule requires all `<button>` elements with a `type="submit"` attribute to not have any click action.
 
 When the `type` attribute of `<button>` elements is `submit`, the action should be on the `<form>` element instead of directly on the button.
 
@@ -11,19 +11,30 @@ By default, the `type` attribute of `<button>` elements is `submit`.
 This rule **forbids** the following:
 
 ```hbs
-<button type="submit" {{on "click" this.handleClick}} />
-<button type="submit" {{action "handleClick"}} />
-<button {{on "click" this.handleClick}} />
-<button {{action "handleClick"}} />
+<form>
+  <button type='submit' {{on 'click' this.handleClick}} />
+  <button type='submit' {{action 'handleClick'}} />
+  <button {{on 'click' this.handleClick}} />
+  <button {{action 'handleClick'}} />
+</form>
 ```
 
 This rule **allows** the following:
 
 ```hbs
-<button type="button" {{on "click" this.handleClick}} />
-<button type="button" {{action "handleClick"}} />
-<button type="submit" />
-<button />
+// In a <form>
+<form>
+  <button type='button' {{on 'click' this.handleClick}} />
+  <button type='button' {{action 'handleClick'}} />
+  <button type='submit' />
+  <button />
+</form>
+
+// Outside a <form>
+<button type='submit' {{on 'click' this.handleClick}} />
+<button type='submit' {{action 'handleClick'}} />
+<button {{on 'click' this.handleClick}} />
+<button {{action 'handleClick'}} />
 ```
 
 ## Related Rules

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -15,6 +15,7 @@ import modifiernamecase from './modifier-name-case.js';
 import noabstractroles from './no-abstract-roles.js';
 import noaccesskeyattribute from './no-accesskey-attribute.js';
 import noactionmodifiers from './no-action-modifiers.js';
+import noactiononsubmitbutton from './no-action-on-submit-button.js';
 import noaction from './no-action.js';
 import noargspaths from './no-args-paths.js';
 import noargumentsforhtmlelements from './no-arguments-for-html-elements.js';
@@ -135,6 +136,7 @@ export default {
   'no-abstract-roles': noabstractroles,
   'no-accesskey-attribute': noaccesskeyattribute,
   'no-action-modifiers': noactionmodifiers,
+  'no-action-on-submit-button': noactiononsubmitbutton,
   'no-action': noaction,
   'no-args-paths': noargspaths,
   'no-arguments-for-html-elements': noargumentsforhtmlelements,

--- a/lib/rules/no-action-on-submit-button.js
+++ b/lib/rules/no-action-on-submit-button.js
@@ -1,6 +1,8 @@
 import Rule from './_base.js';
+import hasParentTag from '../helpers/has-parent-tag.js';
 
-const ERROR_MESSAGE = 'A `<button>` with `type="submit"` should have no click action';
+const ERROR_MESSAGE =
+  'In a `<form>`, a `<button>` with `type="submit"` should have no click action';
 
 export default class NoActionOnSubmitButton extends Rule {
   logNode({ node, message }) {
@@ -43,10 +45,15 @@ export default class NoActionOnSubmitButton extends Rule {
     }
 
     return {
-      ElementNode(node) {
+      ElementNode(node, path) {
         let { tag, attributes, modifiers } = node;
 
         if (tag !== 'button') {
+          return;
+        }
+
+        // is this button in a <form>?
+        if (!hasParentTag(path, 'form')) {
           return;
         }
 

--- a/lib/rules/no-action-on-submit-button.js
+++ b/lib/rules/no-action-on-submit-button.js
@@ -1,0 +1,75 @@
+import Rule from './_base.js';
+
+const ERROR_MESSAGE = 'A `<button>` with `type="submit"` should have no click action';
+
+export default class NoActionOnSubmitButton extends Rule {
+  logNode({ node, message }) {
+    return this.log({
+      node,
+      message,
+      line: node.loc && node.loc.start.line,
+      column: node.loc && node.loc.start.column,
+      source: this.sourceForNode(node),
+    });
+  }
+
+  visitor() {
+    function isTypeAttribute(attribute) {
+      return attribute.name === 'type';
+    }
+
+    function isOnClickModifier(modifier) {
+      let { path, params } = modifier;
+
+      return (
+        path.original === 'on' &&
+        params.length > 0 &&
+        params[0].type === 'StringLiteral' &&
+        params[0].value === 'click'
+      );
+    }
+
+    function isOnClickParameter(parameter) {
+      return parameter.key === 'on' && parameter.value.original === 'click';
+    }
+
+    function isDisallowedActionModifier(modifier) {
+      let { path, hash } = modifier;
+
+      let noParameter = hash.pairs.length === 0;
+      let onClickParameter = hash.pairs.find(isOnClickParameter);
+
+      return path.original === 'action' && (noParameter || onClickParameter);
+    }
+
+    return {
+      ElementNode(node) {
+        let { tag, attributes, modifiers } = node;
+
+        if (tag !== 'button') {
+          return;
+        }
+
+        let typeAttribute = attributes.find(isTypeAttribute);
+        let onClickModifier = modifiers.find(isOnClickModifier);
+        let actionModifier = modifiers.find(isDisallowedActionModifier);
+
+        // undefined button type fallbacks on "submit"
+        if (!typeAttribute) {
+          if (actionModifier || onClickModifier) {
+            return this.logNode({ node, message: ERROR_MESSAGE });
+          }
+          return;
+        }
+
+        let { type, chars } = typeAttribute.value;
+
+        if (type === 'TextNode' && chars === 'submit') {
+          if (actionModifier || onClickModifier) {
+            return this.logNode({ node, message: ERROR_MESSAGE });
+          }
+        }
+      },
+    };
+  }
+}

--- a/test/unit/rules/no-action-on-submit-button-test.js
+++ b/test/unit/rules/no-action-on-submit-button-test.js
@@ -1,0 +1,213 @@
+import generateRuleTests from '../../helpers/rule-test-harness.js';
+
+generateRuleTests({
+  name: 'no-action-on-submit-button',
+
+  config: true,
+
+  good: [
+    // valid buttons with "button" type
+    '<button type="button" />',
+    '<button type="button" {{action this.handleClick}} />',
+    '<button type="button" {{action this.handleClick on="click"}} />',
+    '<button type="button" {{action this.handleMouseover on="mouseOver"}} />',
+    '<button type="button" {{on "click" this.handleClick}} />',
+    '<button type="button" {{on "mouseover" this.handleMouseover}} />',
+
+    // valid buttons with "submit" type
+    '<button />',
+    '<button type="submit" />',
+    '<button type="submit" {{action this.handleMouseover on="mouseOver"}} />',
+    '<button type="submit" {{on "mouseover" this.handleMouseover}} />',
+
+    // valid div elements
+    '<div/>',
+    '<div></div>',
+    '<div type="submit"></div>',
+    '<div type="submit" {{action this.handleClick}}></div>',
+    '<div type="submit" {{on "click" this.handleClick}}></div>',
+  ],
+
+  bad: [
+    {
+      template: '<button {{action this.handleClick}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 38,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "rule": "no-action-on-submit-button",
+              "severity": 2,
+              "source": "<button {{action this.handleClick}} />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<button {{action this.handleClick on="click"}}/>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 48,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "rule": "no-action-on-submit-button",
+              "severity": 2,
+              "source": "<button {{action this.handleClick on=\\"click\\"}}/>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<button {{on "click" this.handleClick}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 42,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "rule": "no-action-on-submit-button",
+              "severity": 2,
+              "source": "<button {{on \\"click\\" this.handleClick}} />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<button type="submit" {{action this.handleClick}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 52,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "rule": "no-action-on-submit-button",
+              "severity": 2,
+              "source": "<button type=\\"submit\\" {{action this.handleClick}} />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<button type="submit" {{action this.handleClick on="click"}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 63,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "rule": "no-action-on-submit-button",
+              "severity": 2,
+              "source": "<button type=\\"submit\\" {{action this.handleClick on=\\"click\\"}} />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<button type="submit" {{action (fn this.someAction "foo")}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 62,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "rule": "no-action-on-submit-button",
+              "severity": 2,
+              "source": "<button type=\\"submit\\" {{action (fn this.someAction \\"foo\\")}} />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<button type="submit" {{on "click" this.handleClick}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 56,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "rule": "no-action-on-submit-button",
+              "severity": 2,
+              "source": "<button type=\\"submit\\" {{on \\"click\\" this.handleClick}} />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<button type="submit" {{on "click" (fn this.addNumber 123)}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 63,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "rule": "no-action-on-submit-button",
+              "severity": 2,
+              "source": "<button type=\\"submit\\" {{on \\"click\\" (fn this.addNumber 123)}} />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<div><button type="submit" {{action this.handleClick}} /></div>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 11,
+              "endColumn": 63,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "rule": "no-action-on-submit-button",
+              "severity": 2,
+              "source": "<button type=\\"submit\\" {{action this.handleClick}} />",
+            },
+          ]
+        `);
+      },
+    },
+  ],
+});

--- a/test/unit/rules/no-action-on-submit-button-test.js
+++ b/test/unit/rules/no-action-on-submit-button-test.js
@@ -6,41 +6,51 @@ generateRuleTests({
   config: true,
 
   good: [
-    // valid buttons with "button" type
-    '<button type="button" />',
-    '<button type="button" {{action this.handleClick}} />',
-    '<button type="button" {{action this.handleClick on="click"}} />',
-    '<button type="button" {{action this.handleMouseover on="mouseOver"}} />',
-    '<button type="button" {{on "click" this.handleClick}} />',
-    '<button type="button" {{on "mouseover" this.handleMouseover}} />',
+    // valid buttons with "button" type, in a form
+    '<form><button type="button" /></form>',
+    '<form><button type="button" {{action this.handleClick}} /></form>',
+    '<form><button type="button" {{action this.handleClick on="click"}} /></form>',
+    '<form><button type="button" {{action this.handleMouseover on="mouseOver"}} /></form>',
+    '<form><button type="button" {{on "click" this.handleClick}} /></form>',
+    '<form><button type="button" {{on "mouseover" this.handleMouseover}} /></form>',
 
-    // valid buttons with "submit" type
-    '<button />',
-    '<button type="submit" />',
-    '<button type="submit" {{action this.handleMouseover on="mouseOver"}} />',
-    '<button type="submit" {{on "mouseover" this.handleMouseover}} />',
+    // valid buttons with "submit" type, in a form
+    '<form><button /></form>',
+    '<form><button type="submit" /></form>',
+    '<form><button type="submit" {{action this.handleMouseover on="mouseOver"}} /></form>',
+    '<form><button type="submit" {{on "mouseover" this.handleMouseover}} /></form>',
 
-    // valid div elements
-    '<div/>',
-    '<div></div>',
-    '<div type="submit"></div>',
-    '<div type="submit" {{action this.handleClick}}></div>',
-    '<div type="submit" {{on "click" this.handleClick}}></div>',
+    // valid div elements, in a form
+    '<form><div/></form>',
+    '<form><div></div></form>',
+    '<form><div type="submit"></div></form>',
+    '<form><div type="submit" {{action this.handleClick}}></div></form>',
+    '<form><div type="submit" {{on "click" this.handleClick}}></div></form>',
+
+    // valid buttons, only outside a form
+    '<button {{action this.handleClick}} />',
+    '<button {{action this.handleClick on="click"}}/>',
+    '<button {{on "click" this.handleClick}} />',
+    '<button type="submit" {{action this.handleClick}} />',
+    '<button type="submit" {{action this.handleClick on="click"}} />',
+    '<button type="submit" {{action (fn this.someAction "foo")}} />',
+    '<button type="submit" {{on "click" this.handleClick}} />',
+    '<button type="submit" {{on "click" (fn this.addNumber 123)}} />',
   ],
 
   bad: [
     {
-      template: '<button {{action this.handleClick}} />',
+      template: '<form><button {{action this.handleClick}} /></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 38,
+              "column": 6,
+              "endColumn": 44,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "message": "In a \`<form>\`, a \`<button>\` with \`type=\\"submit\\"\` should have no click action",
               "rule": "no-action-on-submit-button",
               "severity": 2,
               "source": "<button {{action this.handleClick}} />",
@@ -50,17 +60,17 @@ generateRuleTests({
       },
     },
     {
-      template: '<button {{action this.handleClick on="click"}}/>',
+      template: '<form><button {{action this.handleClick on="click"}}/></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 48,
+              "column": 6,
+              "endColumn": 54,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "message": "In a \`<form>\`, a \`<button>\` with \`type=\\"submit\\"\` should have no click action",
               "rule": "no-action-on-submit-button",
               "severity": 2,
               "source": "<button {{action this.handleClick on=\\"click\\"}}/>",
@@ -70,17 +80,17 @@ generateRuleTests({
       },
     },
     {
-      template: '<button {{on "click" this.handleClick}} />',
+      template: '<form><button {{on "click" this.handleClick}} /></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 42,
+              "column": 6,
+              "endColumn": 48,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "message": "In a \`<form>\`, a \`<button>\` with \`type=\\"submit\\"\` should have no click action",
               "rule": "no-action-on-submit-button",
               "severity": 2,
               "source": "<button {{on \\"click\\" this.handleClick}} />",
@@ -90,17 +100,17 @@ generateRuleTests({
       },
     },
     {
-      template: '<button type="submit" {{action this.handleClick}} />',
+      template: '<form><button type="submit" {{action this.handleClick}} /></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 52,
+              "column": 6,
+              "endColumn": 58,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "message": "In a \`<form>\`, a \`<button>\` with \`type=\\"submit\\"\` should have no click action",
               "rule": "no-action-on-submit-button",
               "severity": 2,
               "source": "<button type=\\"submit\\" {{action this.handleClick}} />",
@@ -110,17 +120,17 @@ generateRuleTests({
       },
     },
     {
-      template: '<button type="submit" {{action this.handleClick on="click"}} />',
+      template: '<form><button type="submit" {{action this.handleClick on="click"}} /></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 63,
+              "column": 6,
+              "endColumn": 69,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "message": "In a \`<form>\`, a \`<button>\` with \`type=\\"submit\\"\` should have no click action",
               "rule": "no-action-on-submit-button",
               "severity": 2,
               "source": "<button type=\\"submit\\" {{action this.handleClick on=\\"click\\"}} />",
@@ -130,17 +140,17 @@ generateRuleTests({
       },
     },
     {
-      template: '<button type="submit" {{action (fn this.someAction "foo")}} />',
+      template: '<form><button type="submit" {{action (fn this.someAction "foo")}} /></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 62,
+              "column": 6,
+              "endColumn": 68,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "message": "In a \`<form>\`, a \`<button>\` with \`type=\\"submit\\"\` should have no click action",
               "rule": "no-action-on-submit-button",
               "severity": 2,
               "source": "<button type=\\"submit\\" {{action (fn this.someAction \\"foo\\")}} />",
@@ -150,17 +160,17 @@ generateRuleTests({
       },
     },
     {
-      template: '<button type="submit" {{on "click" this.handleClick}} />',
+      template: '<form><button type="submit" {{on "click" this.handleClick}} /></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 56,
+              "column": 6,
+              "endColumn": 62,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "message": "In a \`<form>\`, a \`<button>\` with \`type=\\"submit\\"\` should have no click action",
               "rule": "no-action-on-submit-button",
               "severity": 2,
               "source": "<button type=\\"submit\\" {{on \\"click\\" this.handleClick}} />",
@@ -170,17 +180,17 @@ generateRuleTests({
       },
     },
     {
-      template: '<button type="submit" {{on "click" (fn this.addNumber 123)}} />',
+      template: '<form><button type="submit" {{on "click" (fn this.addNumber 123)}} /></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 63,
+              "column": 6,
+              "endColumn": 69,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "message": "In a \`<form>\`, a \`<button>\` with \`type=\\"submit\\"\` should have no click action",
               "rule": "no-action-on-submit-button",
               "severity": 2,
               "source": "<button type=\\"submit\\" {{on \\"click\\" (fn this.addNumber 123)}} />",
@@ -190,7 +200,7 @@ generateRuleTests({
       },
     },
     {
-      template: '<div><button type="submit" {{action this.handleClick}} /></div>',
+      template: '<form><div><button type="submit" {{action this.handleClick}} /></div></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -200,7 +210,7 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "A \`<button>\` with \`type=\\"submit\\"\` should have no click action",
+              "message": "In a \`<form>\`, a \`<button>\` with \`type=\\"submit\\"\` should have no click action",
               "rule": "no-action-on-submit-button",
               "severity": 2,
               "source": "<button type=\\"submit\\" {{action this.handleClick}} />",


### PR DESCRIPTION
Fixes https://github.com/ember-template-lint/ember-template-lint/issues/44.

It implements the rule proposal of `no-action-on-submit-button`.

# no-action-on-submit-button

This rule requires all `<button>` elements with a `type="submit"` attribute to not have any action.

When the `type` attribute of `<button>` elements is `submit`, the action should be on the `<form>` element instead of directly on the button.

By default, the `type` attribute of `<button>` elements is `submit`.

## Examples

This rule **forbids** the following:

```hbs
<form>
  <button type='submit' {{on 'click' this.handleClick}} />
  <button type='submit' {{action 'handleClick'}} />
  <button {{on 'click' this.handleClick}} />
  <button {{action 'handleClick'}} />
</form>
```

This rule **allows** the following:

```hbs
// In a <form>
<form>
  <button type='button' {{on 'click' this.handleClick}} />
  <button type='button' {{action 'handleClick'}} />
  <button type='submit' />
  <button />
</form>

// Outside a <form>
<button type='submit' {{on 'click' this.handleClick}} />
<button type='submit' {{action 'handleClick'}} />
<button {{on 'click' this.handleClick}} />
<button {{action 'handleClick'}} />
```
