### PR TITLE
Adds `--clean-todo` option to provide separate functionality to cleanup stale and expired todos

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -188,6 +188,11 @@ function parseArgv(_argv) {
         default: false,
         boolean: true,
       },
+      'clean-todo': {
+        describe: 'Removes todos that are expired or invalid',
+        default: false,
+        boolean: true,
+      },
       'todo-days-to-warn': {
         describe: 'Number of days after its creation date that a todo transitions into a warning',
         type: 'number',

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -189,7 +189,7 @@ function parseArgv(_argv) {
         boolean: true,
       },
       'clean-todo': {
-        describe: 'Removes todos that are expired or invalid',
+        describe: 'Remove expired and invalid todo files',
         default: false,
         boolean: true,
       },

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -26,7 +26,13 @@ If you want to see todos as part of `ember-template-lint`'s output, you can incl
 ember-template-lint . --include-todo
 ```
 
-If an error is fixed manually, `ember-template-lint` will let you know that there's an outstanding todo file. You can remove this file by running `--clean-todo`
+If an error is fixed manually, `ember-template-lint` will let you know that there's an expired todo file. You'll see this error:
+
+```bash
+error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
+```
+
+You can fix this error/remove the expired todo file by running `--clean-todo`
 
 ```bash
 ember-template-lint . --clean-todo

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -2,7 +2,7 @@
 
 Linting is a fundamental tool to help ensure the quality of a codebase. Ensuring there are as few linting errors as possible (ideally 0), is a useful measure of a baseline of code hygiene.
 
-It's common to leverage linting not just for syntax adherence, but also to direct developers to employ standardized patterns. As such, it's a fairly routine activity to introduce new lint rules into a codebase. This introduction, while necessary, can cause unintended friction, such as:
+It's common to leverage linting not only for syntax adherence, but also to direct developers to employ standardized patterns. As such, it's a fairly routine activity to introduce new lint rules into a codebase. This introduction, while necessary, can cause unintended friction, such as:
 
 - new lint errors being introduced where they previously didn't exist
 - causing unintended delays to shipping new fixes and features
@@ -26,10 +26,10 @@ If you want to see todos as part of `ember-template-lint`'s output, you can incl
 ember-template-lint . --include-todo
 ```
 
-If an error is fixed manually, `ember-template-lint` will let you know that there's an outstanding todo file. You can remove this file by running `--fix`
+If an error is fixed manually, `ember-template-lint` will let you know that there's an outstanding todo file. You can remove this file by running `--clean-todo`
 
 ```bash
-ember-template-lint . --fix
+ember-template-lint . --clean-todo
 ```
 
 ### Configuring Due Dates

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -26,13 +26,13 @@ If you want to see todos as part of `ember-template-lint`'s output, you can incl
 ember-template-lint . --include-todo
 ```
 
-If an error is fixed manually, `ember-template-lint` will let you know that there's an expired todo file. You'll see this error:
+If an error is fixed manually, `ember-template-lint` will let you know that there's a stale todo file. You'll see this error:
 
 ```bash
-error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
+error  Todo violation passes no-vague-rules rule. Please run `ember-template-lint /path/to/file.hbs --clean-todo` to remove this todo from the todo list.
 ```
 
-You can fix this error/remove the expired todo file by running `--clean-todo`
+You can fix this error/remove the stale todo file by running `--clean-todo`
 
 ```bash
 ember-template-lint . --clean-todo

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -42,15 +42,11 @@ module.exports = class TodoHandler {
       writeTodoOptions
     );
 
-    if (itemsToRemoveFromTodos.size > 0) {
+    if (remove.size > 0) {
       if (shouldFix) {
-        applyTodoChanges(
-          getTodoStorageDirPath(this._workingDir),
-          new Map(),
-          itemsToRemoveFromTodos
-        );
+        applyTodoChanges(getTodoStorageDirPath(this._workingDir), new Map(), remove);
       } else {
-        for (const [, todo] of itemsToRemoveFromTodos) {
+        for (const [, todo] of remove) {
           results.push({
             rule: 'invalid-todo-violation-rule',
             message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`ember-template-lint ${todo.filePath} --clean-todo\` to remove this todo from the todo list.`,
@@ -63,11 +59,11 @@ module.exports = class TodoHandler {
       }
     }
 
-    if (expiredTodos.size > 0) {
-      applyTodoChanges(getTodoStorageDirPath(this._workingDir), new Map(), expiredTodos);
+    if (expired.size > 0) {
+      applyTodoChanges(getTodoStorageDirPath(this._workingDir), new Map(), expired);
     }
 
-    for (const todo of [...existingTodos.values()]) {
+    for (const todo of [...stable.values()]) {
       let severity = getSeverity(todo);
 
       if (severity === ERROR_SEVERITY) {

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -42,6 +42,10 @@ module.exports = class TodoHandler {
       writeTodoOptions
     );
 
+    if (expired.size > 0) {
+      applyTodoChanges(getTodoStorageDirPath(this._workingDir), new Map(), expired);
+    }
+
     if (remove.size > 0) {
       if (shouldFix) {
         applyTodoChanges(getTodoStorageDirPath(this._workingDir), new Map(), remove);
@@ -57,10 +61,6 @@ module.exports = class TodoHandler {
           });
         }
       }
-    }
-
-    if (expired.size > 0) {
-      applyTodoChanges(getTodoStorageDirPath(this._workingDir), new Map(), expired);
     }
 
     for (const todo of [...stable.values()]) {

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -36,8 +36,7 @@ module.exports = class TodoHandler {
 
     let existingTodoFiles = await readTodosForFilePath(this._workingDir, writeTodoOptions.filePath);
 
-    // this should represent the batches - add, remove, stable, expired
-    let [, itemsToRemoveFromTodos, existingTodos, expiredTodos] = await getTodoBatches(
+    let [, remove, stable, expired] = await getTodoBatches(
       buildTodoData(this._workingDir, this._buildResult(results)),
       existingTodoFiles,
       writeTodoOptions
@@ -65,19 +64,7 @@ module.exports = class TodoHandler {
     }
 
     if (expiredTodos.size > 0) {
-      if (shouldFix) {
-        applyTodoChanges(getTodoStorageDirPath(this._workingDir), new Map(), expiredTodos);
-      } else {
-        for (const [, todo] of expiredTodos) {
-          results.push({
-            rule: 'expired-todo-rule',
-            message: `Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.`,
-            filePath: todo.filePath,
-            severity: 2,
-            isFixable: true,
-          });
-        }
-      }
+      applyTodoChanges(getTodoStorageDirPath(this._workingDir), new Map(), expiredTodos);
     }
 
     for (const todo of [...existingTodos.values()]) {

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -36,7 +36,8 @@ module.exports = class TodoHandler {
 
     let existingTodoFiles = await readTodosForFilePath(this._workingDir, writeTodoOptions.filePath);
 
-    let [, itemsToRemoveFromTodos, existingTodos] = await getTodoBatches(
+    // this should represent the batches - add, remove, stable, expired
+    let [, itemsToRemoveFromTodos, existingTodos, expiredTodos] = await getTodoBatches(
       buildTodoData(this._workingDir, this._buildResult(results)),
       existingTodoFiles,
       writeTodoOptions
@@ -56,6 +57,22 @@ module.exports = class TodoHandler {
             message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`ember-template-lint ${todo.filePath} --clean-todo\` to remove this todo from the todo list.`,
             filePath: todo.filePath,
             moduleId: todo.moduleId,
+            severity: 2,
+            isFixable: true,
+          });
+        }
+      }
+    }
+
+    if (expiredTodos.size > 0) {
+      if (shouldFix) {
+        applyTodoChanges(getTodoStorageDirPath(this._workingDir), new Map(), expiredTodos);
+      } else {
+        for (const [, todo] of expiredTodos) {
+          results.push({
+            rule: 'expired-todo-rule',
+            message: `Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.`,
+            filePath: todo.filePath,
             severity: 2,
             isFixable: true,
           });

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -53,7 +53,7 @@ module.exports = class TodoHandler {
         for (const [, todo] of itemsToRemoveFromTodos) {
           results.push({
             rule: 'invalid-todo-violation-rule',
-            message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`ember-template-lint ${todo.filePath} --fix\` to remove this todo from the todo list.`,
+            message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`ember-template-lint ${todo.filePath} --clean-todo\` to remove this todo from the todo list.`,
             filePath: todo.filePath,
             moduleId: todo.moduleId,
             severity: 2,

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -260,7 +260,6 @@ class Linter {
     return currentSource;
   }
 
-  // checks to see if config is being overridden so it doesn't remove something that should stay
   _getShouldRemove(options, isOverridingConfig) {
     let config = this._moduleStatusCache.getConfigForFile(options);
     let rules = new Set(Object.keys(config.rules).filter((ruleId) => config.rules[ruleId]));

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -260,6 +260,7 @@ class Linter {
     return currentSource;
   }
 
+  // checks to see if config is being overridden so it doesn't remove something that should stay
   _getShouldRemove(options, isOverridingConfig) {
     let config = this._moduleStatusCache.getConfigForFile(options);
     let rules = new Set(Object.keys(config.rules).filter((ruleId) => config.rules[ruleId]));

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^8.0.0",
+    "@ember-template-lint/todo-utils": "^8.1.0",
     "chalk": "^4.1.1",
     "date-fns": "^2.21.1",
     "ember-template-recast": "^5.0.1",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -64,6 +64,8 @@ describe('ember-template-lint executable', function () {
                                         errors to todos         [boolean] [default: false]
             --include-todo              Include todos in the results
                                                                 [boolean] [default: false]
+            --clean-todo                Remove expired and invalid todo files
+                                                                [boolean] [default: false]
             --todo-days-to-warn         Number of days after its creation date that a todo
                                         transitions into a warning                [number]
             --todo-days-to-error        Number of days after its creation date that a todo
@@ -118,6 +120,8 @@ describe('ember-template-lint executable', function () {
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos         [boolean] [default: false]
             --include-todo              Include todos in the results
+                                                                [boolean] [default: false]
+            --clean-todo                Remove expired and invalid todo files
                                                                 [boolean] [default: false]
             --todo-days-to-warn         Number of days after its creation date that a todo
                                         transitions into a warning                [number]
@@ -427,6 +431,8 @@ describe('ember-template-lint executable', function () {
             --update-todo               Update list of linting todos by transforming lint
                                         errors to todos         [boolean] [default: false]
             --include-todo              Include todos in the results
+                                                                [boolean] [default: false]
+            --clean-todo                Remove expired and invalid todo files
                                                                 [boolean] [default: false]
             --todo-days-to-warn         Number of days after its creation date that a todo
                                         transitions into a warning                [number]

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -340,7 +340,7 @@ describe('todo usage', () => {
       expect(todoDirs).toHaveLength(0);
     });
 
-    it('errors if a todo item has expired when running without params', async function () {
+    it('removes expired todo file if a todo item has expired when running without params', async function () {
       project.setConfig({
         rules: {
           'require-button-type': true,

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -374,10 +374,9 @@ describe('todo usage', () => {
       expect(result.stdout).toMatchInlineSnapshot(`
         "app/templates/require-button-type.hbs
           1:0  error  All \`<button>\` elements should have a valid \`type\` attribute  require-button-type
-          -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-        ✖ 2 problems (2 errors, 0 warnings)
-          2 errors and 0 warnings potentially fixable with the \`--fix\` option."
+        ✖ 1 problems (1 errors, 0 warnings)
+          1 errors and 0 warnings potentially fixable with the \`--fix\` option."
       `);
 
       // run clean-todo, and expect that this will delete the expired todo item
@@ -396,16 +395,6 @@ describe('todo usage', () => {
       ✖ 1 problems (1 errors, 0 warnings)
         1 errors and 0 warnings potentially fixable with the \`--fix\` option."
     `);
-      expect(todoDirs).toHaveLength(0);
-
-      // run fix, and expect that this will fix the auto-fixable error
-      await run(['app/templates/require-button-type.hbs', '--fix']);
-
-      // run normally again and expect no errors and no todos
-      result = await run(['.']);
-
-      expect(result.exitCode).toEqual(0);
-      expect(result.stdout).toEqual('');
       expect(todoDirs).toHaveLength(0);
     });
 
@@ -1182,10 +1171,8 @@ describe('todo usage', () => {
       expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/application.hbs
             1:5  error  Non-translated string used  no-bare-strings
-            -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-          ✖ 2 problems (2 errors, 0 warnings)
-            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
+          ✖ 1 problems (1 errors, 0 warnings)"
         `);
     });
 
@@ -1216,10 +1203,8 @@ describe('todo usage', () => {
       expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/application.hbs
             1:5  error  Non-translated string used  no-bare-strings
-            -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-          ✖ 2 problems (2 errors, 0 warnings)
-            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
+          ✖ 1 problems (1 errors, 0 warnings)"
         `);
     });
 
@@ -1249,10 +1234,8 @@ describe('todo usage', () => {
       expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/application.hbs
             1:5  error  Non-translated string used  no-bare-strings
-            -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-          ✖ 2 problems (2 errors, 0 warnings)
-            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
+          ✖ 1 problems (1 errors, 0 warnings)"
         `);
     });
 
@@ -1287,10 +1270,8 @@ describe('todo usage', () => {
       expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/application.hbs
             1:5  error  Non-translated string used  no-bare-strings
-            -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-          ✖ 2 problems (2 errors, 0 warnings)
-            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
+          ✖ 1 problems (1 errors, 0 warnings)"
         `);
     });
 
@@ -1320,10 +1301,8 @@ describe('todo usage', () => {
       expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/application.hbs
             1:5  error  Non-translated string used  no-bare-strings
-            -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-          ✖ 2 problems (2 errors, 0 warnings)
-            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
+          ✖ 1 problems (1 errors, 0 warnings)"
         `);
     });
   });

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -355,13 +355,13 @@ describe('todo usage', () => {
         },
       });
 
-      // change the date so errorDate is before today
       project.writeTodoConfig({
         error: 5,
       });
 
       // generate todo based on existing error
       await run(['.', '--update-todo'], {
+        // change the date so errorDate is before today
         env: {
           TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
         },
@@ -1256,7 +1256,7 @@ describe('todo usage', () => {
         `);
     });
 
-    it('should set todo to error if both warnDate and errorDate have expired via config', async function () {
+    it('should set todo to error and display an expired todo message if both warnDate and errorDate have expired via config', async function () {
       project.setConfig({
         rules: {
           'no-bare-strings': true,
@@ -1294,7 +1294,7 @@ describe('todo usage', () => {
         `);
     });
 
-    it('should set todo to error if both warnDate and errorDate have expired via options', async function () {
+    it('should set todo to error and display expired todo message if both warnDate and errorDate have expired via options', async function () {
       project.setConfig({
         rules: {
           'no-bare-strings': true,

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -321,14 +321,14 @@ describe('todo usage', () => {
       expect(result.exitCode).toEqual(1);
       expect(result.stdout).toMatchInlineSnapshot(`
         "app/templates/require-button-type.hbs
-          -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`ember-template-lint app/templates/require-button-type.hbs --fix\` to remove this todo from the todo list.  invalid-todo-violation-rule
+          -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`ember-template-lint app/templates/require-button-type.hbs --clean-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
 
         ✖ 1 problems (1 errors, 0 warnings)
           1 errors and 0 warnings potentially fixable with the \`--fix\` option."
       `);
 
       // run fix, and expect that this will delete the outstanding todo item
-      await run(['app/templates/require-button-type.hbs', '--fix']);
+      await run(['app/templates/require-button-type.hbs', '--clean-todo']);
 
       // run normally again and expect no error
       result = await run(['.']);

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -367,8 +367,10 @@ describe('todo usage', () => {
         },
       });
 
-      // run normally and expect an error for not running --clean-todo
+      // run normally and expect the issue to be back in the error state and there to be no todo
       let result = await run(['.']);
+
+      let todoDirs = fs.readdirSync(getTodoStorageDirPath(project.baseDir));
 
       expect(result.exitCode).toEqual(1);
       expect(result.stdout).toMatchInlineSnapshot(`
@@ -378,23 +380,6 @@ describe('todo usage', () => {
         ✖ 1 problems (1 errors, 0 warnings)
           1 errors and 0 warnings potentially fixable with the \`--fix\` option."
       `);
-
-      // run clean-todo, and expect that this will delete the expired todo item
-      await run(['app/templates/require-button-type.hbs', '--clean-todo']);
-
-      // run normally again and expect only the error
-      result = await run(['.']);
-
-      let todoDirs = fs.readdirSync(getTodoStorageDirPath(project.baseDir));
-
-      expect(result.exitCode).toEqual(1);
-      expect(result.stdout).toMatchInlineSnapshot(`
-      "app/templates/require-button-type.hbs
-        1:0  error  All \`<button>\` elements should have a valid \`type\` attribute  require-button-type
-
-      ✖ 1 problems (1 errors, 0 warnings)
-        1 errors and 0 warnings potentially fixable with the \`--fix\` option."
-    `);
       expect(todoDirs).toHaveLength(0);
     });
 

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -1141,7 +1141,7 @@ describe('todo usage', () => {
         `);
     });
 
-    it('should set todo to error and provide expired message if errorDate has expired via config', async function () {
+    it('should set todo to error if errorDate has expired via config', async function () {
       project.setConfig({
         rules: {
           'no-bare-strings': true,
@@ -1208,7 +1208,7 @@ describe('todo usage', () => {
         `);
     });
 
-    it('should set todo to error and display an expired todo message if errorDate has expired via option', async function () {
+    it('should set todo to error if errorDate has expired via option', async function () {
       project.setConfig({
         rules: {
           'no-bare-strings': true,
@@ -1239,7 +1239,7 @@ describe('todo usage', () => {
         `);
     });
 
-    it('should set todo to error and display an expired todo message if both warnDate and errorDate have expired via config', async function () {
+    it('should set todo to error if both warnDate and errorDate have expired via config', async function () {
       project.setConfig({
         rules: {
           'no-bare-strings': true,
@@ -1275,7 +1275,7 @@ describe('todo usage', () => {
         `);
     });
 
-    it('should set todo to error and display expired todo message if both warnDate and errorDate have expired via options', async function () {
+    it('should set todo to error if both warnDate and errorDate have expired via options', async function () {
       project.setConfig({
         rules: {
           'no-bare-strings': true,

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -1184,12 +1184,11 @@ describe('todo usage', () => {
             1:5  error  Non-translated string used  no-bare-strings
             -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-          ✖ 1 problems (1 errors, 0 warnings)
+          ✖ 2 problems (2 errors, 0 warnings)
             1 errors and 0 warnings potentially fixable with the \`--fix\` option."
         `);
     });
 
-    // TODO update this test to add expired message
     it('should set todo to error if errorDate has expired via env var', async function () {
       project.setConfig({
         rules: {
@@ -1217,12 +1216,13 @@ describe('todo usage', () => {
       expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/application.hbs
             1:5  error  Non-translated string used  no-bare-strings
+            -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-          ✖ 1 problems (1 errors, 0 warnings)"
+          ✖ 2 problems (2 errors, 0 warnings)
+            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
         `);
     });
 
-    // TODO update this test to include expired message
     it('should set todo to error and display an expired todo message if errorDate has expired via option', async function () {
       project.setConfig({
         rules: {
@@ -1249,12 +1249,13 @@ describe('todo usage', () => {
       expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/application.hbs
             1:5  error  Non-translated string used  no-bare-strings
+            -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-          ✖ 1 problems (1 errors, 0 warnings)"
+          ✖ 2 problems (2 errors, 0 warnings)
+            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
         `);
     });
 
-    // TODO update this test to show expired message
     it('should set todo to error if both warnDate and errorDate have expired via config', async function () {
       project.setConfig({
         rules: {
@@ -1286,12 +1287,13 @@ describe('todo usage', () => {
       expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/application.hbs
             1:5  error  Non-translated string used  no-bare-strings
+            -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-          ✖ 1 problems (1 errors, 0 warnings)"
+          ✖ 2 problems (2 errors, 0 warnings)
+            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
         `);
     });
 
-    // TODO update this test to show expired message
     it('should set todo to error if both warnDate and errorDate have expired via options', async function () {
       project.setConfig({
         rules: {
@@ -1318,8 +1320,10 @@ describe('todo usage', () => {
       expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/application.hbs
             1:5  error  Non-translated string used  no-bare-strings
+            -:-  error  Expired todos exist. Please run \`ember-template-lint --clean-todo\` to remove expired todos.  expired-todo-rule
 
-          ✖ 1 problems (1 errors, 0 warnings)"
+          ✖ 2 problems (2 errors, 0 warnings)
+            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
         `);
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -410,12 +410,12 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@ember-template-lint/todo-utils@^8.0.0":
-  version "8.0.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-8.0.0.tgz#db18b2bbc26fb372062d827138b7e1bb659a30ae"
-  integrity sha512-bqULTNLWr93SRfM+MkPFN4qdYvdzmvwiPBaHpxQM67qnZ1BCs4Mr7zV8GF8OSmSKbyPNMAN2ZyxsPbNRbN6o3g==
+"@ember-template-lint/todo-utils@^8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-8.1.0.tgz#0fe8ef9ebd1948dea34d27d89a2e245687bb57d9"
+  integrity sha512-fnxDli4RfYGVBXc64D0fg7ifkSrNE8J/ee4eqQLzTrsUJbisWMlmU2NTHm990XcZkulYkCnkiLKERU/k1tx5IQ==
   dependencies:
-    "@types/eslint" "^7.2.7"
+    "@types/eslint" "^7.2.10"
     fs-extra "^9.1.0"
     slash "^3.0.0"
     tslib "^2.1.0"
@@ -1076,10 +1076,10 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/eslint@^7.2.7":
-  version "7.2.7"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.7.tgz#f7ef1cf0dceab0ae6f9a976a0a9af14ab1baca26"
-  integrity sha512-EHXbc1z2GoQRqHaAT7+grxlTJ3WE2YNeD6jlpPoRc83cCoThRY+NUWjCUZaYmk51OICkPXn2hhphcWcWXgNW0Q==
+"@types/eslint@^7.2.10":
+  version "7.2.10"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.10.tgz#4b7a9368d46c0f8cd5408c23288a59aa2394d917"
+  integrity sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"


### PR DESCRIPTION
If merged, this PR:

- bumps todo-utils dependency to 8.1.0 (minor)
- adds `--clean-todo` flag, to provide a way to remove expired (errorDate is before today) and invalid todo files. 
- updates instructions printed to terminal
- updates documentation to include new flag