### PR TITLE
Fixes `--clean-todo` flag to actually do the cleaning

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -401,7 +401,7 @@ async function run() {
       fileResults = await linter.processTodos(
         linterOptions,
         fileResults,
-        options.fix,
+        options.fix || options.cleanTodo,
         isOverridingConfig
       );
     }

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -29,7 +29,7 @@ module.exports = class TodoHandler {
     return todoBatchCounts;
   }
 
-  async processResults(results, shouldFix, writeTodoOptions) {
+  async processResults(results, shouldCleanTodos, writeTodoOptions) {
     if (!todoStorageDirExists(this._workingDir)) {
       return results;
     }
@@ -47,7 +47,7 @@ module.exports = class TodoHandler {
     }
 
     if (remove.size > 0) {
-      if (shouldFix) {
+      if (shouldCleanTodos) {
         applyTodoChanges(getTodoStorageDirPath(this._workingDir), new Map(), remove);
       } else {
         for (const [, todo] of remove) {

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -281,8 +281,8 @@ class Linter {
     return todoBatchCounts;
   }
 
-  async processTodos(options, results, shouldFix, isOverridingConfig) {
-    let fileResults = await this._todoHandler.processResults(results, shouldFix, {
+  async processTodos(options, results, shouldCleanTodos, isOverridingConfig) {
+    let fileResults = await this._todoHandler.processResults(results, shouldCleanTodos, {
       filePath: options.filePath,
       // skip removing todo files if the config is overridden as this can result in todos being incorrectly removed
       shouldRemove: this._getShouldRemove(options, isOverridingConfig),


### PR DESCRIPTION
The `--clean-todo` flag was missing from the todo-handler, resulting in this flag effectively being a noop. This fix ensures that both `--clean-todo` and `--fix` work for cleaning todos, though we prefer users run the narrowly scoped `--clean-todo`, as it changes less and results in more predictable effects.