### PR TITLE
Update require-valid-alt-text rule to require dynamic alt if src is dynamic

### DIFF
--- a/docs/rule/builtin-component-arguments.md
+++ b/docs/rule/builtin-component-arguments.md
@@ -50,7 +50,7 @@ This rule **allows** the following:
 
 ## Related Rules
 
-- [no-unknown-arguments-for-builtin-components](no-unknown-arguments-for-builtin-components.md)
+* [no-unknown-arguments-for-builtin-components](no-unknown-arguments-for-builtin-components.md)
 
 ## References
 

--- a/docs/rule/no-input-tagname.md
+++ b/docs/rule/no-input-tagname.md
@@ -20,8 +20,7 @@ This rule **forbids** the following:
 ## Related rules
 
 * [no-link-to-tagname](no-link-to-tagname.md)
-- [no-unknown-arguments-for-builtin-components](no-unknown-arguments-for-builtin-components.md)
-
+* [no-unknown-arguments-for-builtin-components](no-unknown-arguments-for-builtin-components.md)
 
 ## References
 

--- a/docs/rule/no-link-to-tagname.md
+++ b/docs/rule/no-link-to-tagname.md
@@ -49,7 +49,6 @@ This rule **allows** the following:
 - [no-input-tagname](no-input-tagname.md)
 - [no-unknown-arguments-for-builtin-components](no-unknown-arguments-for-builtin-components.md)
 
-
 ## References
 
 - [Ember guides/LinkTo component](https://guides.emberjs.com/release/routing/linking-between-routes/#toc_the-linkto--component)

--- a/docs/rule/require-valid-alt-text.md
+++ b/docs/rule/require-valid-alt-text.md
@@ -22,6 +22,9 @@ If it's not a meaningful image, it should have an empty alt attribute value and 
 
 Numbers are not considered valid alt text, and this rule disallows using only numbers in alt text.
 
+If `src` has a dynamic value, `alt` must also have a dynamic value. If `src` changes and `alt` does not, the
+alternative text is no longer describing the content correctly.
+
 This rule **forbids** the following:
 
 ```hbs
@@ -32,6 +35,8 @@ This rule **forbids** the following:
 <img src="baz" alt="Picture of baz fixing a bug." />
 <img src="b52.jpg" alt="52" />
 <img src="foo" alt="foo as a banana" role="presentation">
+<img src={{url}} alt="something">
+<img alt="path/to/zoey.jpg" src="https://www.bar.com/lol/{{item}}">
 ```
 
 This rule **allows** the following:
@@ -43,6 +48,9 @@ This rule **allows** the following:
 <img src="baz" alt="Baz taking a {{photo}}" /> // This is valid since photo is a variable name.
 <img src="b52.jpg" alt="b52 bomber jet" />
 <img src="foo" alt="" role="presentation"> // This is valid because it has a role of presentation.
+<img src={{url}} alt={{picture}}>
+<img src="https://www.blah.com/item/{{item}}" alt="{{item}}">
+<img src="https://www.blah.com/item/{{item}}" alt="blah of {{item}}">
 ```
 
 ### `<object>`
@@ -101,3 +109,5 @@ This rule **allows** the following:
 * [WCAG Criterion 1.1.1 - Non-text Content](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html)
 * [HTML 5.2 spec - the img element](https://www.w3.org/TR/html5/semantics-embedded-content.html#the-img-element)
 * [Failure of Success Criterion 1.1.1 due to providing a text alternative that is not null (e.g., alt="spacer" or alt="image") for images that should be ignored by assistive technology](https://www.w3.org/WAI/WCAG21/Techniques/failures/F39)
+* [Failure of Success Criterion 1.1.1 and 4.1.2 due to not updating text alternatives when changes to non-text content occur](https://www.w3.org/WAI/WCAG21/Techniques/failures/F20)
+* [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)

--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -104,6 +104,26 @@ module.exports = class RequireValidAltText extends Rule {
               message: 'The alt text must not be the same as the image source',
               node,
             });
+          } else if (
+            srcValue &&
+            (srcValue.type === 'MustacheStatement' ||
+              (srcValue.type === 'ConcatStatement' &&
+                srcValue.parts.some(({ type }) => type === 'MustacheStatement')))
+          ) {
+            // If src is dynamic, we need to check if alt is dynamic
+            let isAltValueDyanmic = altValue.type === 'MustacheStatement';
+
+            // need to find if some part is dynamic
+            if (altValue.type === 'ConcatStatement') {
+              isAltValueDyanmic = altValue.parts.some(({ type }) => type === 'MustacheStatement');
+            }
+
+            if (!isAltValueDyanmic) {
+              this.logNode({
+                message: 'If src has a dynamic value, alt must also have a dynamic value',
+                node,
+              });
+            }
           } else {
             const altAttribute = AstNodeInfo.findAttribute(node, 'alt');
             if (altAttribute.value) {

--- a/test/unit/recommended-config-test.js
+++ b/test/unit/recommended-config-test.js
@@ -47,7 +47,7 @@ describe('recommended config', function () {
   ensureValid('<FooBar as |baz|><baz.Derp></baz.Derp></FooBar>');
 
   // This ensures that we don't face this issue again => https://github.com/ember-template-lint/ember-template-lint/issues/253
-  ensureValid('<img alt="special thing" src={{some-dir/some-thing this.x}}>');
+  ensureValid('<img alt={{alt}} src={{some-dir/some-thing this.x}}>');
 
   // This ensures that we don't face this issue again => https://github.com/ember-template-lint/ember-template-lint/issues/443
   ensureValid(`

--- a/test/unit/rules/require-valid-alt-text-test.js
+++ b/test/unit/rules/require-valid-alt-text-test.js
@@ -22,6 +22,12 @@ generateRuleTests({
     '<img alt="name {{picture}}">',
     '<img aria-hidden="true">',
     '<img alt="{{picture}}">',
+    '<img src={{url}} alt={{picture}}>',
+    '<img src="{{url}}" alt="{{picture}}">',
+    '<img src={{url}} alt="{{picture}}">',
+    '<img src="{{url}}" alt={{picture}}>',
+    '<img src="https://www.blah.com/item/{{item}}" alt="{{item}}">',
+    '<img src="https://www.blah.com/item/{{item}}" alt="blah of {{item}}">',
     '<img alt="" role="none">',
     '<img alt="" role="presentation">',
 
@@ -105,6 +111,33 @@ generateRuleTests({
       result: {
         message: 'The alt text must not be the same as the image source',
         source: '<img alt="path/to/zoey.jpg" src="path/to/zoey.jpg">',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<img alt="path/to/zoey.jpg" src={{url}}>',
+      result: {
+        message: 'If src has a dynamic value, alt must also have a dynamic value',
+        source: '<img alt="path/to/zoey.jpg" src={{url}}>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<img alt="path/to/zoey.jpg" src="{{url}}">',
+      result: {
+        message: 'If src has a dynamic value, alt must also have a dynamic value',
+        source: '<img alt="path/to/zoey.jpg" src="{{url}}">',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<img alt="path/to/zoey.jpg" src="https://www.bar.com/lol/{{item}}">',
+      result: {
+        message: 'If src has a dynamic value, alt must also have a dynamic value',
+        source: '<img alt="path/to/zoey.jpg" src="https://www.bar.com/lol/{{item}}">',
         line: 1,
         column: 0,
       },


### PR DESCRIPTION
This PR addresses issue https://github.com/ember-template-lint/ember-template-lint/issues/1555 

Good:
```
<img src={{image}}  alt={{imageAlt}} />
```

Bad:
```
<img src={{image}} alt="the team poses as a group at the fall company picnic" />
```

We want to update `require-valid-alt-text` to make sure that if `src` is dynamic, `alt` should be dynamic as well.

In this PR:
- If `src` is `MustacheStatement` or has `MustacheStatement` we check if `alt` is dynamic 
- Added docs 
- Added tests
- Ran lint, so that's why you see other files