### PR TITLE
Resolved issue where test was looking for directories incorrectly

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -70,7 +70,10 @@ function resolveProjectConfig(workingDir, options) {
     // we are explicitly using `--no-config-path` flag
     return {};
   } else {
-    configPath = findUp.sync(CONFIG_FILE_NAME);
+    // look for our config file relative to the specified working directory
+    configPath = findUp.sync(CONFIG_FILE_NAME, {
+      cwd: workingDir,
+    });
 
     if (configPath === undefined) {
       // we weren't given an explicit --config-path argument, and we couldn't

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -615,15 +615,37 @@ describe('determineRuleConfig', function () {
 });
 
 describe('resolveProjectConfig', function () {
-  it('should return an empty object when options.config is set explicitly false', function () {
+  it('should return an empty object when options.configPath is set explicitly false', function () {
     let project = Project.defaultSetup();
 
     try {
-      const config = resolveProjectConfig(project.baseDir, { config: false });
+      const config = resolveProjectConfig(project.baseDir, { configPath: false });
 
       expect(config).toEqual({});
     } finally {
       project.dispose();
+    }
+  });
+
+  it('should search for config relative to the specified working directory', function () {
+    let project1 = Project.defaultSetup();
+    let project2 = Project.defaultSetup();
+
+    project1.chdir();
+
+    project2.setConfig({
+      extends: 'foo',
+    });
+
+    try {
+      const config = resolveProjectConfig(project2.baseDir, {});
+
+      expect(config).toEqual({
+        extends: 'foo',
+      });
+    } finally {
+      project1.dispose();
+      project2.dispose();
     }
   });
 });


### PR DESCRIPTION
If merged, this PR resolves these issues: 
- an issue where the the `get-config` function was looking too far up the parent directories for a config file
- an issue where one of the tests in `get-config-test` was looking for `options.config` instead of `options.configPath`

Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.