### PR TITLE
feat(todos): Adds support for configuring todo decay days by rule

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -9,7 +9,11 @@ const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 
-const { getTodoStorageDirPath, getTodoConfig } = require('@ember-template-lint/todo-utils');
+const {
+  getTodoStorageDirPath,
+  getTodoConfig,
+  validateConfig,
+} = require('@ember-template-lint/todo-utils');
 const chalk = require('chalk');
 const getStdin = require('get-stdin');
 const globby = require('globby');
@@ -296,15 +300,6 @@ async function run() {
   let positional = options._;
   let config;
   let isOverridingConfig = _isOverridingConfig(options);
-  let todoInfo = {
-    added: 0,
-    removed: 0,
-    todoConfig: getTodoConfig(
-      options.workingDirectory,
-      'ember-template-lint',
-      getTodoConfigFromCommandLineOptions(options)
-    ),
-  };
 
   if (options.config) {
     try {
@@ -320,7 +315,25 @@ async function run() {
     options.configPath = false;
   }
 
+  let todoConfigResult = validateConfig(options.workingDirectory);
+
+  if (!todoConfigResult.isValid) {
+    console.error(todoConfigResult.message);
+    process.exitCode = 1;
+    return;
+  }
+
   let linter;
+  let todoInfo = {
+    added: 0,
+    removed: 0,
+    todoConfig: getTodoConfig(
+      options.workingDirectory,
+      'ember-template-lint',
+      getTodoConfigFromCommandLineOptions(options)
+    ),
+  };
+
   try {
     linter = new Linter({
       workingDir: options.workingDirectory,

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -301,6 +301,7 @@ async function run() {
     removed: 0,
     todoConfig: getTodoConfig(
       options.workingDirectory,
+      'ember-template-lint',
       getTodoConfigFromCommandLineOptions(options)
     ),
   };

--- a/lib/formatters/pretty.js
+++ b/lib/formatters/pretty.js
@@ -67,16 +67,16 @@ class PrettyPrinter {
         todoSummary += `, ${todoInfo.removed} todos removed`;
       }
 
-      if (todoInfo.todoConfig) {
-        let todoConfig = todoInfo.todoConfig;
+      if (todoInfo.todoConfig && todoInfo.todoConfig.daysToDecay) {
+        let daysToDecay = todoInfo.todoConfig.daysToDecay;
         let todoConfigSummary = [];
 
-        if (todoConfig.warn) {
-          todoConfigSummary.push(`warn after ${todoConfig.warn}`);
+        if (daysToDecay.warn) {
+          todoConfigSummary.push(`warn after ${daysToDecay.warn}`);
         }
 
-        if (todoConfig.error) {
-          todoConfigSummary.push(`error after ${todoConfig.error}`);
+        if (daysToDecay.error) {
+          todoConfigSummary.push(`error after ${daysToDecay.error}`);
         }
 
         if (todoConfigSummary.length) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^9.0.0",
+    "@ember-template-lint/todo-utils": "^9.1.2",
     "chalk": "^4.1.1",
     "date-fns": "^2.22.1",
     "ember-template-recast": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^8.1.0",
+    "@ember-template-lint/todo-utils": "^9.0.0",
     "chalk": "^4.1.1",
     "date-fns": "^2.22.1",
     "ember-template-recast": "^5.0.3",

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -392,49 +392,6 @@ describe('todo usage', () => {
       expect(todoDirs).toHaveLength(0);
     });
 
-    it('removes expired todo file if a todo item has expired when running with --clean-todo', async function () {
-      project.setConfig({
-        rules: {
-          'require-button-type': true,
-        },
-      });
-
-      project.write({
-        app: {
-          templates: {
-            'require-button-type.hbs': '<button>Check Expiration</button>',
-          },
-        },
-      });
-
-      project.setLegacyTodoConfig({
-        error: 5,
-      });
-
-      // generate todo based on existing error
-      await run(['.', '--update-todo'], {
-        // change the date so errorDate is before today
-        env: {
-          TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
-        },
-      });
-
-      // run normally and expect the issue to be back in the error state and there to be no todo
-      let result = await run(['.', '--clean-todo']);
-
-      let todoDirs = fs.readdirSync(getTodoStorageDirPath(project.baseDir));
-
-      expect(result.exitCode).toEqual(1);
-      expect(result.stdout).toMatchInlineSnapshot(`
-        "app/templates/require-button-type.hbs
-          1:0  error  All \`<button>\` elements should have a valid \`type\` attribute  require-button-type
-
-        ✖ 1 problems (1 errors, 0 warnings)
-          1 errors and 0 warnings potentially fixable with the \`--fix\` option."
-      `);
-      expect(todoDirs).toHaveLength(0);
-    });
-
     it('outputs empty summary for no todos or errors', async function () {
       project.setConfig({
         rules: {
@@ -666,553 +623,6 @@ describe('todo usage', () => {
         `);
     });
 
-    it('should error if daysToDecay.error is less than daysToDecay.warn in package.json', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        warn: 10,
-        error: 5,
-      });
-
-      let result = await run(['.', '--update-todo']);
-
-      expect(result.stderr).toMatch(
-        'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
-      );
-    });
-
-    it('should create todos with correct warn date set via package.json', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        warn: 10,
-      });
-
-      let result = await run(['.', '--update-todo']);
-
-      const todos = [...(await readTodos(project.baseDir)).values()];
-
-      expect(result.exitCode).toEqual(0);
-
-      for (const todo of todos) {
-        expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(10);
-      }
-    });
-
-    it('should create todos with correct warn date set via env var (overrides package.json)', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        warn: 10,
-      });
-
-      let result = await run(['.', '--update-todo'], {
-        env: {
-          TODO_DAYS_TO_WARN: '30',
-        },
-      });
-
-      const todos = [...(await readTodos(project.baseDir)).values()];
-
-      expect(result.exitCode).toEqual(0);
-
-      for (const todo of todos) {
-        expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(30);
-      }
-    });
-
-    it('should create todos with correct warn date set via option (overrides env var)', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        warn: 10,
-      });
-
-      let result = await run(['.', '--update-todo', '--todo-days-to-warn', '30'], {
-        env: {
-          TODO_DAYS_TO_WARN: 20,
-        },
-      });
-
-      const todos = [...(await readTodos(project.baseDir)).values()];
-
-      expect(result.exitCode).toEqual(0);
-
-      for (const todo of todos) {
-        expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(30);
-      }
-    });
-
-    it('should create todos with correct error date set via package.json', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        error: 10,
-      });
-
-      let result = await run(['.', '--update-todo']);
-
-      const todos = [...(await readTodos(project.baseDir)).values()];
-
-      expect(result.exitCode).toEqual(0);
-
-      for (const todo of todos) {
-        expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(10);
-      }
-    });
-
-    it('should create todos with correct error date set via env var (overrides package.json)', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        error: 10,
-      });
-
-      let result = await run(['.', '--update-todo'], {
-        env: {
-          TODO_DAYS_TO_ERROR: '30',
-        },
-      });
-
-      const todos = [...(await readTodos(project.baseDir)).values()];
-
-      expect(result.exitCode).toEqual(0);
-
-      for (const todo of todos) {
-        expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(30);
-      }
-    });
-
-    it('should create todos with correct error date set via option (overrides env var)', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        error: 10,
-      });
-
-      let result = await run(['.', '--update-todo', '--todo-days-to-error', '30'], {
-        env: {
-          TODO_DAYS_TO_ERROR: 20,
-        },
-      });
-
-      const todos = [...(await readTodos(project.baseDir)).values()];
-
-      expect(result.exitCode).toEqual(0);
-
-      for (const todo of todos) {
-        expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(30);
-      }
-    });
-
-    it('should create todos with correct dates set for warn and error via package.json', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        warn: 5,
-        error: 10,
-      });
-
-      let result = await run(['.', '--update-todo']);
-
-      const todos = [...(await readTodos(project.baseDir)).values()];
-
-      expect(result.exitCode).toEqual(0);
-
-      for (const todo of todos) {
-        expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(5);
-        expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(10);
-      }
-    });
-
-    it('should create todos with correct dates set for warn and error via env vars (overrides package.json)', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        warn: 5,
-        error: 10,
-      });
-
-      let result = await run(['.', '--update-todo'], {
-        env: {
-          TODO_DAYS_TO_WARN: 10,
-          TODO_DAYS_TO_ERROR: 20,
-        },
-      });
-
-      const todos = [...(await readTodos(project.baseDir)).values()];
-
-      expect(result.exitCode).toEqual(0);
-
-      for (const todo of todos) {
-        expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(10);
-        expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(20);
-      }
-    });
-
-    it('should create todos with correct dates set for warn and error via options (overrides env vars)', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        warn: 5,
-        error: 10,
-      });
-
-      let result = await run(
-        ['.', '--update-todo', '--todo-days-to-warn', '10', '--todo-days-to-error', '20'],
-        {
-          env: {
-            TODO_DAYS_TO_WARN: 7,
-            TODO_DAYS_TO_ERROR: 11,
-          },
-        }
-      );
-
-      const todos = [...(await readTodos(project.baseDir)).values()];
-
-      expect(result.exitCode).toEqual(0);
-
-      for (const todo of todos) {
-        expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(10);
-        expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(20);
-      }
-    });
-
-    it('should create todos with correct dates set for error while excluding warn', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-      project.setLegacyTodoConfig({
-        warn: 5,
-        error: 10,
-      });
-
-      let result = await run([
-        '.',
-        '--update-todo',
-        '--no-todo-days-to-warn',
-        '--todo-days-to-error',
-        '20',
-      ]);
-
-      const todos = [...(await readTodos(project.baseDir)).values()];
-
-      expect(result.exitCode).toEqual(0);
-
-      for (const todo of todos) {
-        expect(todo.warnDate).toBeFalsy();
-        expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(20);
-      }
-    });
-
-    it('should set to todo if warnDate is not expired', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-
-      project.setLegacyTodoConfig({
-        warn: 5,
-      });
-
-      let result = await run(['.', '--update-todo']);
-
-      result = await run(['.', '--include-todo']);
-
-      expect(result.exitCode).toEqual(0);
-      expect(result.stdout).toMatchInlineSnapshot(`
-          "app/templates/application.hbs
-            1:5  todo  Non-translated string used  no-bare-strings
-
-          ✖ 1 problems (0 errors, 0 warnings, 1 todos)"
-        `);
-    });
-
-    it('should set to todo if errorDate is not expired', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-
-      project.setLegacyTodoConfig({
-        error: 5,
-      });
-
-      let result = await run(['.', '--update-todo']);
-
-      result = await run(['.', '--include-todo']);
-
-      expect(result.exitCode).toEqual(0);
-      expect(result.stdout).toMatchInlineSnapshot(`
-          "app/templates/application.hbs
-            1:5  todo  Non-translated string used  no-bare-strings
-
-          ✖ 1 problems (0 errors, 0 warnings, 1 todos)"
-        `);
-    });
-
-    it('should set todo to warn if warnDate has expired via config', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-
-      project.setLegacyTodoConfig({
-        warn: 5,
-      });
-
-      await run(['.', '--update-todo'], {
-        env: {
-          TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
-        },
-      });
-
-      const result = await run(['.']);
-
-      expect(result.exitCode).toEqual(0);
-      expect(result.stdout).toMatchInlineSnapshot(`
-          "app/templates/application.hbs
-            1:5  warning  Non-translated string used  no-bare-strings
-
-          ✖ 1 problems (0 errors, 1 warnings)"
-        `);
-    });
-
-    it('should set todo to warn if warnDate has expired via option', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-
-      await run(['.', '--update-todo', '--todo-days-to-warn', '5'], {
-        env: {
-          TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
-        },
-      });
-
-      const result = await run(['.']);
-
-      expect(result.exitCode).toEqual(0);
-      expect(result.stdout).toMatchInlineSnapshot(`
-          "app/templates/application.hbs
-            1:5  warning  Non-translated string used  no-bare-strings
-
-          ✖ 1 problems (0 errors, 1 warnings)"
-        `);
-    });
-
-    it('should set todo to warn if warnDate has expired but errorDate has not', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-
-      project.setLegacyTodoConfig({
-        warn: 5,
-        error: 10,
-      });
-
-      await run(['.', '--update-todo'], {
-        env: {
-          TODO_CREATED_DATE: subDays(new Date(), 7).toJSON(),
-        },
-      });
-
-      const result = await run(['.']);
-
-      expect(result.exitCode).toEqual(0);
-      expect(result.stdout).toMatchInlineSnapshot(`
-          "app/templates/application.hbs
-            1:5  warning  Non-translated string used  no-bare-strings
-
-          ✖ 1 problems (0 errors, 1 warnings)"
-        `);
-    });
-
-    it('should set todo to error if errorDate has expired via config', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-
-      project.setLegacyTodoConfig({
-        error: 5,
-      });
-
-      await run(['.', '--update-todo'], {
-        env: {
-          TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
-        },
-      });
-
-      const result = await run(['.']);
-
-      expect(result.exitCode).toEqual(1);
-      expect(result.stdout).toMatchInlineSnapshot(`
-          "app/templates/application.hbs
-            1:5  error  Non-translated string used  no-bare-strings
-
-          ✖ 1 problems (1 errors, 0 warnings)"
-        `);
-    });
-
     it('should set todo to error if errorDate has expired via env var', async function () {
       project.setConfig({
         rules: {
@@ -1276,42 +686,6 @@ describe('todo usage', () => {
         `);
     });
 
-    it('should set todo to error if both warnDate and errorDate have expired via config', async function () {
-      project.setConfig({
-        rules: {
-          'no-bare-strings': true,
-        },
-      });
-      project.write({
-        app: {
-          templates: {
-            'application.hbs': '<div>Bare strings are bad...</div>',
-          },
-        },
-      });
-
-      project.setLegacyTodoConfig({
-        warn: 5,
-        error: 10,
-      });
-
-      await run(['.', '--update-todo'], {
-        env: {
-          TODO_CREATED_DATE: subDays(new Date(), 11).toJSON(),
-        },
-      });
-
-      const result = await run(['.']);
-
-      expect(result.exitCode).toEqual(1);
-      expect(result.stdout).toMatchInlineSnapshot(`
-          "app/templates/application.hbs
-            1:5  error  Non-translated string used  no-bare-strings
-
-          ✖ 1 problems (1 errors, 0 warnings)"
-        `);
-    });
-
     it('should set todo to error if both warnDate and errorDate have expired via options', async function () {
       project.setConfig({
         rules: {
@@ -1342,5 +716,661 @@ describe('todo usage', () => {
           ✖ 1 problems (1 errors, 0 warnings)"
         `);
     });
+
+    for (const { isLegacy, setTodoConfig } of [
+      {
+        isLegacy: true,
+        setTodoConfig: (daysToDecay) => project.setLegacyPackageJsonTodoConfig(daysToDecay),
+      },
+      {
+        isLegacy: false,
+        setTodoConfig: (daysToDecay) =>
+          project.setPackageJsonTodoConfig('ember-template-lint', daysToDecay),
+      },
+      {
+        isLegacy: false,
+        setTodoConfig: (daysToDecay) => project.setLintTodorc('ember-template-lint', daysToDecay),
+      },
+    ]) {
+      it('removes expired todo file if a todo item has expired when running with --clean-todo', async function () {
+        project.setConfig({
+          rules: {
+            'require-button-type': true,
+          },
+        });
+
+        project.write({
+          app: {
+            templates: {
+              'require-button-type.hbs': '<button>Check Expiration</button>',
+            },
+          },
+        });
+
+        setTodoConfig({
+          error: 5,
+        });
+
+        // generate todo based on existing error
+        await run(['.', '--update-todo'], {
+          // change the date so errorDate is before today
+          env: {
+            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+          },
+        });
+
+        // run normally and expect the issue to be back in the error state and there to be no todo
+        let result = await run(['.', '--clean-todo']);
+
+        let todoDirs = fs.readdirSync(getTodoStorageDirPath(project.baseDir));
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toMatchInlineSnapshot(`
+              "app/templates/require-button-type.hbs
+                1:0  error  All \`<button>\` elements should have a valid \`type\` attribute  require-button-type
+
+              ✖ 1 problems (1 errors, 0 warnings)
+                1 errors and 0 warnings potentially fixable with the \`--fix\` option."
+            `);
+        expect(todoDirs).toHaveLength(0);
+      });
+
+      it('should error if daysToDecay.error is less than daysToDecay.warn in package.json', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          warn: 10,
+          error: 5,
+        });
+
+        let result = await run(['.', '--update-todo']);
+
+        expect(result.stderr).toMatch(
+          'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
+        );
+      });
+
+      it('should create todos with correct warn date set via package.json', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          warn: 10,
+        });
+
+        let result = await run(['.', '--update-todo']);
+
+        const todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+
+        for (const todo of todos) {
+          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(10);
+        }
+      });
+
+      it('should create todos with correct warn date set via env var (overrides package.json)', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          warn: 10,
+        });
+
+        let result = await run(['.', '--update-todo'], {
+          env: {
+            TODO_DAYS_TO_WARN: '30',
+          },
+        });
+
+        const todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+
+        for (const todo of todos) {
+          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(30);
+        }
+      });
+
+      it('should create todos with correct warn date set via option (overrides env var)', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          warn: 10,
+        });
+
+        let result = await run(['.', '--update-todo', '--todo-days-to-warn', '30'], {
+          env: {
+            TODO_DAYS_TO_WARN: 20,
+          },
+        });
+
+        const todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+
+        for (const todo of todos) {
+          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(30);
+        }
+      });
+
+      it('should create todos with correct error date set via package.json', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          error: 10,
+        });
+
+        let result = await run(['.', '--update-todo']);
+
+        const todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+
+        for (const todo of todos) {
+          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+            10
+          );
+        }
+      });
+
+      it('should create todos with correct error date set via env var (overrides package.json)', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          error: 10,
+        });
+
+        let result = await run(['.', '--update-todo'], {
+          env: {
+            TODO_DAYS_TO_ERROR: '30',
+          },
+        });
+
+        const todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+
+        for (const todo of todos) {
+          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+            30
+          );
+        }
+      });
+
+      it('should create todos with correct error date set via option (overrides env var)', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          error: 10,
+        });
+
+        let result = await run(['.', '--update-todo', '--todo-days-to-error', '30'], {
+          env: {
+            TODO_DAYS_TO_ERROR: 20,
+          },
+        });
+
+        const todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+
+        for (const todo of todos) {
+          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+            30
+          );
+        }
+      });
+
+      it('should create todos with correct dates set for warn and error via package.json', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        let result = await run(['.', '--update-todo']);
+
+        const todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+
+        for (const todo of todos) {
+          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(5);
+          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+            10
+          );
+        }
+      });
+
+      it('should create todos with correct dates set for warn and error via env vars (overrides package.json)', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        let result = await run(['.', '--update-todo'], {
+          env: {
+            TODO_DAYS_TO_WARN: 10,
+            TODO_DAYS_TO_ERROR: 20,
+          },
+        });
+
+        const todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+
+        for (const todo of todos) {
+          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(10);
+          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+            20
+          );
+        }
+      });
+
+      it('should create todos with correct dates set for warn and error via options (overrides env vars)', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        let result = await run(
+          ['.', '--update-todo', '--todo-days-to-warn', '10', '--todo-days-to-error', '20'],
+          {
+            env: {
+              TODO_DAYS_TO_WARN: 7,
+              TODO_DAYS_TO_ERROR: 11,
+            },
+          }
+        );
+
+        const todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+
+        for (const todo of todos) {
+          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(10);
+          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+            20
+          );
+        }
+      });
+
+      it('should create todos with correct dates set for error while excluding warn', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+        setTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        let result = await run([
+          '.',
+          '--update-todo',
+          '--no-todo-days-to-warn',
+          '--todo-days-to-error',
+          '20',
+        ]);
+
+        const todos = [...(await readTodos(project.baseDir)).values()];
+
+        expect(result.exitCode).toEqual(0);
+
+        for (const todo of todos) {
+          expect(todo.warnDate).toBeFalsy();
+          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+            20
+          );
+        }
+      });
+
+      it('should set to todo if warnDate is not expired', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        setTodoConfig({
+          warn: 5,
+        });
+
+        let result = await run(['.', '--update-todo']);
+
+        result = await run(['.', '--include-todo']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toMatchInlineSnapshot(`
+                "app/templates/application.hbs
+                  1:5  todo  Non-translated string used  no-bare-strings
+
+                ✖ 1 problems (0 errors, 0 warnings, 1 todos)"
+              `);
+      });
+
+      it('should set to todo if errorDate is not expired', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        setTodoConfig({
+          error: 5,
+        });
+
+        let result = await run(['.', '--update-todo']);
+
+        result = await run(['.', '--include-todo']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toMatchInlineSnapshot(`
+                "app/templates/application.hbs
+                  1:5  todo  Non-translated string used  no-bare-strings
+
+                ✖ 1 problems (0 errors, 0 warnings, 1 todos)"
+              `);
+      });
+
+      it('should set todo to warn if warnDate has expired via config', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        setTodoConfig({
+          warn: 5,
+        });
+
+        await run(['.', '--update-todo'], {
+          env: {
+            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+          },
+        });
+
+        const result = await run(['.']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toMatchInlineSnapshot(`
+                "app/templates/application.hbs
+                  1:5  warning  Non-translated string used  no-bare-strings
+
+                ✖ 1 problems (0 errors, 1 warnings)"
+              `);
+      });
+
+      it('should set todo to warn if warnDate has expired via option', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        await run(['.', '--update-todo', '--todo-days-to-warn', '5'], {
+          env: {
+            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+          },
+        });
+
+        const result = await run(['.']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toMatchInlineSnapshot(`
+                "app/templates/application.hbs
+                  1:5  warning  Non-translated string used  no-bare-strings
+
+                ✖ 1 problems (0 errors, 1 warnings)"
+              `);
+      });
+
+      it('should set todo to warn if warnDate has expired but errorDate has not', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        setTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        await run(['.', '--update-todo'], {
+          env: {
+            TODO_CREATED_DATE: subDays(new Date(), 7).toJSON(),
+          },
+        });
+
+        const result = await run(['.']);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toMatchInlineSnapshot(`
+                "app/templates/application.hbs
+                  1:5  warning  Non-translated string used  no-bare-strings
+
+                ✖ 1 problems (0 errors, 1 warnings)"
+              `);
+      });
+
+      it('should set todo to error if errorDate has expired via config', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        setTodoConfig({
+          error: 5,
+        });
+
+        await run(['.', '--update-todo'], {
+          env: {
+            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+          },
+        });
+
+        const result = await run(['.']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toMatchInlineSnapshot(`
+                "app/templates/application.hbs
+                  1:5  error  Non-translated string used  no-bare-strings
+
+                ✖ 1 problems (1 errors, 0 warnings)"
+              `);
+      });
+
+      it('should set todo to error if both warnDate and errorDate have expired via config', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div>Bare strings are bad...</div>',
+            },
+          },
+        });
+
+        setTodoConfig({
+          warn: 5,
+          error: 10,
+        });
+
+        await run(['.', '--update-todo'], {
+          env: {
+            TODO_CREATED_DATE: subDays(new Date(), 11).toJSON(),
+          },
+        });
+
+        const result = await run(['.']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toMatchInlineSnapshot(`
+                "app/templates/application.hbs
+                  1:5  error  Non-translated string used  no-bare-strings
+
+                ✖ 1 problems (1 errors, 0 warnings)"
+              `);
+      });
+    }
   });
 });

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -811,7 +811,7 @@ describe('todo usage', () => {
           expect(todoDirs).toHaveLength(0);
         });
 
-        it('should error if daysToDecay.error is less than daysToDecay.warn in package.json', async function () {
+        it('should error if daysToDecay.error is less than daysToDecay.warn in config', async function () {
           project.setConfig({
             rules: {
               'no-bare-strings': true,
@@ -836,7 +836,7 @@ describe('todo usage', () => {
           );
         });
 
-        it('should create todos with correct warn date set via package.json', async function () {
+        it('should create todos with correct warn date set via config', async function () {
           project.setConfig({
             rules: {
               'no-bare-strings': true,
@@ -866,7 +866,7 @@ describe('todo usage', () => {
           }
         });
 
-        it('should create todos with correct warn date set via env var (overrides package.json)', async function () {
+        it('should create todos with correct warn date set via env var (overrides config)', async function () {
           project.setConfig({
             rules: {
               'no-bare-strings': true,
@@ -934,7 +934,7 @@ describe('todo usage', () => {
           }
         });
 
-        it('should create todos with correct error date set via package.json', async function () {
+        it('should create todos with correct error date set via config', async function () {
           project.setConfig({
             rules: {
               'no-bare-strings': true,
@@ -964,7 +964,7 @@ describe('todo usage', () => {
           }
         });
 
-        it('should create todos with correct error date set via env var (overrides package.json)', async function () {
+        it('should create todos with correct error date set via env var (overrides config)', async function () {
           project.setConfig({
             rules: {
               'no-bare-strings': true,
@@ -1032,7 +1032,7 @@ describe('todo usage', () => {
           }
         });
 
-        it('should create todos with correct dates set for warn and error via package.json', async function () {
+        it('should create todos with correct dates set for warn and error via config', async function () {
           project.setConfig({
             rules: {
               'no-bare-strings': true,
@@ -1066,7 +1066,7 @@ describe('todo usage', () => {
           }
         });
 
-        it('should create todos with correct dates set for warn and error via env vars (overrides package.json)', async function () {
+        it('should create todos with correct dates set for warn and error via env vars (overrides config)', async function () {
           project.setConfig({
             rules: {
               'no-bare-strings': true,

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -717,659 +717,722 @@ describe('todo usage', () => {
         `);
     });
 
-    for (const { isLegacy, setTodoConfig } of [
+    for (const { name, isLegacy, setTodoConfig } of [
       {
+        name: 'Legacy todo configuration',
         isLegacy: true,
         setTodoConfig: (daysToDecay) => project.setLegacyPackageJsonTodoConfig(daysToDecay),
       },
       {
+        name: 'Package.json todo configuration',
         isLegacy: false,
-        setTodoConfig: (daysToDecay) =>
-          project.setPackageJsonTodoConfig('ember-template-lint', daysToDecay),
+        setTodoConfig: (daysToDecay, daysToDecayByRule) =>
+          project.setPackageJsonTodoConfig('ember-template-lint', daysToDecay, daysToDecayByRule),
       },
       {
+        name: '.lint-todorc.js todo configuration',
         isLegacy: false,
-        setTodoConfig: (daysToDecay) => project.setLintTodorc('ember-template-lint', daysToDecay),
+        setTodoConfig: (daysToDecay, daysToDecayByRule) =>
+          project.setLintTodorc('ember-template-lint', daysToDecay, daysToDecayByRule),
       },
     ]) {
-      it('removes expired todo file if a todo item has expired when running with --clean-todo', async function () {
-        project.setConfig({
-          rules: {
-            'require-button-type': true,
-          },
-        });
-
-        project.write({
-          app: {
-            templates: {
-              'require-button-type.hbs': '<button>Check Expiration</button>',
+      describe(name, () => {
+        it('removes expired todo file if a todo item has expired when running with --clean-todo', async function () {
+          project.setConfig({
+            rules: {
+              'require-button-type': true,
             },
-          },
-        });
+          });
 
-        setTodoConfig({
-          error: 5,
-        });
+          project.write({
+            app: {
+              templates: {
+                'require-button-type.hbs': '<button>Check Expiration</button>',
+              },
+            },
+          });
 
-        // generate todo based on existing error
-        await run(['.', '--update-todo'], {
-          // change the date so errorDate is before today
-          env: {
-            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
-          },
-        });
+          setTodoConfig({
+            error: 5,
+          });
 
-        // run normally and expect the issue to be back in the error state and there to be no todo
-        let result = await run(['.', '--clean-todo']);
+          // generate todo based on existing error
+          await run(['.', '--update-todo'], {
+            // change the date so errorDate is before today
+            env: {
+              TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+            },
+          });
 
-        let todoDirs = fs.readdirSync(getTodoStorageDirPath(project.baseDir));
+          // run normally and expect the issue to be back in the error state and there to be no todo
+          let result = await run(['.', '--clean-todo']);
 
-        expect(result.exitCode).toEqual(1);
-        expect(result.stdout).toMatchInlineSnapshot(`
+          let todoDirs = fs.readdirSync(getTodoStorageDirPath(project.baseDir));
+
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout).toMatchInlineSnapshot(`
               "app/templates/require-button-type.hbs
                 1:0  error  All \`<button>\` elements should have a valid \`type\` attribute  require-button-type
 
               ✖ 1 problems (1 errors, 0 warnings)
                 1 errors and 0 warnings potentially fixable with the \`--fix\` option."
             `);
-        expect(todoDirs).toHaveLength(0);
-      });
-
-      it('should error if daysToDecay.error is less than daysToDecay.warn in package.json', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
+          expect(todoDirs).toHaveLength(0);
         });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+
+        it('should error if daysToDecay.error is less than daysToDecay.warn in package.json', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
             },
-          },
-        });
-        setTodoConfig({
-          warn: 10,
-          error: 5,
-        });
-
-        let result = await run(['.', '--update-todo']);
-
-        expect(result.stderr).toMatch(
-          'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
-        );
-      });
-
-      it('should create todos with correct warn date set via package.json', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
-        });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
             },
-          },
-        });
-        setTodoConfig({
-          warn: 10,
-        });
+          });
+          setTodoConfig({
+            warn: 10,
+            error: 5,
+          });
 
-        let result = await run(['.', '--update-todo']);
+          let result = await run(['.', '--update-todo']);
 
-        const todos = [...(await readTodos(project.baseDir)).values()];
-
-        expect(result.exitCode).toEqual(0);
-
-        for (const todo of todos) {
-          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(10);
-        }
-      });
-
-      it('should create todos with correct warn date set via env var (overrides package.json)', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
-        });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
-            },
-          },
-        });
-        setTodoConfig({
-          warn: 10,
-        });
-
-        let result = await run(['.', '--update-todo'], {
-          env: {
-            TODO_DAYS_TO_WARN: '30',
-          },
-        });
-
-        const todos = [...(await readTodos(project.baseDir)).values()];
-
-        expect(result.exitCode).toEqual(0);
-
-        for (const todo of todos) {
-          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(30);
-        }
-      });
-
-      it('should create todos with correct warn date set via option (overrides env var)', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
-        });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
-            },
-          },
-        });
-        setTodoConfig({
-          warn: 10,
-        });
-
-        let result = await run(['.', '--update-todo', '--todo-days-to-warn', '30'], {
-          env: {
-            TODO_DAYS_TO_WARN: 20,
-          },
-        });
-
-        const todos = [...(await readTodos(project.baseDir)).values()];
-
-        expect(result.exitCode).toEqual(0);
-
-        for (const todo of todos) {
-          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(30);
-        }
-      });
-
-      it('should create todos with correct error date set via package.json', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
-        });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
-            },
-          },
-        });
-        setTodoConfig({
-          error: 10,
-        });
-
-        let result = await run(['.', '--update-todo']);
-
-        const todos = [...(await readTodos(project.baseDir)).values()];
-
-        expect(result.exitCode).toEqual(0);
-
-        for (const todo of todos) {
-          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
-            10
+          expect(result.stderr).toMatch(
+            'The provided todo configuration contains invalid values. The `warn` value (10) must be less than the `error` value (5).'
           );
-        }
-      });
-
-      it('should create todos with correct error date set via env var (overrides package.json)', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
         });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+
+        it('should create todos with correct warn date set via package.json', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
             },
-          },
-        });
-        setTodoConfig({
-          error: 10,
-        });
-
-        let result = await run(['.', '--update-todo'], {
-          env: {
-            TODO_DAYS_TO_ERROR: '30',
-          },
-        });
-
-        const todos = [...(await readTodos(project.baseDir)).values()];
-
-        expect(result.exitCode).toEqual(0);
-
-        for (const todo of todos) {
-          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
-            30
-          );
-        }
-      });
-
-      it('should create todos with correct error date set via option (overrides env var)', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
-        });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
             },
-          },
-        });
-        setTodoConfig({
-          error: 10,
-        });
+          });
+          setTodoConfig({
+            warn: 10,
+          });
 
-        let result = await run(['.', '--update-todo', '--todo-days-to-error', '30'], {
-          env: {
-            TODO_DAYS_TO_ERROR: 20,
-          },
-        });
+          let result = await run(['.', '--update-todo']);
 
-        const todos = [...(await readTodos(project.baseDir)).values()];
+          const todos = [...(await readTodos(project.baseDir)).values()];
 
-        expect(result.exitCode).toEqual(0);
+          expect(result.exitCode).toEqual(0);
 
-        for (const todo of todos) {
-          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
-            30
-          );
-        }
-      });
-
-      it('should create todos with correct dates set for warn and error via package.json', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
-        });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
-            },
-          },
-        });
-        setTodoConfig({
-          warn: 5,
-          error: 10,
-        });
-
-        let result = await run(['.', '--update-todo']);
-
-        const todos = [...(await readTodos(project.baseDir)).values()];
-
-        expect(result.exitCode).toEqual(0);
-
-        for (const todo of todos) {
-          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(5);
-          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
-            10
-          );
-        }
-      });
-
-      it('should create todos with correct dates set for warn and error via env vars (overrides package.json)', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
-        });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
-            },
-          },
-        });
-        setTodoConfig({
-          warn: 5,
-          error: 10,
-        });
-
-        let result = await run(['.', '--update-todo'], {
-          env: {
-            TODO_DAYS_TO_WARN: 10,
-            TODO_DAYS_TO_ERROR: 20,
-          },
-        });
-
-        const todos = [...(await readTodos(project.baseDir)).values()];
-
-        expect(result.exitCode).toEqual(0);
-
-        for (const todo of todos) {
-          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(10);
-          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
-            20
-          );
-        }
-      });
-
-      it('should create todos with correct dates set for warn and error via options (overrides env vars)', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
-        });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
-            },
-          },
-        });
-        setTodoConfig({
-          warn: 5,
-          error: 10,
-        });
-
-        let result = await run(
-          ['.', '--update-todo', '--todo-days-to-warn', '10', '--todo-days-to-error', '20'],
-          {
-            env: {
-              TODO_DAYS_TO_WARN: 7,
-              TODO_DAYS_TO_ERROR: 11,
-            },
+          for (const todo of todos) {
+            expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(
+              10
+            );
           }
-        );
-
-        const todos = [...(await readTodos(project.baseDir)).values()];
-
-        expect(result.exitCode).toEqual(0);
-
-        for (const todo of todos) {
-          expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(10);
-          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
-            20
-          );
-        }
-      });
-
-      it('should create todos with correct dates set for error while excluding warn', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
         });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+
+        it('should create todos with correct warn date set via env var (overrides package.json)', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
             },
-          },
-        });
-        setTodoConfig({
-          warn: 5,
-          error: 10,
-        });
-
-        let result = await run([
-          '.',
-          '--update-todo',
-          '--no-todo-days-to-warn',
-          '--todo-days-to-error',
-          '20',
-        ]);
-
-        const todos = [...(await readTodos(project.baseDir)).values()];
-
-        expect(result.exitCode).toEqual(0);
-
-        for (const todo of todos) {
-          expect(todo.warnDate).toBeFalsy();
-          expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
-            20
-          );
-        }
-      });
-
-      it('should set to todo if warnDate is not expired', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
-        });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
             },
-          },
+          });
+          setTodoConfig({
+            warn: 10,
+          });
+
+          let result = await run(['.', '--update-todo'], {
+            env: {
+              TODO_DAYS_TO_WARN: '30',
+            },
+          });
+
+          const todos = [...(await readTodos(project.baseDir)).values()];
+
+          expect(result.exitCode).toEqual(0);
+
+          for (const todo of todos) {
+            expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(
+              30
+            );
+          }
         });
 
-        setTodoConfig({
-          warn: 5,
+        it('should create todos with correct warn date set via option (overrides env var)', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
+          setTodoConfig({
+            warn: 10,
+          });
+
+          let result = await run(['.', '--update-todo', '--todo-days-to-warn', '30'], {
+            env: {
+              TODO_DAYS_TO_WARN: 20,
+            },
+          });
+
+          const todos = [...(await readTodos(project.baseDir)).values()];
+
+          expect(result.exitCode).toEqual(0);
+
+          for (const todo of todos) {
+            expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(
+              30
+            );
+          }
         });
 
-        let result = await run(['.', '--update-todo']);
+        it('should create todos with correct error date set via package.json', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
+          setTodoConfig({
+            error: 10,
+          });
 
-        result = await run(['.', '--include-todo']);
+          let result = await run(['.', '--update-todo']);
 
-        expect(result.exitCode).toEqual(0);
-        expect(result.stdout).toMatchInlineSnapshot(`
+          const todos = [...(await readTodos(project.baseDir)).values()];
+
+          expect(result.exitCode).toEqual(0);
+
+          for (const todo of todos) {
+            expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+              10
+            );
+          }
+        });
+
+        it('should create todos with correct error date set via env var (overrides package.json)', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
+          setTodoConfig({
+            error: 10,
+          });
+
+          let result = await run(['.', '--update-todo'], {
+            env: {
+              TODO_DAYS_TO_ERROR: '30',
+            },
+          });
+
+          const todos = [...(await readTodos(project.baseDir)).values()];
+
+          expect(result.exitCode).toEqual(0);
+
+          for (const todo of todos) {
+            expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+              30
+            );
+          }
+        });
+
+        it('should create todos with correct error date set via option (overrides env var)', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
+          setTodoConfig({
+            error: 10,
+          });
+
+          let result = await run(['.', '--update-todo', '--todo-days-to-error', '30'], {
+            env: {
+              TODO_DAYS_TO_ERROR: 20,
+            },
+          });
+
+          const todos = [...(await readTodos(project.baseDir)).values()];
+
+          expect(result.exitCode).toEqual(0);
+
+          for (const todo of todos) {
+            expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+              30
+            );
+          }
+        });
+
+        it('should create todos with correct dates set for warn and error via package.json', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
+          setTodoConfig({
+            warn: 5,
+            error: 10,
+          });
+
+          let result = await run(['.', '--update-todo']);
+
+          const todos = [...(await readTodos(project.baseDir)).values()];
+
+          expect(result.exitCode).toEqual(0);
+
+          for (const todo of todos) {
+            expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(
+              5
+            );
+            expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+              10
+            );
+          }
+        });
+
+        it('should create todos with correct dates set for warn and error via env vars (overrides package.json)', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
+          setTodoConfig({
+            warn: 5,
+            error: 10,
+          });
+
+          let result = await run(['.', '--update-todo'], {
+            env: {
+              TODO_DAYS_TO_WARN: 10,
+              TODO_DAYS_TO_ERROR: 20,
+            },
+          });
+
+          const todos = [...(await readTodos(project.baseDir)).values()];
+
+          expect(result.exitCode).toEqual(0);
+
+          for (const todo of todos) {
+            expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(
+              10
+            );
+            expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+              20
+            );
+          }
+        });
+
+        it('should create todos with correct dates set for warn and error via options (overrides env vars)', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
+          setTodoConfig({
+            warn: 5,
+            error: 10,
+          });
+
+          let result = await run(
+            ['.', '--update-todo', '--todo-days-to-warn', '10', '--todo-days-to-error', '20'],
+            {
+              env: {
+                TODO_DAYS_TO_WARN: 7,
+                TODO_DAYS_TO_ERROR: 11,
+              },
+            }
+          );
+
+          const todos = [...(await readTodos(project.baseDir)).values()];
+
+          expect(result.exitCode).toEqual(0);
+
+          for (const todo of todos) {
+            expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(
+              10
+            );
+            expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+              20
+            );
+          }
+        });
+
+        it('should create todos with correct dates set for error while excluding warn', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
+          setTodoConfig({
+            warn: 5,
+            error: 10,
+          });
+
+          let result = await run([
+            '.',
+            '--update-todo',
+            '--no-todo-days-to-warn',
+            '--todo-days-to-error',
+            '20',
+          ]);
+
+          const todos = [...(await readTodos(project.baseDir)).values()];
+
+          expect(result.exitCode).toEqual(0);
+
+          for (const todo of todos) {
+            expect(todo.warnDate).toBeFalsy();
+            expect(differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))).toEqual(
+              20
+            );
+          }
+        });
+
+        it('should set to todo if warnDate is not expired', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
+            },
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
+
+          setTodoConfig({
+            warn: 5,
+          });
+
+          let result = await run(['.', '--update-todo']);
+
+          result = await run(['.', '--include-todo']);
+
+          expect(result.exitCode).toEqual(0);
+          expect(result.stdout).toMatchInlineSnapshot(`
                 "app/templates/application.hbs
                   1:5  todo  Non-translated string used  no-bare-strings
 
                 ✖ 1 problems (0 errors, 0 warnings, 1 todos)"
               `);
-      });
-
-      it('should set to todo if errorDate is not expired', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
         });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+
+        it('should set to todo if errorDate is not expired', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
             },
-          },
-        });
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
 
-        setTodoConfig({
-          error: 5,
-        });
+          setTodoConfig({
+            error: 5,
+          });
 
-        let result = await run(['.', '--update-todo']);
+          let result = await run(['.', '--update-todo']);
 
-        result = await run(['.', '--include-todo']);
+          result = await run(['.', '--include-todo']);
 
-        expect(result.exitCode).toEqual(0);
-        expect(result.stdout).toMatchInlineSnapshot(`
+          expect(result.exitCode).toEqual(0);
+          expect(result.stdout).toMatchInlineSnapshot(`
                 "app/templates/application.hbs
                   1:5  todo  Non-translated string used  no-bare-strings
 
                 ✖ 1 problems (0 errors, 0 warnings, 1 todos)"
               `);
-      });
-
-      it('should set todo to warn if warnDate has expired via config', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
         });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+
+        it('should set todo to warn if warnDate has expired via config', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
             },
-          },
-        });
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
 
-        setTodoConfig({
-          warn: 5,
-        });
+          setTodoConfig({
+            warn: 5,
+          });
 
-        await run(['.', '--update-todo'], {
-          env: {
-            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
-          },
-        });
+          await run(['.', '--update-todo'], {
+            env: {
+              TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+            },
+          });
 
-        const result = await run(['.']);
+          const result = await run(['.']);
 
-        expect(result.exitCode).toEqual(0);
-        expect(result.stdout).toMatchInlineSnapshot(`
+          expect(result.exitCode).toEqual(0);
+          expect(result.stdout).toMatchInlineSnapshot(`
                 "app/templates/application.hbs
                   1:5  warning  Non-translated string used  no-bare-strings
 
                 ✖ 1 problems (0 errors, 1 warnings)"
               `);
-      });
-
-      it('should set todo to warn if warnDate has expired via option', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
         });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+
+        it('should set todo to warn if warnDate has expired via option', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
             },
-          },
-        });
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
 
-        await run(['.', '--update-todo', '--todo-days-to-warn', '5'], {
-          env: {
-            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
-          },
-        });
+          await run(['.', '--update-todo', '--todo-days-to-warn', '5'], {
+            env: {
+              TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+            },
+          });
 
-        const result = await run(['.']);
+          const result = await run(['.']);
 
-        expect(result.exitCode).toEqual(0);
-        expect(result.stdout).toMatchInlineSnapshot(`
+          expect(result.exitCode).toEqual(0);
+          expect(result.stdout).toMatchInlineSnapshot(`
                 "app/templates/application.hbs
                   1:5  warning  Non-translated string used  no-bare-strings
 
                 ✖ 1 problems (0 errors, 1 warnings)"
               `);
-      });
-
-      it('should set todo to warn if warnDate has expired but errorDate has not', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
         });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+
+        it('should set todo to warn if warnDate has expired but errorDate has not', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
             },
-          },
-        });
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
 
-        setTodoConfig({
-          warn: 5,
-          error: 10,
-        });
+          setTodoConfig({
+            warn: 5,
+            error: 10,
+          });
 
-        await run(['.', '--update-todo'], {
-          env: {
-            TODO_CREATED_DATE: subDays(new Date(), 7).toJSON(),
-          },
-        });
+          await run(['.', '--update-todo'], {
+            env: {
+              TODO_CREATED_DATE: subDays(new Date(), 7).toJSON(),
+            },
+          });
 
-        const result = await run(['.']);
+          const result = await run(['.']);
 
-        expect(result.exitCode).toEqual(0);
-        expect(result.stdout).toMatchInlineSnapshot(`
+          expect(result.exitCode).toEqual(0);
+          expect(result.stdout).toMatchInlineSnapshot(`
                 "app/templates/application.hbs
                   1:5  warning  Non-translated string used  no-bare-strings
 
                 ✖ 1 problems (0 errors, 1 warnings)"
               `);
-      });
-
-      it('should set todo to error if errorDate has expired via config', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
         });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+
+        it('should set todo to error if errorDate has expired via config', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
             },
-          },
-        });
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
 
-        setTodoConfig({
-          error: 5,
-        });
+          setTodoConfig({
+            error: 5,
+          });
 
-        await run(['.', '--update-todo'], {
-          env: {
-            TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
-          },
-        });
+          await run(['.', '--update-todo'], {
+            env: {
+              TODO_CREATED_DATE: subDays(new Date(), 10).toJSON(),
+            },
+          });
 
-        const result = await run(['.']);
+          const result = await run(['.']);
 
-        expect(result.exitCode).toEqual(1);
-        expect(result.stdout).toMatchInlineSnapshot(`
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout).toMatchInlineSnapshot(`
                 "app/templates/application.hbs
                   1:5  error  Non-translated string used  no-bare-strings
 
                 ✖ 1 problems (1 errors, 0 warnings)"
               `);
-      });
-
-      it('should set todo to error if both warnDate and errorDate have expired via config', async function () {
-        project.setConfig({
-          rules: {
-            'no-bare-strings': true,
-          },
         });
-        project.write({
-          app: {
-            templates: {
-              'application.hbs': '<div>Bare strings are bad...</div>',
+
+        it('should set todo to error if both warnDate and errorDate have expired via config', async function () {
+          project.setConfig({
+            rules: {
+              'no-bare-strings': true,
             },
-          },
-        });
+          });
+          project.write({
+            app: {
+              templates: {
+                'application.hbs': '<div>Bare strings are bad...</div>',
+              },
+            },
+          });
 
-        setTodoConfig({
-          warn: 5,
-          error: 10,
-        });
+          setTodoConfig({
+            warn: 5,
+            error: 10,
+          });
 
-        await run(['.', '--update-todo'], {
-          env: {
-            TODO_CREATED_DATE: subDays(new Date(), 11).toJSON(),
-          },
-        });
+          await run(['.', '--update-todo'], {
+            env: {
+              TODO_CREATED_DATE: subDays(new Date(), 11).toJSON(),
+            },
+          });
 
-        const result = await run(['.']);
+          const result = await run(['.']);
 
-        expect(result.exitCode).toEqual(1);
-        expect(result.stdout).toMatchInlineSnapshot(`
+          expect(result.exitCode).toEqual(1);
+          expect(result.stdout).toMatchInlineSnapshot(`
                 "app/templates/application.hbs
                   1:5  error  Non-translated string used  no-bare-strings
 
                 ✖ 1 problems (1 errors, 0 warnings)"
               `);
+        });
+
+        if (!isLegacy) {
+          it('should set todos to correct dates for specific rules', async () => {
+            project.setConfig({
+              rules: {
+                'no-bare-strings': true,
+              },
+            });
+            project.write({
+              app: {
+                templates: {
+                  'application.hbs': '<div>Bare strings are bad...</div>',
+                },
+              },
+            });
+
+            setTodoConfig(
+              {
+                warn: 5,
+                error: 10,
+              },
+              {
+                'no-bare-strings': {
+                  warn: 10,
+                  error: 20,
+                },
+              }
+            );
+
+            let result = await run(['.', '--update-todo']);
+
+            const todos = [...(await readTodos(project.baseDir)).values()];
+
+            expect(result.exitCode).toEqual(0);
+
+            for (const todo of todos) {
+              expect(differenceInDays(new Date(todo.warnDate), new Date(todo.createdDate))).toEqual(
+                10
+              );
+              expect(
+                differenceInDays(new Date(todo.errorDate), new Date(todo.createdDate))
+              ).toEqual(20);
+            }
+          });
+        }
       });
     }
   });

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -45,7 +45,7 @@ describe('todo usage', () => {
         },
       });
 
-      project.setLegacyPackageJsonTodoConfig({
+      project.setShorthandPackageJsonTodoConfig({
         warn: 5,
         error: 10,
       });
@@ -750,9 +750,9 @@ describe('todo usage', () => {
     });
     for (const { name, isLegacy, setTodoConfig } of [
       {
-        name: 'Legacy todo configuration',
+        name: 'Shorthand todo configuration',
         isLegacy: true,
-        setTodoConfig: (daysToDecay) => project.setLegacyPackageJsonTodoConfig(daysToDecay),
+        setTodoConfig: (daysToDecay) => project.setShorthandPackageJsonTodoConfig(daysToDecay),
       },
       {
         name: 'Package.json todo configuration',

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -31,6 +31,38 @@ describe('todo usage', () => {
   });
 
   describe('with/without --update-todo and --include-todo params', function () {
+    it('errors if todo config exists in both package.json and .lint-todorc.js', async function () {
+      project.setConfig({
+        rules: {
+          'no-bare-strings': true,
+        },
+      });
+      project.write({
+        app: {
+          templates: {
+            'application.hbs': '<h2>Here too!!</h2><div>Bare strings are bad...</div>',
+          },
+        },
+      });
+
+      project.setLegacyPackageJsonTodoConfig({
+        warn: 5,
+        error: 10,
+      });
+
+      project.setLintTodorc({
+        warn: 5,
+        error: 10,
+      });
+
+      let result = await run(['.']);
+
+      expect(result.exitCode).toEqual(1);
+      expect(result.stderr).toMatchInlineSnapshot(
+        `"You cannot have todo configurations in both package.json and .lint-todorc.js. Please move the configuration from the package.json to the .lint-todorc.js"`
+      );
+    });
+
     it('does not create `.lint-todo` dir without --update-todo param', async function () {
       project.setConfig({
         rules: {
@@ -716,7 +748,6 @@ describe('todo usage', () => {
           ✖ 1 problems (1 errors, 0 warnings)"
         `);
     });
-
     for (const { name, isLegacy, setTodoConfig } of [
       {
         name: 'Legacy todo configuration',

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -407,7 +407,7 @@ describe('todo usage', () => {
         },
       });
 
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         error: 5,
       });
 
@@ -679,7 +679,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 10,
         error: 5,
       });
@@ -704,7 +704,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 10,
       });
 
@@ -732,7 +732,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 10,
       });
 
@@ -764,7 +764,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 10,
       });
 
@@ -796,7 +796,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         error: 10,
       });
 
@@ -824,7 +824,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         error: 10,
       });
 
@@ -856,7 +856,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         error: 10,
       });
 
@@ -888,7 +888,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 5,
         error: 10,
       });
@@ -918,7 +918,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 5,
         error: 10,
       });
@@ -953,7 +953,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 5,
         error: 10,
       });
@@ -991,7 +991,7 @@ describe('todo usage', () => {
           },
         },
       });
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 5,
         error: 10,
       });
@@ -1028,7 +1028,7 @@ describe('todo usage', () => {
         },
       });
 
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 5,
       });
 
@@ -1059,7 +1059,7 @@ describe('todo usage', () => {
         },
       });
 
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         error: 5,
       });
 
@@ -1090,7 +1090,7 @@ describe('todo usage', () => {
         },
       });
 
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 5,
       });
 
@@ -1156,7 +1156,7 @@ describe('todo usage', () => {
         },
       });
 
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 5,
         error: 10,
       });
@@ -1192,7 +1192,7 @@ describe('todo usage', () => {
         },
       });
 
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         error: 5,
       });
 
@@ -1290,7 +1290,7 @@ describe('todo usage', () => {
         },
       });
 
-      project.writeTodoConfig({
+      project.setLegacyTodoConfig({
         warn: 5,
         error: 10,
       });

--- a/test/helpers/fake-project.js
+++ b/test/helpers/fake-project.js
@@ -87,14 +87,48 @@ module.exports = class FakeProject extends FixturifyProject {
     this.writeSync();
   }
 
-  setLegacyTodoConfig(todoConfig) {
+  setLegacyPackageJsonTodoConfig(daysToDecay) {
     this.pkg = Object.assign({}, this.pkg, {
       lintTodo: {
-        daysToDecay: todoConfig,
+        daysToDecay,
       },
     });
 
     this.writeSync();
+  }
+
+  setPackageJsonTodoConfig(engine, daysToDecay, daysToDecayByRule) {
+    const todoConfig = {
+      lintTodo: {
+        [engine]: {
+          daysToDecay,
+        },
+      },
+    };
+
+    if (daysToDecayByRule) {
+      todoConfig.lintTodo[engine].daysToDecayByRule = daysToDecayByRule;
+    }
+
+    this.pkg = Object.assign({}, this.pkg, todoConfig);
+
+    this.writeSync();
+  }
+
+  setLintTodorc(engine, daysToDecay, daysToDecayByRule) {
+    const todoConfig = {
+      [engine]: {
+        daysToDecay,
+      },
+    };
+
+    if (daysToDecayByRule) {
+      todoConfig[engine].daysToDecayByRule = daysToDecayByRule;
+    }
+
+    this.write({
+      '.lint-todorc.js': `module.exports = ${JSON.stringify(todoConfig, null, 2)}`,
+    });
   }
 
   chdir() {

--- a/test/helpers/fake-project.js
+++ b/test/helpers/fake-project.js
@@ -87,7 +87,7 @@ module.exports = class FakeProject extends FixturifyProject {
     this.writeSync();
   }
 
-  writeTodoConfig(todoConfig) {
+  setLegacyTodoConfig(todoConfig) {
     this.pkg = Object.assign({}, this.pkg, {
       lintTodo: {
         daysToDecay: todoConfig,

--- a/test/helpers/fake-project.js
+++ b/test/helpers/fake-project.js
@@ -87,7 +87,7 @@ module.exports = class FakeProject extends FixturifyProject {
     this.writeSync();
   }
 
-  setLegacyPackageJsonTodoConfig(daysToDecay) {
+  setShorthandPackageJsonTodoConfig(daysToDecay) {
     this.pkg = Object.assign({}, this.pkg, {
       lintTodo: {
         daysToDecay,

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,12 +521,12 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@ember-template-lint/todo-utils@^8.1.0":
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-8.1.0.tgz#0fe8ef9ebd1948dea34d27d89a2e245687bb57d9"
-  integrity sha512-fnxDli4RfYGVBXc64D0fg7ifkSrNE8J/ee4eqQLzTrsUJbisWMlmU2NTHm990XcZkulYkCnkiLKERU/k1tx5IQ==
+"@ember-template-lint/todo-utils@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-9.0.0.tgz#9166f7853117d6ea3ae747c2c91ea82d291e5dd5"
+  integrity sha512-ZLk2v2BTtrJhaCYzEL4tDcbKBbJuAK3KVZ8iHX50D2VOA1KCUfWIN6qN+eg/rjquSGOhCWFW10ouX7MFdgFemw==
   dependencies:
-    "@types/eslint" "^7.2.10"
+    "@types/eslint" "^7.2.12"
     fs-extra "^9.1.0"
     slash "^3.0.0"
     tslib "^2.1.0"
@@ -1203,10 +1203,10 @@
     "@types/node" "*"
     "@types/responselike" "*"
 
-"@types/eslint@^7.2.10":
-  version "7.2.10"
-  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.10.tgz#4b7a9368d46c0f8cd5408c23288a59aa2394d917"
-  integrity sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==
+"@types/eslint@^7.2.12":
+  version "7.2.13"
+  resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-7.2.13.tgz#e0ca7219ba5ded402062ad6f926d491ebb29dd53"
+  integrity sha512-LKmQCWAlnVHvvXq4oasNUMTJJb2GwSyTY8+1C7OH5ILR8mPLaljv1jxL1bXW3xB3jFbQxTKxJAvI8PyjB09aBg==
   dependencies:
     "@types/estree" "*"
     "@types/json-schema" "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,15 +521,15 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@ember-template-lint/todo-utils@^9.0.0":
-  version "9.0.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-9.0.0.tgz#9166f7853117d6ea3ae747c2c91ea82d291e5dd5"
-  integrity sha512-ZLk2v2BTtrJhaCYzEL4tDcbKBbJuAK3KVZ8iHX50D2VOA1KCUfWIN6qN+eg/rjquSGOhCWFW10ouX7MFdgFemw==
+"@ember-template-lint/todo-utils@^9.1.2":
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-9.1.2.tgz#acadb0378acb12d5220a397143a69f197b4a3a05"
+  integrity sha512-wHRL/YQc/CtPabV7GuYLtS2A592GCd54aY544JOH4OXnpepZkxy5dp18iaNbtErihBW/+sIJr8/JvsCxw5T3Wg==
   dependencies:
     "@types/eslint" "^7.2.12"
     fs-extra "^9.1.0"
     slash "^3.0.0"
-    tslib "^2.1.0"
+    tslib "^2.2.0"
 
 "@eslint/eslintrc@^0.4.2":
   version "0.4.2"
@@ -7218,10 +7218,10 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+tslib@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
+  integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
Implements #1880 and supersedes #1964.

This change adds support for using a config file, `.lint-todorc.js`. This config is a superset of the old config, which was simply:

```json
{
  "lintTodo": {
    "daysToDecay": {
      "warn": 5,
      "error": 10
    }
  }
}
```

The new structure adds a level of nesting, allowing you to specify which `engine` the config section applies to:

```json
 {
   "lintTodo": {
     "ember-template-lint": {
       "daysToDecay": {
         "warn": 5,
         "error": 10
       },
       "daysToDecayByRule": {
         "no-bare-strings": { "warn": 10, "error": 20 }
       }
     }
   }
 }
```
In addition, you can now configure `daysToDecay` by ruleID, allowing more fine-grained configuration of decay dates. It also provides a single source of truth for configuring those dates.

As of this change, we now support

1. Legacy configs, such as those in the first example above
2. Configuration in `package.json`
3. Configuration in `.lint-todorc.js`