### PR TITLE
Fix `require-input-label` to allow inputs within a `<label>` to have an `id` attribute

### DIFF
--- a/lib/rules/require-input-label.js
+++ b/lib/rules/require-input-label.js
@@ -54,6 +54,9 @@ module.exports = class RequireInputLabel extends Rule {
         if (labelCount === 1) {
           return;
         }
+        if (hasValidLabelParent(path) && AstNodeInfo.hasAttribute(node, 'id')) {
+          return;
+        }
 
         let message = labelCount === 0 ? ERROR_MESSAGE_NO_LABEL : ERROR_MESSAGE_MULTIPLE_LABEL;
         this.log({

--- a/test/unit/rules/require-input-label-test.js
+++ b/test/unit/rules/require-input-label-test.js
@@ -94,7 +94,7 @@ generateRuleTests({
       },
     },
     {
-      template: '<label><input /></label>',
+      template: '<label><input></label>',
       result: {
         message: ERROR_MESSAGE,
         line: 1,

--- a/test/unit/rules/require-input-label-test.js
+++ b/test/unit/rules/require-input-label-test.js
@@ -99,7 +99,7 @@ generateRuleTests({
         message: ERROR_MESSAGE,
         line: 1,
         column: 7,
-        source: '<input />',
+        source: '<input>',
       },
     },
     {

--- a/test/unit/rules/require-input-label-test.js
+++ b/test/unit/rules/require-input-label-test.js
@@ -13,6 +13,7 @@ generateRuleTests({
 
   good: [
     '<label>LabelText<input /></label>',
+    '<label>LabelText<input id="foo" /></label>',
     '<label><input />LabelText</label>',
     '<label>LabelText<Input /></label>',
     '<label><Input />LabelText</label>',
@@ -24,7 +25,9 @@ generateRuleTests({
     '<input ...attributes/>', // we are unable to correctly determine if this has a label or not, so we have to allow it
     '<Input ...attributes />',
     '<Input id="foo" />',
+    '<label>text<Input id="foo" /></label>',
     '{{input id="foo"}}',
+    '<label>text{{input id="foo"}}</label>',
     '<label>Text here<Input /></label>',
     '<label>Text here {{input}}</label>',
     '<input id="label-input" ...attributes>',
@@ -91,12 +94,12 @@ generateRuleTests({
       },
     },
     {
-      template: '<label><input></label>',
+      template: '<label><input /></label>',
       result: {
         message: ERROR_MESSAGE,
         line: 1,
         column: 7,
-        source: '<input>',
+        source: '<input />',
       },
     },
     {


### PR DESCRIPTION
If merged, this PR resolves the issue where a form element nested inside of a `<label>` element was throwing a invalid "multiple labels" error if the form element also had an `id` attribute. 

Details: 
- Added condition to allow `<label>text<input id="foo" /></label>`.
- Updated tests to include additional valid scenarios.

Please consider using [conventional comments](https://conventionalcomments.org/) when reviewing this PR.

