### PR TITLE
Implement `no-route-action` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Each rule has emojis denoting:
 | [no-redundant-fn](./docs/rule/no-redundant-fn.md)                                                         | :white_check_mark: |             |            | :wrench: |
 | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)                                   | :white_check_mark: |             | :keyboard: | :wrench: |
 | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md)                                     |                    |             |            |          |
+| [no-route-action](./docs/rule/no-route-action.md)                                                         |                    |             |            |          |
 | [no-shadowed-elements](./docs/rule/no-shadowed-elements.md)                                               | :white_check_mark: |             |            |          |
 | [no-this-in-template-only-components](./docs/rule/no-this-in-template-only-components.md)                 |                    |             |            | :wrench: |
 | [no-trailing-spaces](./docs/rule/no-trailing-spaces.md)                                                   |                    | :nail_care: |            |          |

--- a/docs/rule/no-route-action.md
+++ b/docs/rule/no-route-action.md
@@ -1,6 +1,6 @@
 # no-route-action
 
-This rule disallows the usage of route-action.
+This rule disallows the usage of `route-action`.
 
 [ember-route-action-helper](https://github.com/DockYard/ember-route-action-helper) is a popular addon that it's only purpose was to avoid creating controllers, something we no longer have a desire to do given the current state of the framework.
 

--- a/docs/rule/no-route-action.md
+++ b/docs/rule/no-route-action.md
@@ -2,7 +2,7 @@
 
 This rule disallows the usage of `route-action`.
 
-[ember-route-action-helper](https://github.com/DockYard/ember-route-action-helper) is a popular addon that it's only purpose was to avoid creating controllers, something we no longer have a desire to do given the current state of the framework.
+[ember-route-action-helper](https://github.com/DockYard/ember-route-action-helper) was a popular addon used to avoid creating controllers just to add actions to routes. Given the changes in Ember since ember-route-action-helper was useful, controllers are now a useful pattern we want to encourage and discourage the use of route-action.
 
 Most route actions should either be sent to the controller first or encapsulated within a downstream component instead. We should never be escaping the DDAU hierarchy to lob actions up to the route.
 

--- a/docs/rule/no-route-action.md
+++ b/docs/rule/no-route-action.md
@@ -19,17 +19,17 @@ This rule **forbids** the following:
 ```
 
 ```hbs
-<CustomComponent onUpdate={{route-action 'foo'}} />
+<CustomComponent @onUpdate={{route-action 'foo'}} />
 ```
 
 ```hbs
-<CustomComponent onUpdate={{route-action 'foo' 'bar'}} />
+<CustomComponent @onUpdate={{route-action 'foo' 'bar'}} />
 ```
 
 Instead, use controller actions as the following:
 
 ```hbs
-{{custom-component onUpdate=(this.updateFoo)}}
+{{custom-component onUpdate=this.updateFoo}}
 ```
 
 ```hbs
@@ -37,11 +37,11 @@ Instead, use controller actions as the following:
 ```
 
 ```hbs
-<CustomComponent onUpdate={{this.updateFoo}} />
+<CustomComponent @onUpdate={{this.updateFoo}} />
 ```
 
 ```hbs
-<CustomComponent onUpdate={{fn this.updateFoo 'bar'}} />
+<CustomComponent @onUpdate={{fn this.updateFoo 'bar'}} />
 ```
 
 ## References

--- a/docs/rule/no-route-action.md
+++ b/docs/rule/no-route-action.md
@@ -1,0 +1,45 @@
+# no-route-action
+
+This rule disallows the usage of route-action.
+
+[ember-route-action-helper](https://github.com/DockYard/ember-route-action-helper) is a popular addon that it's only purpose was to avoid creating controllers, something we no longer have a desire to do given the current state of the framework.
+
+Most route actions should either be sent to the controller first or encapsulated within a downstream component instead. We should never be escaping the DDAU hierarchy to lob actions up to the route.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+{{custom-component onUpdate=(route-action 'updateFoo')}}
+```
+
+```hbs
+{{custom-component onUpdate=(route-action 'updateFoo' 'bar')}}
+```
+
+```hbs
+<CustomComponent onUpdate={{route-action 'foo'}} />
+```
+
+```hbs
+<CustomComponent onUpdate={{route-action 'foo' 'bar'}} />
+```
+
+Instead, use controller actions as the following:
+
+```hbs
+{{custom-component onUpdate=(this.updateFoo)}}
+```
+
+```hbs
+{{custom-component onUpdate=(fn this.updateFoo 'bar')}}
+```
+
+```hbs
+<CustomComponent onUpdate={{this.updateFoo}} />
+```
+
+```hbs
+<CustomComponent onUpdate={{fn this.updateFoo 'bar'}} />
+```

--- a/docs/rule/no-route-action.md
+++ b/docs/rule/no-route-action.md
@@ -2,7 +2,7 @@
 
 This rule disallows the usage of `route-action`.
 
-[ember-route-action-helper](https://github.com/DockYard/ember-route-action-helper) was a popular addon used to avoid creating controllers just to add actions to routes. Given the changes in Ember since ember-route-action-helper was useful, controllers are now a useful pattern we want to encourage and discourage the use of route-action.
+[ember-route-action-helper](https://github.com/DockYard/ember-route-action-helper) was a popular addon used to add actions to a route without creating a separate controller. Given the changes in Ember since ember-route-action-helper was a widely used pattern, controllers are now encouraged and we want to discourage the use of route-action.
 
 Most route actions should either be sent to the controller first or encapsulated within a downstream component instead. We should never be escaping the DDAU hierarchy to lob actions up to the route.
 

--- a/docs/rule/no-route-action.md
+++ b/docs/rule/no-route-action.md
@@ -43,3 +43,9 @@ Instead, use controller actions as the following:
 ```hbs
 <CustomComponent onUpdate={{fn this.updateFoo 'bar'}} />
 ```
+
+## References
+
+* [ember-route-action-helper](https://github.com/DockYard/ember-route-action-helper)
+* [Ember guides/Controllers](https://guides.emberjs.com/release/routing/controllers/)
+* [Ember Best Practices: What are controllers good for?](https://dockyard.com/blog/2017/06/16/ember-best-practices-what-are-controllers-good-for)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -71,6 +71,7 @@ module.exports = {
   'no-redundant-fn': require('./no-redundant-fn'),
   'no-redundant-landmark-role': require('./no-redundant-landmark-role'),
   'no-restricted-invocations': require('./no-restricted-invocations'),
+  'no-route-action': require('./no-route-action'),
   'no-shadowed-elements': require('./no-shadowed-elements'),
   'no-this-in-template-only-components': require('./no-this-in-template-only-components'),
   'no-trailing-spaces': require('./no-trailing-spaces'),

--- a/lib/rules/no-route-action.js
+++ b/lib/rules/no-route-action.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const Rule = require('./base');
+
+const ERROR_MESSAGE = 'Do not use `route-action` as %. Instead, use controller actions.';
+
+module.exports = class NoRouteAction extends Rule {
+  visitor() {
+    const isLocal = this.isLocal.bind(this);
+    const log = this.log.bind(this);
+    const sourceForNode = this.sourceForNode.bind(this);
+    let closestTag = null;
+
+    function detectRouteAction(node, usageContext) {
+      if (isLocal(node.path)) {
+        return;
+      }
+      let maybeAction = node.path.original;
+      if (node.path.type === 'StringLiteral') {
+        return;
+      }
+      if (maybeAction !== 'route-action') {
+        return;
+      }
+      if (node.path.data === true || node.path.this === true) {
+        return;
+      }
+      log({
+        message: ERROR_MESSAGE.replace('%', usageContext),
+        line: node.loc && node.loc.start.line,
+        column: node.loc && node.loc.start.column,
+        source: sourceForNode(node),
+      });
+    }
+
+    return {
+      SubExpression: (node) => {
+        detectRouteAction(node, '(route-action ...)');
+      },
+      MustacheStatement: (node) => {
+        detectRouteAction(node, '{{route-action ...}}');
+      },
+      ElementNode: (node) => {
+        closestTag = node.tag;
+      },
+      ElementModifierStatement: (node) => {
+        detectRouteAction(node, `<${closestTag} {{route-action ...}} />`);
+      },
+    };
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/no-route-action-test.js
+++ b/test/unit/rules/no-route-action-test.js
@@ -15,6 +15,10 @@ generateRuleTests({
     `<CustomComponent @onUpdate={{if true (action 'updateFoo')}} />`,
     `<CustomComponent @onUpdate={{if true (fn this.updateFoo 'bar')}} />`,
     `<CustomComponent @onUpdate={{if true (this.updateFoo)}} />`,
+    `{{yield (hash
+      someProp="someVal"
+      updateFoo=(fn this.updateFoo)
+    )}}`,
 
     // MustacheStatement
     `<CustomComponent @onUpdate={{action 'updateFoo'}} />`,
@@ -50,6 +54,19 @@ generateRuleTests({
         line: 1,
         column: 28,
         source: "(route-action 'updateFoo' 'bar')",
+      },
+    },
+    {
+      template: `{{yield (hash
+        someProp="someVal"
+        updateFoo=(route-action 'updateFoo')
+      )}}`,
+      result: {
+        message:
+          'Do not use `route-action` as (route-action ...). Instead, use controller actions.',
+        line: 3,
+        column: 18,
+        source: "(route-action 'updateFoo')",
       },
     },
 

--- a/test/unit/rules/no-route-action-test.js
+++ b/test/unit/rules/no-route-action-test.js
@@ -11,15 +11,15 @@ generateRuleTests({
     // SubExpression
     `{{custom-component onUpdate=(action 'updateFoo')}}`,
     `{{custom-component onUpdate=(fn this.updateFoo 'bar')}}`,
-    `{{custom-component onUpdate=(this.updateFoo)}}`,
-    `<CustomComponent onUpdate={{if true (action 'updateFoo')}} />`,
-    `<CustomComponent onUpdate={{if true (fn this.updateFoo 'bar')}} />`,
-    `<CustomComponent onUpdate={{if true (this.updateFoo)}} />`,
+    `{{custom-component onUpdate=this.updateFoo}}`,
+    `<CustomComponent @onUpdate={{if true (action 'updateFoo')}} />`,
+    `<CustomComponent @onUpdate={{if true (fn this.updateFoo 'bar')}} />`,
+    `<CustomComponent @onUpdate={{if true (this.updateFoo)}} />`,
 
     // MustacheStatement
-    `<CustomComponent onUpdate={{action 'updateFoo'}} />`,
-    `<CustomComponent onUpdate={{fn this.updateFoo 'bar'}} />`,
-    `<CustomComponent onUpdate={{this.updateFoo}} />`,
+    `<CustomComponent @onUpdate={{action 'updateFoo'}} />`,
+    `<CustomComponent @onUpdate={{fn this.updateFoo 'bar'}} />`,
+    `<CustomComponent @onUpdate={{this.updateFoo}} />`,
 
     // ElementModifierStatement
     `<div {{action 'updateFoo'}}></div>`,
@@ -33,12 +33,12 @@ generateRuleTests({
   bad: [
     // SubExpression
     {
-      template: `<CustomComponent onUpdate={{if true (route-action 'updateFoo' 'bar')}} />`,
+      template: `<CustomComponent @onUpdate={{if true (route-action 'updateFoo' 'bar')}} />`,
       result: {
         message:
           'Do not use `route-action` as (route-action ...). Instead, use controller actions.',
         line: 1,
-        column: 36,
+        column: 37,
         source: "(route-action 'updateFoo' 'bar')",
       },
     },
@@ -56,23 +56,23 @@ generateRuleTests({
     // MustacheStatement
     {
       template: `<CustomComponent
-        onUpdate={{route-action 'updateFoo'}}
+        @onUpdate={{route-action 'updateFoo'}}
       />`,
       result: {
         message:
           'Do not use `route-action` as {{route-action ...}}. Instead, use controller actions.',
         line: 2,
-        column: 17,
+        column: 18,
         source: "{{route-action 'updateFoo'}}",
       },
     },
     {
-      template: `<CustomComponent onUpdate={{route-action 'updateFoo' 'bar'}} />`,
+      template: `<CustomComponent @onUpdate={{route-action 'updateFoo' 'bar'}} />`,
       result: {
         message:
           'Do not use `route-action` as {{route-action ...}}. Instead, use controller actions.',
         line: 1,
-        column: 26,
+        column: 27,
         source: "{{route-action 'updateFoo' 'bar'}}",
       },
     },

--- a/test/unit/rules/no-route-action-test.js
+++ b/test/unit/rules/no-route-action-test.js
@@ -1,0 +1,92 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'no-route-action',
+
+  config: true,
+
+  good: [
+    // SubExpression
+    `{{custom-component onUpdate=(action 'updateFoo')}}`,
+    `{{custom-component onUpdate=(fn this.updateFoo 'bar')}}`,
+    `{{custom-component onUpdate=(this.updateFoo)}}`,
+    `<CustomComponent onUpdate={{if true (action 'updateFoo')}} />`,
+    `<CustomComponent onUpdate={{if true (fn this.updateFoo 'bar')}} />`,
+    `<CustomComponent onUpdate={{if true (this.updateFoo)}} />`,
+
+    // MustacheStatement
+    `<CustomComponent onUpdate={{action 'updateFoo'}} />`,
+    `<CustomComponent onUpdate={{fn this.updateFoo 'bar'}} />`,
+    `<CustomComponent onUpdate={{this.updateFoo}} />`,
+
+    // ElementModifierStatement
+    `<div {{action 'updateFoo'}}></div>`,
+    `<div {{fn this.updateFoo 'bar'}}></div>`,
+    `<div {{this.updateFoo}}></div>`,
+
+    // Other
+    `<div></div>`,
+  ],
+
+  bad: [
+    // SubExpression
+    {
+      template: `<CustomComponent onUpdate={{if true (route-action 'updateFoo' 'bar')}} />`,
+      result: {
+        message:
+          'Do not use `route-action` as (route-action ...). Instead, use controller actions.',
+        line: 1,
+        column: 36,
+        source: "(route-action 'updateFoo' 'bar')",
+      },
+    },
+    {
+      template: `{{custom-component onUpdate=(route-action 'updateFoo' 'bar')}}`,
+      result: {
+        message:
+          'Do not use `route-action` as (route-action ...). Instead, use controller actions.',
+        line: 1,
+        column: 28,
+        source: "(route-action 'updateFoo' 'bar')",
+      },
+    },
+
+    // MustacheStatement
+    {
+      template: `<CustomComponent
+        onUpdate={{route-action 'updateFoo'}}
+      />`,
+      result: {
+        message:
+          'Do not use `route-action` as {{route-action ...}}. Instead, use controller actions.',
+        line: 2,
+        column: 17,
+        source: "{{route-action 'updateFoo'}}",
+      },
+    },
+    {
+      template: `<CustomComponent onUpdate={{route-action 'updateFoo' 'bar'}} />`,
+      result: {
+        message:
+          'Do not use `route-action` as {{route-action ...}}. Instead, use controller actions.',
+        line: 1,
+        column: 26,
+        source: "{{route-action 'updateFoo' 'bar'}}",
+      },
+    },
+
+    // ElementModifierStatement
+    {
+      template: `<div {{route-action 'updateFoo'}}></div>`,
+      result: {
+        message:
+          'Do not use `route-action` as <div {{route-action ...}} />. Instead, use controller actions.',
+        line: 1,
+        column: 5,
+        source: "{{route-action 'updateFoo'}}",
+      },
+    },
+  ],
+});


### PR DESCRIPTION
# no-route-action

This rule disallows the usage of `route-action`.

[ember-route-action-helper](https://github.com/DockYard/ember-route-action-helper) was a popular addon used to add actions to a route without creating a separate controller. Given the changes in Ember since ember-route-action-helper was a widely used pattern, controllers are now encouraged and we want to discourage the use of route-action.

Most route actions should either be sent to the controller first or encapsulated within a downstream component instead. We should never be escaping the DDAU hierarchy to lob actions up to the route.

## Examples

This rule **forbids** the following:

```hbs
<CustomComponent @onUpdate={{route-action 'updateFoo'}} />
```

```hbs
<CustomComponent @onUpdate={{route-action 'updateFoo' 'bar'}} />
```

```hbs
{{custom-component onUpdate=(route-action 'updateFoo')}}
```

```hbs
{{custom-component onUpdate=(route-action 'updateFoo' 'bar')}}
```

With the given route:
```js
// app/routes/foo.js
export default class extends Route {
  @action
  updateFoo(baz) {
    // ...
  }
}
```

This rule **allows** the following:

```hbs
<CustomComponent @onUpdate={{this.updateFoo}} />
```

```hbs
<CustomComponent @onUpdate={{fn this.updateFoo 'bar'}} />
```

```hbs
{{custom-component onUpdate=this.updateFoo}}
```

```hbs
{{custom-component onUpdate=(fn this.updateFoo 'bar')}}
```

With the given controller:
```js
// app/controllers/foo.js
export default class extends Controller {
  @action
  updateFoo(baz) {
    // ...
  }
}
```

## Migration

The example below shows how to migrate from route-action to controller actions.

**Before**

```js
// app/routes/posts.js
export default class extends Route {
  model(params) {
    return this.store.query('post', { page: params.page })
  }

  @action
  goToPage(pageNum) {
    this.transitionTo({ queryParams: { page: pageNum } });
  }
}
```

```js
// app/controllers/posts.js
export default class extends Controller {
  queryParams = ['page'];
  page = 1;
}
```

```hbs
{{#each @model as |post|}}
  <Post @title={{post.title}} @content={{post.content}} />
{{/each}}

<button {{action (route-action 'goToPage' 1)}}>1</button>
<button {{action (route-action 'goToPage' 2)}}>2</button>
<button {{action (route-action 'goToPage' 3)}}>3</button>
```

**After**

```js
// app/routes/posts.js
export default class extends Route {
  model(params) {
    return this.store.query('post', { page: params.page })
  }
}
```

```js
// app/controllers/posts.js
export default class extends Controller {
  queryParams = ['page'];
  page = 1;

  @action
  goToPage(pageNum) {
    this.transitionToRoute({ queryParams: { page: pageNum } });
  }
}
```

```hbs
{{#each @model as |post|}}
  <Post @title={{post.title}} @content={{post.content}} />
{{/each}}

<button {{on 'click' (fn this.goToPage 1)}}>1</button>
<button {{on 'click' (fn this.goToPage 2)}}>2</button>
<button {{on 'click' (fn this.goToPage 3)}}>3</button>
```

## References

* [ember-route-action-helper](https://github.com/DockYard/ember-route-action-helper)
* [Ember guides/Controllers](https://guides.emberjs.com/release/routing/controllers/)
* [Ember Best Practices: What are controllers good for?](https://dockyard.com/blog/2017/06/16/ember-best-practices-what-are-controllers-good-for)
