### PR TITLE
Fixes the SARIF formatter to correctly filter output by severity

### DIFF
--- a/lib/formatters/sarif.js
+++ b/lib/formatters/sarif.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const url = require('url');
 
 const writeOutputFile = require('../helpers/write-output-file');
+const Linter = require('../linter');
 
 function getResultLevel(message) {
   if (message.fatal || message.severity === 2) {
@@ -86,8 +87,24 @@ class SarifPrinter {
           }
         }
 
-        if (result.messages.length > 0) {
-          for (const message of result.messages) {
+        let fileErrors = result.messages;
+        let filteredMessages;
+
+        if (fileErrors.length > 0) {
+          let errorsFiltered = fileErrors.filter(
+            (error) => error.severity === Linter.ERROR_SEVERITY
+          );
+          let warnings = this.options.quiet
+            ? []
+            : fileErrors.filter((error) => error.severity === Linter.WARNING_SEVERITY);
+          let todos =
+            this.options.quiet || !this.options.includeTodo
+              ? []
+              : fileErrors.filter((error) => error.severity === Linter.TODO_SEVERITY);
+
+          filteredMessages = [...errorsFiltered, ...warnings, ...todos];
+
+          for (const message of filteredMessages) {
             const sarifRepresentation = {
               level: getResultLevel(message),
               message: {

--- a/test/fixtures/sarif/results-errors-warnings-todos.json
+++ b/test/fixtures/sarif/results-errors-warnings-todos.json
@@ -1,0 +1,51 @@
+{
+  "files": {
+    "app/templates/application.hbs": {
+      "filePath": "app/templates/application.hbs",
+      "messages": [
+        {
+          "rule": "no-bare-strings",
+          "severity": 2,
+          "filePath": "app/templates/application.hbs",
+          "message": "Non-translated string used",
+          "line": 1,
+          "column": 4,
+          "source": "Here too!!"
+        },
+        {
+          "rule": "no-bare-strings",
+          "severity": 1,
+          "filePath": "app/templates/application.hbs",
+          "message": "Non-translated string used",
+          "line": 1,
+          "column": 24,
+          "source": "Bare strings are bad..."
+        },
+        {
+          "rule": "no-html-comments",
+          "severity": -1,
+          "filePath": "app/templates/application.hbs",
+          "message": "HTML comment detected",
+          "line": 1,
+          "column": 53,
+          "source": "<!-- bad html comment! -->",
+          "fix": {
+            "text": "{{! bad html comment! }}"
+          }
+        }
+      ],
+      "errorCount": 2,
+      "warningCount": 1,
+      "todoCount": 0,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0,
+      "fixableTodoCount": 0
+    }
+  },
+  "errorCount": 2,
+  "warningCount": 1,
+  "todoCount": 0,
+  "fixableErrorCount": 0,
+  "fixableWarningCount": 0,
+  "fixableTodoCount": 0
+}

--- a/test/fixtures/sarif/results-errors-warnings.json
+++ b/test/fixtures/sarif/results-errors-warnings.json
@@ -1,0 +1,51 @@
+{
+  "files": {
+    "app/templates/application.hbs": {
+      "filePath": "app/templates/application.hbs",
+      "messages": [
+        {
+          "rule": "no-bare-strings",
+          "severity": 2,
+          "filePath": "app/templates/application.hbs",
+          "message": "Non-translated string used",
+          "line": 1,
+          "column": 4,
+          "source": "Here too!!"
+        },
+        {
+          "rule": "no-bare-strings",
+          "severity": 2,
+          "filePath": "app/templates/application.hbs",
+          "message": "Non-translated string used",
+          "line": 1,
+          "column": 24,
+          "source": "Bare strings are bad..."
+        },
+        {
+          "rule": "no-html-comments",
+          "severity": 1,
+          "filePath": "app/templates/application.hbs",
+          "message": "HTML comment detected",
+          "line": 1,
+          "column": 53,
+          "source": "<!-- bad html comment! -->",
+          "fix": {
+            "text": "{{! bad html comment! }}"
+          }
+        }
+      ],
+      "errorCount": 2,
+      "warningCount": 1,
+      "todoCount": 0,
+      "fixableErrorCount": 0,
+      "fixableWarningCount": 0,
+      "fixableTodoCount": 0
+    }
+  },
+  "errorCount": 2,
+  "warningCount": 1,
+  "todoCount": 0,
+  "fixableErrorCount": 0,
+  "fixableWarningCount": 0,
+  "fixableTodoCount": 0
+}


### PR DESCRIPTION
The SARIF formatter contained a bug where it would include all severities in results without respecting the `--quiet` or `--include-todo` options. this resulted in a discrepancy in the results when run locally using the pretty formatter and those that were gathered using the SARIF formatter. 