### PR TITLE
Ensure `deprecated-inline-view-helper` allows named blocks named `"view"`

### DIFF
--- a/lib/rules/deprecated-inline-view-helper.js
+++ b/lib/rules/deprecated-inline-view-helper.js
@@ -36,12 +36,18 @@ function logMessage(context, loc, actual, expected) {
 
 function manageMustacheViewInvocation(context, node, isBlockStatement) {
   let pairs = node.hash.pairs;
-
+  const isYield =
+    node.path.original === 'yield' && node.path.this === false && node.path.data === false;
   if (pairs.length > 0) {
     for (const currentPair of pairs) {
       let originalValue = currentPair.value.original;
 
-      if (typeof originalValue === 'string' && originalValue.split('.')[0] === 'view') {
+      if (
+        typeof originalValue === 'string' &&
+        originalValue.split('.')[0] === 'view' &&
+        !isYield &&
+        currentPair.key !== 'to'
+      ) {
         if (isBlockStatement) {
           context.processInBlockStatement(node, currentPair);
         } else {

--- a/test/unit/rules/deprecated-inline-view-helper-test.js
+++ b/test/unit/rules/deprecated-inline-view-helper-test.js
@@ -23,6 +23,9 @@ generateRuleTests({
     '{{42}}',
     '{{null}}',
     '{{undefined}}',
+    '{{has-block "view"}}',
+    '{{yield to="view"}}',
+    '{{#if (has-block "view")}}{{yield to="view"}}{{/if}}',
   ],
 
   bad: [


### PR DESCRIPTION
resolves: https://github.com/ember-template-lint/ember-template-lint/issues/1971