### PR TITLE
Removed modifier support for `no-route-action` rule

### DIFF
--- a/lib/rules/no-route-action.js
+++ b/lib/rules/no-route-action.js
@@ -6,47 +6,36 @@ const ERROR_MESSAGE = 'Do not use `route-action` as %. Instead, use controller a
 
 module.exports = class NoRouteAction extends Rule {
   visitor() {
-    const isLocal = this.isLocal.bind(this);
-    const log = this.log.bind(this);
-    const sourceForNode = this.sourceForNode.bind(this);
-    let closestTag = null;
-
-    function detectRouteAction(node, usageContext) {
-      if (isLocal(node.path)) {
-        return;
-      }
-      let maybeAction = node.path.original;
-      if (node.path.type === 'StringLiteral') {
-        return;
-      }
-      if (maybeAction !== 'route-action') {
-        return;
-      }
-      if (node.path.data === true || node.path.this === true) {
-        return;
-      }
-      log({
-        message: ERROR_MESSAGE.replace('%', usageContext),
-        line: node.loc && node.loc.start.line,
-        column: node.loc && node.loc.start.column,
-        source: sourceForNode(node),
-      });
-    }
-
     return {
       SubExpression: (node) => {
-        detectRouteAction(node, '(route-action ...)');
+        this.detectRouteAction(node, '(route-action ...)');
       },
       MustacheStatement: (node) => {
-        detectRouteAction(node, '{{route-action ...}}');
-      },
-      ElementNode: (node) => {
-        closestTag = node.tag;
-      },
-      ElementModifierStatement: (node) => {
-        detectRouteAction(node, `<${closestTag} {{route-action ...}} />`);
+        this.detectRouteAction(node, '{{route-action ...}}');
       },
     };
+  }
+
+  detectRouteAction(node, usageContext) {
+    if (this.isLocal(node.path)) {
+      return;
+    }
+    let maybeAction = node.path.original;
+    if (node.path.type === 'StringLiteral') {
+      return;
+    }
+    if (maybeAction !== 'route-action') {
+      return;
+    }
+    if (node.path.data === true || node.path.this === true) {
+      return;
+    }
+    this.log({
+      message: ERROR_MESSAGE.replace('%', usageContext),
+      line: node.loc && node.loc.start.line,
+      column: node.loc && node.loc.start.column,
+      source: this.sourceForNode(node),
+    });
   }
 };
 

--- a/test/unit/rules/no-route-action-test.js
+++ b/test/unit/rules/no-route-action-test.js
@@ -25,11 +25,6 @@ generateRuleTests({
     `<CustomComponent @onUpdate={{fn this.updateFoo 'bar'}} />`,
     `<CustomComponent @onUpdate={{this.updateFoo}} />`,
 
-    // ElementModifierStatement
-    `<div {{action 'updateFoo'}}></div>`,
-    `<div {{fn this.updateFoo 'bar'}}></div>`,
-    `<div {{this.updateFoo}}></div>`,
-
     // Other
     `<div></div>`,
   ],
@@ -91,18 +86,6 @@ generateRuleTests({
         line: 1,
         column: 27,
         source: "{{route-action 'updateFoo' 'bar'}}",
-      },
-    },
-
-    // ElementModifierStatement
-    {
-      template: `<div {{route-action 'updateFoo'}}></div>`,
-      result: {
-        message:
-          'Do not use `route-action` as <div {{route-action ...}} />. Instead, use controller actions.',
-        line: 1,
-        column: 5,
-        source: "{{route-action 'updateFoo'}}",
       },
     },
   ],


### PR DESCRIPTION
[ember-route-action-helper](https://github.com/DockYard/ember-route-action-helper) doesn't have `route-action` modifier. In this case, removed modifier support for `no-route-action` rule.
This fixes issue raised on: https://github.com/ember-template-lint/ember-template-lint/pull/2030#issuecomment-896931655

Also removed binds for class methods and instead of just call them normally.