### PR TITLE
Add `require-valid-named-block-naming-format` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ Each rule has emojis denoting:
 | [require-lang-attribute](./docs/rule/require-lang-attribute.md)                                           | ✅  |     | ⌨️  |     |
 | [require-splattributes](./docs/rule/require-splattributes.md)                                             |     |     |     |     |
 | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                                           | ✅  |     | ⌨️  |     |
+| [require-valid-named-block-naming-format](./docs/rule/require-valid-named-block-naming-format.md)         |     |     |     |     |
 | [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)                                   |     | 💅  |     |     |
 | [simple-unless](./docs/rule/simple-unless.md)                                                             | ✅  |     |     |     |
 | [splat-attributes-only](./docs/rule/splat-attributes-only.md)                                             | ✅  |     |     |     |

--- a/docs/rule/require-valid-named-block-naming-format.md
+++ b/docs/rule/require-valid-named-block-naming-format.md
@@ -1,0 +1,55 @@
+# require-valid-named-block-naming-format
+
+Require named blocks to use a valid naming format (`camelCase` or `kebab-case`).
+
+The default naming format used is `camelCase`.
+
+## Examples
+
+This rule **forbids** the following when the `camelCase` naming format is enabled:
+
+```hbs
+{{yield to="foo-bar"}}
+{{has-block "foo-bar"}}
+{{if (has-block "foo-bar")}}
+{{has-block-params "foo-bar"}}
+{{if (has-block-params "foo-bar")}}
+```
+
+This rule **allows** the following when the `camelCase` naming format is enabled:
+
+```hbs
+{{yield to="fooBar"}}
+{{has-block "fooBar"}}
+{{if (has-block "fooBar")}}
+{{has-block-params "fooBar"}}
+{{if (has-block-params "fooBar")}}
+```
+
+This rule **forbids** the following when the `kebab-case` naming format is enabled:
+
+```hbs
+{{yield to="fooBar"}}
+{{has-block "fooBar"}}
+{{if (has-block "fooBar")}}
+{{has-block-params "fooBar"}}
+{{if (has-block-params "fooBar")}}
+```
+
+This rule **allows** the following when the `kebab-case` naming format is enabled:
+
+```hbs
+{{yield to="foo-bar"}}
+{{has-block "foo-bar"}}
+{{if (has-block "foo-bar")}}
+{{has-block-params "foo-bar"}}
+{{if (has-block-params "foo-bar")}}
+```
+
+## Configuration
+
+- string -- `'camelCase'` Requires the use of the `camelCase` naming format. `'kebab-case'` Requires the use of the `kebab-case` naming format.
+
+## References
+
+- [Naming convention (programming)](https://en.wikipedia.org/wiki/Naming_convention_(programming))

--- a/lib/helpers/camelize.js
+++ b/lib/helpers/camelize.js
@@ -1,0 +1,10 @@
+// Implementation taken from `Ember.String.camelize`.
+
+const REG_EXP_SYMBOLS = /([\s._-])+(.)?/g;
+const REG_EXP_LETTERS = /(^|\/)([A-Z])/g;
+
+module.exports = function camelize(string) {
+  return string
+    .replace(REG_EXP_SYMBOLS, (match, separator, char) => (char ? char.toUpperCase() : ''))
+    .replace(REG_EXP_LETTERS, (match) => match.toLowerCase());
+};

--- a/lib/rules/require-valid-named-block-naming-format.js
+++ b/lib/rules/require-valid-named-block-naming-format.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const camelize = require('../helpers/camelize');
+const createConfigErrorMessage = require('../helpers/create-error-message');
+const dasherize = require('../helpers/dasherize-component-name');
+const { match } = require('../helpers/node-matcher');
+const Rule = require('./_base');
+
+const FORMAT = {
+  CAMEL_CASE: 'camelCase',
+  KEBAB_CASE: 'kebab-case',
+};
+
+const FORMAT_METHOD = {
+  [FORMAT.CAMEL_CASE]: camelize,
+  [FORMAT.KEBAB_CASE]: dasherize,
+};
+
+const FORMATS = Object.values(FORMAT);
+const DEFAULT_FORMAT = FORMAT.CAMEL_CASE;
+
+module.exports = class RequireValidNamedBlockNamingFormat extends Rule {
+  parseConfig(config) {
+    let configType = typeof config;
+
+    switch (configType) {
+      case 'boolean':
+        return config ? DEFAULT_FORMAT : false;
+      case 'string':
+        if (FORMATS.includes(config)) {
+          return config;
+        }
+        break;
+      case 'undefined':
+        return false;
+    }
+
+    let errorMessage = createConfigErrorMessage(
+      this.ruleName,
+      FORMATS.map(
+        (format) => `  * "${format}" - Requires the use of the "${format}" naming format.`
+      ),
+      config
+    );
+
+    throw new Error(errorMessage);
+  }
+
+  visitor() {
+    return {
+      MustacheStatement(node) {
+        if (isHasBlockNode(node)) {
+          this._checkHasBlockNode(node);
+        } else if (isYieldNode(node)) {
+          this._checkYieldNode(node);
+        }
+      },
+
+      SubExpression(node) {
+        if (isHasBlockNode(node)) {
+          this._checkHasBlockNode(node);
+        }
+      },
+    };
+  }
+
+  _checkHasBlockNode(node) {
+    let nameArgument = node.params[0];
+
+    if (nameArgument && nameArgument.type === 'StringLiteral') {
+      this._checkNamedBlockName(nameArgument.original, nameArgument);
+    }
+  }
+
+  _checkYieldNode(node) {
+    let toArgument = node.hash.pairs.find((pair) => pair.key === 'to');
+
+    if (toArgument && toArgument.value.type === 'StringLiteral') {
+      this._checkNamedBlockName(toArgument.value.original, toArgument);
+    }
+  }
+
+  _checkNamedBlockName(name, node) {
+    let formatMethod = FORMAT_METHOD[this.config];
+    let requiredName = formatMethod(name);
+
+    if (name !== requiredName) {
+      this.log({
+        message: createErrorMessage(this.config, name, requiredName),
+        node,
+      });
+    }
+  }
+};
+
+function isHasBlockNode(node) {
+  return (
+    match(node.path, { original: 'has-block', type: 'PathExpression' }) ||
+    match(node.path, { original: 'has-block-params', type: 'PathExpression' })
+  );
+}
+
+function isYieldNode(node) {
+  return match(node.path, { original: 'yield', type: 'PathExpression' });
+}
+
+function createErrorMessage(format, from, to) {
+  return `Named blocks are required to use the "${format}" naming format. Please change "${from}" to "${to}".`;
+}
+
+module.exports.FORMAT = FORMAT;
+module.exports.createErrorMessage = createErrorMessage;

--- a/test/unit/rules/require-valid-named-block-naming-format-test.js
+++ b/test/unit/rules/require-valid-named-block-naming-format-test.js
@@ -1,0 +1,228 @@
+'use strict';
+
+const {
+  createErrorMessage,
+  FORMAT,
+} = require('../../../lib/rules/require-valid-named-block-naming-format');
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'require-valid-named-block-naming-format',
+
+  config: true,
+
+  good: [
+    // Default config.
+    '{{yield}}',
+    '{{yield to="fooBar"}}',
+
+    '{{has-block}}',
+    '{{has-block "fooBar"}}',
+
+    '{{if (has-block)}}',
+    '{{if (has-block "fooBar")}}',
+
+    '{{has-block-params}}',
+    '{{has-block-params "fooBar"}}',
+
+    '{{if (has-block-params)}}',
+    '{{if (has-block-params "fooBar")}}',
+
+    // Explicit config: `camelCase`.
+    {
+      config: FORMAT.CAMEL_CASE,
+      template: '{{yield to="fooBar"}}',
+    },
+    {
+      config: FORMAT.CAMEL_CASE,
+      template: '{{has-block "fooBar"}}',
+    },
+    {
+      config: FORMAT.CAMEL_CASE,
+      template: '{{if (has-block "fooBar")}}',
+    },
+    {
+      config: FORMAT.CAMEL_CASE,
+      template: '{{has-block-params "fooBar"}}',
+    },
+    {
+      config: FORMAT.CAMEL_CASE,
+      template: '{{if (has-block-params "fooBar")}}',
+    },
+
+    // Explicit config: `kebab-case`.
+    {
+      config: FORMAT.KEBAB_CASE,
+      template: '{{yield to="foo-bar"}}',
+    },
+    {
+      config: FORMAT.KEBAB_CASE,
+      template: '{{has-block "foo-bar"}}',
+    },
+    {
+      config: FORMAT.KEBAB_CASE,
+      template: '{{if (has-block "foo-bar")}}',
+    },
+    {
+      config: FORMAT.KEBAB_CASE,
+      template: '{{has-block-params "foo-bar"}}',
+    },
+    {
+      config: FORMAT.KEBAB_CASE,
+      template: '{{if (has-block-params "foo-bar")}}',
+    },
+  ],
+
+  bad: [
+    // Default config.
+    {
+      template: '{{yield to="foo-bar"}}',
+      result: {
+        message: createErrorMessage(FORMAT.CAMEL_CASE, 'foo-bar', 'fooBar'),
+        line: 1,
+        column: 8,
+        source: 'to="foo-bar"',
+      },
+    },
+    {
+      template: '{{has-block "foo-bar"}}',
+      result: {
+        message: createErrorMessage(FORMAT.CAMEL_CASE, 'foo-bar', 'fooBar'),
+        line: 1,
+        column: 12,
+        source: '"foo-bar"',
+      },
+    },
+    {
+      template: '{{if (has-block "foo-bar")}}',
+      result: {
+        message: createErrorMessage(FORMAT.CAMEL_CASE, 'foo-bar', 'fooBar'),
+        line: 1,
+        column: 16,
+        source: '"foo-bar"',
+      },
+    },
+    {
+      template: '{{has-block-params "foo-bar"}}',
+      result: {
+        message: createErrorMessage(FORMAT.CAMEL_CASE, 'foo-bar', 'fooBar'),
+        line: 1,
+        column: 19,
+        source: '"foo-bar"',
+      },
+    },
+    {
+      template: '{{if (has-block-params "foo-bar")}}',
+      result: {
+        message: createErrorMessage(FORMAT.CAMEL_CASE, 'foo-bar', 'fooBar'),
+        line: 1,
+        column: 23,
+        source: '"foo-bar"',
+      },
+    },
+
+    // Explicit config: `camelCase`.
+    {
+      config: FORMAT.CAMEL_CASE,
+      template: '{{yield to="foo-bar"}}',
+      result: {
+        message: createErrorMessage(FORMAT.CAMEL_CASE, 'foo-bar', 'fooBar'),
+        line: 1,
+        column: 8,
+        source: 'to="foo-bar"',
+      },
+    },
+    {
+      config: FORMAT.CAMEL_CASE,
+      template: '{{has-block "foo-bar"}}',
+      result: {
+        message: createErrorMessage(FORMAT.CAMEL_CASE, 'foo-bar', 'fooBar'),
+        line: 1,
+        column: 12,
+        source: '"foo-bar"',
+      },
+    },
+    {
+      config: FORMAT.CAMEL_CASE,
+      template: '{{if (has-block "foo-bar")}}',
+      result: {
+        message: createErrorMessage(FORMAT.CAMEL_CASE, 'foo-bar', 'fooBar'),
+        line: 1,
+        column: 16,
+        source: '"foo-bar"',
+      },
+    },
+    {
+      config: FORMAT.CAMEL_CASE,
+      template: '{{has-block-params "foo-bar"}}',
+      result: {
+        message: createErrorMessage(FORMAT.CAMEL_CASE, 'foo-bar', 'fooBar'),
+        line: 1,
+        column: 19,
+        source: '"foo-bar"',
+      },
+    },
+    {
+      config: FORMAT.CAMEL_CASE,
+      template: '{{if (has-block-params "foo-bar")}}',
+      result: {
+        message: createErrorMessage(FORMAT.CAMEL_CASE, 'foo-bar', 'fooBar'),
+        line: 1,
+        column: 23,
+        source: '"foo-bar"',
+      },
+    },
+
+    // Explicit config: `kebab-case`.
+    {
+      config: FORMAT.KEBAB_CASE,
+      template: '{{yield to="fooBar"}}',
+      result: {
+        message: createErrorMessage(FORMAT.KEBAB_CASE, 'fooBar', 'foo-bar'),
+        line: 1,
+        column: 8,
+        source: 'to="fooBar"',
+      },
+    },
+    {
+      config: FORMAT.KEBAB_CASE,
+      template: '{{has-block "fooBar"}}',
+      result: {
+        message: createErrorMessage(FORMAT.KEBAB_CASE, 'fooBar', 'foo-bar'),
+        line: 1,
+        column: 12,
+        source: '"fooBar"',
+      },
+    },
+    {
+      config: FORMAT.KEBAB_CASE,
+      template: '{{if (has-block "fooBar")}}',
+      result: {
+        message: createErrorMessage(FORMAT.KEBAB_CASE, 'fooBar', 'foo-bar'),
+        line: 1,
+        column: 16,
+        source: '"fooBar"',
+      },
+    },
+    {
+      config: FORMAT.KEBAB_CASE,
+      template: '{{has-block-params "fooBar"}}',
+      result: {
+        message: createErrorMessage(FORMAT.KEBAB_CASE, 'fooBar', 'foo-bar'),
+        line: 1,
+        column: 19,
+        source: '"fooBar"',
+      },
+    },
+    {
+      config: FORMAT.KEBAB_CASE,
+      template: '{{if (has-block-params "fooBar")}}',
+      result: {
+        message: createErrorMessage(FORMAT.KEBAB_CASE, 'fooBar', 'foo-bar'),
+        line: 1,
+        column: 23,
+        source: '"fooBar"',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Adds a new rule `require-valid-named-block-naming-format` to enforce consistent naming of named blocks.

Possible options are `camelCase` (default) and `kebab-case`.
`PascalCase` isn't an option because [named blocks must start with a lower case letter](https://github.com/glimmerjs/glimmer-vm/blob/3874a63ce863f94078d93d22cba66dbb23c496d3/packages/%40glimmer/integration-tests/test/syntax/named-blocks-test.ts#L74-L83).

Wasn't sure which format to pick as the default so just picked `camelCase`, but can easily change to `kebab-case`.

Closes #1772.