### PR TITLE
Converting --clean-todo to a default, providing --no-clean-todo option

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -15,6 +15,7 @@ const {
   validateConfig,
 } = require('@ember-template-lint/todo-utils');
 const chalk = require('chalk');
+const ci = require('ci-info');
 const getStdin = require('get-stdin');
 const globby = require('globby');
 const isGlob = require('is-glob');
@@ -194,7 +195,7 @@ function parseArgv(_argv) {
       },
       'clean-todo': {
         describe: 'Remove expired and invalid todo files',
-        default: true,
+        default: !ci.isCI,
         boolean: true,
       },
       'todo-days-to-warn': {

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -194,7 +194,7 @@ function parseArgv(_argv) {
       },
       'clean-todo': {
         describe: 'Remove expired and invalid todo files',
-        default: false,
+        default: true,
         boolean: true,
       },
       'todo-days-to-warn': {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@ember-template-lint/todo-utils": "^10.0.0",
     "chalk": "^4.1.2",
+    "ci-info": "^3.2.0",
     "date-fns": "^2.24.0",
     "ember-template-recast": "^5.0.3",
     "find-up": "^5.0.0",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -382,6 +382,9 @@ Options:
 
   describe('reading from stdin', function () {
     describe('given no path', function () {
+      setupEnvVar('CI', null);
+      setupEnvVar('GITHUB_ACTIONS', null);
+
       it('should print errors', async function () {
         project.setConfig({
           rules: {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -26,6 +26,9 @@ describe('ember-template-lint executable', function () {
   });
 
   describe('basic usage', function () {
+    setupEnvVar('CI', null);
+    setupEnvVar('GITHUB_ACTIONS', null);
+
     describe('without any parameters', function () {
       it('should emit help text', async function () {
         let result = await run([]);

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -32,56 +32,56 @@ describe('ember-template-lint executable', function () {
 
         expect(result.exitCode).toEqual(1);
         expect(result.stderr).toMatchInlineSnapshot(`
-          "ember-template-lint [options] [files..]
+"ember-template-lint [options] [files..]
 
-          Options:
-            --config-path               Define a custom config path
-                                                 [string] [default: \\".template-lintrc.js\\"]
-            --config                    Define a custom configuration to be used - (e.g.
-                                        '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
-                                                                                  [string]
-            --quiet                     Ignore warnings and only show errors     [boolean]
-            --rule                      Specify a rule and its severity to add that rule
-                                        to loaded rules - (e.g. \`no-implicit-this:error\`
-                                        or \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
-                                                                                  [string]
-            --filename                  Used to indicate the filename to be assumed for
-                                        contents from STDIN                       [string]
-            --fix                       Fix any errors that are reported as fixable
-                                                                [boolean] [default: false]
-            --format                    Specify format to be used in printing output
-                                                              [string] [default: \\"pretty\\"]
-            --json                      Format output as json
-                                         [deprecated: Use --format=json instead] [boolean]
-            --output-file               Specify file to write report to           [string]
-            --verbose                   Output errors with source description    [boolean]
-            --working-directory, --cwd  Path to a directory that should be considered as
-                                        the current working directory.
-                                                                   [string] [default: \\".\\"]
-            --no-config-path            Does not use the local template-lintrc, will use a
-                                        blank template-lintrc instead            [boolean]
-            --update-todo               Update list of linting todos by transforming lint
-                                        errors to todos         [boolean] [default: false]
-            --include-todo              Include todos in the results
-                                                                [boolean] [default: false]
-            --clean-todo                Remove expired and invalid todo files
-                                                                [boolean] [default: false]
-            --todo-days-to-warn         Number of days after its creation date that a todo
-                                        transitions into a warning                [number]
-            --todo-days-to-error        Number of days after its creation date that a todo
-                                        transitions into an error                 [number]
-            --ignore-pattern            Specify custom ignore pattern (can be disabled
-                                        with --no-ignore-pattern)
-                        [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --no-inline-config          Prevent inline configuration comments from
-                                        changing config or rules                 [boolean]
-            --print-config              Print the configuration for the given file
-                                                                [boolean] [default: false]
-            --max-warnings              Number of warnings to trigger nonzero exit code
-                                                                                  [number]
-            --help                      Show help                                [boolean]
-            --version                   Show version number                      [boolean]"
-        `);
+Options:
+  --config-path               Define a custom config path
+                                       [string] [default: \\".template-lintrc.js\\"]
+  --config                    Define a custom configuration to be used - (e.g.
+                              '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
+                                                                        [string]
+  --quiet                     Ignore warnings and only show errors     [boolean]
+  --rule                      Specify a rule and its severity to add that rule
+                              to loaded rules - (e.g. \`no-implicit-this:error\`
+                              or \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
+                                                                        [string]
+  --filename                  Used to indicate the filename to be assumed for
+                              contents from STDIN                       [string]
+  --fix                       Fix any errors that are reported as fixable
+                                                      [boolean] [default: false]
+  --format                    Specify format to be used in printing output
+                                                    [string] [default: \\"pretty\\"]
+  --json                      Format output as json
+                               [deprecated: Use --format=json instead] [boolean]
+  --output-file               Specify file to write report to           [string]
+  --verbose                   Output errors with source description    [boolean]
+  --working-directory, --cwd  Path to a directory that should be considered as
+                              the current working directory.
+                                                         [string] [default: \\".\\"]
+  --no-config-path            Does not use the local template-lintrc, will use a
+                              blank template-lintrc instead            [boolean]
+  --update-todo               Update list of linting todos by transforming lint
+                              errors to todos         [boolean] [default: false]
+  --include-todo              Include todos in the results
+                                                      [boolean] [default: false]
+  --clean-todo                Remove expired and invalid todo files
+                                                       [boolean] [default: true]
+  --todo-days-to-warn         Number of days after its creation date that a todo
+                              transitions into a warning                [number]
+  --todo-days-to-error        Number of days after its creation date that a todo
+                              transitions into an error                 [number]
+  --ignore-pattern            Specify custom ignore pattern (can be disabled
+                              with --no-ignore-pattern)
+              [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
+  --no-inline-config          Prevent inline configuration comments from
+                              changing config or rules                 [boolean]
+  --print-config              Print the configuration for the given file
+                                                      [boolean] [default: false]
+  --max-warnings              Number of warnings to trigger nonzero exit code
+                                                                        [number]
+  --help                      Show help                                [boolean]
+  --version                   Show version number                      [boolean]"
+`);
       });
     });
 
@@ -91,56 +91,56 @@ describe('ember-template-lint executable', function () {
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toMatchInlineSnapshot(`
-          "ember-template-lint [options] [files..]
+"ember-template-lint [options] [files..]
 
-          Options:
-            --config-path               Define a custom config path
-                                                 [string] [default: \\".template-lintrc.js\\"]
-            --config                    Define a custom configuration to be used - (e.g.
-                                        '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
-                                                                                  [string]
-            --quiet                     Ignore warnings and only show errors     [boolean]
-            --rule                      Specify a rule and its severity to add that rule
-                                        to loaded rules - (e.g. \`no-implicit-this:error\`
-                                        or \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
-                                                                                  [string]
-            --filename                  Used to indicate the filename to be assumed for
-                                        contents from STDIN                       [string]
-            --fix                       Fix any errors that are reported as fixable
-                                                                [boolean] [default: false]
-            --format                    Specify format to be used in printing output
-                                                              [string] [default: \\"pretty\\"]
-            --json                      Format output as json
-                                         [deprecated: Use --format=json instead] [boolean]
-            --output-file               Specify file to write report to           [string]
-            --verbose                   Output errors with source description    [boolean]
-            --working-directory, --cwd  Path to a directory that should be considered as
-                                        the current working directory.
-                                                                   [string] [default: \\".\\"]
-            --no-config-path            Does not use the local template-lintrc, will use a
-                                        blank template-lintrc instead            [boolean]
-            --update-todo               Update list of linting todos by transforming lint
-                                        errors to todos         [boolean] [default: false]
-            --include-todo              Include todos in the results
-                                                                [boolean] [default: false]
-            --clean-todo                Remove expired and invalid todo files
-                                                                [boolean] [default: false]
-            --todo-days-to-warn         Number of days after its creation date that a todo
-                                        transitions into a warning                [number]
-            --todo-days-to-error        Number of days after its creation date that a todo
-                                        transitions into an error                 [number]
-            --ignore-pattern            Specify custom ignore pattern (can be disabled
-                                        with --no-ignore-pattern)
-                        [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --no-inline-config          Prevent inline configuration comments from
-                                        changing config or rules                 [boolean]
-            --print-config              Print the configuration for the given file
-                                                                [boolean] [default: false]
-            --max-warnings              Number of warnings to trigger nonzero exit code
-                                                                                  [number]
-            --help                      Show help                                [boolean]
-            --version                   Show version number                      [boolean]"
-        `);
+Options:
+  --config-path               Define a custom config path
+                                       [string] [default: \\".template-lintrc.js\\"]
+  --config                    Define a custom configuration to be used - (e.g.
+                              '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
+                                                                        [string]
+  --quiet                     Ignore warnings and only show errors     [boolean]
+  --rule                      Specify a rule and its severity to add that rule
+                              to loaded rules - (e.g. \`no-implicit-this:error\`
+                              or \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
+                                                                        [string]
+  --filename                  Used to indicate the filename to be assumed for
+                              contents from STDIN                       [string]
+  --fix                       Fix any errors that are reported as fixable
+                                                      [boolean] [default: false]
+  --format                    Specify format to be used in printing output
+                                                    [string] [default: \\"pretty\\"]
+  --json                      Format output as json
+                               [deprecated: Use --format=json instead] [boolean]
+  --output-file               Specify file to write report to           [string]
+  --verbose                   Output errors with source description    [boolean]
+  --working-directory, --cwd  Path to a directory that should be considered as
+                              the current working directory.
+                                                         [string] [default: \\".\\"]
+  --no-config-path            Does not use the local template-lintrc, will use a
+                              blank template-lintrc instead            [boolean]
+  --update-todo               Update list of linting todos by transforming lint
+                              errors to todos         [boolean] [default: false]
+  --include-todo              Include todos in the results
+                                                      [boolean] [default: false]
+  --clean-todo                Remove expired and invalid todo files
+                                                       [boolean] [default: true]
+  --todo-days-to-warn         Number of days after its creation date that a todo
+                              transitions into a warning                [number]
+  --todo-days-to-error        Number of days after its creation date that a todo
+                              transitions into an error                 [number]
+  --ignore-pattern            Specify custom ignore pattern (can be disabled
+                              with --no-ignore-pattern)
+              [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
+  --no-inline-config          Prevent inline configuration comments from
+                              changing config or rules                 [boolean]
+  --print-config              Print the configuration for the given file
+                                                      [boolean] [default: false]
+  --max-warnings              Number of warnings to trigger nonzero exit code
+                                                                        [number]
+  --help                      Show help                                [boolean]
+  --version                   Show version number                      [boolean]"
+`);
       });
     });
   });
@@ -404,56 +404,56 @@ describe('ember-template-lint executable', function () {
         expect(result.exitCode).toEqual(1);
         expect(result.stdout).toBeFalsy();
         expect(result.stderr).toMatchInlineSnapshot(`
-          "ember-template-lint [options] [files..]
+"ember-template-lint [options] [files..]
 
-          Options:
-            --config-path               Define a custom config path
-                                                 [string] [default: \\".template-lintrc.js\\"]
-            --config                    Define a custom configuration to be used - (e.g.
-                                        '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
-                                                                                  [string]
-            --quiet                     Ignore warnings and only show errors     [boolean]
-            --rule                      Specify a rule and its severity to add that rule
-                                        to loaded rules - (e.g. \`no-implicit-this:error\`
-                                        or \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
-                                                                                  [string]
-            --filename                  Used to indicate the filename to be assumed for
-                                        contents from STDIN                       [string]
-            --fix                       Fix any errors that are reported as fixable
-                                                                [boolean] [default: false]
-            --format                    Specify format to be used in printing output
-                                                              [string] [default: \\"pretty\\"]
-            --json                      Format output as json
-                                         [deprecated: Use --format=json instead] [boolean]
-            --output-file               Specify file to write report to           [string]
-            --verbose                   Output errors with source description    [boolean]
-            --working-directory, --cwd  Path to a directory that should be considered as
-                                        the current working directory.
-                                                                   [string] [default: \\".\\"]
-            --no-config-path            Does not use the local template-lintrc, will use a
-                                        blank template-lintrc instead            [boolean]
-            --update-todo               Update list of linting todos by transforming lint
-                                        errors to todos         [boolean] [default: false]
-            --include-todo              Include todos in the results
-                                                                [boolean] [default: false]
-            --clean-todo                Remove expired and invalid todo files
-                                                                [boolean] [default: false]
-            --todo-days-to-warn         Number of days after its creation date that a todo
-                                        transitions into a warning                [number]
-            --todo-days-to-error        Number of days after its creation date that a todo
-                                        transitions into an error                 [number]
-            --ignore-pattern            Specify custom ignore pattern (can be disabled
-                                        with --no-ignore-pattern)
-                        [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --no-inline-config          Prevent inline configuration comments from
-                                        changing config or rules                 [boolean]
-            --print-config              Print the configuration for the given file
-                                                                [boolean] [default: false]
-            --max-warnings              Number of warnings to trigger nonzero exit code
-                                                                                  [number]
-            --help                      Show help                                [boolean]
-            --version                   Show version number                      [boolean]"
-        `);
+Options:
+  --config-path               Define a custom config path
+                                       [string] [default: \\".template-lintrc.js\\"]
+  --config                    Define a custom configuration to be used - (e.g.
+                              '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
+                                                                        [string]
+  --quiet                     Ignore warnings and only show errors     [boolean]
+  --rule                      Specify a rule and its severity to add that rule
+                              to loaded rules - (e.g. \`no-implicit-this:error\`
+                              or \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
+                                                                        [string]
+  --filename                  Used to indicate the filename to be assumed for
+                              contents from STDIN                       [string]
+  --fix                       Fix any errors that are reported as fixable
+                                                      [boolean] [default: false]
+  --format                    Specify format to be used in printing output
+                                                    [string] [default: \\"pretty\\"]
+  --json                      Format output as json
+                               [deprecated: Use --format=json instead] [boolean]
+  --output-file               Specify file to write report to           [string]
+  --verbose                   Output errors with source description    [boolean]
+  --working-directory, --cwd  Path to a directory that should be considered as
+                              the current working directory.
+                                                         [string] [default: \\".\\"]
+  --no-config-path            Does not use the local template-lintrc, will use a
+                              blank template-lintrc instead            [boolean]
+  --update-todo               Update list of linting todos by transforming lint
+                              errors to todos         [boolean] [default: false]
+  --include-todo              Include todos in the results
+                                                      [boolean] [default: false]
+  --clean-todo                Remove expired and invalid todo files
+                                                       [boolean] [default: true]
+  --todo-days-to-warn         Number of days after its creation date that a todo
+                              transitions into a warning                [number]
+  --todo-days-to-error        Number of days after its creation date that a todo
+                              transitions into an error                 [number]
+  --ignore-pattern            Specify custom ignore pattern (can be disabled
+                              with --no-ignore-pattern)
+              [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
+  --no-inline-config          Prevent inline configuration comments from
+                              changing config or rules                 [boolean]
+  --print-config              Print the configuration for the given file
+                                                      [boolean] [default: false]
+  --max-warnings              Number of warnings to trigger nonzero exit code
+                                                                        [number]
+  --help                      Show help                                [boolean]
+  --version                   Show version number                      [boolean]"
+`);
       });
     });
 

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -355,7 +355,7 @@ describe('todo usage', () => {
       expect(todos).toHaveLength(3);
     });
 
-    it('errors if a todo item is no longer valid when running without params, and cleans using --fix', async function () {
+    it('errors if a todo item is no longer valid when running with --no-clean-todo, and cleans using --fix', async function () {
       project.setConfig({
         rules: {
           'require-button-type': true,
@@ -382,8 +382,8 @@ describe('todo usage', () => {
         },
       });
 
-      // run normally and expect an error for not running --fix
-      let result = await run(['.']);
+      // run normally with --no-clean-todo and expect an error for not running --fix
+      let result = await run(['.', '--no-clean-todo']);
 
       expect(result.exitCode).toEqual(1);
       expect(result.stdout).toMatchInlineSnapshot(`
@@ -407,7 +407,7 @@ describe('todo usage', () => {
       expect(todoDirs).toHaveLength(0);
     });
 
-    it('errors if a todo item is no longer valid when running without params, and cleans using --clean-todo', async function () {
+    it('errors if a todo item is no longer valid when running with --no-clean-todo, and cleans without --no-clean-todo', async function () {
       project.setConfig({
         rules: {
           'require-button-type': true,
@@ -434,8 +434,8 @@ describe('todo usage', () => {
         },
       });
 
-      // run normally and expect an error for not running --fix
-      let result = await run(['.']);
+      // run normally with --no-clean-todo and expect an error for not running --fix
+      let result = await run(['.', '--no-clean-todo']);
 
       expect(result.exitCode).toEqual(1);
       expect(result.stdout).toMatchInlineSnapshot(`
@@ -447,7 +447,7 @@ describe('todo usage', () => {
       `);
 
       // run fix, and expect that this will delete the outstanding todo item
-      await run(['app/templates/require-button-type.hbs', '--clean-todo']);
+      await run(['app/templates/require-button-type.hbs']);
 
       // run normally again and expect no error
       result = await run(['.']);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2068,6 +2068,11 @@ ci-info@^3.1.1:
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.1.1.tgz#9a32fcefdf7bcdb6f0a7e1c0f8098ec57897b80a"
   integrity sha512-kdRWLBIJwdsYJWYJFtAFFYxybguqeF91qpZaggjG5Nf8QKdizFG2hjqvaTXbxFIcYbSaD74KpAXv6BSm17DHEQ==
 
+ci-info@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.2.0.tgz#2876cb948a498797b5236f0095bc057d0dca38b6"
+  integrity sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==
+
 cjs-module-lexer@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.1.tgz#2fd46d9906a126965aa541345c499aaa18e8cd73"


### PR DESCRIPTION
Requiring users to explicitly call `--clean-todo` after pushing an artificial error in our results causes the following:

- a mismatched count of _actual_ errors vs. artificial errors from todos that need cleaning
- extra work for the user to clean the todos when they really just want them cleaned

In light of this, we've inversed the functionality, so that the process of cleaning todos is the default, and you can opt out by using `--no-clean-todo`. We're taking advantage of yargs' auto-inverting when using `--no` on boolean options.