### PR TITLE
Stricter validation of rule doc notices

### DIFF
--- a/docs/rule/no-positional-data-test-selectors.md
+++ b/docs/rule/no-positional-data-test-selectors.md
@@ -1,8 +1,11 @@
 # no-positional-data-test-selectors
 
+✅ The `extends: 'recommended'` property in a configuration file enables this rule.
+
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 ## Motivation
 
-✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
 [ember-test-selectors](https://github.com/simplabs/ember-test-selectors) is a very popular library that enables better element selectors for testing.
 
@@ -35,8 +38,6 @@ And suggests using the following instead:
 {{#foo-bar data-test-blah=true}}
 {{/foo-bar}}
 ```
-
-🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
 
 ## References
 

--- a/docs/rule/no-redundant-fn.md
+++ b/docs/rule/no-redundant-fn.md
@@ -2,6 +2,8 @@
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 The `fn` helper can be used to bind arguments to another function. Using it
 without any arguments is redundant because then the inner function could just
 be used directly.
@@ -26,10 +28,6 @@ This rule **allows** the following:
 ```hbs
 <button {{on "click" (fn this.handleClick "foo")}}>Click Me</button>
 ```
-
-## Migration
-
-🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
 
 ## References
 

--- a/docs/rule/no-redundant-landmark-role.md
+++ b/docs/rule/no-redundant-landmark-role.md
@@ -1,6 +1,7 @@
 # no-redundant-landmark-role
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
+
 🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
 
 If a landmark element is used, any role provided will either be redundant or incorrect.

--- a/docs/rule/no-this-in-template-only-components.md
+++ b/docs/rule/no-this-in-template-only-components.md
@@ -1,8 +1,8 @@
 # no-this-in-template-only-components
 
-There is no `this` context in template-only components.
-
 🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
+There is no `this` context in template-only components.
 
 ## Examples
 

--- a/docs/rule/require-has-block-helper.md
+++ b/docs/rule/require-has-block-helper.md
@@ -2,6 +2,8 @@
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 In Ember 3.26 the properties `hasBlock` and `hasBlockParams` were deprecated. Their replacement is to use `has-block` and `has-block-params` helpers instead.
 
 This rule prevents the usage of `hasBlock` and `hasBlockParams` and suggests using `has-block` or `has-block-params` instead.
@@ -43,8 +45,6 @@ This rule **allows** the following:
 ```
 
 ## Migration
-
-🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
 
 - `{{hasBlock}}`-> `{{has-block}}
 - `{{hasBlockParams}}`-> `{{has-block-params}}

--- a/test/unit/rule-setup-test.js
+++ b/test/unit/rule-setup-test.js
@@ -45,39 +45,59 @@ describe('rules setup is correct', function () {
     }
   });
 
-  it('should have the right contents (title, examples, notices, references) for each rule documentation file', function () {
-    const CONFIG_MSG_RECOMMENDED =
-      "✅ The `extends: 'recommended'` property in a configuration file enables this rule.";
-    const CONFIG_MSG_STYLISTIC =
-      "💅 The `extends: 'stylistic'` property in a configuration file enables this rule.";
-    const FIXABLE_NOTICE =
-      '🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.';
+  describe('rule documentation files', function () {
+    const MESSAGES = {
+      configRecommended:
+        "✅ The `extends: 'recommended'` property in a configuration file enables this rule.",
+      configStylistic:
+        "💅 The `extends: 'stylistic'` property in a configuration file enables this rule.",
+      fixable:
+        '🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.',
+    };
 
     for (const ruleName of expectedRules) {
-      const filePath = path.join(__dirname, '..', '..', 'docs', 'rule', `${ruleName}.md`);
-      const file = readFileSync(filePath, 'utf8');
+      describe(ruleName, function () {
+        it('should have the right contents (title, notices, examples, references)', function () {
+          const filePath = path.join(__dirname, '..', '..', 'docs', 'rule', `${ruleName}.md`);
+          const file = readFileSync(filePath, 'utf8');
+          const lines = file.split('\n');
 
-      expect(file).toContain(`# ${ruleName}`); // Title header.
-      expect(file).toContain('## Examples'); // Examples section header.
-      expect(file).toContain('## References');
+          expect(lines[0]).toStrictEqual(`# ${ruleName}`); // Title header.
+          expect(file).toContain('## Examples'); // Examples section header.
+          expect(file).toContain('## References');
 
-      if (RULE_NAMES_RECOMMENDED.has(ruleName)) {
-        expect(file).toContain(CONFIG_MSG_RECOMMENDED);
-      } else {
-        expect(file).not.toContain(CONFIG_MSG_RECOMMENDED);
-      }
+          const expectedNotices = [];
+          const unexpectedNotices = [];
+          if (RULE_NAMES_RECOMMENDED.has(ruleName)) {
+            expectedNotices.push('configRecommended');
+          } else {
+            unexpectedNotices.push('configRecommended');
+          }
+          if (RULE_NAMES_STYLISTIC.has(ruleName)) {
+            expectedNotices.push('configStylistic');
+          } else {
+            unexpectedNotices.push('configStylistic');
+          }
+          if (isRuleFixable(ruleName)) {
+            expectedNotices.push('fixable');
+          } else {
+            unexpectedNotices.push('fixable');
+          }
 
-      if (RULE_NAMES_STYLISTIC.has(ruleName)) {
-        expect(file).toContain(CONFIG_MSG_STYLISTIC);
-      } else {
-        expect(file).not.toContain(CONFIG_MSG_STYLISTIC);
-      }
+          // Ensure that expected notices are present in the correct order.
+          let currentLineNumber = 1;
+          for (const expectedNotice of expectedNotices) {
+            expect(lines[currentLineNumber]).toStrictEqual('');
+            expect(lines[currentLineNumber + 1]).toStrictEqual(MESSAGES[expectedNotice]);
+            currentLineNumber += 2;
+          }
 
-      if (isRuleFixable(ruleName)) {
-        expect(file).toContain(FIXABLE_NOTICE);
-      } else {
-        expect(file).not.toContain(FIXABLE_NOTICE);
-      }
+          // Ensure that unexpected notices are not present.
+          for (const unexpectedNotice of unexpectedNotices) {
+            expect(file).not.toContain(MESSAGES[unexpectedNotice]);
+          }
+        });
+      });
     }
   });
 });


### PR DESCRIPTION
Ensure rule doc notices are at the top of the doc in the correct position/order. And better, more helpful tests.

Inspired by: https://github.com/ember-cli/eslint-plugin-ember/blob/master/tests/rule-setup.js