### PR TITLE
WIP Adds new rule `no-empty-headings`

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Each rule has emojis denoting:
 | [no-duplicate-landmark-elements](./docs/rule/no-duplicate-landmark-elements.md)                           | ✅  |     | ⌨️  |     |
 | [no-dynamic-subexpression-invocations](./docs/rule/no-dynamic-subexpression-invocations.md)               |     |     |     |     |
 | [no-element-event-actions](./docs/rule/no-element-event-actions.md)                                       |     |     |     |     |
+| [no-empty-headings](./docs/rule/no-empty-headings.md)                                                     | ✅  |     | ⌨️  |     |
 | [no-extra-mut-helper-argument](./docs/rule/no-extra-mut-helper-argument.md)                               | ✅  |     |     |     |
 | [no-forbidden-elements](./docs/rule/no-forbidden-elements.md)                                             | ✅  |     |     |     |
 | [no-heading-inside-button](./docs/rule/no-heading-inside-button.md)                                       | ✅  |     | ⌨️  |     |

--- a/docs/rule/no-empty-headings.md
+++ b/docs/rule/no-empty-headings.md
@@ -1,0 +1,51 @@
+# no-empty-headings
+
+Headings relay the structure of a webpage and provide a meaningful, hierarchical order of its content. If headings are empty or its text contents are inaccessible, this could confuse users or prevent them accessing sections of interest.
+
+Disallow headings (h1, h2, etc.) with no accessible text content.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<h*></h*>
+```
+
+```hbs
+<div role="heading"></div>
+```
+
+```hbs
+<h*><span aria-hidden="true">Inaccessible text<span></h*>
+```
+
+This rule **allows** the following:
+
+```hbs
+<h*>Heading Content</h*>
+```
+
+```hbs
+<h*><span>Text</span><h*>
+```
+
+```hbs
+<div role="heading">Heading Content</div>
+```
+
+```hbs
+<h* aria-hidden="true">Heading Content</h*>
+```
+
+```hbs
+<h* hidden>Heading Content</h*>
+```
+
+## Migration
+
+If violations are found, remediation should be planned to ensure text content is present and visible and/or screen-reader accessible. Setting `aria-hidden="false"` or removing `hidden` attributes from the element(s) containing heading text may serve as a quickfix.
+
+## References
+
+- [WCAG SC 2.4.6 Headings and Labels](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html)

--- a/lib/rules/no-empty-headings.js
+++ b/lib/rules/no-empty-headings.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./_base');
+
+const ERROR_MESSAGE = 'Heading (h1, h2, etc.) must contain accessible text content.';
+const headings = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']);
+
+function hasText(textNode) {
+  const nbspRemoved = textNode.chars.replace(/&nbsp;/g, ' ');
+  return nbspRemoved.trim().length > 0;
+}
+
+function isHidden(element) {
+  const ariaHiddenAttr = AstNodeInfo.findAttribute(element, 'aria-hidden');
+
+  return (
+    (ariaHiddenAttr && ariaHiddenAttr.value.chars === 'true') ||
+    AstNodeInfo.hasAttribute(element, 'hidden')
+  );
+}
+
+function getTextNodes(nodes) {
+  return nodes.filter((node) => node.type === 'TextNode');
+}
+
+module.exports = class NoEmptyHeadings extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        const role = AstNodeInfo.findAttribute(node, 'role');
+        const hasHeadingRole = role && role.value.chars === 'heading';
+
+        if (headings.has(node.tag) || hasHeadingRole) {
+          if (isHidden(node)) {
+            return;
+          }
+
+          if (!AstNodeInfo.hasChildren(node)) {
+            this.log({
+              message: ERROR_MESSAGE,
+              node,
+            });
+
+            return;
+          }
+
+          const nodeChildren = AstNodeInfo.childrenFor(node);
+          const textNodes = getTextNodes(nodeChildren);
+          const elementNodes = nodeChildren.filter((child) => child.type === 'ElementNode');
+          let reachableText = 0;
+          let elementTextNodes;
+
+          for (const textNode of textNodes) {
+            if (hasText(textNode)) {
+              reachableText++;
+            }
+          }
+
+          for (const element of elementNodes) {
+            if (!isHidden(element)) {
+              elementTextNodes = getTextNodes(AstNodeInfo.childrenFor(element));
+
+              for (const textNode of elementTextNodes) {
+                if (hasText(textNode)) {
+                  reachableText++;
+                }
+              }
+            }
+          }
+
+          if (!reachableText) {
+            this.log({
+              message: ERROR_MESSAGE,
+              node,
+            });
+          }
+        }
+      },
+    };
+  }
+};
+
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/test/unit/rules/no-empty-headings-test.js
+++ b/test/unit/rules/no-empty-headings-test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const { ERROR_MESSAGE } = require('../../../lib/rules/no-empty-headings');
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'no-empty-headings',
+
+  config: true,
+
+  good: [
+    '<h1>Accessible Heading</h1>',
+    '<h1>Accessible&nbsp;Heading</h1>',
+    '<h1 aria-hidden="true">Valid Heading</h1>',
+    '<h1 aria-hidden="true"><span>Valid Heading</span></h1>',
+    '<h1 aria-hidden="false">Accessible Heading</h1>',
+    '<h1 hidden>Valid Heading</h1>',
+    '<h1 hidden><span>Valid Heading</span></h1>',
+    '<h1><span aria-hidden="true">Hidden text</span><span>Visible text</span></h1>',
+    '<h1><span aria-hidden="true">Hidden text</span>Visible text</h1>',
+    '<div role="heading">Accessible Text</div>',
+    '<div role="heading"><span>Accessible Text</span></div>',
+    '<div role="heading"><span aria-hidden="true">Hidden text</span><span>Visible text</span></div>',
+    '<div role="heading"><span aria-hidden="true">Hidden text</span>Visible text</div>',
+  ],
+
+  bad: [
+    {
+      template: '<h1></h1>',
+      result: {
+        message: ERROR_MESSAGE,
+        source: '<h1></h1>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<h1> \n &nbsp;</h1>',
+      result: {
+        message: ERROR_MESSAGE,
+        source: '<h1> \n &nbsp;</h1>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<h1> &nbsp; <div aria-hidden="true">Some hidden text</div></h1>',
+      result: {
+        message: ERROR_MESSAGE,
+        source: '<h1> &nbsp; <div aria-hidden="true">Some hidden text</div></h1>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<h1><span aria-hidden="true">Inaccessible text</span></h1>',
+      result: {
+        message: ERROR_MESSAGE,
+        source: '<h1><span aria-hidden="true">Inaccessible text</span></h1>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<h1><span hidden>Inaccessible text</span></h1>',
+      result: {
+        message: ERROR_MESSAGE,
+        source: '<h1><span hidden>Inaccessible text</span></h1>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template:
+        '<h1><span aria-hidden="true">Hidden text</span><span aria-hidden="true">Hidden text</span></h1>',
+      result: {
+        message: ERROR_MESSAGE,
+        source:
+          '<h1><span aria-hidden="true">Hidden text</span><span aria-hidden="true">Hidden text</span></h1>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div role="heading"></div>',
+      result: {
+        message: ERROR_MESSAGE,
+        source: '<div role="heading"></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div role="heading"><span aria-hidden="true">Inaccessible text</span></div>',
+      result: {
+        message: ERROR_MESSAGE,
+        source: '<div role="heading"><span aria-hidden="true">Inaccessible text</span></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+    {
+      template: '<div role="heading"><span hidden>Inaccessible text</span></div>',
+      result: {
+        message: ERROR_MESSAGE,
+        source: '<div role="heading"><span hidden>Inaccessible text</span></div>',
+        line: 1,
+        column: 0,
+      },
+    },
+  ],
+});


### PR DESCRIPTION
### WIP / DRAFT
This PR adds the new rule `no-empty-headings` which addresses #2114 .

### Background
Headings relay the structure of a webpage and provide a meaningful, hierarchical order of its content. If headings are empty or its text contents is inaccessible, this could confuse users or prevent them from accessing sections of interest.

This new rule enforces headings have accessible text content. Headings with no text content or content that is hidden (e.g. using aria-hidden) should be disallowed.

Reference: [WCAG SC 2.4.6 Headings and Labels](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html)

**Allowed**:
```
# examples
<h1>Accessible Heading</h1>
<h1 aria-hidden="true">Valid Heading</h1>
<div role="heading"><span>Accessible text</span></div>
```

**Forbidden**:
```
# examples
<h1></h1>
<h1> </h1>
<h1><span aria-hidden=”true”>Inaccessible text</span></h1>
<h1><span hidden>text</span></h1>
```

### Testing

```
Test Suites: 128 passed, 128 total
Tests:       6 skipped, 6842 passed, 6848 total
Snapshots:   86 passed, 86 total
Time:        62.737 s
Ran all test suites.
✨  Done in 80.92s.
```