### PR TITLE
Add autofixer to `quotes` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Each rule has emojis denoting:
 | [no-with](./docs/rule/no-with.md)                                                                         | ✅  |     |     |     |
 | [no-yield-only](./docs/rule/no-yield-only.md)                                                             | ✅  |     |     |     |
 | [no-yield-to-default](./docs/rule/no-yield-to-default.md)                                                 | ✅  |     |     |     |
-| [quotes](./docs/rule/quotes.md)                                                                           |     | 💅  |     |     |
+| [quotes](./docs/rule/quotes.md)                                                                           |     | 💅  |     | 🔧  |
 | [require-button-type](./docs/rule/require-button-type.md)                                                 | ✅  |     |     | 🔧  |
 | [require-context-role](./docs/rule/require-context-role.md)                                               | ✅  |     | ⌨️  |     |
 | [require-each-key](./docs/rule/require-each-key.md)                                                       |     |     |     |     |

--- a/docs/rule/quotes.md
+++ b/docs/rule/quotes.md
@@ -2,6 +2,8 @@
 
 💅 The `extends: 'stylistic'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 Enforce the consistent use of either double or single quotes.
 
 ## Examples

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -55,6 +55,7 @@ module.exports = class Quotes extends Rule {
       AttrNode(node) {
         if (!node.isValueless && node.quoteType === badChar) {
           if (attrValueHasChar(node.value, goodChar)) {
+            // TODO: Autofix blocked on: https://github.com/ember-template-lint/ember-template-recast/issues/698
             return this.log({
               message,
               node,
@@ -77,6 +78,7 @@ module.exports = class Quotes extends Rule {
 
         if (node.quoteType === badChar) {
           if (node.value.includes(goodChar)) {
+            // TODO: Autofix blocked on: https://github.com/ember-template-lint/ember-template-recast/issues/698
             return this.log({
               message,
               node,

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -54,6 +54,12 @@ module.exports = class Quotes extends Rule {
     return {
       AttrNode(node) {
         if (!node.isValueless && node.quoteType === badChar) {
+          if (attrValueHasChar(node.value, goodChar)) {
+            return this.log({
+              message,
+              node,
+            });
+          }
           if (this.mode === 'fix') {
             node.quoteType = goodChar;
           } else {
@@ -70,6 +76,13 @@ module.exports = class Quotes extends Rule {
         let errorSource = this.sourceForNode(path.parentNode);
 
         if (node.quoteType === badChar) {
+          if (node.value.includes(goodChar)) {
+            return this.log({
+              message,
+              node,
+              source: errorSource,
+            });
+          }
           if (this.mode === 'fix') {
             node.quoteType = goodChar;
           } else {
@@ -85,3 +98,14 @@ module.exports = class Quotes extends Rule {
     };
   }
 };
+
+function attrValueHasChar(node, ch) {
+  if (node.type === 'TextNode') {
+    return node.chars.includes(ch);
+  } else if (node.type === 'ConcatStatement') {
+    return node.parts.some((n) => {
+      return n.type === 'TextNode' && n.chars.includes(ch);
+    });
+  }
+  return false;
+}

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -36,14 +36,17 @@ module.exports = class Quotes extends Rule {
 
   visitor() {
     let badChar;
+    let goodChar;
     let message;
     switch (this.config) {
       case 'double':
         badChar = "'";
+        goodChar = '"';
         message = 'you must use double quotes in templates';
         break;
       case 'single':
         badChar = '"';
+        goodChar = "'";
         message = 'you must use single quotes in templates';
         break;
     }
@@ -51,23 +54,32 @@ module.exports = class Quotes extends Rule {
     return {
       AttrNode(node) {
         if (!node.isValueless && node.quoteType === badChar) {
-          return this.log({
-            message,
-            node,
-          });
+          if (this.mode === 'fix') {
+            node.quoteType = goodChar;
+          } else {
+            return this.log({
+              message,
+              node,
+              isFixable: true,
+            });
+          }
         }
       },
 
       StringLiteral(node, path) {
-        let source = this.sourceForNode(node);
         let errorSource = this.sourceForNode(path.parentNode);
 
-        if (source[0] === badChar) {
-          return this.log({
-            message,
-            node,
-            source: errorSource,
-          });
+        if (node.quoteType === badChar) {
+          if (this.mode === 'fix') {
+            node.quoteType = goodChar;
+          } else {
+            return this.log({
+              message,
+              node,
+              source: errorSource,
+              isFixable: true,
+            });
+          }
         }
       },
     };

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -286,21 +286,25 @@ describe('public api', function () {
     });
 
     it('returns whether the source has been fixed + an array of remaining issues with the provided template', async function () {
+      project.write({
+        app: {
+          templates: {
+            'application.hbs': '<div>FORBIDDEN</div>',
+          },
+        },
+      });
+      linter = new Linter({
+        console: mockConsole,
+        config: {
+          plugins: [require('../helpers/failure-plugin')],
+          rules: {
+            'fail-on-word': 'FORBIDDEN',
+          },
+        },
+      });
+
       let templatePath = project.path('app/templates/application.hbs');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
-      let expected = [
-        {
-          column: 7,
-          line: 1,
-          endColumn: 18,
-          endLine: 1,
-          message: 'you must use double quotes in templates',
-          filePath: templatePath,
-          rule: 'quotes',
-          severity: 2,
-          source: "class='mb4'",
-        },
-      ];
 
       let result = await linter.verifyAndFix({
         source: templateContents,
@@ -308,9 +312,28 @@ describe('public api', function () {
         moduleId: templatePath.slice(0, -4),
       });
 
-      expect(result.messages).toEqual(expected);
-      expect(result.output).toEqual(templateContents);
-      expect(result.isFixed).toEqual(false);
+      expect(result).toMatchInlineSnapshot(
+        { messages: [{ filePath: expect.any(String) }] },
+        `
+        Object {
+          "isFixed": false,
+          "messages": Array [
+            Object {
+              "column": 5,
+              "endColumn": 14,
+              "endLine": 1,
+              "filePath": Any<String>,
+              "line": 1,
+              "message": "The string \\"FORBIDDEN\\" is forbidden in templates",
+              "rule": "fail-on-word",
+              "severity": 2,
+              "source": "FORBIDDEN",
+            },
+          ],
+          "output": "<div>FORBIDDEN</div>",
+        }
+      `
+      );
     });
 
     it('ensures template parsing errors are only reported once (not once per-rule)', async function () {
@@ -1394,21 +1417,25 @@ describe('public api', function () {
     });
 
     it('[.html] returns whether the source has been fixed + an array of remaining issues with the provided template', async function () {
+      project.write({
+        app: {
+          templates: {
+            'application.html': '<div>FORBIDDEN</div>',
+          },
+        },
+      });
+      linter = new Linter({
+        console: mockConsole,
+        config: {
+          plugins: [require('../helpers/failure-plugin')],
+          rules: {
+            'fail-on-word': 'FORBIDDEN',
+          },
+        },
+      });
+
       let templatePath = project.path('app/templates/application.html');
       let templateContents = fs.readFileSync(templatePath, { encoding: 'utf8' });
-      let expected = [
-        {
-          column: 7,
-          line: 1,
-          endColumn: 18,
-          endLine: 1,
-          message: 'you must use double quotes in templates',
-          filePath: templatePath,
-          rule: 'quotes',
-          severity: 2,
-          source: "class='mb4'",
-        },
-      ];
 
       let result = await linter.verifyAndFix({
         source: templateContents,
@@ -1416,9 +1443,28 @@ describe('public api', function () {
         moduleId: templatePath.slice(0, -4),
       });
 
-      expect(result.messages).toEqual(expected);
-      expect(result.output).toEqual(templateContents);
-      expect(result.isFixed).toEqual(false);
+      expect(result).toMatchInlineSnapshot(
+        { messages: [{ filePath: expect.any(String) }] },
+        `
+        Object {
+          "isFixed": false,
+          "messages": Array [
+            Object {
+              "column": 5,
+              "endColumn": 14,
+              "endLine": 1,
+              "filePath": Any<String>,
+              "line": 1,
+              "message": "The string \\"FORBIDDEN\\" is forbidden in templates",
+              "rule": "fail-on-word",
+              "severity": 2,
+              "source": "FORBIDDEN",
+            },
+          ],
+          "output": "<div>FORBIDDEN</div>",
+        }
+      `
+      );
     });
 
     it('[.html] ensures template parsing errors are only reported once (not once per-rule)', async function () {

--- a/test/helpers/failure-plugin.js
+++ b/test/helpers/failure-plugin.js
@@ -1,0 +1,25 @@
+const Rule = require('../..').Rule;
+
+// Easily controllable failure for acceptance tests
+class FailOnWord extends Rule {
+  visitor() {
+    return {
+      TextNode(node) {
+        const bad = this.config;
+        if (node.chars.includes(bad)) {
+          this.log({
+            message: `The string "${bad}" is forbidden in templates`,
+            node,
+          });
+        }
+      },
+    };
+  }
+}
+
+module.exports = {
+  name: 'test-helper-failure-plugin',
+  rules: {
+    'fail-on-word': FailOnWord,
+  },
+};

--- a/test/unit/rules/quotes-test.js
+++ b/test/unit/rules/quotes-test.js
@@ -202,6 +202,7 @@ generateRuleTests({
       },
     },
     {
+      // TODO: Autofix blocked on: https://github.com/ember-template-lint/ember-template-recast/issues/698
       config: 'single',
       template: `<img alt="Abdul's house">`,
 
@@ -224,6 +225,7 @@ generateRuleTests({
       },
     },
     {
+      // TODO: Autofix blocked on: https://github.com/ember-template-lint/ember-template-recast/issues/698
       config: 'double',
       template: `<img class='a "so-called" btn {{this.otherClass}}'>`,
 
@@ -246,6 +248,7 @@ generateRuleTests({
       },
     },
     {
+      // TODO: Autofix blocked on: https://github.com/ember-template-lint/ember-template-recast/issues/698
       config: 'single',
       template: `{{helper "Priya's house"}}`,
 

--- a/test/unit/rules/quotes-test.js
+++ b/test/unit/rules/quotes-test.js
@@ -201,6 +201,72 @@ generateRuleTests({
         `);
       },
     },
+    {
+      config: 'single',
+      template: `<img alt="Abdul's house">`,
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 5,
+              "endColumn": 24,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "you must use single quotes in templates",
+              "rule": "quotes",
+              "severity": 2,
+              "source": "alt=\\"Abdul's house\\"",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'double',
+      template: `<img class='a "so-called" btn {{this.otherClass}}'>`,
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 5,
+              "endColumn": 50,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "you must use double quotes in templates",
+              "rule": "quotes",
+              "severity": 2,
+              "source": "class='a \\"so-called\\" btn {{this.otherClass}}'",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'single',
+      template: `{{helper "Priya's house"}}`,
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 9,
+              "endColumn": 24,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "you must use single quotes in templates",
+              "rule": "quotes",
+              "severity": 2,
+              "source": "{{helper \\"Priya's house\\"}}",
+            },
+          ]
+        `);
+      },
+    },
   ],
 
   error: [

--- a/test/unit/rules/quotes-test.js
+++ b/test/unit/rules/quotes-test.js
@@ -35,7 +35,32 @@ generateRuleTests({
   bad: [
     {
       config: 'double',
+      template: "{{component 'one {{thing}} two'}}",
+      fixedTemplate: '{{component "one {{thing}} two"}}',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 12,
+              "endColumn": 31,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "you must use double quotes in templates",
+              "rule": "quotes",
+              "severity": 2,
+              "source": "{{component 'one {{thing}} two'}}",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'double',
       template: "{{component 'test'}}",
+      fixedTemplate: '{{component "test"}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -45,6 +70,7 @@ generateRuleTests({
               "endColumn": 18,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "you must use double quotes in templates",
               "rule": "quotes",
@@ -58,6 +84,7 @@ generateRuleTests({
     {
       config: 'double',
       template: "{{hello x='test'}}",
+      fixedTemplate: '{{hello x="test"}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -67,6 +94,7 @@ generateRuleTests({
               "endColumn": 16,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "you must use double quotes in templates",
               "rule": "quotes",
@@ -80,6 +108,7 @@ generateRuleTests({
     {
       config: 'double',
       template: "<input type='checkbox'>",
+      fixedTemplate: '<input type="checkbox">',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -89,6 +118,7 @@ generateRuleTests({
               "endColumn": 22,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "you must use double quotes in templates",
               "rule": "quotes",
@@ -102,6 +132,7 @@ generateRuleTests({
     {
       config: 'single',
       template: '{{component "test"}}',
+      fixedTemplate: "{{component 'test'}}",
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -111,6 +142,7 @@ generateRuleTests({
               "endColumn": 18,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "you must use single quotes in templates",
               "rule": "quotes",
@@ -124,6 +156,7 @@ generateRuleTests({
     {
       config: 'single',
       template: '{{hello x="test"}}',
+      fixedTemplate: "{{hello x='test'}}",
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -133,6 +166,7 @@ generateRuleTests({
               "endColumn": 16,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "you must use single quotes in templates",
               "rule": "quotes",
@@ -146,6 +180,7 @@ generateRuleTests({
     {
       config: 'single',
       template: '<input type="checkbox">',
+      fixedTemplate: "<input type='checkbox'>",
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -155,6 +190,7 @@ generateRuleTests({
               "endColumn": 22,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "you must use single quotes in templates",
               "rule": "quotes",


### PR DESCRIPTION
Waiting on:
- [x] [Merging quote-changing support to `ember-template-recast`](https://github.com/ember-template-lint/ember-template-recast/pull/653)
- [x] Release `ember-template-recast` including ^
- [x] Upgrade `ember-template-recast` version to `6.1.0`
- [x] Fixing the acceptance test which asserts on remaining unfixable rule violations. Of course I can just change this to have a different rule violation which doesn't currently have a fixer. But it seems better to have some always-failing rule for test purposes. Does anyone have ideas on the best way to add that? Preferably we wouldn't have to add an actual rule to `lib/rules`

Note: this won't autofix when escaping is required, blocked on: https://github.com/ember-template-lint/ember-template-recast/issues/698.
