### PR TITLE
Increase dependabot PR limit to 15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,4 +22,4 @@ updates:
     interval: monthly
     time: "04:00"
     timezone: EST
-  open-pull-requests-limit: 10
+  open-pull-requests-limit: 15


### PR DESCRIPTION
Many of the open PRs we can't merge yet until we drop Node 10 support. This will help us see all the available updates.