### PR TITLE
Fixes incorrect rule test passing fake values

### DIFF
--- a/test/acceptance/rule-test.js
+++ b/test/acceptance/rule-test.js
@@ -251,8 +251,6 @@ describe('rule public api', function () {
                       this.log({
                         message: 'Unclobbered error message',
                         node,
-                        line: 50,
-                        column: 50,
                         source: '<MySpecialThingInferredDoesNotClobberExplicit/>',
                       });
                     }
@@ -293,8 +291,8 @@ describe('rule public api', function () {
         {
           template: '<MySpecialThingInferredDoesNotClobberExplicit/>',
           result: {
-            column: 50,
-            line: 50,
+            column: 0,
+            line: 1,
             endColumn: 47,
             endLine: 1,
             message: 'Unclobbered error message',


### PR DESCRIPTION
One particular rule test was passing fake values, resulting in impossible location values when logging the result (endLine/column were less than start line/column). Fixed in this PR.