### PR TITLE
Noops the console when using the SARIF formatter

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -347,7 +347,10 @@ async function run() {
       config,
       rule: options.rule,
       allowInlineConfig: !options.noInlineConfig,
-      console: options.quiet || options.json || options.format === 'sarif' ? NOOP_CONSOLE : console,
+      console:
+        options.quiet || options.json || ['sarif', 'json'].includes(options.format)
+          ? NOOP_CONSOLE
+          : console,
     });
   } catch (error) {
     console.error(error.message);

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -339,6 +339,8 @@ async function run() {
       getTodoConfigFromCommandLineOptions(options)
     ),
   };
+  let shouldWriteToStdout =
+    options.quiet || options.json || ['sarif', 'json'].includes(options.format);
 
   try {
     linter = new Linter({
@@ -347,10 +349,7 @@ async function run() {
       config,
       rule: options.rule,
       allowInlineConfig: !options.noInlineConfig,
-      console:
-        options.quiet || options.json || ['sarif', 'json'].includes(options.format)
-          ? NOOP_CONSOLE
-          : console,
+      console: shouldWriteToStdout ? NOOP_CONSOLE : console,
     });
   } catch (error) {
     console.error(error.message);

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -347,7 +347,7 @@ async function run() {
       config,
       rule: options.rule,
       allowInlineConfig: !options.noInlineConfig,
-      console: options.quiet || options.json ? NOOP_CONSOLE : console,
+      console: options.quiet || options.json || options.format === 'sarif' ? NOOP_CONSOLE : console,
     });
   } catch (error) {
     console.error(error.message);


### PR DESCRIPTION
We noop the console when either using `--quiet` or the `json` option, but neglect to do so when using formatters that output JSON. This can cause issues when redirecting stdout to a file, such as a JSON or SARIF file, because of deprecation warnings that are emitted, causing invalid JSON (console output is additionally redirected, and coupled with JSON output is written together to a file).

This fix ensures that we additionally noop the console when using either of the `json` or `sarif` formatters via the `--format` option. This ensures that if we redirect stdout that it's valid JSON.