### PR TITLE
Slightly loosening requires for log method parameter requirements

### DIFF
--- a/lib/rules/_base.js
+++ b/lib/rules/_base.js
@@ -518,7 +518,7 @@ module.exports = class {
       severity: this.severity,
     };
     let hasAllLocProps = ['line', 'column', 'endLine', 'endColumn'].every((prop) => prop in result);
-    debugger;
+
     if (this.filePath) {
       defaults.filePath = this.filePath;
     }

--- a/lib/rules/_base.js
+++ b/lib/rules/_base.js
@@ -517,14 +517,16 @@ module.exports = class {
       rule: this.ruleName,
       severity: this.severity,
     };
-
+    let hasAllLocProps = ['line', 'column', 'endLine', 'endColumn'].every((prop) => prop in result);
+    debugger;
     if (this.filePath) {
       defaults.filePath = this.filePath;
     }
 
-    if (!result.node) {
+    if (!result.node && !hasAllLocProps) {
       if (!loggedRules.has(this.ruleName)) {
-        let message = `ember-template-lint: (${this.ruleName}) Calling the log method without passing the node is deprecated. Please ensure you pass node in the log method's result.`;
+        let message = `ember-template-lint: (${this.ruleName}) Calling the log method without passing all required loc (line, column, endLine, endColumn)
+properties or the node property is deprecated. Please ensure you pass either the loc properties or the node in the log method's result.`;
 
         if (process.env.EMBER_TEMPLATE_LINT_DEV_MODE === '1') {
           throw new Error(message);
@@ -537,7 +539,7 @@ module.exports = class {
     }
 
     // perform the node property expansion only if those properties don't exist in result
-    if (result.node) {
+    if (!hasAllLocProps && result.node) {
       let node = result.node;
       delete result.node;
       // if we've passed node, we want to ensure that we're correctly expanding the properties


### PR DESCRIPTION
This change refines the requirements for calls to the base rule's log method, which previously required the node itself, but now only requires the node if all location properties aren't provided.

This addresses situations where it may not be as clear what the node is that's being passed in, or when the node is the `body` itself.