### PR TITLE
Add new rule `no-autofocus-attribute`

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Each rule has emojis denoting:
 | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)                           | ✅  |     |     |     |
 | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                                                 | ✅  |     | ⌨️  | 🔧  |
 | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                                           | ✅  |     |     |     |
-| [no-autofocus-attribute](./docs/rule/no-autofocus-attribute.md)                                                     |     |     | ⌨️  |     |
+| [no-autofocus-attribute](./docs/rule/no-autofocus-attribute.md)                                           |     |     | ⌨️  |     |
 | [no-bare-strings](./docs/rule/no-bare-strings.md)                                                         |     |     |     |     |
 | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md)                     | ✅  |     |     |     |
 | [no-capital-arguments](./docs/rule/no-capital-arguments.md)                                               |     |     |     |     |

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Each rule has emojis denoting:
 | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)                           | ✅  |     |     |     |
 | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                                                 | ✅  |     | ⌨️  | 🔧  |
 | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                                           | ✅  |     |     |     |
+| [no-autofocus-attribute](./docs/rule/no-autofocus-attribute.md)                                           | ✅  |     |     |     |
 | [no-bare-strings](./docs/rule/no-bare-strings.md)                                                         |     |     |     |     |
 | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md)                     | ✅  |     |     |     |
 | [no-capital-arguments](./docs/rule/no-capital-arguments.md)                                               |     |     |     |     |

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Each rule has emojis denoting:
 | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)                           | ✅  |     |     |     |
 | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                                                 | ✅  |     | ⌨️  | 🔧  |
 | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                                           | ✅  |     |     |     |
-| [no-autofocus-attribute](./docs/rule/no-autofocus-attribute.md)                                           | ✅  |     |     |     |
+| [no-autofocus-attribute](./docs/rule/no-autofocus-attribute.md)                                                     |     |     | ⌨️  |     |
 | [no-bare-strings](./docs/rule/no-bare-strings.md)                                                         |     |     |     |     |
 | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md)                     | ✅  |     |     |     |
 | [no-capital-arguments](./docs/rule/no-capital-arguments.md)                                               |     |     |     |     |

--- a/docs/rule/no-autofocus-attribute.md
+++ b/docs/rule/no-autofocus-attribute.md
@@ -1,7 +1,5 @@
 # no-autofocus-attribute
 
-✅ The `extends: 'recommended'` property in a configuration file enables this rule.
-
 The autofocus attribute is a global attribute that indicates an element should be focused on page load. Autofocus reduces accessibility by moving users to an element without warning and context. Its use should be limited to form fields that serve as the main purpose of the page, such as the search input on the Google home page.
 
 This rule takes no arguments.
@@ -21,7 +19,7 @@ This rule **forbids** the following:
 ```
 
 ```hbs
-<input type="password" autofocus="true" />
+<input type="password" autofocus="autofocus" />
 ```
 
 ## References

--- a/docs/rule/no-autofocus-attribute.md
+++ b/docs/rule/no-autofocus-attribute.md
@@ -1,0 +1,30 @@
+# no-autofocus-attribute
+
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
+Enforce no autofocus prop on element. The autofocus attribute is a global attribute that indicates an element should be focused on page load. Because autofocus reduces accessibility by moving users to an element without warning and context, it should not be used.
+
+This rule takes no arguments.
+
+## Examples
+
+This rule **allows** the following:
+
+```hbs
+<input />
+```
+
+This rule **forbids** the following:
+
+```hbs
+<input autofocus />
+```
+
+```hbs
+<input autofocus='true' />
+```
+
+## References
+
+- [MDN Web](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)
+- [Focus Order: Understanding SC 2.4.3](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html)

--- a/docs/rule/no-autofocus-attribute.md
+++ b/docs/rule/no-autofocus-attribute.md
@@ -1,8 +1,8 @@
 # no-autofocus-attribute
 
-🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
-Enforce no autofocus prop on element. The autofocus attribute is a global attribute that indicates an element should be focused on page load. Because autofocus reduces accessibility by moving users to an element without warning and context, it should not be used.
+The autofocus attribute is a global attribute that indicates an element should be focused on page load. Autofocus reduces accessibility by moving users to an element without warning and context. Its use should be limited to form fields that serve as the main purpose of the page, such as the search input on the Google home page.
 
 This rule takes no arguments.
 
@@ -11,20 +11,21 @@ This rule takes no arguments.
 This rule **allows** the following:
 
 ```hbs
-<input />
+<input type="text" />
 ```
 
 This rule **forbids** the following:
 
 ```hbs
-<input autofocus />
+<input type="text" autofocus />
 ```
 
 ```hbs
-<input autofocus='true' />
+<input type="password" autofocus="true" />
 ```
 
 ## References
 
 - [MDN Web](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)
 - [Focus Order: Understanding SC 2.4.3](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html)
+- [The Accessibility of HTML 5 Autofocus](https://brucelawson.co.uk/2009/the-accessibility-of-html-5-autofocus/)

--- a/docs/rule/no-autofocus-attribute.md
+++ b/docs/rule/no-autofocus-attribute.md
@@ -2,8 +2,6 @@
 
 The autofocus attribute is a global attribute that indicates an element should be focused on page load. Autofocus reduces accessibility by moving users to an element without warning and context. Its use should be limited to form fields that serve as the main purpose of the page, such as the search input on the Google home page.
 
-This rule takes no arguments.
-
 ## Examples
 
 This rule **allows** the following:

--- a/lib/config/a11y.js
+++ b/lib/config/a11y.js
@@ -6,6 +6,7 @@ module.exports = {
     'no-abstract-roles': 'error',
     'no-accesskey-attribute': 'error',
     'no-aria-hidden-body': 'error',
+    'no-autofocus-attribute': 'error',
     'no-down-event-binding': 'error',
     'no-duplicate-attributes': 'error',
     'no-duplicate-id': 'error',

--- a/lib/rules/no-autofocus-attribute.js
+++ b/lib/rules/no-autofocus-attribute.js
@@ -12,15 +12,11 @@ module.exports = class NoAutofocusAttribute extends Rule {
       ElementNode(node) {
         const autofocusNode = AstNodeInfo.findAttribute(node, 'autofocus');
         if (autofocusNode) {
-          if (this.mode === 'fix') {
-            node.attributes = node.attributes.filter((a) => a !== autofocusNode);
-          } else {
-            this.log({
-              message: errorMessage,
-              isFixable: true,
-              node: autofocusNode,
-            });
-          }
+          this.log({
+            message: errorMessage,
+            isFixable: false,
+            node: autofocusNode,
+          });
         }
       },
     };

--- a/lib/rules/no-autofocus-attribute.js
+++ b/lib/rules/no-autofocus-attribute.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const AstNodeInfo = require('../helpers/ast-node-info');
+const Rule = require('./_base');
+
+const errorMessage =
+  'No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context';
+
+module.exports = class NoAutofocusAttribute extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        const autofocusNode = AstNodeInfo.findAttribute(node, 'autofocus');
+        if (autofocusNode) {
+          if (this.mode === 'fix') {
+            node.attributes = node.attributes.filter((a) => a !== autofocusNode);
+          } else {
+            this.log({
+              message: errorMessage,
+              isFixable: true,
+              node: autofocusNode,
+            });
+          }
+        }
+      },
+    };
+  }
+};
+
+module.exports.errorMessage = errorMessage;

--- a/lib/rules/no-autofocus-attribute.js
+++ b/lib/rules/no-autofocus-attribute.js
@@ -3,7 +3,7 @@
 const AstNodeInfo = require('../helpers/ast-node-info');
 const Rule = require('./_base');
 
-const errorMessage =
+const ERROR_MESSAGE =
   'No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context';
 
 module.exports = class NoAutofocusAttribute extends Rule {
@@ -13,7 +13,7 @@ module.exports = class NoAutofocusAttribute extends Rule {
         const autofocusNode = AstNodeInfo.findAttribute(node, 'autofocus');
         if (autofocusNode) {
           this.log({
-            message: errorMessage,
+            message: ERROR_MESSAGE,
             isFixable: false,
             node: autofocusNode,
           });
@@ -23,4 +23,4 @@ module.exports = class NoAutofocusAttribute extends Rule {
   }
 };
 
-module.exports.errorMessage = errorMessage;
+module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-autofocus-attribute.js
+++ b/lib/rules/no-autofocus-attribute.js
@@ -6,17 +6,28 @@ const Rule = require('./_base');
 const ERROR_MESSAGE =
   'No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context';
 
+function logAutofocusAttribute(attribute) {
+  this.log({
+    message: ERROR_MESSAGE,
+    isFixable: false,
+    node: attribute,
+  });
+}
+
 module.exports = class NoAutofocusAttribute extends Rule {
   visitor() {
     return {
       ElementNode(node) {
-        const autofocusNode = AstNodeInfo.findAttribute(node, 'autofocus');
-        if (autofocusNode) {
-          this.log({
-            message: ERROR_MESSAGE,
-            isFixable: false,
-            node: autofocusNode,
-          });
+        const autofocusAttribute = AstNodeInfo.findAttribute(node, 'autofocus');
+        if (autofocusAttribute) {
+          logAutofocusAttribute.call(this, autofocusAttribute);
+        }
+      },
+
+      MustacheStatement(node) {
+        const autofocusAttribute = node.hash.pairs.find((pair) => pair.key === 'autofocus');
+        if (autofocusAttribute) {
+          logAutofocusAttribute.call(this, autofocusAttribute);
         }
       },
     };

--- a/test/unit/rules/no-autofocus-attribute-test.js
+++ b/test/unit/rules/no-autofocus-attribute-test.js
@@ -37,13 +37,13 @@ generateRuleTests({
       },
     },
     {
-      template: '<input type="text" autofocus="true" />',
+      template: '<input type="text" autofocus="autofocus" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [
             Object {
               "column": 19,
-              "endColumn": 35,
+              "endColumn": 40,
               "endLine": 1,
               "filePath": "layout.hbs",
               "isFixable": false,
@@ -51,41 +51,20 @@ generateRuleTests({
               "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
               "rule": "no-autofocus-attribute",
               "severity": 2,
-              "source": "autofocus=\\"true\\"",
+              "source": "autofocus=\\"autofocus\\"",
             },
           ]
         `);
       },
     },
     {
-      template: '<input type="text" autofocus={{false}} />',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
-              "column": 19,
-              "endColumn": 38,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "isFixable": false,
-              "line": 1,
-              "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
-              "rule": "no-autofocus-attribute",
-              "severity": 2,
-              "source": "autofocus={{false}}",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<input autofocus={{foo}} />',
+      template: '<input autofocus={{this.foo}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [
             Object {
               "column": 7,
-              "endColumn": 24,
+              "endColumn": 29,
               "endLine": 1,
               "filePath": "layout.hbs",
               "isFixable": false,
@@ -93,7 +72,7 @@ generateRuleTests({
               "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
               "rule": "no-autofocus-attribute",
               "severity": 2,
-              "source": "autofocus={{foo}}",
+              "source": "autofocus={{this.foo}}",
             },
           ]
         `);

--- a/test/unit/rules/no-autofocus-attribute-test.js
+++ b/test/unit/rules/no-autofocus-attribute-test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+const generateRuleTests = require('../../helpers/rule-test-harness');
+
+generateRuleTests({
+  name: 'no-autofocus-attribute',
+
+  config: true,
+
+  good: ['<input />'],
+
+  bad: [
+    {
+      template: '<input autofocus />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 7,
+              "endColumn": 16,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
+              "rule": "no-autofocus-attribute",
+              "severity": 2,
+              "source": "autofocus",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<input autofocus="true" />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 7,
+              "endColumn": 23,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
+              "rule": "no-autofocus-attribute",
+              "severity": 2,
+              "source": "autofocus=\\"true\\"",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<input autofocus={{false}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 7,
+              "endColumn": 26,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
+              "rule": "no-autofocus-attribute",
+              "severity": 2,
+              "source": "autofocus={{false}}",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<input autofocus={{foo}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 7,
+              "endColumn": 24,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
+              "rule": "no-autofocus-attribute",
+              "severity": 2,
+              "source": "autofocus={{foo}}",
+            },
+          ]
+        `);
+      },
+    },
+  ],
+});

--- a/test/unit/rules/no-autofocus-attribute-test.js
+++ b/test/unit/rules/no-autofocus-attribute-test.js
@@ -11,6 +11,7 @@ generateRuleTests({
     '<input />',
     '<input type="text" disabled="true" />',
     '<input type="password" disabled={{false}} />',
+    '<input type="password" disabled />',
     '{{input type="text" disabled=true}}',
     '{{component "input" type="text" disabled=true}}',
     '<div></div>',

--- a/test/unit/rules/no-autofocus-attribute-test.js
+++ b/test/unit/rules/no-autofocus-attribute-test.js
@@ -12,6 +12,10 @@ generateRuleTests({
     '<input type="text" disabled="true" />',
     '<input type="password" disabled={{false}} />',
     '{{input type="text" disabled=true}}',
+    '{{component "input" type="text" disabled=true}}',
+    '<div></div>',
+    '<h1><span>Valid Heading</span></h1>',
+    '<CustomComponent />',
   ],
 
   bad: [
@@ -65,6 +69,111 @@ generateRuleTests({
             Object {
               "column": 7,
               "endColumn": 29,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": false,
+              "line": 1,
+              "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
+              "rule": "no-autofocus-attribute",
+              "severity": 2,
+              "source": "autofocus={{this.foo}}",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '{{input type="text" autofocus=true}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 20,
+              "endColumn": 34,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": false,
+              "line": 1,
+              "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
+              "rule": "no-autofocus-attribute",
+              "severity": 2,
+              "source": "autofocus=true",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '{{component "input" type="text" autofocus=true}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 32,
+              "endColumn": 46,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": false,
+              "line": 1,
+              "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
+              "rule": "no-autofocus-attribute",
+              "severity": 2,
+              "source": "autofocus=true",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<div autofocus="true"></div>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 5,
+              "endColumn": 21,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": false,
+              "line": 1,
+              "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
+              "rule": "no-autofocus-attribute",
+              "severity": 2,
+              "source": "autofocus=\\"true\\"",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<h1 autofocus="autofocus"><span>Valid Heading</span></h1>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 4,
+              "endColumn": 25,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": false,
+              "line": 1,
+              "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
+              "rule": "no-autofocus-attribute",
+              "severity": 2,
+              "source": "autofocus=\\"autofocus\\"",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<CustomComponent autofocus={{this.foo}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 17,
+              "endColumn": 39,
               "endLine": 1,
               "filePath": "layout.hbs",
               "isFixable": false,

--- a/test/unit/rules/no-autofocus-attribute-test.js
+++ b/test/unit/rules/no-autofocus-attribute-test.js
@@ -7,7 +7,12 @@ generateRuleTests({
 
   config: true,
 
-  good: ['<input />'],
+  good: [
+    '<input />',
+    '<input type="text" disabled="true" />',
+    '<input type="password" disabled={{false}} />',
+    '{{input type="text" disabled=true}}',
+  ],
 
   bad: [
     {
@@ -20,7 +25,7 @@ generateRuleTests({
               "endColumn": 16,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": true,
+              "isFixable": false,
               "line": 1,
               "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
               "rule": "no-autofocus-attribute",
@@ -32,16 +37,16 @@ generateRuleTests({
       },
     },
     {
-      template: '<input autofocus="true" />',
+      template: '<input type="text" autofocus="true" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [
             Object {
-              "column": 7,
-              "endColumn": 23,
+              "column": 19,
+              "endColumn": 35,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": true,
+              "isFixable": false,
               "line": 1,
               "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
               "rule": "no-autofocus-attribute",
@@ -53,16 +58,16 @@ generateRuleTests({
       },
     },
     {
-      template: '<input autofocus={{false}} />',
+      template: '<input type="text" autofocus={{false}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [
             Object {
-              "column": 7,
-              "endColumn": 26,
+              "column": 19,
+              "endColumn": 38,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": true,
+              "isFixable": false,
               "line": 1,
               "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
               "rule": "no-autofocus-attribute",
@@ -83,7 +88,7 @@ generateRuleTests({
               "endColumn": 24,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": true,
+              "isFixable": false,
               "line": 1,
               "message": "No autofocus attribute allowed, as it reduces accessibility by moving users to an element without warning and context",
               "rule": "no-autofocus-attribute",

--- a/test/unit/rules/no-autofocus-attribute-test.js
+++ b/test/unit/rules/no-autofocus-attribute-test.js
@@ -16,6 +16,8 @@ generateRuleTests({
     '<div></div>',
     '<h1><span>Valid Heading</span></h1>',
     '<CustomComponent />',
+    '<CustomComponent disabled />',
+    '<CustomComponent disabled=true />',
   ],
 
   bad: [


### PR DESCRIPTION
This PR adds the new rule `no-autofocus-attribute` which fixes #2166 .

### Background
The autofocus attribute is a global attribute that indicates an element should be focused on page load. Autofocus reduces accessibility by moving users to an element without warning and context. Screen reader users may be disoriented by the unexpected navigation, and users of small devices could miss important information preceding the focused element.

This new rule enforces disallowing the use of the autofocus attribute.

Reference: [WCAG SC 2.4.3 Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order.html)

**Allowed**:

```
# examples
<input />
```

**Forbidden**:

```
# examples
<autofocus />
<input autofocus="true" />
```

### Testing
```
Test Suites: 129 passed, 129 total
Tests:       6 skipped, 6979 passed, 6985 total
Snapshots:   877 passed, 877 total
Time:        44.092 s
Ran all test suites.
✨ Done in 53.23s.
```