### PR TITLE
Upgrade ember-template-recast to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "chalk": "^4.1.2",
     "ci-info": "^3.2.0",
     "date-fns": "^2.25.0",
-    "ember-template-recast": "^5.0.3",
+    "ember-template-recast": "^6.0.0",
     "find-up": "^5.0.0",
     "fuse.js": "^6.4.6",
     "get-stdin": "^8.0.0",

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -92,6 +92,11 @@ generateRuleTests({
 
     {
       config: ['₹'],
+      template: '₹',
+    },
+
+    {
+      config: ['₹'],
       template: '&#8377;',
     },
 

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -96,7 +96,7 @@ generateRuleTests({
     },
 
     {
-      config: ['₹'],
+      config: ['&#8377;'],
       template: '&#8377;',
     },
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -549,62 +549,62 @@
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
 
-"@glimmer/global-context@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/global-context/-/global-context-0.65.1.tgz#390224b619f4ca0aca1f1ce4e42a33db76ec9c48"
-  integrity sha512-/nAXRfNFTULhkSB9rD1too5ea35FNtQaIrdU745VPMTsQZc4981OGtn75rJ7jCAPZl5eo17NwKU4ggKDwFMTzg==
+"@glimmer/global-context@0.83.0":
+  version "0.83.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/global-context/-/global-context-0.83.0.tgz#9892b0b94af2be9d4f63dabfa515620469c7aa31"
+  integrity sha512-RQqaKvrVdOPAwsqkPdtJtLeTl/9JNISex6bXURhktcdPDfySOJ0cFbnAdXSFkRrQx1KKgiCrulYc5rYTMp2yCg==
   dependencies:
     "@glimmer/env" "^0.1.7"
 
-"@glimmer/interfaces@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.65.1.tgz#f6212db145cfa7341ae15ff5d82cde5487e1b452"
-  integrity sha512-rvbYPhNvgiVJJYOQCv3zIi0/pEHXr8/qV7oWvlV/R5qpYqJKv8BPrBCA+IZ9G5BhFCMZ2Dtd8aKUfpjKOOoEzg==
+"@glimmer/interfaces@0.83.0":
+  version "0.83.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.83.0.tgz#0b7d9921a3579526bc93e496ac7fecb371fca1a0"
+  integrity sha512-NkjlZCfV2ZHAuH+iZrjL54JDYJpjwbyKaHEVobU6V6D6ZnOVl7rpbzU5sCND3tx4G0f346Z9KjKq0sqEflKI4A==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/reference@^0.65.0":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.65.1.tgz#44515e7bef58c9ce4ea65c2eb3403caec11a2060"
-  integrity sha512-oYXBqgSRlQ2e2gLNZ38ql8c2f4Wl6cFyQETpCuRrhHQTs2IIrzxRiwodLej4JCJEkLQICDdwDtDUe9NP5W0Ijw==
+"@glimmer/reference@^0.83.0":
+  version "0.83.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.83.0.tgz#496bea33cb7f9d5c1751fa1d918e4ebb845d8b60"
+  integrity sha512-12fpoS1b0F+OOus9OReeZnVYIY2eEbbm5grQ31SNXLzWZ9l7fcSVUd3ltCOa8Onr7RGpWWbtY8T2KtOQXnSAaw==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/global-context" "0.65.1"
-    "@glimmer/interfaces" "0.65.1"
-    "@glimmer/util" "0.65.1"
-    "@glimmer/validator" "0.65.1"
+    "@glimmer/global-context" "0.83.0"
+    "@glimmer/interfaces" "0.83.0"
+    "@glimmer/util" "0.83.0"
+    "@glimmer/validator" "0.83.0"
 
-"@glimmer/syntax@^0.65.0":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.65.1.tgz#033e646ea7882d08bfe7d550130ed565b25cf80a"
-  integrity sha512-WRVuNryOMI7OS9vMTivrGDe4wsJ1Z3MNCKlWJUkUNX2SnzLAuHRLwdiiIVCmYwmkI6OWZZrzJEsoHqYq3KCn8Q==
+"@glimmer/syntax@^0.83.0":
+  version "0.83.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/syntax/-/syntax-0.83.0.tgz#5f48edfa56c2475cdeaf4b61b9671de2dc353d0c"
+  integrity sha512-Ft0BPbDlyB/amQPbpOlfvoxH5Qy1/T4ZGvWd8wHEzdW+TKlN8UphOLJwsiSbdEGBu2DqAHwqBf3wxrqAzm/hrQ==
   dependencies:
-    "@glimmer/interfaces" "0.65.1"
-    "@glimmer/util" "0.65.1"
-    "@handlebars/parser" "^1.1.0"
-    simple-html-tokenizer "^0.5.10"
+    "@glimmer/interfaces" "0.83.0"
+    "@glimmer/util" "0.83.0"
+    "@handlebars/parser" "~2.0.0"
+    simple-html-tokenizer "^0.5.11"
 
-"@glimmer/util@0.65.1":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.65.1.tgz#c85ebc13344739c123e0ec6551ae740cf5fd62bf"
-  integrity sha512-+KHvCXJSsY4pbbUqc2x7BMSLkErVYGU9O6gl9CQM3SByjOJ++b//03dziAaglehmiCwfjNUQCfdYWhAp8UpuoA==
+"@glimmer/util@0.83.0":
+  version "0.83.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.83.0.tgz#63d2d8ac79d408970860a69557d9b1baaeec13a9"
+  integrity sha512-pcLoLwwx4SgZVNxqhbz4DmCiq0VWtPcv0fwiT03VD+3j9V/y7TNxs2WoMvruZjMAGFsHFWTdAHWNqDtLnU38cw==
   dependencies:
     "@glimmer/env" "0.1.7"
-    "@glimmer/interfaces" "0.65.1"
+    "@glimmer/interfaces" "0.83.0"
     "@simple-dom/interface" "^1.4.0"
 
-"@glimmer/validator@0.65.1", "@glimmer/validator@^0.65.0":
-  version "0.65.1"
-  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.65.1.tgz#07ebd13952660d341fea8e5b606b512fe1dbc176"
-  integrity sha512-MgPIvGOH4jhWDb93RHbFeSOfVQbUAZHgfovre6NJ3t5k98MfxgsNfyTkTpjzPJW1gVnlRfOTTBqcd8jWoy2xGQ==
+"@glimmer/validator@0.83.0", "@glimmer/validator@^0.83.0":
+  version "0.83.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.83.0.tgz#0c7bc9d2929099912f0b48f4d85e66a513bbfdab"
+  integrity sha512-vIqz/WDgWalfSWXGUkNE+6yd3WqTTVZqHwu/IrBCH6OZOyDeHcoHl+3Y1n2Go64pPXgyslxsyWMciV9wXh9ltw==
   dependencies:
     "@glimmer/env" "^0.1.7"
-    "@glimmer/global-context" "0.65.1"
+    "@glimmer/global-context" "0.83.0"
 
-"@handlebars/parser@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-1.1.0.tgz#d6dbc7574774b238114582410e8fee0dc3532bdf"
-  integrity sha512-rR7tJoSwJ2eooOpYGxGGW95sLq6GXUaS1UtWvN7pei6n2/okYvCGld9vsUTvkl2migxbkszsycwtMf/GEc1k1A==
+"@handlebars/parser@~2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.0.0.tgz#5e8b7298f31ff8f7b260e6b7363c7e9ceed7d9c5"
+  integrity sha512-EP9uEDZv/L5Qh9IWuMUGJRfwhXJ4h1dqKTT4/3+tY0eu7sPis7xh23j61SYUnNF4vqCQvvUXpDo9Bh/+q1zASA==
 
 "@humanwhocodes/config-array@^0.6.0":
   version "0.6.0"
@@ -2268,10 +2268,10 @@ commander@7.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.1.0.tgz#f2eaecf131f10e36e07d894698226e36ae0eb5ff"
   integrity sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==
 
-commander@^6.2.1:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
-  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+commander@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 commander@~8.2.0:
   version "8.2.0"
@@ -2646,22 +2646,22 @@ electron-to-chromium@^1.3.723:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.739.tgz#f07756aa92cabd5a6eec6f491525a64fe62f98b9"
   integrity sha512-+LPJVRsN7hGZ9EIUUiWCpO7l4E3qBYHNadazlucBfsXBbccDFNKUBAgzE68FnkWGJPwD/AfKhSzL+G+Iqb8A4A==
 
-ember-template-recast@^5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/ember-template-recast/-/ember-template-recast-5.0.3.tgz#79df27a70bdce7be17f14db13886afde1e9d02d6"
-  integrity sha512-qsJYQhf29Dk6QMfviXhUPE+byMOs6iRQxUDHgkj8yqjeppvjHaFG96hZi/NAXJTm/M7o3PpfF5YlmeaKtI9UeQ==
+ember-template-recast@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/ember-template-recast/-/ember-template-recast-6.0.0.tgz#8bb40c8c0d41af895f32a6b1b90f3c32e1f8110c"
+  integrity sha512-GVmNflGXpg/siKrW3BVEiJtAXVvpjW/86y3HG/7iy7Boq5s8Gw0ig7vkEka3VPuh2sqYHZOsnUrwWnZFddcEMQ==
   dependencies:
-    "@glimmer/reference" "^0.65.0"
-    "@glimmer/syntax" "^0.65.0"
-    "@glimmer/validator" "^0.65.0"
+    "@glimmer/reference" "^0.83.0"
+    "@glimmer/syntax" "^0.83.0"
+    "@glimmer/validator" "^0.83.0"
     async-promise-queue "^1.0.5"
     colors "^1.4.0"
-    commander "^6.2.1"
+    commander "^8.3.0"
     globby "^11.0.3"
     ora "^5.4.0"
     slash "^3.0.0"
     tmp "^0.2.1"
-    workerpool "^6.1.4"
+    workerpool "^6.1.5"
 
 emittery@^0.8.1:
   version "0.8.1"
@@ -6961,10 +6961,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-simple-html-tokenizer@^0.5.10:
-  version "0.5.10"
-  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.10.tgz#0843e4f00c9677f1c81e3dfeefcee0a4aca8e5d0"
-  integrity sha512-1DHMUmvUOGuUZ9/+cX/+hOhWhRD5dEw6lodn8WuV+T+cQ31hhBcCu1dcDsNotowi4mMaNhrLyKoS+DtB81HdDA==
+simple-html-tokenizer@^0.5.11:
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/simple-html-tokenizer/-/simple-html-tokenizer-0.5.11.tgz#4c5186083c164ba22a7b477b7687ac056ad6b1d9"
+  integrity sha512-C2WEK/Z3HoSFbYq8tI7ni3eOo/NneSPRoPpcM7WdLjFOArFuyXEjAoCdOC3DgMfRyziZQ1hCNR4mrNdWEvD0og==
 
 sinon@^9.0.2:
   version "9.2.4"
@@ -7934,10 +7934,10 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-workerpool@^6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.4.tgz#6a972b6df82e38d50248ee2820aa98e2d0ad3090"
-  integrity sha512-jGWPzsUqzkow8HoAvqaPWTUPCrlPJaJ5tY8Iz7n1uCz3tTp6s3CDG0FF1NsX42WNlkRSW6Mr+CDZGnNoSsKa7g==
+workerpool@^6.1.5:
+  version "6.1.5"
+  resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.5.tgz#0f7cf076b6215fd7e1da903ff6f22ddd1886b581"
+  integrity sha512-XdKkCK0Zqc6w3iTxLckiuJ81tiD/o5rBE/m+nXpRCB+/Sq4DqkfXZ/x0jW02DG1tGsfUGXbTJyZDP+eu67haSw==
 
 wrap-ansi@^5.1.0:
   version "5.1.0"


### PR DESCRIPTION
## Description

Under the hood, this PR upgrades @glimmer/syntax from v0.65.0 to v0.83.0. 

The upgrade is needed to benefit from the latest @glimmer/syntax features. This PR would help resolve: https://github.com/ember-template-lint/ember-template-lint/issues/1963 and https://github.com/ember-template-lint/ember-template-lint/issues/2163.

## A breaking change

This upgrade would be a breaking change.

Indeed, two changes in @glimmer/syntax have some impact in ember-template-recast and consequently in ember-template-lint:
- https://github.com/glimmerjs/glimmer-vm/pull/1284: all html entities are now preserved in codemod mode. Before that change, `₹&#8377;` was parsed to `node.chars: "₹₹"`. After, `₹&#8377;` is parsed to `node.chars: "₹&#8377;"`.  I propose to reflect that change into how the no-bare-strings rule can be configured. See https://github.com/ember-template-lint/ember-template-lint/commit/75b9962d89dd4761574e46a87318a25e6afb80e5 for more information.

- https://github.com/glimmerjs/glimmer-vm/pull/1227 adds a new syntax error:
  > Block parameters must be preceded by the `as` keyword, detected block parameters without `as`

  The [no-invalid-block-param-definition rule](https://github.com/ember-template-lint/ember-template-lint/blob/v3.12.0/docs/rule/no-invalid-block-param-definition.md) was serving the same purpose here in ember-template-lint. As the syntax error has been integrated to @glimmer/syntax, it is not possible to show the lint error anymore. This is why I propose to retire the rule (https://github.com/ember-template-lint/ember-template-lint/commit/4d396ab0971ab883a54b27144c3e8346eef0c6ca).


If these two changes are accepted, they will have to be documented in the next major user guide.

## Links

- [ember-template-recast v6 release notes](https://github.com/ember-template-lint/ember-template-recast/releases/tag/v6.0.0)