### PR TITLE
Fix false negative with `always` setting and template ending with non-text in `eol-last` rule

### DIFF
--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { builders: b } = require('ember-template-recast');
+
 const createErrorMessage = require('../helpers/create-error-message');
 const Rule = require('./_base');
 
@@ -71,15 +73,21 @@ module.exports = class EolLast extends Rule {
 
           let lastNode = node.body[node.body.length - 1];
 
-          if (lastNode.type !== 'TextNode') {
-            return;
-          }
-
           if (this.mode === 'fix') {
-            if (lastNode.chars.endsWith('\n') && this.config === 'never') {
+            if (
+              lastNode.type === 'TextNode' &&
+              lastNode.chars.endsWith('\n') &&
+              this.config === 'never'
+            ) {
               lastNode.chars = lastNode.chars.slice(0, -1);
-            } else if (!lastNode.chars.endsWith('\n') && this.config === 'always') {
+            } else if (
+              lastNode.type === 'TextNode' &&
+              !lastNode.chars.endsWith('\n') &&
+              this.config === 'always'
+            ) {
               lastNode.chars = `${lastNode.chars}\n`;
+            } else if (lastNode.type !== 'TextNode' && this.config === 'always') {
+              node.body.push(b.text('\n'));
             }
           } else {
             let message;

--- a/test/unit/rules/eol-last-test.js
+++ b/test/unit/rules/eol-last-test.js
@@ -25,8 +25,16 @@ generateRuleTests({
       template: 'test\n',
     },
     {
+      config: 'always',
+      template: '<img>\n',
+    },
+    {
       config: 'never',
       template: 'test',
+    },
+    {
+      config: 'never',
+      template: '<img>',
     },
     // test the re-entering of yielded content
     {
@@ -65,6 +73,30 @@ generateRuleTests({
       },
     },
     {
+      config: 'always',
+      template: '<img>',
+      fixedTemplate: '<img>\n',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 0,
+              "endColumn": 5,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "template must end with newline",
+              "rule": "eol-last",
+              "severity": 2,
+              "source": "<img>",
+            },
+          ]
+        `);
+      },
+    },
+    {
       config: 'never',
       template: 'test\n',
       fixedTemplate: 'test',
@@ -83,6 +115,31 @@ generateRuleTests({
               "rule": "eol-last",
               "severity": 2,
               "source": "test
+          ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'never',
+      template: '<img>\n',
+      fixedTemplate: '<img>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 0,
+              "endColumn": 0,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "template cannot end with newline",
+              "rule": "eol-last",
+              "severity": 2,
+              "source": "<img>
           ",
             },
           ]


### PR DESCRIPTION
Fixes #2173.

This was broken when an autofixer was added to this rule in https://github.com/ember-template-lint/ember-template-lint/pull/2020