### PR TITLE
Remove `common-tags` devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
     "@babel/parser": "^7.16.2",
     "@babel/traverse": "^7.16.0",
     "@microsoft/jest-sarif": "^1.0.0-beta.0",
-    "common-tags": "^1.8.0",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-eslint-comments": "^3.2.0",

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { stripIndent } = require('common-tags');
-
 const recommendedConfig = require('../../lib/config/recommended');
 const {
   getProjectConfig,
@@ -255,7 +253,7 @@ describe('get-config', function () {
     });
 
     project.addDevDependency('my-awesome-thing', '0.0.0', (dep) => {
-      dep.files['index.js'] = stripIndent`
+      dep.files['index.js'] = `
         module.exports = {
           name: 'my-awesome-thing',
 
@@ -286,7 +284,7 @@ describe('get-config', function () {
     project.setConfig();
 
     project.addDevDependency('my-awesome-thing', '0.0.0', (dep) => {
-      dep.files['index.js'] = stripIndent`
+      dep.files['index.js'] = `
         module.exports = {
           name: 'my-awesome-thing',
 

--- a/test/unit/recommended-config-test.js
+++ b/test/unit/recommended-config-test.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const stripIndent = require('common-tags').stripIndent;
-
 const Linter = require('../../lib');
 
 describe('recommended config', function () {
@@ -33,15 +31,14 @@ describe('recommended config', function () {
     });
   }
 
-  ensureValid(stripIndent`
-    <md-autocomplete-wrap
-      id={{this.autocompleteWrapperId}}
-      role="listbox"
-      layout="row"
-      class="{{if this.notFloating "md-whiteframe-z1"}} {{if this.notHidden "md-menu-showing"}}"
-    >
-    </md-autocomplete-wrap>
-  `);
+  ensureValid(`
+<md-autocomplete-wrap
+  id={{this.autocompleteWrapperId}}
+  role="listbox"
+  layout="row"
+  class="{{if this.notFloating "md-whiteframe-z1"}} {{if this.notHidden "md-menu-showing"}}"
+>
+</md-autocomplete-wrap>`);
 
   // This ensures that we don't face this issue again => https://github.com/ember-template-lint/ember-template-lint/issues/230
   ensureValid('<FooBar as |baz|><baz.Derp></baz.Derp></FooBar>');

--- a/yarn.lock
+++ b/yarn.lock
@@ -2309,11 +2309,6 @@ common-ancestor-path@^1.0.1:
   resolved "https://registry.yarnpkg.com/common-ancestor-path/-/common-ancestor-path-1.0.1.tgz#4f7d2d1394d91b7abdf51871c62f71eadb0182a7"
   integrity sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w==
 
-common-tags@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
-  integrity sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
-
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"


### PR DESCRIPTION
It was really used only once in test/unit/recommended-config-test.js. Maybe it be removed?