### PR TITLE
Delete config `octane`

### DIFF
--- a/lib/config/octane.js
+++ b/lib/config/octane.js
@@ -1,5 +1,0 @@
-'use strict';
-
-module.exports = {
-  extends: 'recommended',
-};


### PR DESCRIPTION
This config has been deprecated and no longer needed since all of its rules were promoted to `recommended`.

Part of v4 release (https://github.com/ember-template-lint/ember-template-lint/issues/1908).