### PR TITLE
Remove `--json` CLI option

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -149,11 +149,6 @@ function parseArgv(_argv) {
         type: 'string',
         default: 'pretty',
       },
-      json: {
-        describe: 'Format output as json',
-        deprecated: 'Use --format=json instead',
-        boolean: true,
-      },
       'output-file': {
         describe: 'Specify file to write report to',
         type: 'string',
@@ -265,7 +260,7 @@ function printPending(results, options) {
   }
   let pendingListString = JSON.stringify(pendingList, null, 2);
 
-  if (options.json) {
+  if (options.format === 'json') {
     console.log(pendingListString);
   } else {
     console.log(chalk.yellow('WARNING: Print pending is deprecated. Use --update-todo instead.\n'));
@@ -339,8 +334,7 @@ async function run() {
       getTodoConfigFromCommandLineOptions(options)
     ),
   };
-  let shouldWriteToStdout =
-    options.quiet || options.json || ['sarif', 'json'].includes(options.format);
+  let shouldWriteToStdout = options.quiet || ['sarif', 'json'].includes(options.format);
 
   try {
     linter = new Linter({

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -21,7 +21,7 @@ ember-template-lint "app/templates/components/**/*" "app/templates/application.h
 Output errors as pretty-printed JSON string
 
 ```bash
-ember-template-lint "app/templates/application.hbs" --json
+ember-template-lint "app/templates/application.hbs" --format=json
 ```
 
 Ignore warnings / only report errors

--- a/lib/formatters/default.js
+++ b/lib/formatters/default.js
@@ -23,9 +23,7 @@ class DefaultPrinter {
       hasResultData: options.hasResultData,
     };
 
-    const format = options.json ? 'json' : options.format;
-
-    switch (format) {
+    switch (options.format) {
       case 'json': {
         let JsonPrinter = require('./json');
         this.delegates.push(new JsonPrinter(printOptions));

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -54,8 +54,6 @@ describe('ember-template-lint executable', function () {
                                                                 [boolean] [default: false]
             --format                    Specify format to be used in printing output
                                                               [string] [default: \\"pretty\\"]
-            --json                      Format output as json
-                                         [deprecated: Use --format=json instead] [boolean]
             --output-file               Specify file to write report to           [string]
             --verbose                   Output errors with source description    [boolean]
             --working-directory, --cwd  Path to a directory that should be considered as
@@ -113,8 +111,6 @@ describe('ember-template-lint executable', function () {
                                                                 [boolean] [default: false]
             --format                    Specify format to be used in printing output
                                                               [string] [default: \\"pretty\\"]
-            --json                      Format output as json
-                                         [deprecated: Use --format=json instead] [boolean]
             --output-file               Specify file to write report to           [string]
             --verbose                   Output errors with source description    [boolean]
             --working-directory, --cwd  Path to a directory that should be considered as
@@ -429,8 +425,6 @@ describe('ember-template-lint executable', function () {
                                                                 [boolean] [default: false]
             --format                    Specify format to be used in printing output
                                                               [string] [default: \\"pretty\\"]
-            --json                      Format output as json
-                                         [deprecated: Use --format=json instead] [boolean]
             --output-file               Specify file to write report to           [string]
             --verbose                   Output errors with source description    [boolean]
             --working-directory, --cwd  Path to a directory that should be considered as
@@ -560,7 +554,7 @@ describe('ember-template-lint executable', function () {
   });
 
   describe('errors and warnings formatting', function () {
-    describe('without --json param', function () {
+    describe('without --format=json param', function () {
       it('should print properly formatted error messages', async function () {
         project.setConfig({
           rules: {
@@ -956,7 +950,7 @@ describe('ember-template-lint executable', function () {
       });
     });
 
-    describe('with --json param', function () {
+    describe('with --format=json param', function () {
       it('should print valid JSON string with errors', async function () {
         project.setConfig({
           rules: {
@@ -974,7 +968,7 @@ describe('ember-template-lint executable', function () {
           },
         });
 
-        let result = await run(['--json', '.']);
+        let result = await run(['--format=json', '.']);
 
         let expectedOutputData = {};
         expectedOutputData['app/templates/application.hbs'] = [
@@ -1022,7 +1016,7 @@ describe('ember-template-lint executable', function () {
           },
         });
 
-        let result = await run(['.', '--json']);
+        let result = await run(['.', '--format=json']);
 
         let expectedOutputData = {};
         expectedOutputData['app/components/click-me-button.hbs'] = [
@@ -1046,7 +1040,7 @@ describe('ember-template-lint executable', function () {
       });
     });
 
-    describe('with --json param and --quiet', function () {
+    describe('with --format=json param and --quiet', function () {
       it('should print valid JSON string with errors, omitting warnings', async function () {
         project.setConfig({
           rules: {
@@ -1069,7 +1063,7 @@ describe('ember-template-lint executable', function () {
           },
         });
 
-        let result = await run(['.', '--json', '--quiet']);
+        let result = await run(['.', '--format=json', '--quiet']);
 
         let expectedOutputData = {};
         expectedOutputData['app/templates/application.hbs'] = [
@@ -1122,7 +1116,7 @@ describe('ember-template-lint executable', function () {
             },
           },
         });
-        let result = await run(['.', '--json', '--quiet']);
+        let result = await run(['.', '--format=json', '--quiet']);
 
         let expectedOutputData = {};
         expectedOutputData['app/templates/application.hbs'] = [];
@@ -1147,7 +1141,7 @@ describe('ember-template-lint executable', function () {
           },
         });
 
-        let result = await run(['.', '--json']);
+        let result = await run(['.', '--format=json']);
 
         let expectedOutputData = {};
         expectedOutputData['app/components/click-me-button.hbs'] = [
@@ -1427,7 +1421,7 @@ describe('ember-template-lint executable', function () {
       });
     });
 
-    describe('with --print-pending and --json params', function () {
+    describe('with --print-pending and --format=json params', function () {
       it('should print json of pending modules', async function () {
         project.setConfig({
           rules: {
@@ -1450,7 +1444,7 @@ describe('ember-template-lint executable', function () {
           },
         });
 
-        let result = await run(['.', '--print-pending', '--json']);
+        let result = await run(['.', '--print-pending', '--format=json']);
 
         let expectedOutputData = [
           {

--- a/test/acceptance/editors-integration-test.js
+++ b/test/acceptance/editors-integration-test.js
@@ -38,7 +38,7 @@ describe('editors integration', function () {
       project.setConfig({ rules: { 'no-debugger': true } });
       project.write({ 'template.hbs': '{{debugger}}' });
 
-      let result = await run(project, ['--json', '--filename', 'template.hbs'], {
+      let result = await run(project, ['--format', 'json', '--filename', 'template.hbs'], {
         shell: false,
         input: fs.readFileSync(path.resolve('template.hbs')),
       });
@@ -67,7 +67,7 @@ describe('editors integration', function () {
       project.setConfig({ rules: { 'require-button-type': true } });
       project.write({ 'template.hbs': '<button></button>' });
 
-      let result = await run(project, ['--json', '--filename', 'template.hbs', '--fix'], {
+      let result = await run(project, ['--format', 'json', '--filename', 'template.hbs', '--fix'], {
         shell: false,
         input: fs.readFileSync(path.resolve('template.hbs')),
       });

--- a/test/unit/bin/parse-argv-test.js
+++ b/test/unit/bin/parse-argv-test.js
@@ -3,25 +3,25 @@
 const { _parseArgv: parseArgv } = require('../../../bin/ember-template-lint');
 
 describe('parseArgv', function () {
-  describe('--json', function () {
-    it('parses --json option and defaults to true', function () {
-      let argv = parseArgv(['--json']);
-      expect(argv.json).toBe(true);
+  describe('--format', function () {
+    it('parses --format option and defaults correctly', function () {
+      let argv = parseArgv(['--format']);
+      expect(argv.format).toBe('pretty');
     });
 
-    it('parses --json false option', function () {
-      let argv = parseArgv(['--json', 'false', 'other']);
-      expect(argv.json).toBe(false);
+    it('parses --format=json option', function () {
+      let argv = parseArgv(['--format', 'json']);
+      expect(argv.format).toBe('json');
     });
 
-    it('parses --json option with other args before', function () {
-      let argv = parseArgv(['.', '--json']);
-      expect(argv.json).toBe(true);
+    it('parses --format option with other args before', function () {
+      let argv = parseArgv(['.', '--format=json']);
+      expect(argv.format).toBe('json');
     });
 
-    it('parses --json option with other args after', function () {
-      let argv = parseArgv(['--json', '.']);
-      expect(argv.json).toBe(true);
+    it('parses --format option with other args after', function () {
+      let argv = parseArgv(['--format=json', '.']);
+      expect(argv.format).toBe('json');
     });
   });
 


### PR DESCRIPTION
Follow-up to the deprecation of this option in #1907.

Use `--format=json` instead.

Part of v4 release (#1908).