### PR TITLE
Resolve `no-unused-disable` lint errors

### DIFF
--- a/lib/formatters/sarif.js
+++ b/lib/formatters/sarif.js
@@ -33,7 +33,7 @@ class SarifPrinter {
   }
 
   buildSarifLog(results) {
-    const version = require('../../package.json').version; // eslint-disable-line import/extensions
+    const version = require('../../package.json').version;
     const sarifLog = {
       version: '2.1.0',
       $schema: 'http://json.schemastore.org/sarif-2.1.0-rtm.5',

--- a/scripts/update-rules.js
+++ b/scripts/update-rules.js
@@ -12,7 +12,7 @@ const rules = require('../lib/rules');
 const isRuleFixable = require('../test/helpers/is-rule-fixable');
 
 const prettierConfig = {
-  ...require('../.prettierrc.js'), // eslint-disable-line import/extensions
+  ...require('../.prettierrc.js'),
   parser: 'markdown',
 };
 


### PR DESCRIPTION
Resolves:
```
'import/extensions' rule is disabled but never reported
```