### PR TITLE
Update `yargs` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "requireindex": "^1.2.0",
     "resolve": "^1.20.0",
     "v8-compile-cache": "^2.3.0",
-    "yargs": "^16.2.0"
+    "yargs": "^17.2.1"
   },
   "devDependencies": {
     "@babel/parser": "^7.16.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8088,6 +8088,19 @@ yargs@^16.2.0:
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
 
+yargs@^17.2.1:
+  version "17.2.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.2.1.tgz#e2c95b9796a0e1f7f3bf4427863b42e0418191ea"
+  integrity sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==
+  dependencies:
+    cliui "^7.0.2"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.0"
+    y18n "^5.0.5"
+    yargs-parser "^20.2.2"
+
 yeoman-environment@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/yeoman-environment/-/yeoman-environment-3.6.0.tgz#91267ced0d474c4dec330b83f232e72e796c0730"


### PR DESCRIPTION
Part of v4 release (#1908).

https://github.com/yargs/yargs/blob/main/CHANGELOG.md#1700-2021-05-02