### PR TITLE
Add `exports` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "license": "MIT",
   "author": "Robert Jackson <me@rwjblue.com>",
-  "main": "lib/index.js",
+  "exports": "./lib/index.js",
+  "main": "./lib/index.js",
   "bin": "./bin/ember-template-lint.js",
   "scripts": {
     "lint": "npm-run-all lint:* --continue-on-error",


### PR DESCRIPTION
https://nodejs.org/api/packages.html#exports

This prevents users from importing files directly from this package.

[ESLint v8](https://eslint.org/docs/user-guide/migrating-to-8.0.0#the-lib-entrypoint-has-been-removed) also added this restriction.

Ideally, we'll hear from users after making this change if there are additional internals that we need to expose as part of our public NodeJS API in [lib/index.js](https://github.com/ember-template-lint/ember-template-lint/blob/master/lib/index.js).

Part of v4 release (#1908).

TODO:

- [ ] #2209
- [ ] What to do about users who may need to retrieve the default config from [no-bare-strings](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-bare-strings.md)? `const { DEFAULT_CONFIG } = require('ember-template-lint/lib/rules/no-bare-strings');` #2213