### PR TITLE
Expose `generateRuleTests` as named export in public NodeJS API

### DIFF
--- a/docs/node-api.md
+++ b/docs/node-api.md
@@ -1,5 +1,7 @@
 # Node API
 
+## Linter Class
+
 Run templates through the linter's `verify` method like so:
 
 ```js
@@ -21,3 +23,7 @@ let results = await linter.verify({ source: template, filePath: 'some/path/to/te
 - `filePath` - The file path for the file containing the error.
 - `source` - The source that caused the error.
 - `fix` - An object describing how to fix the error.
+
+## Named Exports
+
+- See [lib/index.js](../lib/index.js)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -152,6 +152,83 @@ The base rule also has a few helper functions that can be useful in defining rul
 
   Given an AST node, check if it is derived from a local / block param.
 
+### Writing rule tests
+
+Here's an example of how to write tests for a rule:
+
+```js
+// test/unit/rules/no-negated-condition-test.js
+
+'use strict';
+
+const { generateRuleTests } = require('ember-template-lint');
+const plugin = require('../../..');
+
+generateRuleTests({
+  name: 'no-negated-condition',
+
+  groupMethodBefore: beforeEach,
+  groupingMethod: describe,
+  testMethod: it,
+  plugins: [plugin],
+
+  config: true,
+
+  good: [
+    // Simple string test case:
+    '{{#if condition}}<img>{{/if}}',
+
+    // Object test case:
+    {
+      template: '{{#if condition}}<img>{{/if}}',
+      config: {}, // Custom config for this test case.
+      meta: { moduleId: 'app/templates/index.hbs' }, // Custom filepath for this test case.
+    },
+  ],
+
+  bad: [
+    {
+      template: '{{#if (not condition)}}<img>{{/if}}',
+      fixedTemplate: '{{#unless condition}}<img>{{/unless}}',
+
+      result: {
+        message: ERROR_MESSAGE_USE_UNLESS,
+        source: '{{#if (not condition)}}<img>{{/if}}',
+        line: 1,
+        column: 0,
+        isFixable: true,
+      }
+    },
+
+    {
+      // Jest snapshot test case (which can be automatically updated):
+
+      template: '{{#if (not condition)}}<img>{{/if}}',
+      fixedTemplate: '{{#unless condition}}<img>{{/unless}}',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 0,
+              "endColumn": 35,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Change \`if (not condition)\` to \`unless condition\`.",
+              "rule": "no-negated-condition",
+              "severity": 2,
+              "source": "{{#if (not condition)}}<img>{{/if}}",
+            },
+          ]
+        `);
+      },
+    },
+  ],
+});
+```
+
 ### AST Node Helpers
 
 There are a number of helper functions exported by [`ember-template-lint`](../lib/helpers/ast-node-info.js) that can be used with AST nodes in your rule's visitor handlers.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,15 @@
 'use strict';
 
+// Linter class
 module.exports = require('./linter');
+
+// Rule class
 module.exports.Rule = require('./rules/_base');
-module.exports.ASTHelpers = require('./helpers/ast-node-info');
+
+// Recast dependency
 module.exports.recast = require('ember-template-recast');
+
+// Helpers
+module.exports.ASTHelpers = require('./helpers/ast-node-info');
 module.exports.NodeMatcher = require('./helpers/node-matcher');
+module.exports.generateRuleTests = require('./helpers/rule-test-harness');


### PR DESCRIPTION
This will be needed once we lock down the package by defining `exports` to only expose internals from `lib/index.js` in https://github.com/ember-template-lint/ember-template-lint/pull/2208.

In v4, this will not be allowed:

```js
const generateRuleTests = require("ember-template-lint/lib/helpers/rule-test-harness");
```

Instead, this will be the replacement:

```js
const { generateRuleTests } = require('ember-template-lint');
```

I also added some basic plugin documentation regarding how to write rule tests since that appears to be completely undocumented.