### PR TITLE
Ensure `--print-pending` works with `--format=json` in addition to `--json`

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -265,7 +265,7 @@ function printPending(results, options) {
   }
   let pendingListString = JSON.stringify(pendingList, null, 2);
 
-  if (options.json) {
+  if (options.json || options.format === 'json') {
     console.log(pendingListString);
   } else {
     console.log(chalk.yellow('WARNING: Print pending is deprecated. Use --update-todo instead.\n'));

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -21,7 +21,7 @@ ember-template-lint "app/templates/components/**/*" "app/templates/application.h
 Output errors as pretty-printed JSON string
 
 ```bash
-ember-template-lint "app/templates/application.hbs" --json
+ember-template-lint "app/templates/application.hbs" --format=json
 ```
 
 Ignore warnings / only report errors


### PR DESCRIPTION
Just fixing this bug in `master`, although these options will be removed in v4:

`--json` will be removed in v4: https://github.com/ember-template-lint/ember-template-lint/pull/2193
`--print-pending` will be removed in v4: https://github.com/ember-template-lint/ember-template-lint/pull/2207

Goal: ease the transition to `--format=json` (replacement for `--json`).