### PR TITLE
Upgrade ember-template-recast to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "chalk": "^4.1.2",
     "ci-info": "^3.2.0",
     "date-fns": "^2.25.0",
-    "ember-template-recast": "^6.0.0",
+    "ember-template-recast": "^6.1.0",
     "find-up": "^5.0.0",
     "fuse.js": "^6.4.6",
     "get-stdin": "^8.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,7 +2302,7 @@ electron-to-chromium@^1.3.896:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.902.tgz#926726705c17f9531be23bda545b819b35da665d"
   integrity sha512-zFv5jbtyIr+V9FuT9o439isXbkXQ27mJqZfLXpBKzXugWE8+3RotHbXJlli0/r+Rvdlkut0OOMzeOWLAjH0jCw==
 
-ember-template-recast@^6.0.0:
+ember-template-recast@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/ember-template-recast/-/ember-template-recast-6.1.0.tgz#ea36756200dcff03d9fd7b78750f6e1008c393f8"
   integrity sha512-R4FAxC32ltmtE7SwrxF41MV2sUyrTmRp/2omd5b03Rr8wDHxJ+5DfaL4mCAY1r0/FpS9zoaeAXBzBJxtHTF3lA==


### PR DESCRIPTION
This is a "minor" upgrade that will allow updating quoteType of `AttrNode`s. 

The full release changlog [is here](https://github.com/ember-template-lint/ember-template-recast/releases/tag/v6.1.0).

cc @courajs