### PR TITLE
Change `no-bare-strings` rule options to augment instead of replace the default config 

### DIFF
--- a/docs/migration/v4.md
+++ b/docs/migration/v4.md
@@ -1,1 +1,40 @@
 # Migrating to v4.0.0
+
+## Changes to rule options
+
+### [no-bare-strings](../rule/no-bare-strings.md)
+
+The rules options now augment instead of replace the default config.
+
+In v3, the recommended configuration was:
+
+```javascript
+const { DEFAULT_CONFIG } = require('ember-template-lint/lib/rules/no-bare-strings');
+const additionalCharsToIgnore = ['a', 'b', 'c'];
+const additionalAttributesToCheck = ['data-foo'];
+
+module.exports = {
+  rules: {
+    'no-bare-strings': {
+      allowlist: [...DEFAULT_CONFIG.allowlist, ...additionalCharsToIgnore],
+      globalAttributes: [...DEFAULT_CONFIG.globalAttributes, ...additionalAttributesToCheck],
+    },
+  },
+};
+```
+
+In v4 the configuration should be updated to:
+
+```javascript
+const additionalCharsToIgnore = ['a', 'b', 'c'];
+const additionalAttributesToCheck = ['data-foo'];
+
+module.exports = {
+  rules: {
+    'no-bare-strings': {
+      allowlist: additionalCharsToIgnore,
+      globalAttributes: additionalAttributesToCheck,
+    },
+  },
+};
+```

--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -22,32 +22,17 @@ This rule **allows** the following:
  The following values are valid configuration:
 
 * boolean -- `true` for enabled / `false` for disabled
-* array -- an array of allowlisted strings
+* array -- An array of allowlisted strings (extends the default config)
 * object -- An object with the following keys:
-  * `allowlist` -- An array of allowlisted strings
-  * `globalAttributes` -- An array of attributes to check on every element.
-  * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
+  * `allowlist` -- An array of allowlisted strings (extends the default config)
+  * `globalAttributes` -- An array of attributes to check on every element (extends the default config).
+  * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name (extends the default config).
 
 When the config value of `true` is used the following configuration is used:
 
 * `allowlist` - refer to the `DEFAULT_CONFIG.allowlist` property in the [rule](../lib/rules/no-bare-strings.js)
 * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
 * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
-
-The `DEFAULT_CONFIG` is available as an export. Example use in configuration:
-
-```javascript
-const {
-  DEFAULT_CONFIG
-} = require('ember-template-lint/lib/rules/no-bare-strings');
-const additionalCharsToIgnore = ['a', 'b', 'c'];
-
-module.exports = {
-  rules: {
-    'no-bare-strings': [...DEFAULT_CONFIG.allowlist, ...additionalCharsToIgnore]
-  }
-};
-```
 
 ## References
 

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -328,5 +328,3 @@ module.exports = class NoBareStrings extends Rule {
     }
   }
 };
-
-module.exports.DEFAULT_CONFIG = DEFAULT_CONFIG;

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -147,6 +147,10 @@ function sanitizeConfigArray(allowlist = []) {
   return allowlist.filter((option) => option !== '').sort((a, b) => b.length - a.length);
 }
 
+function augmentedWith(arrayA, arrayB) {
+  return [...new Set([...arrayA, ...arrayB])];
+}
+
 module.exports = class NoBareStrings extends Rule {
   constructor(options) {
     super(options);
@@ -174,13 +178,11 @@ module.exports = class NoBareStrings extends Rule {
         } else if (isValidConfigObjectFormat(config)) {
           // default any missing keys to empty values
           let { allowlist = [], globalAttributes = [], elementAttributes = {} } = config;
-          let list = [...new Set([...DEFAULT_ALLOWLIST, ...allowlist])];
-          let attributesList = [...new Set([...GLOBAL_ATTRIBUTES, ...globalAttributes])];
+          let list = augmentedWith(DEFAULT_ALLOWLIST, allowlist);
+          let attributesList = augmentedWith(GLOBAL_ATTRIBUTES, globalAttributes);
           let elementAttributesList = { ...TAG_ATTRIBUTES };
           for (const [element, attributes] of Object.entries(elementAttributes)) {
-            elementAttributesList[element] = [
-              ...new Set([...attributes, ...TAG_ATTRIBUTES[element]]),
-            ];
+            elementAttributesList[element] = augmentedWith(attributes, TAG_ATTRIBUTES[element]);
           }
           return {
             allowlist: sanitizeConfigArray(list),

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -165,18 +165,27 @@ module.exports = class NoBareStrings extends Rule {
         return config ? DEFAULT_CONFIG : false;
       case 'object':
         if (Array.isArray(config)) {
+          let list = [...new Set([...DEFAULT_ALLOWLIST, ...config])];
           return {
-            allowlist: sanitizeConfigArray(config),
+            allowlist: sanitizeConfigArray(list),
             globalAttributes: GLOBAL_ATTRIBUTES,
             elementAttributes: TAG_ATTRIBUTES,
           };
         } else if (isValidConfigObjectFormat(config)) {
           // default any missing keys to empty values
-          let { allowlist = [] } = config;
+          let { allowlist = [], globalAttributes = [], elementAttributes = {} } = config;
+          let list = [...new Set([...DEFAULT_ALLOWLIST, ...allowlist])];
+          let attributesList = [...new Set([...GLOBAL_ATTRIBUTES, ...globalAttributes])];
+          let elementAttributesList = { ...TAG_ATTRIBUTES };
+          for (const [element, attributes] of Object.entries(elementAttributes)) {
+            elementAttributesList[element] = [
+              ...new Set([...attributes, ...TAG_ATTRIBUTES[element]]),
+            ];
+          }
           return {
-            allowlist: sanitizeConfigArray(allowlist),
-            globalAttributes: config.globalAttributes || [],
-            elementAttributes: config.elementAttributes || {},
+            allowlist: sanitizeConfigArray(list),
+            globalAttributes: attributesList,
+            elementAttributes: elementAttributesList,
           };
         }
         break;
@@ -188,11 +197,11 @@ module.exports = class NoBareStrings extends Rule {
       this.ruleName,
       [
         '  * boolean - `true` to enable / `false` to disable',
-        '  * array -- an array of allowlisted strings',
+        '  * array -- An array of allowlisted strings (extends the default config)',
         '  * object -- An object with the following keys:',
-        '    * `allowlist` -- An array of allowlisted strings',
-        '    * `globalAttributes` -- An array of attributes to check on every element',
-        '    * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name',
+        '    * `allowlist` -- An array of allowlisted strings (extends the default config)',
+        '    * `globalAttributes` -- An array of attributes to check on every element (extends the default config)',
+        '    * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name (extends the default config)',
       ],
       config
     );

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -88,13 +88,13 @@ generateRuleTests({
     },
 
     {
-      // override the allowlist list
+      // extend the allowlist list
       config: ['/', '"'],
       template: '{{t "foo"}} / &lpar;"{{name}}"&rpar;',
     },
 
     {
-      // override the allowlist list
+      // extend the allowlist list
       config: { allowlist: ['/', '"'] },
       template: '{{t "foo"}} / &lpar;"{{name}}"&rpar;',
     },

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -1,19 +1,6 @@
 'use strict';
 
-const rule = require('../../../lib/rules/no-bare-strings');
 const generateRuleTests = require('../../helpers/rule-test-harness');
-
-describe('imports', () => {
-  it('should expose the default config', () => {
-    expect(rule.DEFAULT_CONFIG).toEqual(
-      expect.objectContaining({
-        allowlist: expect.arrayContaining(['&lpar;']),
-        globalAttributes: expect.arrayContaining(['title']),
-        elementAttributes: expect.any(Object),
-      })
-    );
-  });
-});
 
 generateRuleTests({
   name: 'no-bare-strings',
@@ -101,15 +88,27 @@ generateRuleTests({
     },
 
     {
-      // override the globalAttributes list
-      config: { globalAttributes: [] },
-      template: '<a title="hahaha trolol"></a>',
+      // override the allowlist list
+      config: ['/', '"'],
+      template: '{{t "foo"}} / &lpar;"{{name}}"&rpar;',
     },
 
     {
-      // override the elementAttributes list
-      config: { elementAttributes: {} },
-      template: '<input placeholder="hahaha">',
+      // override the allowlist list
+      config: { allowlist: ['/', '"'] },
+      template: '{{t "foo"}} / &lpar;"{{name}}"&rpar;',
+    },
+
+    {
+      // extend the globalAttributes list
+      config: { globalAttributes: ['data-title'] },
+      template: '<a title={{t "title"}} date-title={{t "title"}}></a>',
+    },
+
+    {
+      // extend the elementAttributes list
+      config: { elementAttributes: { input: ['data-placeholder'] } },
+      template: '<input placeholder={{t "placeholder"}} data-placeholder={{t "placeholder"}}>',
     },
 
     {
@@ -445,14 +444,25 @@ generateRuleTests({
 
     {
       config: { globalAttributes: ['data-foo'] },
-      template: '<div data-foo="derpy"></div>',
+      template: '<div title="foo" data-foo="derpy"></div>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [
             Object {
               "column": 5,
-              "endColumn": 20,
+              "endColumn": 15,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Non-translated string used in \`title\` attribute",
+              "rule": "no-bare-strings",
+              "severity": 2,
+              "source": "foo",
+            },
+            Object {
+              "column": 17,
+              "endColumn": 32,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
@@ -468,14 +478,25 @@ generateRuleTests({
 
     {
       config: { elementAttributes: { img: ['data-alt'] } },
-      template: '<img data-alt="some alternate here">',
+      template: '<img alt="foo" data-alt="some alternate here">',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [
             Object {
               "column": 5,
-              "endColumn": 34,
+              "endColumn": 13,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Non-translated string used in \`alt\` attribute",
+              "rule": "no-bare-strings",
+              "severity": 2,
+              "source": "foo",
+            },
+            Object {
+              "column": 15,
+              "endColumn": 44,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
@@ -483,6 +504,28 @@ generateRuleTests({
               "rule": "no-bare-strings",
               "severity": 2,
               "source": "some alternate here",
+            },
+          ]
+        `);
+      },
+    },
+
+    {
+      config: { allowlist: ['/', '"'] },
+      template: '{{t "foo"}} / error / &lpar;"{{name}}"&rpar;',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 11,
+              "endColumn": 29,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Non-translated string used",
+              "rule": "no-bare-strings",
+              "severity": 2,
+              "source": " / error / &lpar;\\"",
             },
           ]
         `);


### PR DESCRIPTION
## Description

This PR would remove the need to import the default config from the `no-bare-strings` rule.


v3 recommended configuration:

```javascript
const { DEFAULT_CONFIG } = require('ember-template-lint/lib/rules/no-bare-strings');
const additionalCharsToIgnore = ['a', 'b', 'c'];
module.exports = {
  rules: {
    'no-bare-strings': [...DEFAULT_CONFIG.allowlist, ...additionalCharsToIgnore],
  },
};
```

In v4 the configuration would have to be updated to:

```javascript
const additionalCharsToIgnore = ['a', 'b', 'c'];
module.exports = {
  rules: {
    'no-bare-strings': additionalCharsToIgnore,
  },
};
```

To exclude the default allowlist, the configuration would be:

```javascript
module.exports = {
  rules: {
    'no-bare-strings': {
      allowlist: additionalCharsToIgnore,
      ignoreDefaultAllowList: true,
    },
  },
};
```

## Related Discussions

If the PR is accepted, I will also add `ignoreDefaultGlobalAttributes` and `ignoreDefaultElementAttributes`. It implements [the first part of your comment]( https://github.com/ember-template-lint/ember-template-lint/pull/2208#issuecomment-974532630) @bmish 