### PR TITLE
Fix Node version on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
+        with:
+          node-version: 12.x
 
       - name: install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,21 +12,22 @@ on:
 
 jobs:
   test:
-    name: Node 12.x - ubuntu
+    name: Node 16.x - ubuntu
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v2
+
       - uses: volta-cli/action@v1
-        with:
-          node-version: 12.x
 
       - name: install dependencies
         run: yarn install --frozen-lockfile
 
       - run: yarn lint
+
       - run: yarn test:jest
+
       - run: yarn update:readme && git diff --exit-code
 
   nodeX:
@@ -44,10 +45,11 @@ jobs:
         # excluded because it is the `test` job above
         exclude:
           - os: ubuntu
-            node-version: 12.x
+            node-version: 16.x
 
     steps:
       - uses: actions/checkout@v2
+
       - uses: volta-cli/action@v1
         with:
           node-version: ${{ matrix.node-version }}
@@ -61,11 +63,11 @@ jobs:
     name: Floating Dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 10
-
     needs: [test]
 
     steps:
       - uses: actions/checkout@v2
+
       - uses: volta-cli/action@v1
         with:
           node-version: 14.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: volta-cli/action@v1
-        with:
-          node-version: 14.x
 
       - name: install dependencies
         run: yarn install --no-lockfile


### PR DESCRIPTION
`volta-cli/action` does not install Node when a `node-version` is not specified, which means this job has been using the Node version included with `ubuntu-latest` (`14.x`) instead of `12.x`.