### PR TITLE
Disallow unexpected properties in rule test cases

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -27,6 +27,153 @@ function cloneSimpleObject(obj) {
   return JSON.parse(JSON.stringify(obj || {}));
 }
 
+const ALLOWED_GENERATE_RULE_TEST_PROPERTIES = new Set([
+  'bad',
+  'config',
+  'error',
+  'focusMethod',
+  'good',
+  'groupMethodBefore',
+  'groupingMethod',
+  'meta',
+  'name',
+  'plugins',
+  'skipDisabledTests',
+  'testMethod',
+]);
+
+const ALLOWED_TEST_CASE_PROPERTIES_GOOD = new Set(['config', 'meta', 'name', 'template']);
+
+const ALLOWED_TEST_CASE_PROPERTIES_BAD = new Set([
+  'config',
+  'fixedTemplate', // Only in bad test cases.
+  'meta',
+  'name',
+  'result',
+  'results',
+  'template',
+  'verifyResults',
+]);
+
+const ALLOWED_TEST_CASE_PROPERTIES_ERROR = new Set([
+  'config',
+  'meta',
+  'name',
+  'result',
+  'results',
+  'template',
+  'verifyResults',
+]);
+
+const ALLOWED_RESULT_PROPERTIES_BAD = new Set([
+  'column',
+  'endColumn',
+  'endLine',
+  'filePath',
+  'isFixable', // Only in bad test cases.
+  'line',
+  'message',
+  'rule',
+  'severity',
+  'source',
+]);
+
+const ALLOWED_RESULT_PROPERTIES_ERROR = new Set([
+  'column',
+  'endColumn',
+  'endLine',
+  'fatal', // Only in error test cases.
+  'filePath',
+  'line',
+  'message',
+  'rule',
+  'severity',
+  'source',
+]);
+
+function validateKeys(instance, allowedKeys, message) {
+  for (const key of Object.keys(instance)) {
+    assert(
+      allowedKeys.has(key),
+      `${message}: ${key}. Expected one of: ${[...allowedKeys.keys()].join(', ')}.`
+    );
+  }
+}
+
+function validateInput(args) {
+  // Validate arguments.
+  assert(args.length === 1, '`generateRuleTests` should only be called with one argument.');
+  assert(
+    typeof args === 'object',
+    '`generateRuleTests` should only be called with an object argument.'
+  );
+
+  const [properties] = args;
+
+  // Validate top-level properties.
+  validateKeys(
+    properties,
+    ALLOWED_GENERATE_RULE_TEST_PROPERTIES,
+    `Unexpected property passed to \`generateRuleTests\``
+  );
+
+  // Validate good test cases.
+  for (const _item of properties.good || []) {
+    let item = typeof _item === 'string' ? { template: _item } : _item;
+    validateKeys(
+      item,
+      ALLOWED_TEST_CASE_PROPERTIES_GOOD,
+      `Unexpected property passed to good test case`
+    );
+  }
+
+  // Validate bad test cases.
+  for (const item of properties.bad || []) {
+    validateKeys(
+      item,
+      ALLOWED_TEST_CASE_PROPERTIES_BAD,
+      `Unexpected property passed to bad test case`
+    );
+
+    assert(
+      !(item.result && item.results),
+      'Bad test case should not have both `result` and `results`.'
+    );
+
+    let results = item.results || (item.result ? [item.result] : []);
+    for (const result of results) {
+      validateKeys(
+        result,
+        ALLOWED_RESULT_PROPERTIES_BAD,
+        `Unexpected property passed to bad test case results`
+      );
+    }
+  }
+
+  // Validate error test cases.
+  for (const item of properties.error || []) {
+    validateKeys(
+      item,
+      ALLOWED_TEST_CASE_PROPERTIES_ERROR,
+      `Unexpected property passed to error test case`
+    );
+
+    assert(
+      !(item.result && item.results),
+      'Error test case should not have both `result` and `results`.'
+    );
+
+    let results = item.results || (item.result ? [item.result] : []);
+    for (const result of results) {
+      validateKeys(
+        result,
+        ALLOWED_RESULT_PROPERTIES_ERROR,
+        `Unexpected property passed to error test case results`
+      );
+    }
+  }
+}
+
 /**
  * allows tests to be defined without needing to setup test infrastructure every time
  * @param  {Array}  [bad=[]]            - an array of items that describe the use case that should fail
@@ -81,20 +228,26 @@ function cloneSimpleObject(obj) {
  * @param  {Object}   [meta]
  * @param  {Array}    plugins             - an array of plugins to load
  */
-module.exports = function generateRuleTests({
-  bad = [],
-  good = [],
-  error = [],
-  name,
-  groupingMethod,
-  groupMethodBefore,
-  testMethod,
-  focusMethod,
-  skipDisabledTests,
-  config: defaultConfig,
-  meta: defaultMeta,
-  plugins,
-}) {
+module.exports = function generateRuleTests(...args) {
+  validateInput(args);
+
+  const [
+    {
+      bad = [],
+      good = [],
+      error = [],
+      name,
+      groupingMethod,
+      groupMethodBefore,
+      testMethod,
+      focusMethod,
+      skipDisabledTests,
+      config: defaultConfig,
+      meta: defaultMeta,
+      plugins,
+    },
+  ] = args;
+
   groupingMethod(name, function () {
     let DISABLE_ALL = '{{! template-lint-disable }}';
     let DISABLE_ONE = `{{! template-lint-disable ${name} }}`;

--- a/lib/rules/no-outlet-outside-routes.js
+++ b/lib/rules/no-outlet-outside-routes.js
@@ -29,5 +29,3 @@ module.exports = class NoOutletOutsideRoutes extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/test/acceptance/rule-test.js
+++ b/test/acceptance/rule-test.js
@@ -387,6 +387,88 @@ describe('rule public api', function () {
       ],
     });
   });
+
+  describe('with wrong number of arguments passed to generateRuleTests', function () {
+    expect(() => generateRuleTests({}, {})).toThrowErrorMatchingInlineSnapshot(
+      `"\`generateRuleTests\` should only be called with one argument."`
+    );
+  });
+
+  describe('with invalid argument type passed to generateRuleTests', function () {
+    expect(() => generateRuleTests(123)).toThrowErrorMatchingInlineSnapshot(
+      `"\`generateRuleTests\` should only be called with an object argument."`
+    );
+  });
+
+  describe('with invalid property in good test case', function () {
+    expect(() =>
+      generateRuleTests({
+        good: [{ foo: true }],
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unexpected property passed to good test case: foo. Expected one of: config, meta, name, template."`
+    );
+  });
+
+  describe('with invalid property in bad test case', function () {
+    expect(() =>
+      generateRuleTests({
+        bad: [{ foo: true }],
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unexpected property passed to bad test case: foo. Expected one of: config, fixedTemplate, meta, name, result, results, template, verifyResults."`
+    );
+  });
+
+  describe('with both `result` and `results` in bad test case', function () {
+    expect(() =>
+      generateRuleTests({
+        bad: [{ result: {}, results: [] }],
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Bad test case should not have both \`result\` and \`results\`."`
+    );
+  });
+
+  describe('with invalid property in bad test case result', function () {
+    expect(() =>
+      generateRuleTests({
+        bad: [{ results: [{ fatal: true }] }], // `fatal` only allowed in error test cases.
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unexpected property passed to bad test case results: fatal. Expected one of: column, endColumn, endLine, filePath, isFixable, line, message, rule, severity, source."`
+    );
+  });
+
+  describe('with invalid property in error test case', function () {
+    expect(() =>
+      generateRuleTests({
+        error: [{ fixedTemplate: true }], // `fixedTemplate` only allowed in bad test cases.
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unexpected property passed to error test case: fixedTemplate. Expected one of: config, meta, name, result, results, template, verifyResults."`
+    );
+  });
+
+  describe('with both `result` and `results` in error test case', function () {
+    expect(() =>
+      generateRuleTests({
+        error: [{ result: {}, results: [] }],
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Error test case should not have both \`result\` and \`results\`."`
+    );
+  });
+
+  describe('with invalid property in error test case result', function () {
+    expect(() =>
+      generateRuleTests({
+        error: [{ results: [{ isFixable: true }] }], // `isFixable` only allowed in bad test cases.
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unexpected property passed to error test case results: isFixable. Expected one of: column, endColumn, endLine, fatal, filePath, line, message, rule, severity, source."`
+    );
+  });
 });
 
 describe('regression tests', function () {

--- a/test/helpers/rule-test-harness.js
+++ b/test/helpers/rule-test-harness.js
@@ -1,8 +1,16 @@
 'use strict';
 
+const assert = require('assert');
+
 const generateRuleTests = require('../../lib/helpers/rule-test-harness');
 
-module.exports = function (options) {
+module.exports = function (...args) {
+  assert(args.length === 1, '`generateRuleTests` should only be called with one argument.');
+  const [options] = args;
+  assert(
+    typeof options === 'object',
+    '`generateRuleTests` should only be called with an object argument.'
+  );
   return generateRuleTests(
     Object.assign({}, options, {
       groupMethodBefore: beforeEach,

--- a/test/unit/rules/no-outlet-outside-routes-test.js
+++ b/test/unit/rules/no-outlet-outside-routes-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { message } = require('../../../lib/rules/no-outlet-outside-routes');
 const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
@@ -16,51 +15,23 @@ generateRuleTests({
       meta: {
         filePath: 'app/templates/foo/route.hbs',
       },
-      result: {
-        message,
-        filePath: 'app/templates/foo/route.hbs',
-        source: '{{outlet}}',
-        line: 1,
-        column: 0,
-      },
     },
     {
       template: '{{outlet}}',
       meta: {
         filePath: 'app/templates/routes/foo.hbs',
       },
-      result: {
-        message,
-        filePath: 'app/templates/routes/foo.hbs',
-        source: '{{outlet}}',
-        line: 1,
-        column: 0,
-      },
     },
     {
       template: '{{#outlet}}Why?!{{/outlet}}',
       meta: {
         filePath: 'app/templates/foo/route.hbs',
       },
-      result: {
-        message,
-        filePath: 'app/templates/foo/route.hbs',
-        source: '{{#outlet}}Why?!{{/outlet}}',
-        line: 1,
-        column: 0,
-      },
     },
     {
       template: '{{#outlet}}Why?!{{/outlet}}',
       meta: {
         filePath: 'app/templates/routes/foo.hbs',
-      },
-      result: {
-        message,
-        filePath: 'app/templates/routes/foo.hbs',
-        source: '{{#outlet}}Why?!{{/outlet}}',
-        line: 1,
-        column: 0,
       },
     },
     {
@@ -68,25 +39,11 @@ generateRuleTests({
       meta: {
         filePath: 'app/templates/something/foo.hbs',
       },
-      result: {
-        message,
-        filePath: 'app/templates/something/foo.hbs',
-        source: '{{#outlet}}Works because ambiguous{{/outlet}}',
-        line: 1,
-        column: 0,
-      },
     },
     {
       template: '{{outlet}}',
       meta: {
         filePath: 'components/templates/application.hbs',
-      },
-      result: {
-        message,
-        filePath: 'components/templates/application.hbs',
-        source: '{{outlet}}',
-        line: 1,
-        column: 0,
       },
     },
   ],

--- a/test/unit/rules/self-closing-void-elements-test.js
+++ b/test/unit/rules/self-closing-void-elements-test.js
@@ -93,7 +93,6 @@ generateRuleTests({
   bad: [
     {
       template: '<area/>',
-      message: "Self-closing void element as <area> is redundant ('layout.hbs'@ L1:C0)",
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`


### PR DESCRIPTION
There are many possible properties that can be used when writing test cases for rules. It's easy to mistakenly make a typo or incorrectly pass these properties without noticing.

This PR will assert/throw when an unexpected property is passed to the rule test harness / in a test case.

ESLint v7 implemented this same feature:
* https://eslint.org/docs/user-guide/migrating-to-7.0.0#additional-validation-added-to-the-ruletester-class
   > It fails test cases if any unknown properties are found in the objects in the errors property. 
* https://github.com/eslint/eslint/pull/12096
* https://github.com/eslint/rfcs/blob/main/designs/2019-rule-tester-improvements/README.md#4-changing-the-errors-property-of-objects-to-fail-on-unknown-properties

TODO:

- [x] Nevermind for now: Consider using a parameter / schema validation library like ajv / json schema. Or maybe not since ESLint didn't use any library to do this.
- [x] Add a test.

Part of v4 release (#1908).

