### PR TITLE
Require auto-fixable test cases to assert the fixed template

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -379,6 +379,15 @@ module.exports = function generateRuleTests(...args) {
 
         assert(actual.length > 0, '`bad` test cases should always emit at least one failure');
 
+        for (const act of actual) {
+          if (act.isFixable) {
+            assert(
+              typeof item.fixedTemplate === 'string',
+              'fixable test cases must assert the `fixedTemplate`'
+            );
+          }
+        }
+
         if (item.fatal) {
           assert.strictEqual(actual.length, 1); // can't have more than one fatal error
           delete actual[0].source; // remove the source (stack trace is not easy to assert)

--- a/test/unit/rules/eol-last-test.js
+++ b/test/unit/rules/eol-last-test.js
@@ -149,6 +149,7 @@ generateRuleTests({
     {
       config: 'editorconfig',
       template: 'test',
+      fixedTemplate: 'test', // TODO: bug
 
       meta: {
         editorConfig: { insert_final_newline: true },
@@ -176,6 +177,7 @@ generateRuleTests({
     {
       config: 'editorconfig',
       template: 'test\n',
+      fixedTemplate: 'test\n', // TODO: bug
 
       meta: {
         editorConfig: { insert_final_newline: false },
@@ -206,6 +208,7 @@ generateRuleTests({
     {
       config: 'never',
       template: '{{#my-component}}\n' + '  test\n' + '{{/my-component}}\n',
+      fixedTemplate: '{{#my-component}}\n' + '  test\n' + '{{/my-component}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`

--- a/test/unit/rules/no-accesskey-attribute-test.js
+++ b/test/unit/rules/no-accesskey-attribute-test.js
@@ -12,6 +12,7 @@ generateRuleTests({
   bad: [
     {
       template: '<button accesskey="n"></button>',
+      fixedTemplate: '<button></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [
@@ -33,6 +34,7 @@ generateRuleTests({
     },
     {
       template: '<button accesskey></button>',
+      fixedTemplate: '<button></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [
@@ -54,6 +56,7 @@ generateRuleTests({
     },
     {
       template: '<button accesskey={{some-key}}></button>',
+      fixedTemplate: '<button></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [
@@ -75,6 +78,7 @@ generateRuleTests({
     },
     {
       template: '<button accesskey="{{some-key}}"></button>',
+      fixedTemplate: '<button></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -181,6 +181,7 @@ const SHARED_BAD = [
   // real world examples
   {
     template: '{{#heading size="1"}}Disallowed heading component{{/heading}}',
+    fixedTemplate: '<Heading @size="1">Disallowed heading component</Heading>',
     results: [
       {
         message: generateError('heading'),


### PR DESCRIPTION
It's best practice to test the autofix output of a test case. Any test case that produces an autofix should assert what the fixed template will look like.

This PR requires that fixable test cases assert the `fixedTemplate`.

ESLint v7 implemented this same feature:
* https://eslint.org/docs/user-guide/migrating-to-7.0.0#additional-validation-added-to-the-ruletester-class
   > It fails test cases if the rule under test provides an autofix but a test case doesn't have an output property. Add an output property to test cases to test the rule's autofix functionality.
* https://github.com/eslint/rfcs/blob/main/designs/2019-rule-tester-improvements/README.md#2-ensuring-to-test-autofix
* There is also a lint rule [eslint-plugin/consistent-output](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/consistent-output.md) designed to help ESLint rule authors remember to assert the autofix output of their test cases.

TODO:

- [x] Add a test.
- [x] Ensure this asserts the correct number of times and the assert is helpful.
- [x] Handle when this uses `verifyResults` too?

Part of v4 release (#1908).

```
  ● no-negated-condition › {{#if (not condition)}}<img>{{/if}}: logs errors

    assert(received)

    Expected value to be equal to:
      true
    Received:
      false
    
    Message:
      fixable test cases must assert the `fixedTemplate`

      382 |         for (const act of actual) {
      383 |           if (act.isFixable) {
    > 384 |             assert(
          |             ^
      385 |               typeof item.fixedTemplate === 'string',
      386 |               'fixable test cases must assert the `fixedTemplate`'
      387 |             );

      at Object.<anonymous> (lib/helpers/rule-test-harness.js:384:13)

Test Suites: 1 failed, 1 total
```