### PR TITLE
When logging a rule violation, require passing the node or all loc properties

### DIFF
--- a/lib/rules/_base.js
+++ b/lib/rules/_base.js
@@ -14,7 +14,6 @@ const MODULE_NAME = Symbol('_moduleName');
 // array so only the first one will log the error, and subsequent rules will
 // see it already in the array and not log it.
 const loggedNodes = [];
-const loggedRules = new Set();
 
 const reLines = /(.*?(?:\r\n?|\n|$))/gm;
 const reWhitespace = /\s+/;
@@ -517,25 +516,21 @@ module.exports = class {
       rule: this.ruleName,
       severity: this.severity,
     };
-    let hasAllLocProps = ['line', 'column', 'endLine', 'endColumn'].every((prop) => prop in result);
+    const REQUIRED_LOC_PROPERTIES = ['line', 'column', 'endLine', 'endColumn'];
+    let hasAllLocProps = REQUIRED_LOC_PROPERTIES.every((prop) => prop in result);
 
     if (this.filePath) {
       defaults.filePath = this.filePath;
     }
 
     if (!result.node && !hasAllLocProps) {
-      if (!loggedRules.has(this.ruleName)) {
-        let message = `ember-template-lint: (${this.ruleName}) Calling the log method without passing all required loc (line, column, endLine, endColumn)
-properties or the node property is deprecated. Please ensure you pass either the loc properties or the node in the log method's result.`;
-
-        if (process.env.EMBER_TEMPLATE_LINT_DEV_MODE === '1') {
-          throw new Error(message);
-        } else {
-          this._console.log(message);
-
-          loggedRules.add(this.ruleName);
-        }
-      }
+      throw new Error(
+        `ember-template-lint: (${
+          this.ruleName
+        }) Must pass the node or all loc properties (${REQUIRED_LOC_PROPERTIES.join(
+          ', '
+        )}) when calling log.`
+      );
     }
 
     // perform the node property expansion only if those properties don't exist in result

--- a/test/jest-setup.js
+++ b/test/jest-setup.js
@@ -1,4 +1,2 @@
 // eslint-disable-next-line import/no-unassigned-import
 require('@microsoft/jest-sarif');
-
-process.env.EMBER_TEMPLATE_LINT_DEV_MODE = '1';


### PR DESCRIPTION
This behavior previously was only enforced when the environment variable `EMBER_TEMPLATE_LINT_DEV_MODE` was set to `1`. Now, that environmental variable is removed, and this behavior is always enforced.

The original functionality here was implemented in:
* https://github.com/ember-template-lint/ember-template-lint/pull/2073
* https://github.com/ember-template-lint/ember-template-lint/issues/2072
* https://github.com/ember-template-lint/ember-template-lint/pull/2167

Part of v4 release (#1908).