### PR TITLE
Add `only` to allowed test case properties

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -42,13 +42,14 @@ const ALLOWED_GENERATE_RULE_TEST_PROPERTIES = new Set([
   'testMethod',
 ]);
 
-const ALLOWED_TEST_CASE_PROPERTIES_GOOD = new Set(['config', 'meta', 'name', 'template']);
+const ALLOWED_TEST_CASE_PROPERTIES_GOOD = new Set(['config', 'meta', 'name', 'only', 'template']);
 
 const ALLOWED_TEST_CASE_PROPERTIES_BAD = new Set([
   'config',
   'fixedTemplate', // Only in bad test cases.
   'meta',
   'name',
+  'only',
   'result',
   'results',
   'template',
@@ -59,6 +60,7 @@ const ALLOWED_TEST_CASE_PROPERTIES_ERROR = new Set([
   'config',
   'meta',
   'name',
+  'only',
   'result',
   'results',
   'template',


### PR DESCRIPTION
Follow-up to #2216.

This should not go in the changelog as it's a bug fix to an unreleased change.