### PR TITLE
Only fixable test cases are allowed to assert `fixedTemplate`

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -379,13 +379,17 @@ module.exports = function generateRuleTests(...args) {
 
         assert(actual.length > 0, '`bad` test cases should always emit at least one failure');
 
-        for (const act of actual) {
-          if (act.isFixable) {
+        for (const violation of actual) {
+          if (violation.isFixable) {
             assert(
               typeof item.fixedTemplate === 'string',
               'fixable test cases must assert the `fixedTemplate`'
             );
           }
+        }
+
+        if (actual.every((violation) => !violation.isFixable)) {
+          assert(!item.fixedTemplate, 'non-fixable test cases should not provide `fixedTemplate`');
         }
 
         if (item.fatal) {

--- a/test/unit/rules/eol-last-test.js
+++ b/test/unit/rules/eol-last-test.js
@@ -149,7 +149,7 @@ generateRuleTests({
     {
       config: 'editorconfig',
       template: 'test',
-      fixedTemplate: 'test', // TODO: bug
+      fixedTemplate: 'test', // TODO: bug https://github.com/ember-template-lint/ember-template-lint/issues/2232
 
       meta: {
         editorConfig: { insert_final_newline: true },
@@ -177,7 +177,7 @@ generateRuleTests({
     {
       config: 'editorconfig',
       template: 'test\n',
-      fixedTemplate: 'test\n', // TODO: bug
+      fixedTemplate: 'test\n', // TODO: bug https://github.com/ember-template-lint/ember-template-lint/issues/2232
 
       meta: {
         editorConfig: { insert_final_newline: false },


### PR DESCRIPTION
Why?

* A test case can be confusing or less clear when it repeats the `template` as the `fixedTemplate`, making it less concise and harder for the reader to determine whether the test case has an autofix.
* A test case with a useless `fixedTemplate` assertion may indicate a bug in the rule.

There's an eslint plugin lint rule [eslint-plugin/prefer-output-null](https://github.com/not-an-aardvark/eslint-plugin-eslint-plugin/blob/master/docs/rules/prefer-output-null.md) that enforces this same requirement.

Part of v4 release (#1908).
