### PR TITLE
Remove unused rule exports

### DIFF
--- a/dev/templates/rule.ejs
+++ b/dev/templates/rule.ejs
@@ -24,4 +24,3 @@ module.exports = class <%- titleCase %> extends Rule {
   }
 };
 
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/deprecated-inline-view-helper.js
+++ b/lib/rules/deprecated-inline-view-helper.js
@@ -155,5 +155,3 @@ module.exports = class DeprecatedInlineViewHelper extends Rule {
     logMessage(this, pair, actual, expected);
   }
 };
-
-module.exports.DEPRECATION_URL = DEPRECATION_URL;

--- a/lib/rules/deprecated-render-helper.js
+++ b/lib/rules/deprecated-render-helper.js
@@ -49,5 +49,3 @@ module.exports = class DeprecatedRenderHelper extends Rule {
     logMessage(this, node, actual, expected);
   }
 };
-
-module.exports.message = message;

--- a/lib/rules/inline-link-to.js
+++ b/lib/rules/inline-link-to.js
@@ -41,5 +41,3 @@ module.exports = class InlineLinkTo extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/lib/rules/modifier-name-case.js
+++ b/lib/rules/modifier-name-case.js
@@ -26,5 +26,3 @@ module.exports = class ModifierNameCase extends Rule {
     };
   }
 };
-
-module.exports.generateErrorMessage = generateErrorMessage;

--- a/lib/rules/no-accesskey-attribute.js
+++ b/lib/rules/no-accesskey-attribute.js
@@ -26,5 +26,3 @@ module.exports = class NoAccesskeyAttribute extends Rule {
     };
   }
 };
-
-module.exports.errorMessage = errorMessage;

--- a/lib/rules/no-action-modifiers.js
+++ b/lib/rules/no-action-modifiers.js
@@ -53,5 +53,3 @@ module.exports = class NoActionModifiers extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-action.js
+++ b/lib/rules/no-action.js
@@ -46,5 +46,3 @@ module.exports = class NoAction extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-arguments-for-html-elements.js
+++ b/lib/rules/no-arguments-for-html-elements.js
@@ -33,5 +33,3 @@ module.exports = class NoArgumentsForHTMLElements extends Rule {
     };
   }
 };
-
-module.exports.makeError = makeError;

--- a/lib/rules/no-aria-hidden-body.js
+++ b/lib/rules/no-aria-hidden-body.js
@@ -27,5 +27,3 @@ module.exports = class NoAriaHiddenBody extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-autofocus-attribute.js
+++ b/lib/rules/no-autofocus-attribute.js
@@ -33,5 +33,3 @@ module.exports = class NoAutofocusAttribute extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-capital-arguments.js
+++ b/lib/rules/no-capital-arguments.js
@@ -48,5 +48,4 @@ module.exports = class NoCapitalArguments extends Rule {
   }
 };
 
-module.exports.ERROR_MESSAGE_CAPITAL = ERROR_MESSAGE_CAPITAL;
 module.exports.ERROR_MESSAGE_RESERVED = ERROR_MESSAGE_RESERVED;

--- a/lib/rules/no-debugger.js
+++ b/lib/rules/no-debugger.js
@@ -26,5 +26,3 @@ module.exports = class NoDebugger extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/lib/rules/no-down-event-binding.js
+++ b/lib/rules/no-down-event-binding.js
@@ -75,5 +75,3 @@ module.exports = class NoDownEventBinding extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-duplicate-id.js
+++ b/lib/rules/no-duplicate-id.js
@@ -248,5 +248,3 @@ module.exports = class NoDuplicateId extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-duplicate-landmark-elements.js
+++ b/lib/rules/no-duplicate-landmark-elements.js
@@ -92,5 +92,3 @@ module.exports = class NoDuplicateLandmarkElements extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-element-event-actions.js
+++ b/lib/rules/no-element-event-actions.js
@@ -35,5 +35,3 @@ function isEventPropertyWithAction(node) {
     node.value.path.original === 'action'
   );
 }
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-empty-headings.js
+++ b/lib/rules/no-empty-headings.js
@@ -86,5 +86,3 @@ module.exports = class NoEmptyHeadings extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-extra-mut-helper-argument.js
+++ b/lib/rules/no-extra-mut-helper-argument.js
@@ -26,5 +26,3 @@ module.exports = class NoExtraMutHelperArgument extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-forbidden-elements.js
+++ b/lib/rules/no-forbidden-elements.js
@@ -105,5 +105,3 @@ module.exports = class NoForbiddenElements extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE_FORBIDDEN_ELEMENTS = ERROR_MESSAGE_FORBIDDEN_ELEMENTS;

--- a/lib/rules/no-heading-inside-button.js
+++ b/lib/rules/no-heading-inside-button.js
@@ -55,5 +55,3 @@ module.exports = class NoHeadingInsideButton extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-implicit-this.js
+++ b/lib/rules/no-implicit-this.js
@@ -151,4 +151,3 @@ module.exports = class NoImplicitThis extends Rule {
 };
 
 module.exports.ARGLESS_BUILTIN_HELPERS = ARGLESS_BUILTIN_HELPERS;
-module.exports.message = message;

--- a/lib/rules/no-input-block.js
+++ b/lib/rules/no-input-block.js
@@ -22,5 +22,3 @@ module.exports = class NoInputBlock extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/lib/rules/no-input-tagname.js
+++ b/lib/rules/no-input-tagname.js
@@ -53,5 +53,3 @@ module.exports = class NoInputTagname extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/lib/rules/no-invalid-role.js
+++ b/lib/rules/no-invalid-role.js
@@ -257,7 +257,3 @@ module.exports = class NoInvalidRole extends Rule {
     };
   }
 };
-
-module.exports.createErrorMessageDisallowedRoleForElement =
-  createErrorMessageDisallowedRoleForElement;
-module.exports.createNonexistentRoleErrorMessage = createNonexistentRoleErrorMessage;

--- a/lib/rules/no-link-to-tagname.js
+++ b/lib/rules/no-link-to-tagname.js
@@ -51,5 +51,3 @@ module.exports = class NoLinkToTagname extends Rule {
     }
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-log.js
+++ b/lib/rules/no-log.js
@@ -26,5 +26,3 @@ module.exports = class NoLog extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-model-argument-in-route-templates.js
+++ b/lib/rules/no-model-argument-in-route-templates.js
@@ -41,5 +41,3 @@ module.exports = class NoModelArgumentInRouteTemplates extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-mut-helper.js
+++ b/lib/rules/no-mut-helper.js
@@ -59,6 +59,3 @@ module.exports = class NoMutHelper extends Rule {
     }
   }
 };
-
-module.exports.message = message;
-module.exports.generateMessageWithAlternative = generateMessageWithAlternative;

--- a/lib/rules/no-negated-condition.js
+++ b/lib/rules/no-negated-condition.js
@@ -98,7 +98,3 @@ module.exports = class NoNegatedCondition extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE_FLIP_IF = ERROR_MESSAGE_FLIP_IF;
-module.exports.ERROR_MESSAGE_USE_IF = ERROR_MESSAGE_USE_IF;
-module.exports.ERROR_MESSAGE_USE_UNLESS = ERROR_MESSAGE_USE_UNLESS;

--- a/lib/rules/no-nested-landmark.js
+++ b/lib/rules/no-nested-landmark.js
@@ -80,5 +80,3 @@ module.exports = class NoNestedLandmark extends Rule {
     return LANDMARK_ELEMENTS.has(node.tag) || ROLES.has(roleValue);
   }
 };
-
-module.exports.createErrorMessage = createErrorMessage;

--- a/lib/rules/no-nested-splattributes.js
+++ b/lib/rules/no-nested-splattributes.js
@@ -32,5 +32,3 @@ module.exports = class NoNestedSplattributes extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-partial.js
+++ b/lib/rules/no-partial.js
@@ -22,5 +22,3 @@ module.exports = class NoPartial extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/lib/rules/no-passed-in-event-handlers.js
+++ b/lib/rules/no-passed-in-event-handlers.js
@@ -140,5 +140,3 @@ module.exports = class NoPassedInEventHandlers extends Rule {
 function makeErrorMessage(eventHandler) {
   return `Event handler methods like \`${eventHandler}\` should not be passed in as a component arguments`;
 }
-
-module.exports.makeErrorMessage = makeErrorMessage;

--- a/lib/rules/no-redundant-fn.js
+++ b/lib/rules/no-redundant-fn.js
@@ -48,5 +48,3 @@ module.exports = class NoRedundantFn extends Rule {
     }
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-redundant-landmark-role.js
+++ b/lib/rules/no-redundant-landmark-role.js
@@ -82,5 +82,3 @@ module.exports = class NoRedundantLandmarkRole extends Rule {
     };
   }
 };
-
-module.exports.createErrorMessage = createErrorMessage;

--- a/lib/rules/no-route-action.js
+++ b/lib/rules/no-route-action.js
@@ -36,5 +36,3 @@ module.exports = class NoRouteAction extends Rule {
     });
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -118,5 +118,3 @@ module.exports = class NoThisInTemplateOnlyComponents extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/lib/rules/no-unbalanced-curlies.js
+++ b/lib/rules/no-unbalanced-curlies.js
@@ -61,5 +61,3 @@ module.exports = class NoUnbalancedCurlies extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-unbound.js
+++ b/lib/rules/no-unbound.js
@@ -30,5 +30,3 @@ module.exports = class NoUnbound extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/lib/rules/no-unknown-arguments-for-builtin-components.js
+++ b/lib/rules/no-unknown-arguments-for-builtin-components.js
@@ -450,7 +450,3 @@ module.exports = class NoUnknownArgumentsForBuiltinComponents extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;
-module.exports.CONFLICT_MESSAGE = CONFLICT_MESSAGE;
-module.exports.REQUIRED_MESSAGE = REQUIRED_MESSAGE;

--- a/lib/rules/no-unnecessary-component-helper.js
+++ b/lib/rules/no-unnecessary-component-helper.js
@@ -45,5 +45,3 @@ module.exports = class NoUnnecessaryComponentHelper extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-valueless-arguments.js
+++ b/lib/rules/no-valueless-arguments.js
@@ -24,5 +24,3 @@ module.exports = class NoValuelessArguments extends Rule {
 function isNamedArgument(attrName) {
   return attrName.startsWith('@');
 }
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-whitespace-for-layout.js
+++ b/lib/rules/no-whitespace-for-layout.js
@@ -29,5 +29,3 @@ module.exports = class NoWhitespaceForLayout extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-whitespace-within-word.js
+++ b/lib/rules/no-whitespace-within-word.js
@@ -147,5 +147,3 @@ module.exports = class NoWhitespaceWithinWord extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-with.js
+++ b/lib/rules/no-with.js
@@ -19,5 +19,3 @@ module.exports = class NoWith extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-yield-only.js
+++ b/lib/rules/no-yield-only.js
@@ -20,5 +20,3 @@ module.exports = class NoYieldOnly extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/no-yield-to-default.js
+++ b/lib/rules/no-yield-to-default.js
@@ -54,5 +54,3 @@ module.exports = class NoYieldToDefault extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/require-button-type.js
+++ b/lib/rules/require-button-type.js
@@ -68,5 +68,3 @@ module.exports = class RequireButtonType extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/require-context-role.js
+++ b/lib/rules/require-context-role.js
@@ -98,5 +98,3 @@ module.exports = class RequireContextRole extends Rule {
     };
   }
 };
-
-module.exports.errorMessage = errorMessage;

--- a/lib/rules/require-each-key.js
+++ b/lib/rules/require-each-key.js
@@ -28,5 +28,3 @@ module.exports = class RequireEachKey extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/require-form-method.js
+++ b/lib/rules/require-form-method.js
@@ -97,5 +97,3 @@ module.exports = class RequireFormMethod extends Rule {
 function makeErrorMessage(methods) {
   return `All \`<form>\` elements should have \`method\` attribute with value of \`${methods}\``;
 }
-
-module.exports.makeErrorMessage = makeErrorMessage;

--- a/lib/rules/require-has-block-helper.js
+++ b/lib/rules/require-has-block-helper.js
@@ -47,5 +47,3 @@ module.exports = class RequireHasBlockHelper extends Rule {
     };
   }
 };
-
-module.exports.getErrorMessage = getErrorMessage;

--- a/lib/rules/require-input-label.js
+++ b/lib/rules/require-input-label.js
@@ -150,6 +150,3 @@ module.exports = class RequireInputLabel extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE_NO_LABEL;
-module.exports.ERROR_MESSAGE_MULTIPLE_LABEL = ERROR_MESSAGE_MULTIPLE_LABEL;

--- a/lib/rules/require-lang-attribute.js
+++ b/lib/rules/require-lang-attribute.js
@@ -36,5 +36,3 @@ module.exports = class RequireLangAttribute extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -109,5 +109,3 @@ module.exports = class RequirePresentationalChildren extends Rule {
     };
   }
 };
-
-module.exports.createErrorMessage = createErrorMessage;

--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -218,5 +218,3 @@ module.exports = class RequireValidAltText extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/require-valid-named-block-naming-format.js
+++ b/lib/rules/require-valid-named-block-naming-format.js
@@ -109,4 +109,3 @@ function createErrorMessage(format, from, to) {
 }
 
 module.exports.FORMAT = FORMAT;
-module.exports.createErrorMessage = createErrorMessage;

--- a/lib/rules/simple-unless.js
+++ b/lib/rules/simple-unless.js
@@ -188,5 +188,3 @@ module.exports = class SimpleUnless extends Rule {
     });
   }
 };
-
-module.exports.messages = messages;

--- a/lib/rules/splat-attributes-only.js
+++ b/lib/rules/splat-attributes-only.js
@@ -18,5 +18,3 @@ module.exports = class SplatAttributesOnly extends Rule {
     };
   }
 };
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/style-concatenation.js
+++ b/lib/rules/style-concatenation.js
@@ -28,5 +28,3 @@ module.exports = class StyleConcatenation extends Rule {
 function isConcatHelper(node) {
   return node && node.type === 'PathExpression' && node.original === 'concat';
 }
-
-module.exports.ERROR_MESSAGE = ERROR_MESSAGE;

--- a/lib/rules/table-groups.js
+++ b/lib/rules/table-groups.js
@@ -183,6 +183,4 @@ module.exports = class TableGroups extends Rule {
   }
 };
 
-module.exports.message = message;
-module.exports.orderingMessage = orderingMessage;
 module.exports.createTableGroupsErrorMessage = createTableGroupsErrorMessage;

--- a/test/fixtures/with-inline-plugins/rules/lint-inline-component.js
+++ b/test/fixtures/with-inline-plugins/rules/lint-inline-component.js
@@ -18,5 +18,3 @@ module.exports = class InlineComponent extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/test/fixtures/with-multiple-extends/plugins/lint-inline-component.js
+++ b/test/fixtures/with-multiple-extends/plugins/lint-inline-component.js
@@ -18,5 +18,3 @@ module.exports = class InlineComponent extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/test/fixtures/with-plugin-with-configurations/plugins/lint-inline-component.js
+++ b/test/fixtures/with-plugin-with-configurations/plugins/lint-inline-component.js
@@ -18,5 +18,3 @@ module.exports = class InlineComponent extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/test/fixtures/with-plugins-overwriting/plugins/lint-inline-component.js
+++ b/test/fixtures/with-plugins-overwriting/plugins/lint-inline-component.js
@@ -18,5 +18,3 @@ module.exports = class InlineComponent extends Rule {
     };
   }
 };
-
-module.exports.message = message;

--- a/test/fixtures/with-plugins/plugins/lint-inline-component.js
+++ b/test/fixtures/with-plugins/plugins/lint-inline-component.js
@@ -18,5 +18,3 @@ module.exports = class InlineComponent extends Rule {
     };
   }
 };
-
-module.exports.message = message;


### PR DESCRIPTION
Most of these are no longer needed after https://github.com/ember-template-lint/ember-template-lint/pull/2150.