### PR TITLE
Disallow unexpected properties at top-level of configuration file

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -130,29 +130,11 @@ function ensureRootProperties(config, source) {
   config.extends = source.extends;
 }
 
-function migrateRulesFromRoot(config, source, options) {
-  let logger = options.console || console;
-
-  let invalidKeysFound = [];
+function validateRootProperties(source) {
   for (let key in source) {
     if (!KNOWN_ROOT_PROPERTIES.has(key)) {
-      invalidKeysFound.push(key);
-
-      config.rules[key] = source[key];
+      throw new Error(`Unknown top-level configuration property detected: ${key}`);
     }
-  }
-
-  if (invalidKeysFound.length > 0) {
-    logger.log(
-      chalk.yellow(
-        `
-        Rule configuration has been moved into a \`rules\` property.
-        Please update your \`${CONFIG_FILE_NAME}\` file.
-        The following rules have been migrated to the \`rules\`
-        property: ${invalidKeysFound}.
-        `
-      )
-    );
   }
 }
 
@@ -441,7 +423,7 @@ function getProjectConfig(workingDir, options) {
     config = {};
 
     ensureRootProperties(config, source);
-    migrateRulesFromRoot(config, source, options);
+    validateRootProperties(source);
 
     config.plugins = processPlugins(workingDir, source.plugins, options);
     config.loadedRules = processLoadedRules(workingDir, config, options);

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -194,28 +194,16 @@ describe('get-config', function () {
     expect(actual.rules['block-indentation']).not.toEqual(expected.rules['block-indentation']);
   });
 
-  it('migrates rules in the config root into `rules` property', function () {
-    let actual = getProjectConfig(project.baseDir, {
-      console: buildFakeConsole(),
-      config: {
-        'no-bare-strings': false,
-      },
-    });
-
-    expect(actual.rules['no-bare-strings']).toEqual({ config: false, severity: 0 });
-  });
-
-  it('rules in the config root trigger a deprecation', function () {
-    let console = buildFakeConsole();
-
-    getProjectConfig(project.baseDir, {
-      console,
-      config: {
-        'no-bare-strings': true,
-      },
-    });
-
-    expect(console.stdout).toMatch(/Rule configuration has been moved/);
+  it('throws when specifying unknown properties in the config root', function () {
+    expect(() =>
+      getProjectConfig(project.baseDir, {
+        config: {
+          foo: false,
+        },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Unknown top-level configuration property detected: foo"`
+    );
   });
 
   it('warns for unknown rules', function () {


### PR DESCRIPTION
This has the effect of dropping support for specifying individual rules in top-level of configuration (which has long been deprecated). Previously, we would migrate unknown properties found in the top-level of the configuration file to the `rules` object, on the assumption that they were rules. Now, we immediately throw an exception.

Part of v4 release (#1908).

ESLint also has this same behavior: https://eslint.org/docs/user-guide/migrating-to-4.0.0#config-validation