### PR TITLE
Disallow extending an invalid configuration

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -106,9 +106,7 @@ function forEachPluginConfiguration(plugins, callback) {
   }
 }
 
-function normalizeExtends(config, options) {
-  let logger = options.console || console;
-
+function normalizeExtends(config) {
   let extendedList = [];
   if (config.extends) {
     if (typeof config.extends === 'string') {
@@ -116,7 +114,7 @@ function normalizeExtends(config, options) {
     } else if (Array.isArray(config.extends)) {
       extendedList = [...config.extends];
     } else {
-      logger.log(chalk.yellow('config.extends should be string or array '));
+      throw new TypeError('config.extends should be string or array');
     }
   }
   return extendedList;
@@ -234,10 +232,8 @@ function processLoadedConfigurations(workingDir, config, options) {
   return loadedConfigurations;
 }
 
-function processExtends(config, options) {
-  let logger = options.console || console;
-
-  let extendedList = normalizeExtends(config, options);
+function processExtends(config) {
+  let extendedList = normalizeExtends(config);
   let extendedRules = {};
 
   if (extendedList) {
@@ -249,18 +245,18 @@ function processExtends(config, options) {
           configuration.loadedConfigurations = config.loadedConfigurations;
 
           // continue chaining `extends` from plugins until done
-          processExtends(configuration, options);
+          processExtends(configuration);
 
           delete configuration.loadedConfigurations;
 
           if (configuration.rules) {
             extendedRules = Object.assign({}, extendedRules, configuration.rules);
           } else {
-            logger.log(chalk.yellow(`Missing rules for extends: ${extendName}`));
+            throw new Error(`Missing rules for extends: ${extendName}`);
           }
         }
       } else {
-        logger.log(chalk.yellow(`Cannot find configuration for extends: ${extendName}`));
+        throw new Error(`Cannot find configuration for extends: ${extendName}`);
       }
 
       delete config.extends;
@@ -428,7 +424,7 @@ function getProjectConfig(workingDir, options) {
     config.plugins = processPlugins(workingDir, source.plugins, options);
     config.loadedRules = processLoadedRules(workingDir, config, options);
     config.loadedConfigurations = processLoadedConfigurations(workingDir, config, options);
-    processExtends(config, options);
+    processExtends(config);
     processIgnores(config);
 
     validateRules(config.rules, config.loadedRules, options);

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -206,6 +206,16 @@ describe('get-config', function () {
     );
   });
 
+  it('throws when providing wrong type for config.extends', function () {
+    expect(() =>
+      getProjectConfig(project.baseDir, {
+        config: {
+          extends: 123,
+        },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(`"config.extends should be string or array"`);
+  });
+
   it('warns for unknown rules', function () {
     let console = buildFakeConsole();
 
@@ -221,17 +231,16 @@ describe('get-config', function () {
     expect(console.stdout).toMatch(/Invalid rule configuration found/);
   });
 
-  it('warns for unknown extends', function () {
-    let console = buildFakeConsole();
-
-    getProjectConfig(project.baseDir, {
-      console,
-      config: {
-        extends: ['recommended', 'plugin1:wrong-extend'],
-      },
-    });
-
-    expect(console.stdout).toMatch(/Cannot find configuration for extends/);
+  it('throws for unknown extends', function () {
+    expect(() =>
+      getProjectConfig(project.baseDir, {
+        config: {
+          extends: ['recommended', 'plugin1:wrong-extend'],
+        },
+      })
+    ).toThrowErrorMatchingInlineSnapshot(
+      `"Cannot find configuration for extends: plugin1:wrong-extend"`
+    );
   });
 
   it('resolves plugins by string', function () {


### PR DESCRIPTION
Previously it was just a warning. 

Part of v4 release (#1908).

