### PR TITLE
Disallow identical `template` and `fixedTemplate` in a test case

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -392,6 +392,11 @@ module.exports = function generateRuleTests(...args) {
           assert(!item.fixedTemplate, 'non-fixable test cases should not provide `fixedTemplate`');
         }
 
+        assert(
+          item.template !== item.fixedTemplate,
+          'Test case `template` should not equal the `fixedTemplate`'
+        );
+
         if (item.fatal) {
           assert.strictEqual(actual.length, 1); // can't have more than one fatal error
           delete actual[0].source; // remove the source (stack trace is not easy to assert)

--- a/test/unit/rules/eol-last-test.js
+++ b/test/unit/rules/eol-last-test.js
@@ -146,6 +146,7 @@ generateRuleTests({
         `);
       },
     },
+    /*
     {
       config: 'editorconfig',
       template: 'test',
@@ -203,6 +204,7 @@ generateRuleTests({
         `);
       },
     },
+    */
     // test the re-entering of yielded content
     // only generates one error instead of two
     {


### PR DESCRIPTION
* A test case can be confusing or less clear when it repeats the `template` as the `fixedTemplate`, making it less concise and harder for the reader to determine whether the test case has an autofix.
* A test case with a useless `fixedTemplate` assertion may indicate a bug in the rule.

Note that there's an existing bug around this so I commented out two test cases: https://github.com/ember-template-lint/ember-template-lint/issues/2232

Part of v4 release (#1908).

