### PR TITLE
Change `no-bare-strings` rule options to augment instead of replace the default config 

### DIFF
--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -22,32 +22,17 @@ This rule **allows** the following:
  The following values are valid configuration:
 
 * boolean -- `true` for enabled / `false` for disabled
-* array -- an array of allowlisted strings
+* array -- an array of allowlisted strings (extends the default config)
 * object -- An object with the following keys:
-  * `allowlist` -- An array of allowlisted strings
-  * `globalAttributes` -- An array of attributes to check on every element.
-  * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
+  * `allowlist` -- An array of allowlisted strings (extends the default config)
+  * `globalAttributes` -- An array of attributes to check on every element (extends the default config)
+  * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name (extends the default config)
 
-When the config value of `true` is used the following configuration is used:
+When the config value of `true` is provided, the following default configuration is used:
 
 * `allowlist` - refer to the `DEFAULT_CONFIG.allowlist` property in the [rule](../lib/rules/no-bare-strings.js)
 * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
 * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
-
-The `DEFAULT_CONFIG` is available as an export. Example use in configuration:
-
-```javascript
-const {
-  DEFAULT_CONFIG
-} = require('ember-template-lint/lib/rules/no-bare-strings');
-const additionalCharsToIgnore = ['a', 'b', 'c'];
-
-module.exports = {
-  rules: {
-    'no-bare-strings': [...DEFAULT_CONFIG.allowlist, ...additionalCharsToIgnore]
-  }
-};
-```
 
 ## References
 

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -1,32 +1,10 @@
 'use strict';
 
-/*
- Disallows the use of bare strings in a template
-
- ```
- {{!-- good  --}}
- <div>{{evaluatesToAString}}</div>
- <div>{{'A string'}}</div>
-
- {{!-- bad --}}
- <div>A bare string</div>
- ```
-
- The following values are valid configuration:
-
-   * boolean -- `true` for enabled / `false` for disabled
-   * array -- an array of allowlisted strings
-   * object -- An object with the following keys:
-     * `allowlist` -- An array of allowlisted strings
-     * `globalAttributes` -- An array of attributes to check on every element.
-     * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name.
- */
-
 const createErrorMessage = require('../helpers/create-error-message');
 const { match } = require('../helpers/node-matcher');
 const Rule = require('./_base');
 
-const GLOBAL_ATTRIBUTES = [
+const DEFAULT_GLOBAL_ATTRIBUTES = [
   'title',
   'aria-label',
   'aria-placeholder',
@@ -34,7 +12,7 @@ const GLOBAL_ATTRIBUTES = [
   'aria-valuetext',
 ];
 
-const TAG_ATTRIBUTES = {
+const DEFAULT_ELEMENT_ATTRIBUTES = {
   input: ['placeholder'],
   Input: ['placeholder', '@placeholder'],
   Textarea: ['placeholder', '@placeholder'],
@@ -113,8 +91,8 @@ const IGNORED_ELEMENTS = new Set(['pre', 'script', 'style', 'template', 'textare
 // Character entity reference chart: https://dev.w3.org/html5/html-author/charref
 const DEFAULT_CONFIG = {
   allowlist: DEFAULT_ALLOWLIST,
-  globalAttributes: GLOBAL_ATTRIBUTES,
-  elementAttributes: TAG_ATTRIBUTES,
+  globalAttributes: DEFAULT_GLOBAL_ATTRIBUTES,
+  elementAttributes: DEFAULT_ELEMENT_ATTRIBUTES,
 };
 
 function isPageTitleHelper(node) {
@@ -147,6 +125,23 @@ function sanitizeConfigArray(allowlist = []) {
   return allowlist.filter((option) => option !== '').sort((a, b) => b.length - a.length);
 }
 
+/**
+ * Example:
+ * obj1 = { img: ['data-alt'] } }
+ * obj2 = { img: ['alt'] } }
+ * result = { img: ['data-alt', 'alt'] } }
+ */
+function mergeObjects(obj1 = {}, obj2 = {}) {
+  const result = {};
+  for (const [key, value] of Object.entries(obj1)) {
+    result[key] = [...(result[key] || []), ...value];
+  }
+  for (const [key, value] of Object.entries(obj2)) {
+    result[key] = [...(result[key] || []), ...value];
+  }
+  return result;
+}
+
 module.exports = class NoBareStrings extends Rule {
   constructor(options) {
     super(options);
@@ -166,17 +161,15 @@ module.exports = class NoBareStrings extends Rule {
       case 'object':
         if (Array.isArray(config)) {
           return {
-            allowlist: sanitizeConfigArray(config),
-            globalAttributes: GLOBAL_ATTRIBUTES,
-            elementAttributes: TAG_ATTRIBUTES,
+            allowlist: [...sanitizeConfigArray(config), ...DEFAULT_ALLOWLIST],
+            globalAttributes: DEFAULT_GLOBAL_ATTRIBUTES,
+            elementAttributes: DEFAULT_ELEMENT_ATTRIBUTES,
           };
         } else if (isValidConfigObjectFormat(config)) {
-          // default any missing keys to empty values
-          let { allowlist = [] } = config;
           return {
-            allowlist: sanitizeConfigArray(allowlist),
-            globalAttributes: config.globalAttributes || [],
-            elementAttributes: config.elementAttributes || {},
+            allowlist: [...sanitizeConfigArray(config.allowlist), ...DEFAULT_ALLOWLIST],
+            globalAttributes: [...(config.globalAttributes || []), ...DEFAULT_GLOBAL_ATTRIBUTES],
+            elementAttributes: mergeObjects(config.elementAttributes, DEFAULT_ELEMENT_ATTRIBUTES),
           };
         }
         break;
@@ -188,11 +181,11 @@ module.exports = class NoBareStrings extends Rule {
       this.ruleName,
       [
         '  * boolean - `true` to enable / `false` to disable',
-        '  * array -- an array of allowlisted strings',
+        '  * array -- an array of allowlisted strings (extends the default config)',
         '  * object -- An object with the following keys:',
-        '    * `allowlist` -- An array of allowlisted strings',
-        '    * `globalAttributes` -- An array of attributes to check on every element',
-        '    * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name',
+        '    * `allowlist` -- An array of allowlisted strings (extends the default config)',
+        '    * `globalAttributes` -- An array of attributes to check on every element (extends the default config)',
+        '    * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name (extends the default config)',
       ],
       config
     );
@@ -319,5 +312,3 @@ module.exports = class NoBareStrings extends Rule {
     }
   }
 };
-
-module.exports.DEFAULT_CONFIG = DEFAULT_CONFIG;


### PR DESCRIPTION
This makes it easier to use the rule and eliminates the need to manually import the default config from the rule (which is no longer allowed as of https://github.com/ember-template-lint/ember-template-lint/pull/2208).

Most of this was inspired by the work @dcyriller did in https://github.com/ember-template-lint/ember-template-lint/pull/2213. I made a few additional improvements.