### PR TITLE
Require `message` when logging rule violation

### DIFF
--- a/lib/rules/_base.js
+++ b/lib/rules/_base.js
@@ -523,6 +523,12 @@ module.exports = class {
       defaults.filePath = this.filePath;
     }
 
+    if (!result.message) {
+      throw new Error(
+        `ember-template-lint: (${this.ruleName}): must provide violation \`message\` when calling log.`
+      );
+    }
+
     if (!result.node && !hasAllLocProps) {
       throw new Error(
         `ember-template-lint: (${

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -177,6 +177,20 @@ describe('base plugin', function () {
       );
     });
 
+    it('throws when logging without violation message', function () {
+      class AwesomeRule extends Rule {
+        visitor() {
+          this.log({ node: {} });
+        }
+      }
+
+      expect(
+        async () => await runRules('foo', [plugin(AwesomeRule, 'awesome-rule', true)])
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"ember-template-lint: (awesome-rule): must provide violation \`message\` when calling log."`
+      );
+    });
+
     it('does not error when accessing editorConfig when no filePath is passed', async function () {
       class AwesomeRule extends Rule {
         visitor() {


### PR DESCRIPTION
Previously, rules were allowed to log violations without a violation `message`. Now, the `message` is required.

ESLint has the same behavior: https://eslint.org/docs/user-guide/migrating-to-5.0.0#rules-are-now-required-to-provide-messages-along-with-reports

> Rules are now required to provide messages along with reports
>
>Previously, it was possible for rules to report AST nodes without providing a report message. This was not intended behavior, and as a result the default formatter would crash if a rule omitted a message. However, it was possible to avoid a crash when using a non-default formatter, such as json.
>
>In ESLint v5, reporting a problem without providing a message always results in an error.
>
>To address: If you have written a custom rule that reports a problem without providing a message, update it to provide a message along with the report.

Part of v4 release (#1908).

