### PR TITLE
Run all CI jobs simultaneously

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,6 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 10
 
-    needs: [test]
-
     strategy:
       matrix:
         os: [ubuntu, windows]
@@ -63,7 +61,6 @@ jobs:
     name: Floating Dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [test]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
We have CI jobs for different versions of Node and floating dependencies.

Previously, these jobs would all wait on the Node 16 job to complete before running. That would unnecessarily slow down CI as we would have to wait twice as long vs. just letting all the jobs run at the same time without waiting for each other.

And since jobs will [fail-fast](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast) by default, this isn't too wasteful.

https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idneeds