### PR TITLE
Exit with error when specifying non-existent file on CLI

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -86,7 +86,12 @@ function expandFileGlobs(workingDir, filePatterns, ignorePattern, glob = execute
       continue;
     }
 
-    for (const filePath of glob(workingDir, pattern, ignorePattern)) {
+    const globResults = glob(workingDir, pattern, ignorePattern);
+    if (!globResults || globResults.length === 0) {
+      throw new Error(`No files matching the pattern were found: "${pattern}"`);
+    }
+
+    for (const filePath of globResults) {
       result.add(filePath);
     }
   }
@@ -316,7 +321,14 @@ async function run() {
     return;
   }
 
-  let filePaths = getFilesToLint(options.workingDirectory, positional, options.ignorePattern);
+  let filePaths;
+  try {
+    filePaths = getFilesToLint(options.workingDirectory, positional, options.ignorePattern);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+    return;
+  }
 
   if (options.printConfig) {
     if (filePaths.size > 1) {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -146,7 +146,7 @@ describe('ember-template-lint executable', function () {
 
   describe('reading files', function () {
     describe('given path to non-existing file', function () {
-      it('should exit without error and any console output', async function () {
+      it('should exit with error', async function () {
         project.setConfig({
           rules: {
             'no-bare-strings': true,
@@ -165,9 +165,11 @@ describe('ember-template-lint executable', function () {
 
         let result = await run(['app/templates/application-1.hbs']);
 
-        expect(result.exitCode).toEqual(0, 'exits without error');
+        expect(result.exitCode).toEqual(1, 'exits with error');
         expect(result.stdout).toBeFalsy();
-        expect(result.stderr).toBeFalsy();
+        expect(result.stderr).toEqual(
+          'No files matching the pattern were found: "app/templates/application-1.hbs"'
+        );
       });
     });
 
@@ -833,6 +835,7 @@ describe('ember-template-lint executable', function () {
               'application.hbs':
                 '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
             },
+            'other.hbs': '<div></div>',
           },
         });
 
@@ -860,6 +863,7 @@ describe('ember-template-lint executable', function () {
               'application.hbs':
                 '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
             },
+            'other.hbs': '<div></div>',
           },
         });
 
@@ -874,6 +878,27 @@ describe('ember-template-lint executable', function () {
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toEqual('');
         expect(result.stderr).toBeFalsy();
+      });
+
+      it('should fail when no files match because of ignore pattern', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        project.write({
+          app: {
+            foo: {
+              'application.hbs': 'Bare strings are bad',
+            },
+          },
+        });
+
+        let result = await run(['app/**/*', '--ignore-pattern', '**/foo/**']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toEqual('');
+        expect(result.stderr).toEqual('No files matching the pattern were found: "app/**/*"');
       });
 
       it('should allow to disable dirs ignored by default', async function () {
@@ -1461,7 +1486,13 @@ describe('ember-template-lint executable', function () {
             'no-html-comments': true,
           },
         });
-        project.writeSync();
+        project.write({
+          app: {
+            templates: {
+              'application.hbs': '<div></div>',
+            },
+          },
+        });
 
         let result = await run(['.', '--format', 'sarif', '--output-file', 'my-results.sarif'], {
           env: {

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -18,7 +18,7 @@ describe('expandFileGlobs', function () {
     it('resolves a basic pattern (different working directory)', function () {
       project.write({ 'application.hbs': 'almost empty' });
 
-      let files = expandFileGlobs(project.baseDir, ['application.hbs', 'other.hbs'], []);
+      let files = expandFileGlobs(project.baseDir, ['application.hbs'], []);
       expect(files).toEqual(new Set(['application.hbs']));
     });
 
@@ -36,21 +36,21 @@ describe('expandFileGlobs', function () {
     });
 
     it('respects a basic ignore option (different working directory)', function () {
-      project.write({ 'application.hbs': 'almost empty' });
+      project.write({ 'application.hbs': 'almost empty', 'other.hbs': 'other' });
 
       let files = expandFileGlobs(
         project.baseDir,
         ['application.hbs', 'other.hbs'],
         ['application.hbs']
       );
-      expect(files).toEqual(new Set([]));
+      expect(files).toEqual(new Set(['other.hbs']));
     });
 
     it('resolves a basic pattern (within working directory)', function () {
       project.chdir();
       project.write({ 'application.hbs': 'almost empty' });
 
-      let files = expandFileGlobs(project.baseDir, ['application.hbs', 'other.hbs'], []);
+      let files = expandFileGlobs(project.baseDir, ['application.hbs'], []);
       expect(files).toEqual(new Set(['application.hbs']));
     });
 
@@ -71,12 +71,19 @@ describe('expandFileGlobs', function () {
       project.chdir();
       project.write({ 'application.hbs': 'almost empty' });
 
-      let files = expandFileGlobs(
-        project.baseDir,
-        ['application.hbs', 'other.hbs'],
-        ['application.hbs']
-      );
+      let files = expandFileGlobs(project.baseDir, ['application.hbs'], ['application.hbs']);
       expect(files).toEqual(new Set([]));
+    });
+
+    it('throws when provided non-existent file', function () {
+      project.chdir();
+      project.write({ 'application.hbs': 'almost empty' });
+
+      expect(() =>
+        expandFileGlobs(project.baseDir, ['other.hbs'], [])
+      ).toThrowErrorMatchingInlineSnapshot(
+        `"No files matching the pattern were found: \\"other.hbs\\""`
+      );
     });
   });
 
@@ -109,6 +116,14 @@ describe('expandFileGlobs', function () {
 
       let files = expandFileGlobs(project.baseDir, ['application.hbs'], ['*']);
       expect(files.has('application.hbs')).toBe(false);
+    });
+
+    it('throws when no matches found because of ignore option', function () {
+      project.write({ 'application.hbs': 'almost empty' });
+
+      expect(() =>
+        expandFileGlobs(project.baseDir, ['*'], ['application.hbs'])
+      ).toThrowErrorMatchingInlineSnapshot(`"No files matching the pattern were found: \\"*\\""`);
     });
   });
 });


### PR DESCRIPTION
If we find no matching files to lint, we will now exit with error, instead of silently existing with success:

```
yarn ember-template-lint foo.hbs
No files matching the pattern were found: "foo.hbs"
error Command failed with exit code 1.
```

This is the same behavior [from ESLint](https://eslint.org/docs/user-guide/migrating-to-5.0.0#linting-nonexistent-files-from-the-command-line-is-now-a-fatal-error):

> Previous versions of ESLint silently ignored any nonexistent files and globs provided on the command line:
>
>$ eslint nonexistent-file.js 'nonexistent-folder/**/*.js' # exits without any errors in ESLint v4
>Many users found this behavior confusing, because if they made a typo in a filename, ESLint would appear to lint that file successfully while actually not linting anything.
>
>ESLint v5 will report a fatal error when either of the following conditions is met:
>
>A file provided on the command line does not exist
>A glob or folder provided on the command line does not match any lintable files
>
>To address: If you encounter an error about missing files after upgrading to ESLint v5, you may want to double-check that there are no typos in the paths you provide to ESLint. To make the error go away, you can simply remove the given files or globs from the list of arguments provided to ESLint on the command line.
>
>If you use a boilerplate generator that relies on this behavior (e.g. to generate a script that runs eslint tests/ in a new project before any test files are actually present), you can work around this issue by adding a dummy file that matches the given pattern (e.g. an empty tests/index.js file).


Note that there's one difference between our behavior and ESLint which is that we exit with failure even if the reason no files matched is because they were ignored by `--ignore-pattern`.

Part of v4 release (#1908).