### PR TITLE
Update reference links for `no-autofocus-attribute` rule

### DIFF
--- a/docs/rule/no-autofocus-attribute.md
+++ b/docs/rule/no-autofocus-attribute.md
@@ -22,6 +22,5 @@ This rule **forbids** the following:
 
 ## References
 
-- [MDN Web](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)
 - [Focus Order: Understanding SC 2.4.3](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-order.html)
-- [The Accessibility of HTML 5 Autofocus](https://brucelawson.co.uk/2009/the-accessibility-of-html-5-autofocus/)
+- [MDN Web](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/autofocus)


### PR DESCRIPTION
Re-ordered the references (WCAG reference should go first) and removed non-spec link (consistent with already implemented a11y-related rules).