### PR TITLE
Remove misleading awaits in tests

### DIFF
--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -20,9 +20,9 @@ describe('ember-template-lint executable', function () {
     project.chdir();
   });
 
-  afterEach(async function () {
+  afterEach(function () {
     process.chdir(ROOT);
-    await project.dispose();
+    project.dispose();
   });
 
   describe('basic usage', function () {

--- a/test/acceptance/editors-integration-test.js
+++ b/test/acceptance/editors-integration-test.js
@@ -29,8 +29,8 @@ describe('editors integration', function () {
     project.chdir();
   });
 
-  afterEach(async function () {
-    await project.dispose();
+  afterEach(function () {
+    project.dispose();
   });
 
   describe('reading from stdin', function () {

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -22,8 +22,8 @@ describe('public api', function () {
     project.chdir();
   });
 
-  afterEach(async function () {
-    await project.dispose();
+  afterEach(function () {
+    project.dispose();
   });
 
   describe('Linter.prototype.loadConfig', function () {
@@ -281,8 +281,8 @@ describe('public api', function () {
       });
     });
 
-    afterEach(async function () {
-      await project.dispose();
+    afterEach(function () {
+      project.dispose();
     });
 
     it('returns whether the source has been fixed + an array of remaining issues with the provided template', async function () {
@@ -419,8 +419,8 @@ describe('public api', function () {
       });
     });
 
-    afterEach(async function () {
-      await project.dispose();
+    afterEach(function () {
+      project.dispose();
     });
 
     it('returns an array of issues with the provided template', async function () {
@@ -1289,8 +1289,8 @@ describe('public api', function () {
       });
     });
 
-    afterEach(async function () {
-      await project.dispose();
+    afterEach(function () {
+      project.dispose();
     });
 
     it('[.html] does not identify errors for ember-cli default app/index.html (3.20)', async function () {

--- a/test/acceptance/stdin-by-platform-test.js
+++ b/test/acceptance/stdin-by-platform-test.js
@@ -30,8 +30,8 @@ describe('ember-template-lint executable', function () {
     project.chdir();
   });
 
-  afterEach(async function () {
-    await project.dispose();
+  afterEach(function () {
+    project.dispose();
   });
 
   describe('command: `node ember-template-lint --filename template.hbs < template.hbs`', function () {

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -25,9 +25,9 @@ describe('todo usage', () => {
     project.chdir();
   });
 
-  afterEach(async function () {
+  afterEach(function () {
     process.chdir(ROOT);
-    await project.dispose();
+    project.dispose();
   });
 
   describe('with/without --update-todo and --include-todo params', function () {

--- a/test/formatters/sarif-test.js
+++ b/test/formatters/sarif-test.js
@@ -146,9 +146,9 @@ describe('', () => {
     project.chdir();
   });
 
-  afterEach(async function () {
+  afterEach(function () {
     process.chdir(ROOT);
-    await project.dispose();
+    project.dispose();
   });
 
   it('should output sarif log with errors only', function () {

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -21,8 +21,8 @@ describe('base plugin', function () {
     editorConfigResolver.resolveEditorConfigFiles();
   });
 
-  afterEach(async () => {
-    await project.dispose();
+  afterEach(() => {
+    project.dispose();
   });
 
   async function runRules(template, rules) {

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -10,8 +10,8 @@ describe('expandFileGlobs', function () {
     project = Project.defaultSetup();
   });
 
-  afterEach(async function () {
-    await project.dispose();
+  afterEach(function () {
+    project.dispose();
   });
 
   describe('basic', function () {

--- a/test/unit/bin/get-files-to-lint-test.js
+++ b/test/unit/bin/get-files-to-lint-test.js
@@ -14,8 +14,8 @@ describe('getFilesToLint', function () {
     project.write({ 'application.hbs': 'almost empty', 'other.hbs': 'ZOMG' });
   });
 
-  afterEach(async function () {
-    await project.dispose();
+  afterEach(function () {
+    project.dispose();
   });
 
   // yarn ember-template-lint --filename application.hbs < application.hbs

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -19,8 +19,8 @@ describe('get-config', function () {
     project = new Project();
   });
 
-  afterEach(async function () {
-    await project.dispose();
+  afterEach(function () {
+    project.dispose();
   });
 
   it('if config is provided directly, it is used', function () {
@@ -657,8 +657,8 @@ describe('getProjectConfig', function () {
     project = Project.defaultSetup();
   });
 
-  afterEach(async function () {
-    await project.dispose();
+  afterEach(function () {
+    project.dispose();
   });
 
   it('processing config is idempotent', function () {

--- a/test/unit/get-editor-config-test.js
+++ b/test/unit/get-editor-config-test.js
@@ -11,8 +11,8 @@ describe('get-editor-config', function () {
     project.chdir();
   });
 
-  afterEach(async function () {
-    await project.dispose();
+  afterEach(function () {
+    project.dispose();
   });
 
   it('able to read and add info from .editorconfig file if exists', function () {


### PR DESCRIPTION
[`FakeProject#dispose`](https://github.com/ember-template-lint/ember-template-lint/blob/893bea44d79127af66c4837f7334e3e372ab0360/test/helpers/fake-project.js#L143) is not async and does not return a promise. (Neither does [`FixturifyProject#dispose`](https://github.com/stefanpenner/node-fixturify-project/blob/v2.1.1/index.ts#L310))

So, these awaits are misleading. I bumped into this because of some
confusing `require-atomic-updates` eslint errors

See test/helpers/fake-project.js or
https://github.com/stefanpenner/node-fixturify-project/blob/v2.1.1/index.ts#L310