### PR TITLE
Todos: Convert to single file storage

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -286,7 +286,7 @@ async function run() {
     try {
       config = JSON.parse(options.config);
     } catch {
-      _console.error('Could not parse specified `--config` as JSON');
+      console.error('Could not parse specified `--config` as JSON');
       process.exitCode = 1;
       return;
     }
@@ -299,13 +299,13 @@ async function run() {
   let todoConfigResult = validateConfig(options.workingDirectory);
 
   if (!todoConfigResult.isValid) {
-    _console.error(todoConfigResult.message);
+    console.error(todoConfigResult.message);
     process.exitCode = 1;
     return;
   }
 
   if (_todoStorageDirExists(options.workingDirectory)) {
-    _console.error(
+    console.error(
       'Found `.lint-todo` directory. Please run `npx @lint-todo/migrator .` to convert to the new todo file format'
     );
     process.exitCode = 1;
@@ -313,7 +313,8 @@ async function run() {
   }
 
   if (options.compactTodo) {
-    compactTodoStorageFile(options.workingDirectory);
+    let { compacted } = compactTodoStorageFile(options.workingDirectory);
+    _console.log(`Removed ${compacted} todos in .lint-todo storage file`);
     process.exitCode = 0;
     return;
   }
@@ -339,13 +340,13 @@ async function run() {
       console: _console,
     });
   } catch (error) {
-    _console.error(error.message);
+    console.error(error.message);
     process.exitCode = 1;
     return;
   }
 
   if ((options.todoDaysToWarn || options.todoDaysToError) && !options.updateTodo) {
-    _console.error(
+    console.error(
       'Using `--todo-days-to-warn` or `--todo-days-to-error` is only valid when the `--update-todo` option is being used.'
     );
     process.exitCode = 1;
@@ -356,7 +357,7 @@ async function run() {
 
   if (options.printConfig) {
     if (filePaths.size > 1) {
-      _console.error('The --print-config option must be used with exactly one file name.');
+      console.error('The --print-config option must be used with exactly one file name.');
       process.exitCode = 1;
       return;
     }

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -314,6 +314,7 @@ async function run() {
 
   if (options.compactTodo) {
     compactTodoStorageFile(options.workingDirectory);
+    process.exitCode = 0;
     return;
   }
 

--- a/docs/todos.md
+++ b/docs/todos.md
@@ -12,7 +12,7 @@ Having the ability to identify violations as `todo`s allows for this incremental
 
 ## Usage
 
-todos are stored in a `.lint-todo/` directory that should be checked in with other source code. Each error generates a unique file, allowing for multiple errors within a single file to be resolved individually with minimal conflicts.
+todos are stored in a `.lint-todo` file that should be checked in with other source code. Each error generates a unique line, allowing for multiple errors within a single file to be resolved individually with minimal conflicts.
 
 To convert errors to todos, you can use the `--update-todo` option. This will convert all active errors to todos, hiding them from the linting output.
 
@@ -37,6 +37,18 @@ You can fix this error/remove the stale todo file by running `--clean-todo`
 ```bash
 ember-template-lint . --clean-todo
 ```
+
+### Compacting the `.lint-todo` file
+
+The `.lint-todo` file is a simple text file that contains a list of all the todo violations. This file can be quite large, especially if you have a lot of todo violations. To reduce the size of this file, you can compact it by running `--compact-todo`.
+
+```bash
+ember-template-lint . --compact-todo
+```
+
+### Resolving `.lint-todo` file conflicts
+
+The `.lint-todo` file can contain merge conflicts if multiple people perform todo operations on separate branches, and ultimately merge the resulting changes. To resolve this, you can run `ember-template-lint .` again, and it will automatically resolve the conflicts.
 
 ### Configuring Due Dates
 

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -1,11 +1,11 @@
 const {
   buildTodoDatum,
   getTodoBatches,
-  todoStorageDirExists,
+  todoStorageFileExists,
   writeTodos,
   readTodosForFilePath,
   applyTodoChanges,
-  getTodoStorageDirPath,
+  getTodoStorageFilePath,
   getSeverity,
 } = require('@ember-template-lint/todo-utils');
 
@@ -24,7 +24,7 @@ module.exports = class TodoHandler {
   }
 
   processResults(results, shouldCleanTodos, writeTodoOptions) {
-    if (!todoStorageDirExists(this._workingDir)) {
+    if (!todoStorageFileExists(this._workingDir)) {
       return results;
     }
 
@@ -39,12 +39,12 @@ module.exports = class TodoHandler {
     if (remove.size > 0 || expired.size > 0) {
       if (shouldCleanTodos) {
         applyTodoChanges(
-          getTodoStorageDirPath(this._workingDir),
-          new Map(),
-          new Map([...remove, ...expired])
+          getTodoStorageFilePath(this._workingDir),
+          new Set(),
+          new Set([...remove, ...expired])
         );
       } else {
-        for (const [, todo] of remove) {
+        for (const todo of remove) {
           results.push({
             rule: 'invalid-todo-violation-rule',
             message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`ember-template-lint ${todo.filePath} --clean-todo\` to remove this todo from the todo list.`,
@@ -57,7 +57,7 @@ module.exports = class TodoHandler {
       }
     }
 
-    for (const todo of stable.values()) {
+    for (const todo of stable) {
       let severity = getSeverity(todo);
 
       if (severity === ERROR_SEVERITY) {

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -5,7 +5,6 @@ const {
   writeTodos,
   readTodosForFilePath,
   applyTodoChanges,
-  getTodoStorageFilePath,
   getSeverity,
 } = require('@ember-template-lint/todo-utils');
 
@@ -38,11 +37,7 @@ module.exports = class TodoHandler {
 
     if (remove.size > 0 || expired.size > 0) {
       if (shouldCleanTodos) {
-        applyTodoChanges(
-          getTodoStorageFilePath(this._workingDir),
-          new Set(),
-          new Set([...remove, ...expired])
-        );
+        applyTodoChanges(this._workingDir, new Set(), new Set([...remove, ...expired]));
       } else {
         for (const todo of remove) {
           results.push({

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^11.0.0-beta.0",
+    "@ember-template-lint/todo-utils": "^11.0.0-beta.1",
     "chalk": "^4.1.2",
     "ci-info": "^3.3.0",
     "date-fns": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^10.0.0",
+    "@ember-template-lint/todo-utils": "^11.0.0-alpha.0",
     "chalk": "^4.1.2",
     "ci-info": "^3.3.0",
     "date-fns": "^2.26.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "dependencies": {
-    "@ember-template-lint/todo-utils": "^11.0.0-alpha.0",
+    "@ember-template-lint/todo-utils": "^11.0.0-beta.0",
     "chalk": "^4.1.2",
     "ci-info": "^3.3.0",
     "date-fns": "^2.26.0",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -67,6 +67,8 @@ describe('ember-template-lint executable', function () {
                                                                 [boolean] [default: false]
             --clean-todo                Remove expired and invalid todo files
                                                                  [boolean] [default: true]
+            --compact-todo              Compacts the .lint-todo storage file, removing
+                                        extraneous todos                         [boolean]
             --todo-days-to-warn         Number of days after its creation date that a todo
                                         transitions into a warning                [number]
             --todo-days-to-error        Number of days after its creation date that a todo
@@ -124,6 +126,8 @@ describe('ember-template-lint executable', function () {
                                                                 [boolean] [default: false]
             --clean-todo                Remove expired and invalid todo files
                                                                  [boolean] [default: true]
+            --compact-todo              Compacts the .lint-todo storage file, removing
+                                        extraneous todos                         [boolean]
             --todo-days-to-warn         Number of days after its creation date that a todo
                                         transitions into a warning                [number]
             --todo-days-to-error        Number of days after its creation date that a todo
@@ -438,6 +442,8 @@ describe('ember-template-lint executable', function () {
                                                                 [boolean] [default: false]
             --clean-todo                Remove expired and invalid todo files
                                                                  [boolean] [default: true]
+            --compact-todo              Compacts the .lint-todo storage file, removing
+                                        extraneous todos                         [boolean]
             --todo-days-to-warn         Number of days after its creation date that a todo
                                         transitions into a warning                [number]
             --todo-days-to-error        Number of days after its creation date that a todo

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,10 +311,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@ember-template-lint/todo-utils@^11.0.0-alpha.0":
-  version "11.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-11.0.0-alpha.0.tgz#df38410b37aac3976a4f502852da929ee9b68f49"
-  integrity sha512-3eT+UTh/MW5yxluznWn7XA9Sa/7LygG3ay8e7Uq16A78kusu5nHk40LVj8u0Xa3njyjPxOs11eh+HsqmI/koRg==
+"@ember-template-lint/todo-utils@^11.0.0-beta.0":
+  version "11.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-11.0.0-beta.0.tgz#3226ddc205d3e4168d961ded8d7f70c65f988051"
+  integrity sha512-rS7QlCAvFFwUj2slCWARFZrhUJOUsqnTrhMy+JXap6C+/qUVRUBomLui/wqjSDRlvjiekGXb1lrpoSdGH8FpYw==
   dependencies:
     "@types/eslint" "^7.2.13"
     fs-extra "^9.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,15 +311,16 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@ember-template-lint/todo-utils@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-10.0.0.tgz#085aafcf31ca04ba4d3a9460f088aed752b90ea8"
-  integrity sha512-US8VKnetBOl8KfKz+rXGsosz6rIETNwSz2F2frM8hIoJfF/d6ME1Iz1K7tPYZEE6SoKqZFlBs5XZPSmzRnabjA==
+"@ember-template-lint/todo-utils@^11.0.0-alpha.0":
+  version "11.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-11.0.0-alpha.0.tgz#df38410b37aac3976a4f502852da929ee9b68f49"
+  integrity sha512-3eT+UTh/MW5yxluznWn7XA9Sa/7LygG3ay8e7Uq16A78kusu5nHk40LVj8u0Xa3njyjPxOs11eh+HsqmI/koRg==
   dependencies:
     "@types/eslint" "^7.2.13"
     fs-extra "^9.1.0"
+    proper-lockfile "^4.1.2"
     slash "^3.0.0"
-    tslib "^2.2.0"
+    tslib "^2.3.1"
 
 "@eslint/eslintrc@^1.0.4":
   version "1.0.4"
@@ -5955,6 +5956,15 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
+proper-lockfile@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz#c8b9de2af6b2f1601067f98e01ac66baa223141f"
+  integrity sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==
+  dependencies:
+    graceful-fs "^4.2.4"
+    retry "^0.12.0"
+    signal-exit "^3.0.2"
+
 protocols@^1.1.0, protocols@^1.4.0:
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/protocols/-/protocols-1.4.8.tgz#48eea2d8f58d9644a4a32caae5d5db290a075ce8"
@@ -6932,7 +6942,7 @@ tsconfig-paths@^3.11.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^2.2.0:
+tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,10 +311,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@ember-template-lint/todo-utils@^11.0.0-beta.0":
-  version "11.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-11.0.0-beta.0.tgz#3226ddc205d3e4168d961ded8d7f70c65f988051"
-  integrity sha512-rS7QlCAvFFwUj2slCWARFZrhUJOUsqnTrhMy+JXap6C+/qUVRUBomLui/wqjSDRlvjiekGXb1lrpoSdGH8FpYw==
+"@ember-template-lint/todo-utils@^11.0.0-beta.1":
+  version "11.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@ember-template-lint/todo-utils/-/todo-utils-11.0.0-beta.1.tgz#67d6a24e6e2328e00103f415c3c10d07bdcb4de2"
+  integrity sha512-HC/iH1HpeCQN+7A4b4oOJUdtq+j4s8xnmOIr5S/bXaUPSngbQmcE2MfMbFpanNyXQQ90avX0cOAkdcafLa928Q==
   dependencies:
     "@types/eslint" "^7.2.13"
     fs-extra "^9.1.0"


### PR DESCRIPTION
As defined in https://github.com/ember-template-lint/ember-template-lint-todo-utils/blob/master/docs/single-file-storage.md, this update uses the new mode of todo storage: single file todos.

Todo: 

- [x] Update documentation to reference `lint-todo` storage file vs. directory
- [x] Update instructions on how to migrate from multi-file to single-file todos via https://github.com/lint-todo/migrator
- [x] Add new CLI option: `--compact-todo`, which will compact the single storage file.

Part of v4 release (#1908).

