### PR TITLE
Rule Configs: Add `no-autofocus-attribute` to `recommended` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Each rule has emojis denoting:
 | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)                           | ✅  |     |     |     |
 | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                                                 | ✅  |     | ⌨️  | 🔧  |
 | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                                           | ✅  |     |     |     |
-| [no-autofocus-attribute](./docs/rule/no-autofocus-attribute.md)                                           |     |     | ⌨️  |     |
+| [no-autofocus-attribute](./docs/rule/no-autofocus-attribute.md)                                           | ✅  |     | ⌨️  |     |
 | [no-bare-strings](./docs/rule/no-bare-strings.md)                                                         |     |     |     |     |
 | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md)                     | ✅  |     |     |     |
 | [no-capital-arguments](./docs/rule/no-capital-arguments.md)                                               | ✅  |     |     |     |

--- a/docs/rule/no-autofocus-attribute.md
+++ b/docs/rule/no-autofocus-attribute.md
@@ -1,5 +1,7 @@
 # no-autofocus-attribute
 
+✅ The `extends: 'recommended'` property in a configuration file enables this rule.
+
 The autofocus attribute is a global attribute that indicates an element should be focused on page load. Autofocus reduces accessibility by moving users to an element without warning and context. Its use should be limited to form fields that serve as the main purpose of the page, such as the search input on the Google home page.
 
 ## Examples

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -8,6 +8,7 @@ module.exports = {
     'link-href-attributes': 'error',
     'link-rel-noopener': 'error',
     'no-abstract-roles': 'error',
+    'no-autofocus-attribute': 'error',
     'no-accesskey-attribute': 'error',
     'no-action': 'error',
     'no-args-paths': 'error',


### PR DESCRIPTION
Adding per this discussion: https://github.com/ember-template-lint/ember-template-lint/pull/2168#discussion_r758601827

Part of v4 release (#1908).

