### PR TITLE
Disallow unknown CLI options

### DIFF
--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -146,6 +146,32 @@ describe('ember-template-lint executable', function () {
         `);
       });
     });
+
+    describe('with non-existent options', function () {
+      it('should exit with failure with one-word option', async function () {
+        const result = await run(['--fake']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toBeFalsy();
+        expect(result.stderr).toMatchInlineSnapshot(`"Unknown option: --fake"`);
+      });
+
+      it('should exit with failure with multi-word option name', async function () {
+        const result = await run(['--fake-option-name']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toBeFalsy();
+        expect(result.stderr).toMatchInlineSnapshot(`"Unknown option: --fake-option-name"`);
+      });
+
+      it('should exit with failure with camelcase name', async function () {
+        const result = await run(['--fakeOptionName']);
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toBeFalsy();
+        expect(result.stderr).toMatchInlineSnapshot(`"Unknown option: --fakeOptionName"`);
+      });
+    });
   });
 
   describe('reading files', function () {
@@ -309,6 +335,40 @@ describe('ember-template-lint executable', function () {
         });
 
         let result = await run(['--working-directory', project.baseDir, 'app/templates/*'], {
+          // run from ember-template-lint's root (forces `--working-directory` to be used)
+          cwd: ROOT,
+        });
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "app/templates/application.hbs
+            1:4  error  Non-translated string used  no-bare-strings
+            1:25  error  Non-translated string used  no-bare-strings
+
+          ✖ 2 problems (2 errors, 0 warnings)"
+        `);
+        expect(result.stderr).toMatchInlineSnapshot('""');
+
+        // SAME TEST, USING ALIAS AS OPTION NAME:
+
+        result = await run(['--cwd', project.baseDir, 'app/templates/*'], {
+          // run from ember-template-lint's root (forces `--working-directory` to be used)
+          cwd: ROOT,
+        });
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "app/templates/application.hbs
+            1:4  error  Non-translated string used  no-bare-strings
+            1:25  error  Non-translated string used  no-bare-strings
+
+          ✖ 2 problems (2 errors, 0 warnings)"
+        `);
+        expect(result.stderr).toMatchInlineSnapshot('""');
+
+        // SAME TEST, USING CAMELCASE VERSION OF OPTION NAME:
+
+        result = await run(['--workingDirectory', project.baseDir, 'app/templates/*'], {
           // run from ember-template-lint's root (forces `--working-directory` to be used)
           cwd: ROOT,
         });

--- a/test/unit/bin/get-possible-option-names-test.js
+++ b/test/unit/bin/get-possible-option-names-test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const {
+  _getPossibleOptionNames: getPossibleOptionNames,
+} = require('../../../bin/ember-template-lint');
+
+describe('getPossibleOptionNames', function () {
+  it('returns correct list of all possible dasherized, camelized, aliased, and negated names', function () {
+    const results = getPossibleOptionNames({
+      foo: {},
+      'foo-bar': {},
+      'no-baz': {},
+      'no-fizz-sizz': {},
+      'option-with-alias': { alias: 'aliased-name' },
+    });
+    expect(results).toMatchInlineSnapshot(`
+      Array [
+        "foo",
+        "foo-bar",
+        "no-baz",
+        "no-fizz-sizz",
+        "option-with-alias",
+        "aliased-name",
+        "foo",
+        "fooBar",
+        "noBaz",
+        "noFizzSizz",
+        "optionWithAlias",
+        "aliasedName",
+        "no-foo",
+        "no-foo-bar",
+        "baz",
+        "fizz-sizz",
+        "no-option-with-alias",
+        "no-aliased-name",
+        "noFoo",
+        "noFooBar",
+        "baz",
+        "fizzSizz",
+        "noOptionWithAlias",
+        "noAliasedName",
+      ]
+    `);
+  });
+});


### PR DESCRIPTION
ESLint also exits with failure when encountering unknown CLI arguments/options:

```
eslint --fake
Invalid option '--fake' - perhaps you meant '--rule'?
error Command failed with exit code 2.
```

New behavior instead of silently ignoring unknown options:

```
ember-template-lint --fake
Unknown option: --fake
error Command failed with exit code 1.
```

I wanted to use yargs' [strictOptions](https://yargs.js.org/docs/#api-reference-strictoptionsenabledtrue) or [strict](https://yargs.js.org/docs/#api-reference-stringkey) to enforce this for us, but it turns out there are other option inconsistencies we would need to address first to use these, especially around [boolean-negation](https://github.com/yargs/yargs-parser#boolean-negation). Instead, I had to implement my own logic for detecting unknown options (hopefully we can eliminate this custom logic eventually).

Part of v4 release (#1908).

