### PR TITLE
Add `requireActionHelper` config option to `no-element-event-actions`

### DIFF
--- a/docs/rule/no-element-event-actions.md
+++ b/docs/rule/no-element-event-actions.md
@@ -21,6 +21,14 @@ This rule **allows** the following:
 <button {{on 'click' this.submit}}>Submit</button>
 ```
 
+## Configuration
+
+The following values are valid configuration:
+
+* boolean - `true` to enable / `false` to disable
+* object -- An object with the following keys:
+  * `actionHelperOptional` -- Apply this rule even when the {{action}} helper is not present
+
 ## References
 
 * [Documentation](https://guides.emberjs.com/release/templates/actions/) for template actions

--- a/docs/rule/no-element-event-actions.md
+++ b/docs/rule/no-element-event-actions.md
@@ -27,7 +27,7 @@ The following values are valid configuration:
 
 * boolean - `true` to enable / `false` to disable
 * object -- An object with the following keys:
-  * `actionHelperOptional` -- Apply this rule even when the {{action}} helper is not present
+  * `requireActionHelper` -- Only apply this rule when the {{action}} helper is present (defaults to `true`)
 
 ## References
 

--- a/lib/rules/no-element-event-actions.js
+++ b/lib/rules/no-element-event-actions.js
@@ -7,7 +7,7 @@ const ERROR_MESSAGE =
   'Do not use HTML element event properties like `onclick`. Instead, use the `on` modifier.';
 
 const DEFAULT_CONFIG = {
-  actionHelperOptional: false,
+  requireActionHelper: true,
 };
 
 function isValidConfigObjectFormat(config) {
@@ -15,7 +15,7 @@ function isValidConfigObjectFormat(config) {
     let value = config[key];
     let valueType = typeof value;
 
-    if (key === 'actionHelperOptional' && valueType !== 'boolean') {
+    if (key === 'requireActionHelper' && valueType !== 'boolean') {
       return false;
     } else if (!(key in DEFAULT_CONFIG)) {
       return false;
@@ -51,8 +51,8 @@ function isEventPropertyWithAction(node) {
     node.type === 'AttrNode' &&
     isDomEventAttributeName(node.name) &&
     node.value.type === 'MustacheStatement' &&
-    ((node.value.path.type === 'PathExpression' && node.value.path.original === 'action') ||
-      this.config.actionHelperOptional)
+    (!this.config.requireActionHelper ||
+      (node.value.path.type === 'PathExpression' && node.value.path.original === 'action'))
   );
 }
 
@@ -68,10 +68,10 @@ function parseConfig(config) {
     case 'object':
       if (isValidConfigObjectFormat(config)) {
         return {
-          actionHelperOptional:
-            'actionHelperOptional' in config
-              ? config.actionHelperOptional
-              : DEFAULT_CONFIG['actionHelperOptional'],
+          requireActionHelper:
+            'requireActionHelper' in config
+              ? config.requireActionHelper
+              : DEFAULT_CONFIG['requireActionHelper'],
         };
       }
       break;
@@ -84,7 +84,7 @@ function parseConfig(config) {
     [
       '  * boolean - `true` to enable / `false` to disable',
       '  * object -- An object with the following keys:',
-      '    * `actionHelperOptional` -- Apply this rule even when the {{action}} helper is not present',
+      '    * `requireActionHelper` -- Only apply this rule even when the {{action}} helper is present (defaults to `true`)',
     ],
     config
   );

--- a/lib/rules/no-element-event-actions.js
+++ b/lib/rules/no-element-event-actions.js
@@ -1,15 +1,35 @@
 'use strict';
 
+const createErrorMessage = require('../helpers/create-error-message');
 const Rule = require('./_base');
 
 const ERROR_MESSAGE =
   'Do not use HTML element event properties like `onclick`. Instead, use the `on` modifier.';
 
+const DEFAULT_CONFIG = {
+  actionHelperOptional: false,
+};
+
+function isValidConfigObjectFormat(config) {
+  for (let key in config) {
+    let value = config[key];
+    let valueType = typeof value;
+
+    if (key === 'actionHelperOptional' && valueType !== 'boolean') {
+      return false;
+    } else if (!(key in DEFAULT_CONFIG)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 module.exports = class NoElementEventActions extends Rule {
   visitor() {
     return {
       ElementNode(node) {
-        const eventProperties = node.attributes.filter(isEventPropertyWithAction);
+        const eventProperties = node.attributes.filter(isEventPropertyWithAction.bind(this));
         for (const eventProperty of eventProperties) {
           this.log({
             message: ERROR_MESSAGE,
@@ -31,9 +51,45 @@ function isEventPropertyWithAction(node) {
     node.type === 'AttrNode' &&
     isDomEventAttributeName(node.name) &&
     node.value.type === 'MustacheStatement' &&
-    node.value.path.type === 'PathExpression' &&
-    node.value.path.original === 'action'
+    ((node.value.path.type === 'PathExpression' && node.value.path.original === 'action') ||
+      this.config.actionHelperOptional)
   );
 }
 
 module.exports.ERROR_MESSAGE = ERROR_MESSAGE;
+
+function parseConfig(config) {
+  let configType = typeof config;
+
+  switch (configType) {
+    case 'boolean':
+      // if `true` use `DEFAULT_CONFIG`
+      return config ? DEFAULT_CONFIG : false;
+    case 'object':
+      if (isValidConfigObjectFormat(config)) {
+        return {
+          actionHelperOptional:
+            'actionHelperOptional' in config
+              ? config.actionHelperOptional
+              : DEFAULT_CONFIG['actionHelperOptional'],
+        };
+      }
+      break;
+    case 'undefined':
+      return false;
+  }
+
+  let errorMessage = createErrorMessage(
+    this.ruleName,
+    [
+      '  * boolean - `true` to enable / `false` to disable',
+      '  * object -- An object with the following keys:',
+      '    * `actionHelperOptional` -- Apply this rule even when the {{action}} helper is not present',
+    ],
+    config
+  );
+
+  throw new Error(errorMessage);
+}
+
+module.exports.parseConfig = parseConfig;

--- a/lib/rules/no-element-event-actions.js
+++ b/lib/rules/no-element-event-actions.js
@@ -47,11 +47,12 @@ function isDomEventAttributeName(name) {
 }
 
 function isEventPropertyWithAction(node) {
+  const config = parseConfig(this.config);
   return (
     node.type === 'AttrNode' &&
     isDomEventAttributeName(node.name) &&
     node.value.type === 'MustacheStatement' &&
-    (!this.config.requireActionHelper ||
+    (!config.requireActionHelper ||
       (node.value.path.type === 'PathExpression' && node.value.path.original === 'action'))
   );
 }

--- a/lib/rules/no-element-event-actions.js
+++ b/lib/rules/no-element-event-actions.js
@@ -11,6 +11,10 @@ const DEFAULT_CONFIG = {
 };
 
 function isValidConfigObjectFormat(config) {
+  if (config === null) {
+    return false;
+  }
+
   for (let key in config) {
     let value = config[key];
     let valueType = typeof value;
@@ -26,6 +30,10 @@ function isValidConfigObjectFormat(config) {
 }
 
 module.exports = class NoElementEventActions extends Rule {
+  parseConfig(config) {
+    return parseConfig(config, this.ruleName);
+  }
+
   visitor() {
     return {
       ElementNode(node) {
@@ -47,19 +55,18 @@ function isDomEventAttributeName(name) {
 }
 
 function isEventPropertyWithAction(node) {
-  const config = parseConfig(this.config);
   return (
     node.type === 'AttrNode' &&
     isDomEventAttributeName(node.name) &&
     node.value.type === 'MustacheStatement' &&
-    (!config.requireActionHelper ||
+    (!this.config.requireActionHelper ||
       (node.value.path.type === 'PathExpression' && node.value.path.original === 'action'))
   );
 }
 
 module.exports.ERROR_MESSAGE = ERROR_MESSAGE;
 
-function parseConfig(config) {
+function parseConfig(config, ruleName) {
   let configType = typeof config;
 
   switch (configType) {
@@ -81,7 +88,7 @@ function parseConfig(config) {
   }
 
   let errorMessage = createErrorMessage(
-    this.ruleName,
+    ruleName,
     [
       '  * boolean - `true` to enable / `false` to disable',
       '  * object -- An object with the following keys:',

--- a/test/unit/rules/no-element-event-actions-test.js
+++ b/test/unit/rules/no-element-event-actions-test.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { parseConfig } = require('../../../lib/rules/no-element-event-actions');
 const generateRuleTests = require('../../helpers/rule-test-harness');
 
 generateRuleTests({
@@ -107,33 +106,43 @@ generateRuleTests({
       },
     },
   ],
-});
 
-describe('no-element-event-actions', () => {
-  describe('parseConfig', () => {
-    const TESTS = [
-      [true, { requireActionHelper: true }],
-      [{ requireActionHelper: true }, { requireActionHelper: true }],
-      [{ requireActionHelper: false }, { requireActionHelper: false }],
-    ];
+  error: [
+    {
+      config: null,
+      template: 'test',
 
-    for (let [input, expected] of TESTS) {
-      test(`${JSON.stringify(input)} -> ${JSON.stringify(expected)}`, () => {
-        expect(parseConfig(input)).toEqual(expected);
-      });
-    }
+      result: {
+        fatal: true,
+        message: 'You specified `null`',
+      },
+    },
+    {
+      config: 'true',
+      template: 'test',
 
-    const FAILURE_TESTS = [
-      null,
-      'error',
-      { invalidOption: true },
-      { requireActionHelper: 'true' },
-    ];
+      result: {
+        fatal: true,
+        message: 'You specified `"true"`',
+      },
+    },
+    {
+      config: { invalidOption: true },
+      template: 'test',
 
-    for (let input of FAILURE_TESTS) {
-      test(`${JSON.stringify(input)} -> Error`, () => {
-        expect(() => parseConfig(input)).toThrow();
-      });
-    }
-  });
+      result: {
+        fatal: true,
+        message: 'You specified `{"invalidOption":true}`',
+      },
+    },
+    {
+      config: { requireActionHelper: 'true' },
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `{"requireActionHelper":"true"}`',
+      },
+    },
+  ],
 });

--- a/test/unit/rules/no-element-event-actions-test.js
+++ b/test/unit/rules/no-element-event-actions-test.js
@@ -17,11 +17,11 @@ generateRuleTests({
     '{{my-component onclick=(action "myAction") someProperty=true}}',
     '<SiteHeader @someFunction={{action "myAction"}} @user={{this.user}} />',
     {
-      config: { actionHelperOptional: false },
+      config: { requireActionHelper: true },
       template: '<button type="button" onclick={{this.myAction}}></button>',
     },
     {
-      config: { actionHelperOptional: false },
+      config: { requireActionHelper: false },
       template: '<button type="button" onclick="myFunction()"></button>',
     },
   ],
@@ -84,7 +84,7 @@ generateRuleTests({
     },
 
     {
-      config: { actionHelperOptional: true },
+      config: { requireActionHelper: false },
       template: '<button type="button" onclick={{this.myAction}}></button>',
 
       verifyResults(results) {
@@ -111,9 +111,9 @@ generateRuleTests({
 describe('no-element-event-actions', () => {
   describe('parseConfig', () => {
     const TESTS = [
-      [true, { actionHelperOptional: false }],
-      [{ actionHelperOptional: true }, { actionHelperOptional: true }],
-      [{ actionHelperOptional: false }, { actionHelperOptional: false }],
+      [true, { requireActionHelper: true }],
+      [{ requireActionHelper: true }, { requireActionHelper: true }],
+      [{ requireActionHelper: false }, { requireActionHelper: false }],
     ];
 
     for (let [input, expected] of TESTS) {
@@ -126,7 +126,7 @@ describe('no-element-event-actions', () => {
       null,
       'error',
       { invalidOption: true },
-      { actionHelperOptional: 'true' },
+      { requireActionHelper: 'true' },
     ];
 
     for (let input of FAILURE_TESTS) {

--- a/test/unit/rules/no-element-event-actions-test.js
+++ b/test/unit/rules/no-element-event-actions-test.js
@@ -16,6 +16,7 @@ generateRuleTests({
     '<button type="button" value={{value}}></button>',
     '{{my-component onclick=(action "myAction") someProperty=true}}',
     '<SiteHeader @someFunction={{action "myAction"}} @user={{this.user}} />',
+    '<button type="button" onclick={{this.myAction}}></button>',
     {
       config: { requireActionHelper: true },
       template: '<button type="button" onclick={{this.myAction}}></button>',


### PR DESCRIPTION
Fixes #1343

This adds a `requireActionHelper` config option to the `no-element-event-actions` rule, which is `true` by default.. When this option is enabled, this rule will apply, only when the `{{action}}` helper is present.

By default, when `no-element-event-actions` is enabled, this fails linting:

```hbs
<button type="button" onclick={{action this.myAction}}>Go!</button>
```

But this does not error:

```hbs
<button type="button" onclick={{this.myAction}}>Go!</button>
```

Setting `requireActionHelper` for `no-element-event-actions` to `false` will cause _both_ of these to error.