### PR TITLE
Updates @lint-todo/utils to latest version for read isolation

### DIFF
--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -1,11 +1,10 @@
 const {
+  applyTodoChanges,
   buildTodoDatum,
-  getTodoBatches,
+  generateTodoBatches,
+  getSeverity,
   todoStorageFileExists,
   writeTodos,
-  readTodosForFilePath,
-  applyTodoChanges,
-  getSeverity,
 } = require('@lint-todo/utils');
 
 const { ERROR_SEVERITY } = require('../get-config');
@@ -27,11 +26,9 @@ module.exports = class TodoHandler {
       return results;
     }
 
-    let existingTodoFiles = readTodosForFilePath(this._workingDir, writeTodoOptions.filePath);
-
-    let { remove, stable, expired } = getTodoBatches(
+    let { remove, stable, expired } = generateTodoBatches(
+      this._workingDir,
       this._buildMaybeTodos(results, writeTodoOptions.todoConfig),
-      existingTodoFiles,
       writeTodoOptions
     );
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -259,6 +259,7 @@ class Linter {
 
   updateTodo(options, results, todoConfig, isOverridingConfig) {
     let todoBatchCounts = this._todoHandler.update(results, {
+      engine: 'ember-template-lint',
       filePath: options.filePath,
       todoConfig,
       // skip removing todo files if the config is overridden as this can result in todos being incorrectly removed
@@ -270,6 +271,7 @@ class Linter {
 
   processTodos(options, results, todoConfig, shouldCleanTodos, isOverridingConfig) {
     let fileResults = this._todoHandler.processResults(results, shouldCleanTodos, {
+      engine: 'ember-template-lint',
       filePath: options.filePath,
       todoConfig,
       // skip removing todo files if the config is overridden as this can result in todos being incorrectly removed

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     ]
   },
   "dependencies": {
-    "@lint-todo/utils": "^11.0.0",
+    "@lint-todo/utils": "^12.0.0",
     "chalk": "^4.1.2",
     "ci-info": "^3.3.0",
     "date-fns": "^2.26.0",

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -7,6 +7,10 @@ const setupEnvVar = require('../helpers/setup-env-var');
 
 const ROOT = process.cwd();
 
+function buildReadOptions() {
+  return { engine: 'ember-template-lint' };
+}
+
 describe('todo usage', () => {
   setupEnvVar('FORCE_COLOR', '0');
 
@@ -107,7 +111,7 @@ describe('todo usage', () => {
 
       await run(['.', '--update-todo']);
 
-      const result = readTodoData(project.baseDir);
+      const result = readTodoData(project.baseDir, buildReadOptions());
 
       expect(result.size).toEqual(0);
     });
@@ -154,7 +158,7 @@ describe('todo usage', () => {
 
       expect(result.exitCode).toEqual(0);
       expect(todoStorageFileExists(project.baseDir)).toEqual(true);
-      expect(readTodoData(project.baseDir).size).toEqual(3);
+      expect(readTodoData(project.baseDir, buildReadOptions()).size).toEqual(3);
 
       project.write({
         app: {
@@ -232,7 +236,7 @@ describe('todo usage', () => {
 
       await run(['.', '--update-todo']);
 
-      let todos = readTodoData(project.baseDir);
+      let todos = readTodoData(project.baseDir, buildReadOptions());
 
       expect(todos.size).toEqual(2);
 
@@ -254,7 +258,7 @@ describe('todo usage', () => {
         '--no-config-path',
       ]);
 
-      todos = readTodoData(project.baseDir);
+      todos = readTodoData(project.baseDir, buildReadOptions());
 
       expect(todos.size).toEqual(3);
     });
@@ -277,7 +281,7 @@ describe('todo usage', () => {
 
       await run(['.', '--update-todo']);
 
-      let todos = readTodoData(project.baseDir);
+      let todos = readTodoData(project.baseDir, buildReadOptions());
 
       expect(todos.size).toEqual(3);
 
@@ -290,7 +294,7 @@ describe('todo usage', () => {
         '--no-config-path',
       ]);
 
-      todos = readTodoData(project.baseDir);
+      todos = readTodoData(project.baseDir, buildReadOptions());
 
       expect(result.exitCode).toEqual(0);
       expect(todos.size).toEqual(3);
@@ -347,7 +351,7 @@ describe('todo usage', () => {
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toEqual('');
-        expect(readTodoData(project.baseDir).size).toEqual(0);
+        expect(readTodoData(project.baseDir, buildReadOptions()).size).toEqual(0);
       });
 
       it('errors if a todo item is no longer valid when running without params, and cleans using --clean-todo', async function () {
@@ -397,7 +401,7 @@ describe('todo usage', () => {
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toEqual('');
-        expect(readTodoData(project.baseDir).size).toEqual(0);
+        expect(readTodoData(project.baseDir, buildReadOptions()).size).toEqual(0);
       });
     });
 
@@ -452,7 +456,7 @@ describe('todo usage', () => {
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toEqual('');
-        expect(readTodoData(project.baseDir).size).toEqual(0);
+        expect(readTodoData(project.baseDir, buildReadOptions()).size).toEqual(0);
       });
 
       it('errors if a todo item is no longer valid when running with --no-clean-todo, and cleans without --no-clean-todo', async function () {
@@ -502,7 +506,7 @@ describe('todo usage', () => {
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toEqual('');
-        expect(readTodoData(project.baseDir).size).toEqual(0);
+        expect(readTodoData(project.baseDir, buildReadOptions()).size).toEqual(0);
       });
     });
 
@@ -889,7 +893,7 @@ describe('todo usage', () => {
               ✖ 1 problems (1 errors, 0 warnings)
                 1 errors and 0 warnings potentially fixable with the \`--fix\` option."
             `);
-          expect(readTodoData(project.baseDir).size).toEqual(0);
+          expect(readTodoData(project.baseDir, buildReadOptions()).size).toEqual(0);
         });
 
         it('should error if daysToDecay.error is less than daysToDecay.warn in config', async function () {
@@ -936,7 +940,7 @@ describe('todo usage', () => {
 
           let result = await run(['.', '--update-todo']);
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 
@@ -970,7 +974,7 @@ describe('todo usage', () => {
             },
           });
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 
@@ -1004,7 +1008,7 @@ describe('todo usage', () => {
             },
           });
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 
@@ -1034,7 +1038,7 @@ describe('todo usage', () => {
 
           let result = await run(['.', '--update-todo']);
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 
@@ -1068,7 +1072,7 @@ describe('todo usage', () => {
             },
           });
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 
@@ -1102,7 +1106,7 @@ describe('todo usage', () => {
             },
           });
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 
@@ -1133,7 +1137,7 @@ describe('todo usage', () => {
 
           let result = await run(['.', '--update-todo']);
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 
@@ -1172,7 +1176,7 @@ describe('todo usage', () => {
             },
           });
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 
@@ -1214,7 +1218,7 @@ describe('todo usage', () => {
             }
           );
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 
@@ -1254,7 +1258,7 @@ describe('todo usage', () => {
             '20',
           ]);
 
-          const todos = readTodoData(project.baseDir);
+          const todos = readTodoData(project.baseDir, buildReadOptions());
 
           expect(result.exitCode).toEqual(0);
 
@@ -1531,7 +1535,7 @@ describe('todo usage', () => {
 
             let result = await run(['.', '--update-todo']);
 
-            const todos = readTodoData(project.baseDir);
+            const todos = readTodoData(project.baseDir, buildReadOptions());
 
             expect(result.exitCode).toEqual(0);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -602,10 +602,10 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@lint-todo/utils@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@lint-todo/utils/-/utils-11.0.0.tgz#adb6f0ba280a45bff2449d548727cbff35714db7"
-  integrity sha512-FwAREUQ0ncD3XDujs34183WjzOeX07KrRwi2AkkIJT2irrTkBPyE9FLs2sjjh+Lnj2OB1d+fDN4BWi9r2Nnt+w==
+"@lint-todo/utils@^12.0.0":
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/@lint-todo/utils/-/utils-12.0.0.tgz#625ae5aa9b93f60a7567a515265af2704bf426a6"
+  integrity sha512-MGIDlAwHS31K26N/Fpt15QopnWSALP8uzCRyKXOpm0PoBuCof6a443wJGLPQlPcqPZUMdf4SjYUgEmleMv3REw==
   dependencies:
     "@types/eslint" "^7.2.13"
     fs-extra "^9.1.0"


### PR DESCRIPTION
The latest version of `@lint-todo/utils` [includes a fix](https://github.com/lint-todo/utils/releases/tag/v12.0.0) for ensuring correct read isolation when reading todo data. This PR updates to that version, and additionally uses a cleaner API for reading todo batches.