### PR TITLE
Disable `requireActionHelper` option on `no-element-event-actions` rule

### DIFF
--- a/docs/rule/no-element-event-actions.md
+++ b/docs/rule/no-element-event-actions.md
@@ -15,6 +15,10 @@ This rule **forbids** the following:
 <button onclick={{action "submit"}}>Submit</button>
 ```
 
+```hbs
+<button onclick={{this.myAction}}>Submit</button>
+```
+
 This rule **allows** the following:
 
 ```hbs
@@ -27,7 +31,7 @@ The following values are valid configuration:
 
 * boolean - `true` to enable / `false` to disable
 * object -- An object with the following keys:
-  * `requireActionHelper` -- Only apply this rule when the {{action}} helper is present (defaults to `true`)
+  * `requireActionHelper` -- Only apply this rule when the {{action}} helper is present (defaults to `false`)
 
 ## References
 

--- a/lib/rules/no-element-event-actions.js
+++ b/lib/rules/no-element-event-actions.js
@@ -7,7 +7,7 @@ const ERROR_MESSAGE =
   'Do not use HTML element event properties like `onclick`. Instead, use the `on` modifier.';
 
 const DEFAULT_CONFIG = {
-  requireActionHelper: true,
+  requireActionHelper: false,
 };
 
 function isValidConfigObjectFormat(config) {
@@ -90,7 +90,7 @@ function parseConfig(config, ruleName) {
     [
       '  * boolean - `true` to enable / `false` to disable',
       '  * object -- An object with the following keys:',
-      '    * `requireActionHelper` -- Only apply this rule even when the {{action}} helper is present (defaults to `true`)',
+      '    * `requireActionHelper` -- Only apply this rule even when the {{action}} helper is present (defaults to `false`)',
     ],
     config
   );

--- a/test/unit/rules/no-element-event-actions-test.js
+++ b/test/unit/rules/no-element-event-actions-test.js
@@ -15,7 +15,6 @@ generateRuleTests({
     '<button type="button" value={{value}}></button>',
     '{{my-component onclick=(action "myAction") someProperty=true}}',
     '<SiteHeader @someFunction={{action "myAction"}} @user={{this.user}} />',
-    '<button type="button" onclick={{this.myAction}}></button>',
     {
       config: { requireActionHelper: true },
       template: '<button type="button" onclick={{this.myAction}}></button>',
@@ -85,6 +84,27 @@ generateRuleTests({
 
     {
       config: { requireActionHelper: false },
+      template: '<button type="button" onclick={{this.myAction}}></button>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 22,
+              "endColumn": 47,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Do not use HTML element event properties like \`onclick\`. Instead, use the \`on\` modifier.",
+              "rule": "no-element-event-actions",
+              "severity": 2,
+              "source": "onclick={{this.myAction}}",
+            },
+          ]
+        `);
+      },
+    },
+    {
       template: '<button type="button" onclick={{this.myAction}}></button>',
 
       verifyResults(results) {


### PR DESCRIPTION
This makes the rule more strict.

Part of v4 release (#1908).

CC: @jamescdavis

Based on this plan: https://github.com/ember-template-lint/ember-template-lint/pull/2269#pullrequestreview-825566157