### PR TITLE
Disallow duplicate test cases

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -364,6 +364,26 @@ module.exports = function generateRuleTests(...args) {
       usedLinters.add(linter);
     }
 
+    /**
+     * Serialize test cases in such a way that we'll be able to conveniently check for duplicates.
+     * @param {Object} item - test case object
+     * @returns {string}
+     */
+    function serializeTestCase(item) {
+      const itemCleanedAndSorted = {};
+      const keysSorted = Object.keys(item).sort(); // Sort to ignore differences in the ordering of test case properties.
+      for (const key of keysSorted) {
+        if (typeof item[key] === 'function') {
+          // Can't serialize functions (e.g. `verifyResults`) so just store them as a boolean since we only care about their presence and not their contents.
+          itemCleanedAndSorted[key] = true;
+        } else {
+          itemCleanedAndSorted[key] = item[key];
+        }
+      }
+      return JSON.stringify(itemCleanedAndSorted);
+    }
+
+    const seenBadTestCases = new Set();
     for (const item of bad) {
       let template = item.template;
 
@@ -373,6 +393,10 @@ module.exports = function generateRuleTests(...args) {
 
       testOrOnly(`${testName}: logs errors`, async function () {
         checkLinterReuse();
+
+        const serializedTestCase = serializeTestCase(item);
+        assert(!seenBadTestCases.has(serializedTestCase), 'detected duplicate `bad` test case');
+        seenBadTestCases.add(serializedTestCase);
 
         let options = prepare(item, item.config);
         let actual = await linter.verify(options);
@@ -496,6 +520,7 @@ module.exports = function generateRuleTests(...args) {
       }
     }
 
+    const seenGoodTestCases = new Set();
     for (const _item of good) {
       let item = typeof _item === 'string' ? { template: _item } : _item;
       let shouldFocus = item.focus === true && typeof focusMethod === 'function';
@@ -505,6 +530,10 @@ module.exports = function generateRuleTests(...args) {
       testOrOnly(`${testName}: passes`, async function () {
         checkLinterReuse();
 
+        const serializedTestCase = serializeTestCase(item);
+        assert(!seenGoodTestCases.has(serializedTestCase), 'detected duplicate `good` test case');
+        seenGoodTestCases.add(serializedTestCase);
+
         let options = prepare(item, item.config);
         let actual = await linter.verify(options);
 
@@ -512,6 +541,7 @@ module.exports = function generateRuleTests(...args) {
       });
     }
 
+    const seenErrorTestCases = new Set();
     for (const item of error) {
       let { name, config, template } = item;
 
@@ -522,6 +552,10 @@ module.exports = function generateRuleTests(...args) {
 
       testOrOnly(`${testName}: errors with config \`${friendlyConfig}\``, async function () {
         checkLinterReuse();
+
+        const serializedTestCase = serializeTestCase(item);
+        assert(!seenErrorTestCases.has(serializedTestCase), 'detected duplicate `error` test case');
+        seenErrorTestCases.add(serializedTestCase);
 
         let options = prepare(item, item.config);
         let actual = await linter.verify(options);

--- a/test/unit/rules/attribute-indentation-test.js
+++ b/test/unit/rules/attribute-indentation-test.js
@@ -1082,51 +1082,6 @@ generateRuleTests({
     },
     {
       config: {
-        'mustache-open-end': 'last-attribute',
-      },
-      template:
-        '{{my-component' +
-        '\n' +
-        '  foo=bar' +
-        '\n' +
-        '  baz=qux' +
-        '\n' +
-        '  my-attr=(component "my-other-component" data=(hash' +
-        '\n' +
-        '    foo=bar' +
-        '\n' +
-        '    foo=bar' +
-        '\n' +
-        '    baz=qux))' +
-        '\n' +
-        '}}',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
-              "column": 0,
-              "endColumn": 2,
-              "endLine": 8,
-              "filePath": "layout.hbs",
-              "line": 8,
-              "message": "Incorrect indentation of close curly braces '}}' for the component '{{my-component}}' beginning at L8:C0. Expected '{{my-component}}' to be at L7:C13.",
-              "rule": "attribute-indentation",
-              "severity": 2,
-              "source": "{{my-component
-            foo=bar
-            baz=qux
-            my-attr=(component \\"my-other-component\\" data=(hash
-              foo=bar
-              foo=bar
-              baz=qux))
-          }}",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      config: {
         'mustache-open-end': 'new-line',
       },
       template:

--- a/test/unit/rules/link-rel-noopener-test.js
+++ b/test/unit/rules/link-rel-noopener-test.js
@@ -117,29 +117,5 @@ generateRuleTests({
         `);
       },
     },
-    {
-      template: '<a href="/some/where" target="_blank" rel="nofollow"></a>',
-      fixedTemplate:
-        '<a href="/some/where" target="_blank" rel="nofollow noopener noreferrer"></a>',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
-              "column": 0,
-              "endColumn": 57,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "isFixable": true,
-              "line": 1,
-              "message": "links with target=\\"_blank\\" must have rel=\\"noopener noreferrer\\"",
-              "rule": "link-rel-noopener",
-              "severity": 2,
-              "source": "<a href=\\"/some/where\\" target=\\"_blank\\" rel=\\"nofollow\\"></a>",
-            },
-          ]
-        `);
-      },
-    },
   ],
 });

--- a/test/unit/rules/no-accesskey-attribute-test.js
+++ b/test/unit/rules/no-accesskey-attribute-test.js
@@ -98,27 +98,5 @@ generateRuleTests({
         `);
       },
     },
-    {
-      template: '<button accesskey="{{some-key}}"></button>',
-      fixedTemplate: '<button></button>',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
-              "column": 8,
-              "endColumn": 32,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "isFixable": true,
-              "line": 1,
-              "message": "No access key attribute allowed. Inconsistencies between keyboard shortcuts and keyboard comments used by screenreader and keyboard only users create a11y complications.",
-              "rule": "no-accesskey-attribute",
-              "severity": 2,
-              "source": "accesskey=\\"{{some-key}}\\"",
-            },
-          ]
-        `);
-      },
-    },
   ],
 });

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -27,10 +27,6 @@ generateRuleTests({
       template: 'tarzan!\t\n  tarzan!',
     },
     {
-      config: ['/', '"'],
-      template: '{{t "foo"}} / "{{name}}"',
-    },
-    {
       config: ['&', '&times;', '4', '3=12'],
       template: '4 &times; 3=12',
     },

--- a/test/unit/rules/no-debugger-test.js
+++ b/test/unit/rules/no-debugger-test.js
@@ -32,27 +32,6 @@ generateRuleTests({
       },
     },
     {
-      template: '{{debugger}}',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
-              "column": 0,
-              "endColumn": 12,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "Unexpected {{debugger}} usage.",
-              "rule": "no-debugger",
-              "severity": 2,
-              "source": "{{debugger}}",
-            },
-          ]
-        `);
-      },
-    },
-    {
       template: '{{#debugger}}Invalid!{{/debugger}}',
 
       verifyResults(results) {

--- a/test/unit/rules/no-duplicate-id-test.js
+++ b/test/unit/rules/no-duplicate-id-test.js
@@ -13,7 +13,6 @@ generateRuleTests({
 
     // Mustache Statements
     '<div id={{"id-00"}}></div>',
-    '<div id={{"id-00"}}></div><div id={{"id-01"}}></div>',
     '<div id={{this.divId00}}></div>',
     '<div id={{this.divId00}}></div><div id={{this.divId01}}></div>',
 

--- a/test/unit/rules/no-invalid-link-text-test.js
+++ b/test/unit/rules/no-invalid-link-text-test.js
@@ -20,10 +20,6 @@ generateRuleTests({
       config: { allowEmptyLinks: true },
       template: '<a href="https://myurl.com"></a>',
     },
-    '<a href="https://myurl.com" aria-labelledby="some-id"></a>',
-    '<a href="https://myurl.com" aria-label="click here to read about our company"></a>',
-    '<a href="https://myurl.com" aria-hidden="true"></a>',
-    '<a href="https://myurl.com" hidden></a>',
   ],
 
   bad: [

--- a/test/unit/rules/no-multiple-empty-lines-test.js
+++ b/test/unit/rules/no-multiple-empty-lines-test.js
@@ -10,7 +10,6 @@ generateRuleTests({
 
   good: [
     '<div>foo</div><div>bar</div>',
-    '<div>foo</div><div>bar</div>',
     '<div>foo</div>\n<div>bar</div>',
     '<div>foo</div>\r\n<div>bar</div>',
     '<div>foo</div>\n\n<div>bar</div>',

--- a/test/unit/rules/no-mut-helper-test.js
+++ b/test/unit/rules/no-mut-helper-test.js
@@ -12,7 +12,6 @@ generateRuleTests({
   good: [
     '<MyComponent @toggled={{this.showAggregatedLine}}/>',
     '<MyComponent @toggle={{set this "isDropdownOpen"}}/>',
-    '<MyComponent @toggle={{set this "isDropdownOpen"}}/>',
     '<MyComponent @onFocusOut={{action "onFocusOutKeySkillsInput" value="target.value"}}/>',
     '<MyComponent {{on "click" (set this "isDropdownOpen" false)}}/>',
     '<MyComponent {{on "change" this.setContactUsSectionDescription}}/>',

--- a/test/unit/rules/no-restricted-invocations-test.js
+++ b/test/unit/rules/no-restricted-invocations-test.js
@@ -603,16 +603,6 @@ generateRuleTests({
       },
     },
     {
-      // Disallows incorrect naming format (disallows nested angle bracket invocation style).
-      config: ['MyComponent'],
-      template: 'test',
-
-      result: {
-        fatal: true,
-        message: 'You specified `["MyComponent"]`',
-      },
-    },
-    {
       // Disallows incorrect naming format.
       config: ['Scope/MyComponent'],
       template: 'test',

--- a/test/unit/rules/require-valid-alt-text-test.js
+++ b/test/unit/rules/require-valid-alt-text-test.js
@@ -19,7 +19,6 @@ generateRuleTests({
 
     '<img alt="some-alt-name">',
     '<img alt="name {{picture}}">',
-    '<img aria-hidden="true">',
     '<img alt="{{picture}}">',
     '<img alt="" role="none">',
     '<img alt="" role="presentation">',


### PR DESCRIPTION
This updates the test runner to fail when it detects duplicate test cases.

Example output:

```
 FAIL  test/unit/rules/no-duplicate-id-test.js
  ● no-duplicate-id › <div id={{"id-00"}}></div><div id={{"id-01"}}></div>: passes

    assert(received)

    Expected value to be equal to:
      true
    Received:
      false
    
    Message:
      detected duplicate `good` test case
```

Part of v4 release (#1908).

TODO:

- [x] Remove duplicate tests found in 11 of our test files
- [x] Add tests