### PR TITLE
Remove `--ignore-engines` from yarn CI script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: install dependencies
-        run: yarn install --frozen-lockfile --ignore-engines
+        run: yarn install --frozen-lockfile
 
       - run: yarn test:jest
 


### PR DESCRIPTION
Not needed.