### PR TITLE
Use built-in `actions/setup-node` for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: volta-cli/action@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
 
       - name: install dependencies
         run: yarn install --frozen-lockfile
@@ -48,7 +51,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: volta-cli/action@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 
@@ -65,7 +69,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: volta-cli/action@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
 
       - name: install dependencies
         run: yarn install --no-lockfile


### PR DESCRIPTION
Just use built-in Node CI Github action.