### PR TITLE
Fix broken markdown links

### DIFF
--- a/docs/rule/_TEMPLATE_.md
+++ b/docs/rule/_TEMPLATE_.md
@@ -1,3 +1,3 @@
 # Template
 
-Please see [dev/new-rule/templates/doc.md](dev/new-rule/templates/doc.md) to find the documentation template for new rules.
+Please see [dev/templates/doc.md](dev/templates/doc.md) to find the documentation template for new rules.

--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -30,7 +30,7 @@ This rule **allows** the following:
 
 When the config value of `true` is used the following configuration is used:
 
-* `allowlist` - refer to the `DEFAULT_CONFIG.allowlist` property in the [rule](../lib/rules/no-bare-strings.js)
+* `allowlist` - refer to the `DEFAULT_CONFIG.allowlist` property in the [rule](../../lib/rules/no-bare-strings.js)
 * `globalAttributes` - `title`, `aria-label`, `aria-placeholder`, `aria-roledescription`, `aria-valuetext`
 * `elementAttributes` - `{ img: ['alt'], input: ['placeholder'] }`
 

--- a/docs/rule/no-triple-curlies.md
+++ b/docs/rule/no-triple-curlies.md
@@ -20,4 +20,4 @@ This rule **allows** the following:
 
 ## References
 
-* See the [documentation](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe) for Ember's `htmlSafe` function
+* See the [documentation](https://api.emberjs.com/ember/release/functions/@ember%2Ftemplate/htmlSafe) for Ember's `htmlSafe` function

--- a/docs/rule/require-each-key.md
+++ b/docs/rule/require-each-key.md
@@ -79,4 +79,4 @@ This rule **allows** the following:
 ## References
 
 * [Specifying Keys](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each#specifying-keys)
-* [The Immutable Pattern in Tracked Properties](https://glimmerjs.com/guides/tracked-properties)
+* [The Immutable Pattern in Tracked Properties](https://glimmerjs.com/guides/tracked-properties) (TODO: fix this link)

--- a/docs/rule/style-concatenation.md
+++ b/docs/rule/style-concatenation.md
@@ -48,7 +48,7 @@ This rule **allows** the following:
 ## References
 
 * See the [Binding Style Attributes](https://emberjs.com/deprecations/v1.x/#toc_binding-style-attributes) Ember deprecation documentation
-* See the [documentation](https://www.emberjs.com/api/ember/release/functions/@ember%2Ftemplate/htmlSafe) for Ember's `htmlSafe` function
+* See the [documentation](https://api.emberjs.com/ember/release/functions/@ember%2Ftemplate/htmlSafe) for Ember's `htmlSafe` function
 * See the [documentation](https://www.emberjs.com/api/ember/release/classes/Ember.Templates.helpers/methods/concat?anchor=concat) for Ember's `concat` handlebars template helper
 * See the [documentation](https://github.com/romulomachado/ember-cli-string-helpers#html-safe) for the `html-safe` handlebars template helper from the `ember-cli-string-helpers` addon
 


### PR DESCRIPTION
Found one of these broken links manually then used used [markdown-link-check](https://github.com/tcort/markdown-link-check) to find the rest.
