### PR TITLE
Update chalk to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "dependencies": {
     "@lint-todo/utils": "^12.0.0",
-    "chalk": "^4.1.2",
+    "chalk": "^5.0.0",
     "ci-info": "^3.3.0",
     "date-fns": "^2.27.0",
     "ember-template-recast": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1757,6 +1757,11 @@ chalk@^2.0.0, chalk@^2.4.1, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+chalk@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.0.0.tgz#bd96c6bb8e02b96e08c0c3ee2a9d90e050c7b832"
+  integrity sha512-/duVOqst+luxCQRKEo4bNxinsOQtMP80ZYm7mMqzuh5PociNL0PvmHFvREJ9ueYL2TxlHjBcmLCdmocx9Vg+IQ==
+
 char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/char-regex/-/char-regex-1.0.2.tgz#d744358226217f981ed58f479b1d6bcc29545dcf"


### PR DESCRIPTION
Unblocked by the ESM conversion.

https://github.com/chalk/chalk/releases/tag/v5.0.0

Part of v4 release (#1908).

