### PR TITLE
Update get-stdin to v9

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "ember-template-recast": "^6.1.0",
     "find-up": "^5.0.0",
     "fuse.js": "^6.4.6",
-    "get-stdin": "^8.0.0",
+    "get-stdin": "^9.0.0",
     "globby": "^11.0.4",
     "is-glob": "^4.0.3",
     "micromatch": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3077,7 +3077,12 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
-get-stdin@^8.0.0, get-stdin@~8.0.0:
+get-stdin@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-9.0.0.tgz#3983ff82e03d56f1b2ea0d3e60325f39d703a575"
+  integrity sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==
+
+get-stdin@~8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
   integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==


### PR DESCRIPTION
Unblocked by the ESM conversion.

https://github.com/sindresorhus/get-stdin/releases/tag/v9.0.0

Part of v4 release (#1908).

