### PR TITLE
Add v4 migration guide

### DIFF
--- a/docs/migration/v4.md
+++ b/docs/migration/v4.md
@@ -1,1 +1,33 @@
 # Migrating to v4.0.0
+
+See the full list of changes in [#1908](https://github.com/ember-template-lint/ember-template-lint/issues/1908).
+
+Below is a rough summary of what to expect.
+
+## Breaking changes for users
+
+* Node.js 10, 13, and 15 are no longer supported
+* Config file validation has become stricter
+* Some rules have become stricter
+* Deprecated rules have been removed
+* Deprecated CLI options have been removed
+* Deprecated pending functionality has been removed in favor of TODOs
+* Linting will fail when a non-existent file is specified
+* Linting will fail when a non-existent CLI option is specified
+* More rules have been added to the `recommended` config
+* The `octane` config has been removed
+* The rule options for `no-bare-strings` now augment instead of replace its default config
+
+## Breaking changes for plugin developers
+
+* Node.js 10, 13, and 15 are no longer supported
+* Rules must now be written in ESM
+* The rule test harness has become stricter
+* The rule test harness is now a named export `generateRuleTests`
+* Rule violation logging requirements have become stricter
+
+## Breaking changes for Node API integration developers
+
+* Node.js 10, 13, and 15 are no longer supported
+* Integrations must now be written in ESM
+* Non-public entry-points are no longer accessible


### PR DESCRIPTION
This is written with a similar format to the ESLint migration guides ([ESLint v8 migration guide example](https://eslint.org/docs/8.0.0/user-guide/migrating-to-8.0.0#remove-lib)).

However, since there are so many changes, I didn't go into detail on any of them, instead referring readers to the [list of v4 changes](https://github.com/ember-template-lint/ember-template-lint/issues/1908) with PR links which ideally have more detail on each change. Most important in this migration guide is giving readers a summary as a starting point. It's too tedious to duplicate everything from the individual PRs which readers can reference.

Feel free to improve this guide.