### PR TITLE
Fix false positives with non-serializable rule configs in duplicate test case check

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -381,6 +381,28 @@ export default function generateRuleTests(...args) {
       return JSON.stringify(itemCleanedAndSorted);
     }
 
+    /**
+     * If possible, check if this test case is a duplicate of one we have seen before.
+     * @param {Object} item - test case object
+     * @param {Set<String>} seenTestCases - set of serialized test cases we have seen so far (managed by this function)
+     * @param {String} testCaseType - what type of test case we're running the check for
+     */
+    function checkDuplicateTestCase(item, seenTestCases, testCaseType) {
+      if (['object', 'function'].includes(typeof item.config)) {
+        // Functions can't be serialized.
+        // Objects like RegExp can't be serialized.
+        // So just ignore configs that can potentially not be serialized.
+        return;
+      }
+
+      const serializedTestCase = serializeTestCase(item);
+      assert(
+        !seenTestCases.has(serializedTestCase),
+        `detected duplicate \`${testCaseType}\` test case`
+      );
+      seenTestCases.add(serializedTestCase);
+    }
+
     const seenBadTestCases = new Set();
     for (const item of bad) {
       let template = item.template;
@@ -392,9 +414,7 @@ export default function generateRuleTests(...args) {
       testOrOnly(`${testName}: logs errors`, async function () {
         checkLinterReuse();
 
-        const serializedTestCase = serializeTestCase(item);
-        assert(!seenBadTestCases.has(serializedTestCase), 'detected duplicate `bad` test case');
-        seenBadTestCases.add(serializedTestCase);
+        checkDuplicateTestCase(item, seenBadTestCases, 'bad');
 
         let options = await prepare(item, item.config);
         let actual = await linter.verify(options);
@@ -528,9 +548,7 @@ export default function generateRuleTests(...args) {
       testOrOnly(`${testName}: passes`, async function () {
         checkLinterReuse();
 
-        const serializedTestCase = serializeTestCase(item);
-        assert(!seenGoodTestCases.has(serializedTestCase), 'detected duplicate `good` test case');
-        seenGoodTestCases.add(serializedTestCase);
+        checkDuplicateTestCase(item, seenGoodTestCases, 'good');
 
         let options = await prepare(item, item.config);
         let actual = await linter.verify(options);
@@ -551,9 +569,7 @@ export default function generateRuleTests(...args) {
       testOrOnly(`${testName}: errors with config \`${friendlyConfig}\``, async function () {
         checkLinterReuse();
 
-        const serializedTestCase = serializeTestCase(item);
-        assert(!seenErrorTestCases.has(serializedTestCase), 'detected duplicate `error` test case');
-        seenErrorTestCases.add(serializedTestCase);
+        checkDuplicateTestCase(item, seenErrorTestCases, 'error');
 
         let options = await prepare(item, item.config);
         let actual = await linter.verify(options);

--- a/test/acceptance/rule-test.js
+++ b/test/acceptance/rule-test.js
@@ -1075,6 +1075,393 @@ describe('regression tests', function () {
     );
   });
 
+  test('when duplicate bad test case with serializable config', async function () {
+    let group;
+    defaultTestHarness({
+      groupingMethod(name, callback) {
+        group = new Group(name, callback);
+      },
+
+      groupMethodBefore(callback) {
+        group.beforeEach.push(callback);
+      },
+
+      testMethod(name, callback) {
+        group.tests.push(new Test(name, callback));
+      },
+
+      plugins: [
+        {
+          name: 'test',
+          rules: {
+            'test-rule': class extends Rule {
+              visitor() {
+                return {
+                  ElementNode(node) {
+                    this.log({
+                      message: 'Do not use MySpecialThing',
+                      node,
+                    });
+                  },
+                };
+              }
+            },
+          },
+        },
+      ],
+
+      name: 'test-rule',
+      config: true,
+
+      bad: [
+        {
+          template: '<MySpecialThing/>',
+          config: 123,
+          results: [
+            {
+              column: 0,
+              line: 1,
+              endColumn: 17,
+              endLine: 1,
+              message: 'Do not use MySpecialThing',
+              source: '<MySpecialThing/>',
+            },
+          ],
+        },
+        {
+          template: '<MySpecialThing/>',
+          config: 123,
+          results: [
+            {
+              column: 0,
+              line: 1,
+              endColumn: 17,
+              endLine: 1,
+              message: 'Do not use MySpecialThing',
+              source: '<MySpecialThing/>',
+            },
+          ],
+        },
+      ],
+    });
+
+    await expect(() => group.run()).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"detected duplicate \`bad\` test case"`
+    );
+  });
+
+  test('when non-duplicate bad test case with object config containing potentially non-serializable members', async function () {
+    let group;
+    defaultTestHarness({
+      groupingMethod(name, callback) {
+        group = new Group(name, callback);
+      },
+
+      groupMethodBefore(callback) {
+        group.beforeEach.push(callback);
+      },
+
+      testMethod(name, callback) {
+        group.tests.push(new Test(name, callback));
+      },
+
+      plugins: [
+        {
+          name: 'test',
+          rules: {
+            'test-rule': class extends Rule {
+              visitor() {
+                return {
+                  ElementNode(node) {
+                    this.log({
+                      message: 'Do not use MySpecialThing',
+                      node,
+                    });
+                  },
+                };
+              }
+            },
+          },
+        },
+      ],
+
+      name: 'test-rule',
+      config: true,
+
+      bad: [
+        {
+          template: '<MySpecialThing/>',
+          config: {
+            someFunction() {
+              return 123;
+            },
+          },
+          results: [
+            {
+              column: 0,
+              line: 1,
+              endColumn: 17,
+              endLine: 1,
+              message: 'Do not use MySpecialThing',
+              source: '<MySpecialThing/>',
+            },
+          ],
+        },
+        {
+          template: '<MySpecialThing/>',
+          config: {
+            someFunction() {
+              return 456;
+            },
+          },
+          results: [
+            {
+              column: 0,
+              line: 1,
+              endColumn: 17,
+              endLine: 1,
+              message: 'Do not use MySpecialThing',
+              source: '<MySpecialThing/>',
+            },
+          ],
+        },
+      ],
+    });
+
+    await group.run(); // should not fail
+  });
+
+  test('when non-duplicate bad test case with non-serializable RegExp config', async function () {
+    let group;
+    defaultTestHarness({
+      groupingMethod(name, callback) {
+        group = new Group(name, callback);
+      },
+
+      groupMethodBefore(callback) {
+        group.beforeEach.push(callback);
+      },
+
+      testMethod(name, callback) {
+        group.tests.push(new Test(name, callback));
+      },
+
+      plugins: [
+        {
+          name: 'test',
+          rules: {
+            'test-rule': class extends Rule {
+              visitor() {
+                return {
+                  ElementNode(node) {
+                    this.log({
+                      message: 'Do not use MySpecialThing',
+                      node,
+                    });
+                  },
+                };
+              }
+            },
+          },
+        },
+      ],
+
+      name: 'test-rule',
+      config: true,
+
+      bad: [
+        {
+          template: '<MySpecialThing/>',
+          config: new RegExp('abc'),
+          results: [
+            {
+              column: 0,
+              line: 1,
+              endColumn: 17,
+              endLine: 1,
+              message: 'Do not use MySpecialThing',
+              source: '<MySpecialThing/>',
+            },
+          ],
+        },
+        {
+          template: '<MySpecialThing/>',
+          config: new RegExp('def'),
+          results: [
+            {
+              column: 0,
+              line: 1,
+              endColumn: 17,
+              endLine: 1,
+              message: 'Do not use MySpecialThing',
+              source: '<MySpecialThing/>',
+            },
+          ],
+        },
+      ],
+    });
+
+    await group.run(); // should not fail
+  });
+
+  test('when non-duplicate bad test case with non-serializable function config', async function () {
+    let group;
+    defaultTestHarness({
+      groupingMethod(name, callback) {
+        group = new Group(name, callback);
+      },
+
+      groupMethodBefore(callback) {
+        group.beforeEach.push(callback);
+      },
+
+      testMethod(name, callback) {
+        group.tests.push(new Test(name, callback));
+      },
+
+      plugins: [
+        {
+          name: 'test',
+          rules: {
+            'test-rule': class extends Rule {
+              visitor() {
+                return {
+                  ElementNode(node) {
+                    this.log({
+                      message: 'Do not use MySpecialThing',
+                      node,
+                    });
+                  },
+                };
+              }
+            },
+          },
+        },
+      ],
+
+      name: 'test-rule',
+      config: true,
+
+      bad: [
+        {
+          template: '<MySpecialThing/>',
+          config: function foo() {
+            return 123;
+          },
+          results: [
+            {
+              column: 0,
+              line: 1,
+              endColumn: 17,
+              endLine: 1,
+              message: 'Do not use MySpecialThing',
+              source: '<MySpecialThing/>',
+            },
+          ],
+        },
+        {
+          template: '<MySpecialThing/>',
+          config: function foo() {
+            return 456;
+          },
+          results: [
+            {
+              column: 0,
+              line: 1,
+              endColumn: 17,
+              endLine: 1,
+              message: 'Do not use MySpecialThing',
+              source: '<MySpecialThing/>',
+            },
+          ],
+        },
+      ],
+    });
+
+    await group.run(); // should not fail
+  });
+
+  test('when non-duplicate bad test case with non-serializable regexp config', async function () {
+    let group;
+    defaultTestHarness({
+      groupingMethod(name, callback) {
+        group = new Group(name, callback);
+      },
+
+      groupMethodBefore(callback) {
+        group.beforeEach.push(callback);
+      },
+
+      testMethod(name, callback) {
+        group.tests.push(new Test(name, callback));
+      },
+
+      plugins: [
+        {
+          name: 'test',
+          rules: {
+            'test-rule': class extends Rule {
+              visitor() {
+                return {
+                  ElementNode(node) {
+                    this.log({
+                      message: 'Do not use MySpecialThing',
+                      node,
+                    });
+                  },
+                };
+              }
+            },
+          },
+        },
+      ],
+
+      name: 'test-rule',
+      config: true,
+
+      bad: [
+        {
+          template: '<MySpecialThing/>',
+          config: {
+            someFunction() {
+              return 123;
+            },
+          },
+          results: [
+            {
+              column: 0,
+              line: 1,
+              endColumn: 17,
+              endLine: 1,
+              message: 'Do not use MySpecialThing',
+              source: '<MySpecialThing/>',
+            },
+          ],
+        },
+        {
+          template: '<MySpecialThing/>',
+          config: {
+            someFunction() {
+              return 456;
+            },
+          },
+          results: [
+            {
+              column: 0,
+              line: 1,
+              endColumn: 17,
+              endLine: 1,
+              message: 'Do not use MySpecialThing',
+              source: '<MySpecialThing/>',
+            },
+          ],
+        },
+      ],
+    });
+
+    await group.run(); // should not fail
+  });
+
   test('when duplicate error test case', async function () {
     let group;
     defaultTestHarness({


### PR DESCRIPTION
Since we check for duplicate test cases by serializing them, we need to be careful about test case data that we can't correctly serialize. This can happen with rule config options that contain non-serializable properties like functions or RegExp. So when we encounter any configs that can potentially include these, we just ignore those test cases from the duplicate test case check.

Follow-up to https://github.com/ember-template-lint/ember-template-lint/pull/2279 where I added a check for duplicate test cases.