### PR TITLE
Tweak ordering of items in v4 migration guide

### DIFF
--- a/docs/migration/v4.md
+++ b/docs/migration/v4.md
@@ -7,14 +7,6 @@ This release is almost entirely focused on breaking changes, as summarized below
 ## Breaking changes for users
 
 * Node.js version support has been raised to `^12.22.0 || ^14.17.0 || >=16.0.0`
-* Config files that directly import rules must now be written in ESM
-* Config file validation has become stricter
-* Some rules have become stricter
-* Deprecated rules have been removed
-* Deprecated CLI options have been removed
-* Deprecated pending functionality has been removed in favor of TODOs
-* Linting will fail when a non-existent file is specified
-* Linting will fail when a non-existent CLI option is specified
 * More [rules](../../README.md#rules) have been added to the `recommended` config
   * [no-autofocus-attribute](../rule/no-autofocus-attribute.md)
   * [no-capital-arguments](../rule/no-capital-arguments.md)
@@ -35,6 +27,14 @@ This release is almost entirely focused on breaking changes, as summarized below
   * [require-valid-named-block-naming-format](../rule/require-valid-named-block-naming-format.md)
 * The `octane` config has been removed (was previously merged into `recommended`)
 * The rule options for [no-bare-strings](../rule/no-bare-strings.md) now augment instead of replace its default config
+* Some rules have become stricter
+* Deprecated rules have been removed
+* Deprecated CLI options have been removed
+* Deprecated pending functionality has been removed in favor of TODOs
+* Linting will fail when a non-existent file is specified
+* Linting will fail when a non-existent CLI option is specified
+* Config file validation has become stricter
+* Config files that directly import rules must now be written in ESM (this is rare)
 
 ## Breaking changes for plugin developers
 


### PR DESCRIPTION
Put more important items that affect lots of users first.

Follow-up to:
* #2302
* #2297