### PR TITLE
Remove `no-dynamic-subexpression-invocations` rule from `recommended` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Each rule has emojis denoting:
 | [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                                         | ✅  |     | ⌨️  |     |
 | [no-duplicate-id](./docs/rule/no-duplicate-id.md)                                                         | ✅  |     | ⌨️  |     |
 | [no-duplicate-landmark-elements](./docs/rule/no-duplicate-landmark-elements.md)                           | ✅  |     | ⌨️  |     |
-| [no-dynamic-subexpression-invocations](./docs/rule/no-dynamic-subexpression-invocations.md)               | ✅  |     |     |     |
+| [no-dynamic-subexpression-invocations](./docs/rule/no-dynamic-subexpression-invocations.md)               |     |     |     |     |
 | [no-element-event-actions](./docs/rule/no-element-event-actions.md)                                       |     |     |     |     |
 | [no-empty-headings](./docs/rule/no-empty-headings.md)                                                     | ✅  |     | ⌨️  |     |
 | [no-extra-mut-helper-argument](./docs/rule/no-extra-mut-helper-argument.md)                               | ✅  |     |     |     |

--- a/docs/migration/v4.md
+++ b/docs/migration/v4.md
@@ -11,7 +11,6 @@ This release is almost entirely focused on breaking changes, as summarized below
   * [no-autofocus-attribute](../rule/no-autofocus-attribute.md)
   * [no-capital-arguments](../rule/no-capital-arguments.md)
   * [no-class-bindings](../rule/no-class-bindings.md)
-  * [no-dynamic-subexpression-invocations](../rule/no-dynamic-subexpression-invocations.md)
   * [no-empty-headings](../rule/no-empty-headings.md)
   * [no-link-to-tagname](../rule/no-link-to-tagname.md)
   * [no-model-argument-in-route-templates](../rule/no-model-argument-in-route-templates.md)

--- a/docs/rule/no-dynamic-subexpression-invocations.md
+++ b/docs/rule/no-dynamic-subexpression-invocations.md
@@ -1,7 +1,5 @@
 # no-dynamic-subexpression-invocations
 
-✅ The `extends: 'recommended'` property in a configuration file enables this rule.
-
 When using Ember versions prior to 3.25 the usage of dynamic invocations for
 helpers and modifiers did not work. Unfortunately, some versions of Ember
 silently ignored additional arguments (3.16) wherease others throw a very

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -22,7 +22,6 @@ export default {
     'no-duplicate-attributes': 'error',
     'no-duplicate-id': 'error',
     'no-duplicate-landmark-elements': 'error',
-    'no-dynamic-subexpression-invocations': 'error',
     'no-empty-headings': 'error',
     'no-extra-mut-helper-argument': 'error',
     'no-forbidden-elements': 'error',


### PR DESCRIPTION
In order to keep this lint, it needs to be a no-op for Ember 3.25+
I don't know how much of the ecosystem is on 3.25+ yet, but I have 
_many_ projects on 3.25+
(and using local helpers)

Fixes https://github.com/ember-template-lint/ember-template-lint/issues/2307