### PR TITLE
Remove `no-model-argument-in-route-templates` rule from `recommended` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Each rule has emojis denoting:
 | [no-link-to-positional-params](./docs/rule/no-link-to-positional-params.md)                               | ✅  |     |     |     |
 | [no-link-to-tagname](./docs/rule/no-link-to-tagname.md)                                                   | ✅  |     |     |     |
 | [no-log](./docs/rule/no-log.md)                                                                           | ✅  |     |     |     |
-| [no-model-argument-in-route-templates](./docs/rule/no-model-argument-in-route-templates.md)               | ✅  |     |     | 🔧  |
+| [no-model-argument-in-route-templates](./docs/rule/no-model-argument-in-route-templates.md)               |     |     |     | 🔧  |
 | [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                                         |     | 💅  |     |     |
 | [no-mut-helper](./docs/rule/no-mut-helper.md)                                                             | ✅  |     |     |     |
 | [no-negated-condition](./docs/rule/no-negated-condition.md)                                               | ✅  |     |     | 🔧  |

--- a/docs/migration/v4.md
+++ b/docs/migration/v4.md
@@ -14,7 +14,6 @@ This release is almost entirely focused on breaking changes, as summarized below
   * [no-dynamic-subexpression-invocations](../rule/no-dynamic-subexpression-invocations.md)
   * [no-empty-headings](../rule/no-empty-headings.md)
   * [no-link-to-tagname](../rule/no-link-to-tagname.md)
-  * [no-model-argument-in-route-templates](../rule/no-model-argument-in-route-templates.md)
   * [no-mut-helper](../rule/no-mut-helper.md)
   * [no-route-action](../rule/no-route-action.md)
   * [no-valueless-arguments](../rule/no-valueless-arguments.md)

--- a/docs/rule/no-model-argument-in-route-templates.md
+++ b/docs/rule/no-model-argument-in-route-templates.md
@@ -1,7 +1,5 @@
 # no-model-argument-in-route-templates
 
-✅ The `extends: 'recommended'` property in a configuration file enables this rule.
-
 🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
 
 Usage of `{{@model}}` in route templates was introduced to simplify the mental

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -41,7 +41,6 @@ export default {
     'no-link-to-positional-params': 'error',
     'no-link-to-tagname': 'error',
     'no-log': 'error',
-    'no-model-argument-in-route-templates': 'error',
     'no-mut-helper': 'error',
     'no-negated-condition': 'error',
     'no-nested-interactive': 'error',


### PR DESCRIPTION
Related discussion: https://github.com/ember-template-lint/ember-template-lint/issues/1908#issuecomment-1004010809