### PR TITLE
Remove `no-mut-helper` rule from `recommended` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Each rule has emojis denoting:
 | [no-log](./docs/rule/no-log.md)                                                                           | ✅  |     |     |     |
 | [no-model-argument-in-route-templates](./docs/rule/no-model-argument-in-route-templates.md)               |     |     |     | 🔧  |
 | [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                                         |     | 💅  |     |     |
-| [no-mut-helper](./docs/rule/no-mut-helper.md)                                                             | ✅  |     |     |     |
+| [no-mut-helper](./docs/rule/no-mut-helper.md)                                                             |     |     |     |     |
 | [no-negated-condition](./docs/rule/no-negated-condition.md)                                               | ✅  |     |     | 🔧  |
 | [no-nested-interactive](./docs/rule/no-nested-interactive.md)                                             | ✅  |     | ⌨️  |     |
 | [no-nested-landmark](./docs/rule/no-nested-landmark.md)                                                   | ✅  |     | ⌨️  |     |

--- a/docs/migration/v4.md
+++ b/docs/migration/v4.md
@@ -13,7 +13,6 @@ This release is almost entirely focused on breaking changes, as summarized below
   * [no-class-bindings](../rule/no-class-bindings.md)
   * [no-empty-headings](../rule/no-empty-headings.md)
   * [no-link-to-tagname](../rule/no-link-to-tagname.md)
-  * [no-mut-helper](../rule/no-mut-helper.md)
   * [no-route-action](../rule/no-route-action.md)
   * [no-valueless-arguments](../rule/no-valueless-arguments.md)
   * [no-whitespace-for-layout](../rule/no-whitespace-for-layout.md)

--- a/docs/rule/no-mut-helper.md
+++ b/docs/rule/no-mut-helper.md
@@ -1,7 +1,5 @@
 # no-mut-helper
 
-✅ The `extends: 'recommended'` property in a configuration file enables this rule.
-
 ## Reasons to not use [the `mut` helper](https://api.emberjs.com/ember/release/classes/Ember.Templates.helpers/methods/each?anchor=mut)
 
 1. General problems in the programming model:

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -40,7 +40,6 @@ export default {
     'no-link-to-positional-params': 'error',
     'no-link-to-tagname': 'error',
     'no-log': 'error',
-    'no-mut-helper': 'error',
     'no-negated-condition': 'error',
     'no-nested-interactive': 'error',
     'no-nested-landmark': 'error',


### PR DESCRIPTION
Related discussion: https://github.com/ember-template-lint/ember-template-lint/issues/1908#issuecomment-1004016193