### PR TITLE
Fix false negatives with `block-indentation` rule

### DIFF
--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -302,10 +302,12 @@ module.exports = class BlockIndentation extends Rule {
 
     const indexOfNodeInTemplate = this.template.body.indexOf(node);
     const isDirectChildOfTemplate = indexOfNodeInTemplate !== -1;
-    let startColumn = node.loc.start.column;
+    const hasLeadingContent =
+      !isDirectChildOfTemplate || this.hasLeadingContent(node, this.template.body);
+    const startColumn = node.loc.start.column;
 
     // If it's not a direct child of the template the block start is already fixed by the validateBlockChildren function
-    if (isDirectChildOfTemplate && startColumn !== 0) {
+    if (isDirectChildOfTemplate && startColumn !== 0 && !hasLeadingContent) {
       if (this.mode === 'fix') {
         const previousNode = this.template.body[indexOfNodeInTemplate - 1];
         if (previousNode.type === 'TextNode') {
@@ -421,36 +423,7 @@ module.exports = class BlockIndentation extends Rule {
         break;
       }
 
-      // We might not actually be the first thing on the line. We might be
-      // preceded by another element or statement, or by some text. So walk
-      // backwards looking for something else on this line.
-      let hasLeadingContent = false;
-      for (let j = i - 2; j >= 0; j--) {
-        let sibling = children[j];
-        if (sibling.loc && sibling.type !== 'TextNode') {
-          // Found an element or statement. If it's on this line, then we
-          // have leading content, so set the flag and break. If it's not
-          // on this line, then we've scanned back to a previous line, so
-          // we can also break.
-          if (sibling.loc.end.line === child.loc.start.line) {
-            hasLeadingContent = true;
-          }
-          break;
-        } else {
-          let lines = sibling.chars.split(/[\n\r]/);
-          let lastLine = lines[lines.length - 1];
-          if (lastLine.trim()) {
-            // The last line in this text node has non-whitespace content, so
-            // set the flag.
-            hasLeadingContent = true;
-          }
-          if (lines.length > 1) {
-            // There are multiple lines meaning we've now scanned back to a
-            // previous line, so we can break.
-            break;
-          }
-        }
-      }
+      const hasLeadingContent = this.hasLeadingContent(child, children);
 
       if (hasLeadingContent) {
         // There's content before us on the same line, so we don't care about
@@ -582,6 +555,41 @@ module.exports = class BlockIndentation extends Rule {
     }
 
     return node;
+  }
+
+  hasLeadingContent(node, parentChildren) {
+    const currentIndex = parentChildren.indexOf(node);
+    // We might not actually be the first thing on the line. We might be
+    // preceded by another element or statement, or by some text. So walk
+    // backwards looking for something else on this line.
+    for (let j = currentIndex - 1; j >= 0; j--) {
+      let sibling = parentChildren[j];
+      if (sibling.loc && sibling.type !== 'TextNode') {
+        // Found an element or statement. If it's on this line, then we
+        // have leading content, so set the flag and break. If it's not
+        // on this line, then we've scanned back to a previous line, so
+        // we can also break.
+        if (sibling.loc.end.line === node.loc.start.line) {
+          return true;
+        }
+        break;
+      } else {
+        let lines = sibling.chars.split(/[\n\r]/);
+        let lastLine = lines[lines.length - 1];
+        if (lastLine.trim()) {
+          // The last line in this text node has non-whitespace content, so
+          // set the flag.
+          return true;
+        }
+        if (lines.length > 1) {
+          // There are multiple lines meaning we've now scanned back to a
+          // previous line, so we can break.
+          break;
+        }
+      }
+    }
+
+    return false;
   }
 
   getDisplayNameForNode(node) {

--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -192,18 +192,14 @@ module.exports = class BlockIndentation extends Rule {
     this.seen = new Set();
 
     return {
-      Template(node) {
-        if (this.mode === 'fix') {
-          if (
-            node.body[0] &&
-            node.body[0].type === 'TextNode' &&
-            !removeWhitespaceEnd(node.body[0].chars)
-          ) {
-            // We need to remove the text node in this case
-            node.body.shift();
-          }
-        }
-        return node;
+      Template: {
+        enter(node) {
+          this.template = node;
+          return node;
+        },
+        exit() {
+          this.template = null;
+        },
       },
 
       BlockStatement(node) {
@@ -281,7 +277,7 @@ module.exports = class BlockIndentation extends Rule {
       }
 
       // Recreate the node only if the source has changed, otherwise this would mean useless computation and possible mistake
-      if (sourceBeforeFix !== this.sourceEdited) {
+      if (sourceBeforeFix !== this.sourceEdited && this.sourceEdited) {
         fixedNode = this.fixLine(
           this.sourceEdited.split('\n'),
           0,
@@ -302,20 +298,30 @@ module.exports = class BlockIndentation extends Rule {
       return node;
     }
 
+    const indexOfNodeInTemplate = this.template.body.indexOf(node);
+    const isDirectChildOfTemplate = indexOfNodeInTemplate !== -1;
     let startColumn = node.loc.start.column;
     let startLine = node.loc.start.line;
+    const shouldValidate = startLine === 1 || isDirectChildOfTemplate;
 
-    if (startLine === 1 && startColumn !== 0) {
+    if (shouldValidate && startColumn !== 0) {
       if (this.mode === 'fix') {
-        // If we are in a child (path set) we want to edit directly the source and not the source of the node
-        const elementSource = path
-          ? this.sourceEdited || this.source.join('')
-          : sourceForLoc(this.sourceEdited || this.source, {
-              end: node.loc.end,
-              start: { line: node.loc.start.line, column: 0 },
-            });
-        const fixedNode = this.fixLine(elementSource.split('\n'), 0, startColumn, 0, path);
-        return fixedNode;
+        if (isDirectChildOfTemplate) {
+          const previousNode = this.template.body[indexOfNodeInTemplate - 1];
+          if (previousNode.type === 'TextNode') {
+            previousNode.chars = removeWhitespaceEnd(previousNode.chars);
+          }
+        } else {
+          // If we are in a child (path set) we want to edit directly the source and not the source of the node
+          const elementSource = path
+            ? this.sourceEdited || this.source.join('')
+            : sourceForLoc(this.sourceEdited || this.source, {
+                end: node.loc.end,
+                start: { line: node.loc.start.line, column: 0 },
+              });
+          const fixedNode = this.fixLine(elementSource.split('\n'), 0, startColumn, 0, path);
+          return fixedNode;
+        }
       } else {
         let isElementNode = node && node.type === 'ElementNode';
         let displayName = isElementNode ? node.tag : node.path.original;

--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -232,6 +232,7 @@ module.exports = class BlockIndentation extends Rule {
     // issues (since the column of the start block was already checked in the
     // parent's validateBlockChildren())
     if (node.loc.start.line === node.loc.end.line || this.seen.has(node)) {
+      this.seen.add(fixedNode);
       return fixedNode;
     }
 
@@ -294,8 +295,8 @@ module.exports = class BlockIndentation extends Rule {
     return fixedNode;
   }
 
-  validateBlockStart(node, path) {
-    if (!this.shouldValidateBlockEnd(node)) {
+  validateBlockStart(node) {
+    if (!this.shouldValidateBlockStart(node)) {
       return node;
     }
 
@@ -306,21 +307,9 @@ module.exports = class BlockIndentation extends Rule {
     // If it's not a direct child of the template the block start is already fixed by the validateBlockChildren function
     if (isDirectChildOfTemplate && startColumn !== 0) {
       if (this.mode === 'fix') {
-        if (isDirectChildOfTemplate) {
-          const previousNode = this.template.body[indexOfNodeInTemplate - 1];
-          if (previousNode.type === 'TextNode') {
-            previousNode.chars = removeWhitespaceEnd(previousNode.chars);
-          }
-        } else {
-          // If we are in a child (path set) we want to edit directly the source and not the source of the node
-          const elementSource = path
-            ? this.sourceEdited || this.source.join('')
-            : sourceForLoc(this.sourceEdited || this.source, {
-                end: node.loc.end,
-                start: { line: node.loc.start.line, column: 0 },
-              });
-          const fixedNode = this.fixLine(elementSource.split('\n'), 0, startColumn, 0, path);
-          return fixedNode;
+        const previousNode = this.template.body[indexOfNodeInTemplate - 1];
+        if (previousNode.type === 'TextNode') {
+          previousNode.chars = removeWhitespaceEnd(previousNode.chars);
         }
       } else {
         let isElementNode = node && node.type === 'ElementNode';
@@ -624,7 +613,7 @@ module.exports = class BlockIndentation extends Rule {
     const line = lines[lineNumber];
 
     // If line starts with only white spaces...
-    if (line.startsWith(' '.repeat(actualColumn))) {
+    if (line.startsWith(' '.repeat(actualColumn)) || actualColumn === expectedColumn) {
       // ... then it means we just need to fix the number of whitespace
       lines[lineNumber] = actualColumn
         ? line.replace(/^ +/, ' '.repeat(expectedColumn))
@@ -636,7 +625,9 @@ module.exports = class BlockIndentation extends Rule {
       )}${line.slice(Math.max(0, actualColumn))}`;
     }
 
-    let node = parse(lines.join('\n')).body.find((node) => node.type !== 'TextNode');
+    this.sourceEdited = lines.join('\n');
+
+    let node = parse(this.sourceEdited).body.find((node) => node.type !== 'TextNode');
     node = get(node, path);
 
     // As we recreate a new node the _isElseIfBlock is not set anymore so we need to recompute it
@@ -645,8 +636,6 @@ module.exports = class BlockIndentation extends Rule {
 
       elseBlockStatement._isElseIfBlock = true;
     }
-
-    this.sourceEdited = lines.join('\n');
 
     return node;
   }
@@ -668,6 +657,42 @@ module.exports = class BlockIndentation extends Rule {
     return false;
   }
 
+  sourceDoesNotMatchNode(node, shouldIncludeEndingToken) {
+    let source = sourceForLoc(this.sourceEdited || this.source, node.loc);
+    let endingToken = `/${node.path.original}`;
+    let indexOfEnding = source.lastIndexOf(endingToken);
+
+    // Do not validate if source doesn't match node (if vs iframe)
+    let charAfterEnding = source[indexOfEnding + endingToken.length];
+    if (indexOfEnding !== -1 && !VALID_FOLLOWING_CHARS.has(charAfterEnding)) {
+      return true;
+    }
+
+    return !shouldIncludeEndingToken || indexOfEnding !== -1;
+  }
+
+  shouldValidateBlockStart(node) {
+    if (node._isElseIfBlock) {
+      return false;
+    }
+
+    // do not validate indentation on VOID_TAG's
+    if (VOID_TAGS[node.tag]) {
+      return true;
+    }
+
+    if (this.isWithinIgnoredElement()) {
+      return false;
+    }
+
+    // do not validate nodes without children (whitespace will count as TextNodes)
+    if (node && node.type === 'ElementNode') {
+      return true;
+    }
+
+    return this.sourceDoesNotMatchNode(node, false);
+  }
+
   shouldValidateBlockEnd(node) {
     if (node._isElseIfBlock) {
       return false;
@@ -687,17 +712,7 @@ module.exports = class BlockIndentation extends Rule {
       return AstNodeInfo.hasChildren(node);
     }
 
-    let source = sourceForLoc(this.sourceEdited || this.source, node.loc);
-    let endingToken = `/${node.path.original}`;
-    let indexOfEnding = source.lastIndexOf(endingToken);
-
-    // Do not validate if source doesn't match node (if vs iframe)
-    let charAfterEnding = source[indexOfEnding + endingToken.length];
-    if (indexOfEnding !== -1 && !VALID_FOLLOWING_CHARS.has(charAfterEnding)) {
-      return false;
-    }
-
-    return indexOfEnding !== -1;
+    return this.sourceDoesNotMatchNode(node, true);
   }
 
   endingControlCharCount(node) {

--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -226,14 +226,15 @@ module.exports = class BlockIndentation extends Rule {
    * @returns {Node}
    */
   process(node, path) {
+    let fixedNode = this.validateBlockStart(node, path);
+
     // Nodes that start and end on the same line cannot have any indentation
     // issues (since the column of the start block was already checked in the
     // parent's validateBlockChildren())
     if (node.loc.start.line === node.loc.end.line || this.seen.has(node)) {
-      return node;
+      return fixedNode;
     }
 
-    let fixedNode = this.validateBlockStart(node, path);
     fixedNode = this.validateBlockElse(fixedNode, path);
     fixedNode = this.validateBlockEnd(fixedNode, path);
     fixedNode = this.validateBlockChildren(fixedNode, path);
@@ -301,10 +302,9 @@ module.exports = class BlockIndentation extends Rule {
     const indexOfNodeInTemplate = this.template.body.indexOf(node);
     const isDirectChildOfTemplate = indexOfNodeInTemplate !== -1;
     let startColumn = node.loc.start.column;
-    let startLine = node.loc.start.line;
-    const shouldValidate = startLine === 1 || isDirectChildOfTemplate;
 
-    if (shouldValidate && startColumn !== 0) {
+    // If it's not a direct child of the template the block start is already fixed by the validateBlockChildren function
+    if (isDirectChildOfTemplate && startColumn !== 0) {
       if (this.mode === 'fix') {
         if (isDirectChildOfTemplate) {
           const previousNode = this.template.body[indexOfNodeInTemplate - 1];
@@ -687,7 +687,7 @@ module.exports = class BlockIndentation extends Rule {
       return AstNodeInfo.hasChildren(node);
     }
 
-    let source = this.sourceForNode(node);
+    let source = sourceForLoc(this.sourceEdited || this.source, node.loc);
     let endingToken = `/${node.path.original}`;
     let indexOfEnding = source.lastIndexOf(endingToken);
 
@@ -706,7 +706,7 @@ module.exports = class BlockIndentation extends Rule {
       return 3;
     }
 
-    let source = this.sourceForNode(node);
+    let source = sourceForLoc(this.sourceEdited || this.source, node.loc);
     let endingToken = `/${node.path.original}`;
     let indexOfEnding = source.lastIndexOf(endingToken);
 

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -145,7 +145,7 @@ generateRuleTests({
       config: {
         ignoreComments: true,
       },
-      template: '  {{! Comment }}\n<div>foo</div>',
+      template: '  {{! Comment }}<div>foo</div>',
     },
     {
       config: {
@@ -169,7 +169,7 @@ generateRuleTests({
       config: {
         ignoreComments: true,
       },
-      template: '  <!-- Comment -->\n<div>foo</div>',
+      template: '  <!-- Comment --><div>foo</div>',
     },
     {
       config: {
@@ -226,6 +226,13 @@ generateRuleTests({
         '  {{! Comment }}',
         '{{/if}}',
       ].join('\n'),
+    },
+    {
+      template:
+        '{{relativeDate}} <span class="my-apps-date-connected__absolute">({{absoluteDate}})</span>',
+    },
+    {
+      template: '<title></title>\n<path/><path/>',
     },
   ],
 

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -26,7 +26,7 @@ generateRuleTests({
       '  <iframe src="some_url"></iframe>',
       '{{/if}}',
     ].join('\n'),
-    '\n  {{#each cats as |dog|}}\n  {{/each}}',
+    '\n{{#each cats as |dog|}}\n{{/each}}',
     '<div><p>Stuff</p></div>',
     '<div>\n  <p>Stuff Here</p>\n</div>',
     '{{#if isMorning}}\n' +
@@ -227,17 +227,30 @@ generateRuleTests({
         '{{/if}}',
       ].join('\n'),
     },
-  ],
+  ].filter((value, index) => index >= 0),
 
   bad: [
     {
       // start and end must be the same indentation
       template: '\n  {{#each cats as |dog|}}\n        {{/each}}',
-      fixedTemplate: '\n  {{#each cats as |dog|}}\n  {{/each}}',
+      fixedTemplate: '\n{{#each cats as |dog|}}\n{{/each}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           Array [
+            Object {
+              "column": 2,
+              "endColumn": 17,
+              "endLine": 3,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 2,
+              "message": "Incorrect indentation for \`{{#each}}\` beginning at L2:C2. Expected \`{{#each}}\` to be at an indentation of 0, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#each cats as |dog|}}
+                  {{/each}}",
+            },
             Object {
               "column": 17,
               "endColumn": 17,
@@ -1177,6 +1190,30 @@ generateRuleTests({
               "source": "<div>
           test{{! Comment }}
           </div>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<div>\n</div>\n  <span>\n  </span>',
+      fixedTemplate: '<div>\n</div>\n<span>\n</span>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 2,
+              "endColumn": 9,
+              "endLine": 4,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 3,
+              "message": "Incorrect indentation for \`<span>\` beginning at L3:C2. Expected \`<span>\` to be at an indentation of 0, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<span>
+            </span>",
             },
           ]
         `);

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -1255,5 +1255,71 @@ generateRuleTests({
         `);
       },
     },
+    {
+      template: '<div>\n</div>\n  {{#if foo}}\n    {{#if bar}}\n    {{/if}}\n  {{/if}}',
+      fixedTemplate: '<div>\n</div>\n{{#if foo}}\n  {{#if bar}}\n  {{/if}}\n{{/if}}',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 2,
+              "endColumn": 9,
+              "endLine": 6,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 3,
+              "message": "Incorrect indentation for \`{{#if}}\` beginning at L3:C2. Expected \`{{#if}}\` to be at an indentation of 0, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+              {{#if bar}}
+              {{/if}}
+            {{/if}}",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '  <h3></h3>\n  <div>\n    <div>\n      <div>\n      </div>\n    </div>\n  </div>',
+      fixedTemplate: '<h3></h3>\n<div>\n  <div>\n    <div>\n    </div>\n  </div>\n</div>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 2,
+              "endColumn": 11,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Incorrect indentation for \`<h3>\` beginning at L1:C2. Expected \`<h3>\` to be at an indentation of 0, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<h3></h3>",
+            },
+            Object {
+              "column": 2,
+              "endColumn": 8,
+              "endLine": 7,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 2,
+              "message": "Incorrect indentation for \`<div>\` beginning at L2:C2. Expected \`<div>\` to be at an indentation of 0, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div>
+              <div>
+                <div>
+                </div>
+              </div>
+            </div>",
+            },
+          ]
+        `);
+      },
+    },
   ],
 });

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -145,7 +145,7 @@ generateRuleTests({
       config: {
         ignoreComments: true,
       },
-      template: '{{! Comment }}<div>foo</div>',
+      template: '  {{! Comment }}\n<div>foo</div>',
     },
     {
       config: {
@@ -169,7 +169,7 @@ generateRuleTests({
       config: {
         ignoreComments: true,
       },
-      template: '<!-- Comment --><div>foo</div>',
+      template: '  <!-- Comment -->\n<div>foo</div>',
     },
     {
       config: {
@@ -227,7 +227,7 @@ generateRuleTests({
         '{{/if}}',
       ].join('\n'),
     },
-  ].filter((value, index) => index >= 0),
+  ],
 
   bad: [
     {
@@ -1214,6 +1214,42 @@ generateRuleTests({
               "severity": 2,
               "source": "<span>
             </span>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '  <title>Title</title>\n  <g>\n  </g>',
+      fixedTemplate: '<title>Title</title>\n<g>\n</g>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 2,
+              "endColumn": 22,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Incorrect indentation for \`<title>\` beginning at L1:C2. Expected \`<title>\` to be at an indentation of 0, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<title>Title</title>",
+            },
+            Object {
+              "column": 2,
+              "endColumn": 6,
+              "endLine": 3,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 2,
+              "message": "Incorrect indentation for \`<g>\` beginning at L2:C2. Expected \`<g>\` to be at an indentation of 0, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<g>
+            </g>",
             },
           ]
         `);


### PR DESCRIPTION
# Summary
A lot of issues were not detected by this rule.
The following examples are invalid but were considered as valid:
```hbs
<div></div>
  <span></span>
```
```hbs

  <span></span>
```

Basically, everything that is NOT on the first line and is a direct child of the template was considered as valid 