### PR TITLE
Update eslint-plugin-import-helpers to 1.2.1

### DIFF
--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -100,7 +100,6 @@ import requirevalidalttext from './require-valid-alt-text.js';
 import requirevalidnamedblocknamingformat from './require-valid-named-block-naming-format.js';
 import selfclosingvoidelements from './self-closing-void-elements.js';
 import simpleunless from './simple-unless.js';
-
 import splatattributesonly from './splat-attributes-only.js';
 import styleconcatenation from './style-concatenation.js';
 import tablegroups from './table-groups.js';

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.25.4",
-    "eslint-plugin-import-helpers": "^1.2.0",
+    "eslint-plugin-import-helpers": "^1.2.1",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-unicorn": "^40.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2583,10 +2583,10 @@ eslint-plugin-filenames@^1.3.2:
     lodash.snakecase "4.1.1"
     lodash.upperfirst "4.3.1"
 
-eslint-plugin-import-helpers@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-import-helpers/-/eslint-plugin-import-helpers-1.2.0.tgz#36c6b19ee1470237aff3bb5a10c19fc1f325dc13"
-  integrity sha512-xlGTXwavBcvILcJJIuFZkXE6eMr86BgpcWTzUD0HepvYiTJXtN2enEsJT6SnuXONWflIgw24p9xWA1P/ZY2Nyw==
+eslint-plugin-import-helpers@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import-helpers/-/eslint-plugin-import-helpers-1.2.1.tgz#22c7ac66c964e8257b2a6fb4aff8a51b35cbdc6d"
+  integrity sha512-BSqLlCnyX4tWGlvPUTpBgUoaFiWxXSztpk9SozZVW4TZU1ygZuF0Lrfn9CO5xx1XT+PVAR9yroP9JPRyB4rAjQ==
 
 eslint-plugin-import@^2.25.4:
   version "2.25.4"


### PR DESCRIPTION
Includes this bug fix to eliminate the unwanted blank line after 100 imports in our rules index:
* https://github.com/Tibfib/eslint-plugin-import-helpers/pull/44
* https://github.com/Tibfib/eslint-plugin-import-helpers/releases/tag/v1.2.1