### PR TITLE
Fix bug with newlines and cleanup `no-unbalanced-curlies` rule

### DIFF
--- a/lib/rules/no-unbalanced-curlies.js
+++ b/lib/rules/no-unbalanced-curlies.js
@@ -17,17 +17,6 @@ export default class NoUnbalancedCurlies extends Rule {
         }
         let source = this.sourceForNode(node);
 
-        let { loc } = node;
-
-        if (!loc) {
-          this.log({
-            message: ERROR_MESSAGE,
-            source,
-            node,
-          });
-          return;
-        }
-
         let isMustache = false;
         try {
           let result = parse(chars);
@@ -43,6 +32,7 @@ export default class NoUnbalancedCurlies extends Rule {
           return;
         }
 
+        let { loc } = node;
         let lineNum = loc.start.line;
         let colNum = loc.start.column;
         let lines = chars.match(reLines);

--- a/lib/rules/no-unbalanced-curlies.js
+++ b/lib/rules/no-unbalanced-curlies.js
@@ -28,29 +28,33 @@ export default class NoUnbalancedCurlies extends Rule {
           return;
         }
 
+        let isMustache = false;
+        try {
+          let result = parse(chars);
+          if (result.body.length && result.body[0].type === 'MustacheStatement') {
+            isMustache = true;
+          }
+        } catch {
+          // Not Mustache then. We'll proceed to find
+          // the exact location of the error.
+        }
+
+        if (isMustache) {
+          return;
+        }
+
         let lineNum = loc.start.line;
         let colNum = loc.start.column;
         let lines = chars.match(reLines);
         for (const line of lines) {
           if (line.includes(DISALLOWED_CHARS)) {
-            let isMustache = false;
-            try {
-              let result = parse(chars);
-              if (result.body.length && result.body[0].type === 'MustacheStatement') {
-                isMustache = true;
-              }
-            } catch {
-              isMustache = false;
-            }
-            if (!isMustache) {
-              this.log({
-                message: ERROR_MESSAGE,
-                line: lineNum,
-                node,
-                column: colNum + line.indexOf(DISALLOWED_CHARS),
-                source,
-              });
-            }
+            this.log({
+              message: ERROR_MESSAGE,
+              line: lineNum,
+              node,
+              column: colNum + line.indexOf(DISALLOWED_CHARS),
+              source,
+            });
           }
           lineNum++;
           colNum = 1;

--- a/lib/rules/no-unbalanced-curlies.js
+++ b/lib/rules/no-unbalanced-curlies.js
@@ -3,7 +3,7 @@ import { parse } from 'ember-template-recast';
 import Rule from './_base.js';
 
 const ERROR_MESSAGE = 'Unbalanced curlies detected';
-const DISALLOWED_CHARS = '}}';
+const SUSPECT_CHARS = '}}';
 
 const reLines = /(.*?(?:\r\n?|\n|$))/gm;
 
@@ -12,7 +12,7 @@ export default class NoUnbalancedCurlies extends Rule {
     return {
       TextNode(node) {
         let { chars } = node;
-        if (!chars.includes(DISALLOWED_CHARS)) {
+        if (!chars.includes(SUSPECT_CHARS)) {
           return;
         }
         let source = this.sourceForNode(node);
@@ -37,12 +37,12 @@ export default class NoUnbalancedCurlies extends Rule {
         let colNum = loc.start.column;
         let lines = chars.match(reLines);
         for (const line of lines) {
-          if (line.includes(DISALLOWED_CHARS)) {
+          if (line.includes(SUSPECT_CHARS)) {
             this.log({
               message: ERROR_MESSAGE,
               line: lineNum,
               node,
-              column: colNum + line.indexOf(DISALLOWED_CHARS),
+              column: colNum + line.indexOf(SUSPECT_CHARS),
               source,
             });
           }

--- a/lib/rules/no-unbalanced-curlies.js
+++ b/lib/rules/no-unbalanced-curlies.js
@@ -35,7 +35,7 @@ export default class NoUnbalancedCurlies extends Rule {
           if (line.includes(DISALLOWED_CHARS)) {
             let isMustache = false;
             try {
-              let result = parse(line);
+              let result = parse(chars);
               if (result.body.length && result.body[0].type === 'MustacheStatement') {
                 isMustache = true;
               }

--- a/test/unit/rules/no-unbalanced-curlies-test.js
+++ b/test/unit/rules/no-unbalanced-curlies-test.js
@@ -13,6 +13,7 @@ generateRuleTests({
     '\\{{foo}}',
     '\\{{foo}}\\{{foo}}',
     '\\{{foo}}{{foo}}',
+    '\\{{foo\n}}',
   ],
 
   bad: [


### PR DESCRIPTION
Fixes #2330, which reports a false positive when there's a newline inside escaped curlies.

I have been away from Ember and JS for a bit, but I was able to figure things out a bit from my original PR at #1222. If I have this right, the line-by-line solution (mentioned in the issue) was intended to properly detect the location of error in order to report it. Without thinking much, it looks like I decided to parse each individual line, instead of the whole TextNode. This is corrected in the first two commits (one as a simple fix, another to avoid multiple parses), thus fixing the issue.

Additionally, I noticed the test coverage warning and had a look into this too. I removed unused code that I don't remember why I added in the first place. I suspect I copied it from some other rule, but now I can't find any other example. Now coverage for this test is at 100%.

Finally, I changed the name of the constant `DISALLOWED_CHARS` to `SUSPECT_CHARS` as it better describes its function: having these chars is necessary but not sufficient for the rule to be triggered.