### PR TITLE
Convert path to URL before import of config/plugin for Windows support

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -91,7 +91,7 @@ export async function resolveProjectConfig(workingDir, options) {
   options.resolvedConfigPath = configPath;
 
   try {
-    const { default: config } = await import(configPath);
+    const { default: config } = await import(pathToFileURL(configPath));
     return config;
   } catch (error) {
     // Fallback to ensure we can load CJS configs in Node versions before 16 (TODO: remove eventually).

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -502,12 +502,7 @@ describe('ember-template-lint executable', function () {
         expect(path.isAbsolute(configPath)).toBeTruthy();
         expect(fs.existsSync(configPath)).toBeTruthy();
 
-        let result = await runBin(
-          '--filename',
-          'app/templates/application.hbs',
-          '--config-path',
-          configPath
-        );
+        let result = await runBin('app/templates/application.hbs', '--config-path', configPath);
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toBeFalsy();

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -483,12 +483,12 @@ describe('ember-template-lint executable', function () {
   describe('multiplatform config resolve', function () {
     describe('given absolute config path and path to single file without errors', function () {
       it('should exit without error and any console output', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': false,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs':
@@ -502,7 +502,12 @@ describe('ember-template-lint executable', function () {
         expect(path.isAbsolute(configPath)).toBeTruthy();
         expect(fs.existsSync(configPath)).toBeTruthy();
 
-        let result = await run(['app/templates/application.hbs', '--config-path', configPath]);
+        let result = await runBin(
+          '--filename',
+          'app/templates/application.hbs',
+          '--config-path',
+          configPath
+        );
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toBeFalsy();

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -502,12 +502,7 @@ describe('ember-template-lint executable', function () {
         expect(path.isAbsolute(configPath)).toBeTruthy();
         expect(fs.existsSync(configPath)).toBeTruthy();
 
-        let result = await run([
-          '--config-path',
-          configPath,
-          '--filename',
-          'app/templates/application.hbs',
-        ]);
+        let result = await run(['app/templates/application.hbs', '--config-path', configPath]);
 
         expect(result.exitCode).toEqual(0);
         expect(result.stdout).toBeFalsy();

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -480,6 +480,42 @@ describe('ember-template-lint executable', function () {
     });
   });
 
+  describe('multiplatform config resolve', function () {
+    describe('given absolute config path and path to single file without errors', function () {
+      it('should exit without error and any console output', async function () {
+        project.setConfig({
+          rules: {
+            'no-bare-strings': false,
+          },
+        });
+        project.write({
+          app: {
+            templates: {
+              'application.hbs':
+                '<h2>Love for bare strings!!!</h2> <div>Bare strings are great!</div>',
+            },
+          },
+        });
+
+        let configPath = path.join(project.baseDir, '.template-lintrc.js');
+
+        expect(path.isAbsolute(configPath)).toBeTruthy();
+        expect(fs.existsSync(configPath)).toBeTruthy();
+
+        let result = await run([
+          '--config-path',
+          configPath,
+          '--filename',
+          'app/templates/application.hbs',
+        ]);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toBeFalsy();
+        expect(result.stderr).toBeFalsy();
+      });
+    });
+  });
+
   describe('reading from stdin', function () {
     describe('given no path', function () {
       setupEnvVar('CI', null);


### PR DESCRIPTION
fixes https://github.com/ember-template-lint/ember-template-lint/issues/2336

I'm not sure how to test it, because chain for this function is quite long, should we create unit test for 'requirePlugin' function itself?