### PR TITLE
Support the `modifier` helper in the `modifier-name-case` rule

### DIFF
--- a/docs/rule/modifier-name-case.md
+++ b/docs/rule/modifier-name-case.md
@@ -16,12 +16,14 @@ This rule **forbids** the following:
 
 ```hbs
 <div {{didInsert}}></div>
+<div {{(if @isContentEditable (modifier "contentEditable"))}}></div>
 ```
 
 This rule **allows** the following:
 
 ```hbs
 <div {{did-insert}}></div>
+<div {{(if @isContentEditable (modifier "content-editable"))}}></div>
 ```
 
 ## References

--- a/lib/rules/modifier-name-case.js
+++ b/lib/rules/modifier-name-case.js
@@ -1,4 +1,5 @@
 import dasherize from '../helpers/dasherize-component-name.js';
+import { match } from '../helpers/node-matcher.js';
 import Rule from './_base.js';
 
 function generateErrorMessage(modifierName) {
@@ -10,17 +11,37 @@ export default class ModifierNameCase extends Rule {
   visitor() {
     return {
       ElementModifierStatement(node) {
-        let modifierName = node.path.original;
+        this._validateModifierName(node.path);
+      },
 
-        if (modifierName === dasherize(modifierName)) {
+      SubExpression(node) {
+        if (!isModifierHelper(node)) {
           return;
         }
 
-        this.log({
-          message: generateErrorMessage(modifierName),
-          node: node.path,
-        });
+        let nameParam = node.params[0];
+
+        if (nameParam && nameParam.type === 'StringLiteral') {
+          this._validateModifierName(nameParam);
+        }
       },
     };
   }
+
+  _validateModifierName(node) {
+    let modifierName = node.original;
+
+    if (typeof modifierName !== 'string' || modifierName === dasherize(modifierName)) {
+      return;
+    }
+
+    this.log({
+      message: generateErrorMessage(modifierName),
+      node,
+    });
+  }
+}
+
+function isModifierHelper(node) {
+  return match(node.path, { original: 'modifier', type: 'PathExpression' });
 }

--- a/test/unit/rules/modifier-name-case-test.js
+++ b/test/unit/rules/modifier-name-case-test.js
@@ -14,6 +14,9 @@ generateRuleTests({
     '<button onclick={{doAThing "foo"}}></button>',
     '<a href="#" onclick={{amazingActionThing "foo"}} {{did-insert}}></a>',
     '<div didInsert></div>',
+    '<div {{(modifier "foo-bar")}}></div>',
+    '<div {{(if this.foo (modifier "foo-bar"))}}></div>',
+    '<div {{(modifier this.fooBar)}}></div>',
   ],
 
   bad: [
@@ -72,6 +75,46 @@ generateRuleTests({
               "rule": "modifier-name-case",
               "severity": 2,
               "source": "doSomething",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<div {{(modifier "fooBar")}}></div>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 17,
+              "endColumn": 25,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Use dasherized names for modifier invocation. Please replace \`fooBar\` with \`foo-bar\`.",
+              "rule": "modifier-name-case",
+              "severity": 2,
+              "source": "\\"fooBar\\"",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<div {{(if this.foo (modifier "fooBar"))}}></div>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          Array [
+            Object {
+              "column": 30,
+              "endColumn": 38,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Use dasherized names for modifier invocation. Please replace \`fooBar\` with \`foo-bar\`.",
+              "rule": "modifier-name-case",
+              "severity": 2,
+              "source": "\\"fooBar\\"",
             },
           ]
         `);


### PR DESCRIPTION
At the moment, the `modifier-name-case` rule throws the following error when using the `modifier` helper:

<img width="566" alt="Screenshot 2022-01-18 at 11 22 53" src="https://user-images.githubusercontent.com/7403183/149919012-37fc5570-84b4-402f-89ae-f2138e6ed115.png">

This PR aims to fix that.