### PR TITLE
Changes jest snapshot format to not print prototype information.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "setupFilesAfterEnv": [
       "<rootDir>/test/jest-setup.js"
     ],
+    "snapshotFormat": {
+      "printBasicPrototype": false
+    },
     "testMatch": [
       "<rootDir>/test/**/*-test.js"
     ]

--- a/test/acceptance/__snapshots__/rule-test.js.snap
+++ b/test/acceptance/__snapshots__/rule-test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`rule public api general test harness support no-elements can use verifyResults directly (with external snapshots): logs errors 1`] = `
-Array [
-  Object {
+[
+  {
     "column": 0,
     "endColumn": 11,
     "endLine": 1,

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1515,9 +1515,9 @@ describe('ember-template-lint executable', function () {
 
         expect(result.exitCode).toEqual(1);
         expect(JSON.parse(result.stdout)).toMatchInlineSnapshot(`
-          Object {
-            "app/templates/application.hbs": Array [
-              Object {
+          {
+            "app/templates/application.hbs": [
+              {
                 "column": 4,
                 "endColumn": 14,
                 "endLine": 1,
@@ -1528,7 +1528,7 @@ describe('ember-template-lint executable', function () {
                 "severity": 2,
                 "source": "Here too!!",
               },
-              Object {
+              {
                 "column": 25,
                 "endColumn": 48,
                 "endLine": 1,

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -328,10 +328,10 @@ describe('public api', function () {
       expect(result).toMatchInlineSnapshot(
         { messages: [{ filePath: expect.any(String) }] },
         `
-        Object {
+        {
           "isFixed": false,
-          "messages": Array [
-            Object {
+          "messages": [
+            {
               "column": 5,
               "endColumn": 14,
               "endLine": 1,
@@ -1302,10 +1302,10 @@ describe('public api', function () {
       expect(result).toMatchInlineSnapshot(
         { messages: [{ filePath: expect.any(String) }] },
         `
-        Object {
+        {
           "isFixed": false,
-          "messages": Array [
-            Object {
+          "messages": [
+            {
               "column": 5,
               "endColumn": 14,
               "endLine": 1,

--- a/test/acceptance/rule-test.js
+++ b/test/acceptance/rule-test.js
@@ -85,8 +85,8 @@ describe('rule public api', function () {
           template: '<div></div>',
           verifyResults(results) {
             expect(results).toMatchInlineSnapshot(`
-              Array [
-                Object {
+              [
+                {
                   "column": 0,
                   "endColumn": 11,
                   "endLine": 1,
@@ -342,8 +342,8 @@ describe('rule public api', function () {
           template: '<div></div>',
           verifyResults(results) {
             expect(results).toMatchInlineSnapshot(`
-              Array [
-                Object {
+              [
+                {
                   "column": 0,
                   "endColumn": 11,
                   "endLine": 1,
@@ -366,8 +366,8 @@ describe('rule public api', function () {
           template: '<div></div>',
           verifyResults(results) {
             expect(results).toMatchInlineSnapshot(`
-              Array [
-                Object {
+              [
+                {
                   "column": 0,
                   "endColumn": 11,
                   "endLine": 1,
@@ -578,7 +578,7 @@ describe('regression tests', function () {
     await group.run();
 
     expect(group.runLog).toMatchInlineSnapshot(`
-      Array [
+      [
         "<div></div>: logs errors",
         "<div></div>: passes when rule is disabled",
         "<div></div>: passes when disabled via inline comment - single rule",
@@ -669,7 +669,7 @@ describe('regression tests', function () {
     );
 
     expect(group.runLog).toMatchInlineSnapshot(`
-      Array [
+      [
         "<div></div>: logs errors",
       ]
     `);

--- a/test/unit/bin/get-possible-option-names-test.js
+++ b/test/unit/bin/get-possible-option-names-test.js
@@ -10,7 +10,7 @@ describe('getPossibleOptionNames', function () {
       'option-with-alias': { alias: 'aliased-name' },
     });
     expect(results).toMatchInlineSnapshot(`
-      Array [
+      [
         "foo",
         "foo-bar",
         "no-baz",

--- a/test/unit/rules/attribute-indentation-test.js
+++ b/test/unit/rules/attribute-indentation-test.js
@@ -943,8 +943,8 @@ generateRuleTests({
         '  baz=qux/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 11,
               "endLine": 5,
@@ -959,7 +959,7 @@ generateRuleTests({
               stuff}}
             baz=qux/>",
             },
-            Object {
+            {
               "column": 9,
               "endColumn": 11,
               "endLine": 4,
@@ -997,8 +997,8 @@ generateRuleTests({
         '/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 2,
               "endLine": 7,
@@ -1015,7 +1015,7 @@ generateRuleTests({
             baz=qux
           />",
             },
-            Object {
+            {
               "column": 2,
               "endColumn": 4,
               "endLine": 5,
@@ -1055,8 +1055,8 @@ generateRuleTests({
         '}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 2,
               "endLine": 8,
@@ -1098,8 +1098,8 @@ generateRuleTests({
         '    baz=qux))}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 15,
               "endLine": 7,
@@ -1127,8 +1127,8 @@ generateRuleTests({
       template: '<input' + '\n' + '  foo=bar' + '\n' + '  baz=bar' + '\n' + '>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 1,
               "endLine": 4,
@@ -1153,8 +1153,8 @@ generateRuleTests({
       template: '<input' + '\n' + '  foo=bar' + '\n' + '  baz=qux>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 10,
               "endLine": 3,
@@ -1179,8 +1179,8 @@ generateRuleTests({
       template: '<input disabled' + '\n' + '>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 1,
               "endLine": 2,
@@ -1192,7 +1192,7 @@ generateRuleTests({
               "source": "<input disabled
           >",
             },
-            Object {
+            {
               "column": 0,
               "endColumn": 1,
               "endLine": 2,
@@ -1216,8 +1216,8 @@ generateRuleTests({
       template: '<div disabled' + '\n' + '/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 2,
               "endLine": 2,
@@ -1229,7 +1229,7 @@ generateRuleTests({
               "source": "<div disabled
           />",
             },
-            Object {
+            {
               "column": 0,
               "endColumn": 2,
               "endLine": 2,
@@ -1254,8 +1254,8 @@ generateRuleTests({
         '<input disabled type="text" value="abc" class="classy classic classist" id="input-now">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 87,
               "endLine": 1,
@@ -1266,7 +1266,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<input disabled type=\\"text\\" value=\\"abc\\" class=\\"classy classic classist\\" id=\\"input-now\\">",
             },
-            Object {
+            {
               "column": 16,
               "endColumn": 87,
               "endLine": 1,
@@ -1277,7 +1277,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<input disabled type=\\"text\\" value=\\"abc\\" class=\\"classy classic classist\\" id=\\"input-now\\">",
             },
-            Object {
+            {
               "column": 28,
               "endColumn": 87,
               "endLine": 1,
@@ -1288,7 +1288,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<input disabled type=\\"text\\" value=\\"abc\\" class=\\"classy classic classist\\" id=\\"input-now\\">",
             },
-            Object {
+            {
               "column": 40,
               "endColumn": 87,
               "endLine": 1,
@@ -1299,7 +1299,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<input disabled type=\\"text\\" value=\\"abc\\" class=\\"classy classic classist\\" id=\\"input-now\\">",
             },
-            Object {
+            {
               "column": 72,
               "endColumn": 87,
               "endLine": 1,
@@ -1310,7 +1310,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<input disabled type=\\"text\\" value=\\"abc\\" class=\\"classy classic classist\\" id=\\"input-now\\">",
             },
-            Object {
+            {
               "column": 86,
               "endColumn": 87,
               "endLine": 1,
@@ -1351,8 +1351,8 @@ generateRuleTests({
         ' }}</a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 7,
               "endLine": 10,
@@ -1384,8 +1384,8 @@ generateRuleTests({
         '<a href="https://www.emberjs.com" class="emberjs-home link" rel="noopener" target="_blank">Ember JS</a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 103,
               "endLine": 1,
@@ -1396,7 +1396,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<a href=\\"https://www.emberjs.com\\" class=\\"emberjs-home link\\" rel=\\"noopener\\" target=\\"_blank\\">Ember JS</a>",
             },
-            Object {
+            {
               "column": 34,
               "endColumn": 103,
               "endLine": 1,
@@ -1407,7 +1407,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<a href=\\"https://www.emberjs.com\\" class=\\"emberjs-home link\\" rel=\\"noopener\\" target=\\"_blank\\">Ember JS</a>",
             },
-            Object {
+            {
               "column": 60,
               "endColumn": 103,
               "endLine": 1,
@@ -1418,7 +1418,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<a href=\\"https://www.emberjs.com\\" class=\\"emberjs-home link\\" rel=\\"noopener\\" target=\\"_blank\\">Ember JS</a>",
             },
-            Object {
+            {
               "column": 75,
               "endColumn": 103,
               "endLine": 1,
@@ -1429,7 +1429,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<a href=\\"https://www.emberjs.com\\" class=\\"emberjs-home link\\" rel=\\"noopener\\" target=\\"_blank\\">Ember JS</a>",
             },
-            Object {
+            {
               "column": 90,
               "endColumn": 103,
               "endLine": 1,
@@ -1440,7 +1440,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<a href=\\"https://www.emberjs.com\\" class=\\"emberjs-home link\\" rel=\\"noopener\\" target=\\"_blank\\">Ember JS</a>",
             },
-            Object {
+            {
               "column": 99,
               "endColumn": 103,
               "endLine": 1,
@@ -1463,8 +1463,8 @@ generateRuleTests({
       template: '{{contact-details firstName=firstName lastName=lastName}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 57,
               "endLine": 1,
@@ -1475,7 +1475,7 @@ generateRuleTests({
               "severity": 2,
               "source": "{{contact-details firstName=firstName lastName=lastName}}",
             },
-            Object {
+            {
               "column": 38,
               "endColumn": 57,
               "endLine": 1,
@@ -1486,7 +1486,7 @@ generateRuleTests({
               "severity": 2,
               "source": "{{contact-details firstName=firstName lastName=lastName}}",
             },
-            Object {
+            {
               "column": 55,
               "endColumn": 57,
               "endLine": 1,
@@ -1521,8 +1521,8 @@ generateRuleTests({
         '{{/each}}</a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 13,
               "endLine": 7,
@@ -1555,8 +1555,8 @@ generateRuleTests({
         '{{/contact-details}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 1,
               "endColumn": 20,
               "endLine": 4,
@@ -1570,7 +1570,7 @@ generateRuleTests({
            {{contact.fullName}}
           {{/contact-details}}",
             },
-            Object {
+            {
               "column": 21,
               "endColumn": 20,
               "endLine": 4,
@@ -1584,7 +1584,7 @@ generateRuleTests({
            {{contact.fullName}}
           {{/contact-details}}",
             },
-            Object {
+            {
               "column": 38,
               "endColumn": 20,
               "endLine": 4,
@@ -1598,7 +1598,7 @@ generateRuleTests({
            {{contact.fullName}}
           {{/contact-details}}",
             },
-            Object {
+            {
               "column": 51,
               "endColumn": 20,
               "endLine": 4,
@@ -1631,8 +1631,8 @@ generateRuleTests({
         '{{/contact-details}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 20,
               "endLine": 6,
@@ -1662,8 +1662,8 @@ generateRuleTests({
         '{{/contact-details}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 20,
               "endLine": 3,
@@ -1676,7 +1676,7 @@ generateRuleTests({
             {{fullName}}
           {{/contact-details}}",
             },
-            Object {
+            {
               "column": 39,
               "endColumn": 20,
               "endLine": 3,
@@ -1689,7 +1689,7 @@ generateRuleTests({
             {{fullName}}
           {{/contact-details}}",
             },
-            Object {
+            {
               "column": 57,
               "endColumn": 20,
               "endLine": 3,
@@ -1702,7 +1702,7 @@ generateRuleTests({
             {{fullName}}
           {{/contact-details}}",
             },
-            Object {
+            {
               "column": 65,
               "endColumn": 20,
               "endLine": 3,
@@ -1715,7 +1715,7 @@ generateRuleTests({
             {{fullName}}
           {{/contact-details}}",
             },
-            Object {
+            {
               "column": 78,
               "endColumn": 20,
               "endLine": 3,
@@ -1728,7 +1728,7 @@ generateRuleTests({
             {{fullName}}
           {{/contact-details}}",
             },
-            Object {
+            {
               "column": 91,
               "endColumn": 20,
               "endLine": 3,
@@ -1759,8 +1759,8 @@ generateRuleTests({
         '{{/contact-details}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 6,
@@ -1776,7 +1776,7 @@ generateRuleTests({
             {{contact.fullName}}
           {{/contact-details}}",
             },
-            Object {
+            {
               "column": 12,
               "endColumn": 20,
               "endLine": 6,
@@ -1805,8 +1805,8 @@ generateRuleTests({
         '{{if (or logout.isRunning (not session.isAuthenticated)) "Logging Out..." "Log Out"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 85,
               "endLine": 1,
@@ -1817,7 +1817,7 @@ generateRuleTests({
               "severity": 2,
               "source": "{{if (or logout.isRunning (not session.isAuthenticated)) \\"Logging Out...\\" \\"Log Out\\"}}",
             },
-            Object {
+            {
               "column": 57,
               "endColumn": 85,
               "endLine": 1,
@@ -1828,7 +1828,7 @@ generateRuleTests({
               "severity": 2,
               "source": "{{if (or logout.isRunning (not session.isAuthenticated)) \\"Logging Out...\\" \\"Log Out\\"}}",
             },
-            Object {
+            {
               "column": 74,
               "endColumn": 85,
               "endLine": 1,
@@ -1839,7 +1839,7 @@ generateRuleTests({
               "severity": 2,
               "source": "{{if (or logout.isRunning (not session.isAuthenticated)) \\"Logging Out...\\" \\"Log Out\\"}}",
             },
-            Object {
+            {
               "column": 83,
               "endColumn": 85,
               "endLine": 1,
@@ -1859,8 +1859,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 2,
               "endLine": 3,
@@ -1882,8 +1882,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 12,
               "endLine": 4,
@@ -1928,8 +1928,8 @@ generateRuleTests({
         '</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 6,
               "endLine": 10,
@@ -1949,7 +1949,7 @@ generateRuleTests({
           {{/contact-details}}
           </div>",
             },
-            Object {
+            {
               "column": 21,
               "endColumn": 20,
               "endLine": 9,
@@ -2001,8 +2001,8 @@ generateRuleTests({
         '</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 12,
@@ -2024,7 +2024,7 @@ generateRuleTests({
           {{/contact-details}}
           </div>",
             },
-            Object {
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 11,
@@ -2075,8 +2075,8 @@ generateRuleTests({
         '</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 6,
               "endLine": 11,
@@ -2097,7 +2097,7 @@ generateRuleTests({
           {{/contact-details}}
           </div>",
             },
-            Object {
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 10,
@@ -2148,8 +2148,8 @@ generateRuleTests({
         '</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 11,
@@ -2170,7 +2170,7 @@ generateRuleTests({
           {{/contact-details}}
           </div>",
             },
-            Object {
+            {
               "column": 21,
               "endColumn": 20,
               "endLine": 10,
@@ -2200,8 +2200,8 @@ generateRuleTests({
       </form>`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 13,
               "endLine": 6,
@@ -2216,7 +2216,7 @@ generateRuleTests({
                 >
                 </form>",
             },
-            Object {
+            {
               "column": 8,
               "endColumn": 13,
               "endLine": 6,
@@ -2241,8 +2241,8 @@ generateRuleTests({
       baz}}{{/foo}}`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 11,
               "endLine": 3,

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -242,8 +242,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 17,
               "endLine": 3,
@@ -256,7 +256,7 @@ generateRuleTests({
               "source": "{{#each cats as |dog|}}
                   {{/each}}",
             },
-            Object {
+            {
               "column": 17,
               "endColumn": 17,
               "endLine": 3,
@@ -279,8 +279,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 8,
               "endLine": 2,
@@ -303,8 +303,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 30,
               "endColumn": 30,
               "endLine": 2,
@@ -327,8 +327,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 3,
@@ -352,8 +352,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 3,
@@ -389,8 +389,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 11,
               "endLine": 5,
@@ -416,8 +416,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 6,
               "endLine": 3,
@@ -441,8 +441,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 4,
@@ -467,8 +467,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 4,
@@ -500,8 +500,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 17,
               "endColumn": 17,
               "endLine": 3,
@@ -527,8 +527,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 6,
               "endLine": 4,
@@ -553,8 +553,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 3,
@@ -578,8 +578,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 7,
               "endLine": 3,
@@ -618,8 +618,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 9,
               "endLine": 6,
@@ -647,8 +647,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 9,
               "endLine": 3,
@@ -685,8 +685,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 6,
               "endLine": 5,
@@ -729,8 +729,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 7,
               "endLine": 6,
@@ -772,8 +772,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 0,
               "endLine": 5,
@@ -799,8 +799,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 4,
@@ -825,8 +825,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 6,
               "endLine": 3,
@@ -856,8 +856,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 5,
@@ -883,8 +883,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 1,
               "endColumn": 7,
               "endLine": 2,
@@ -897,7 +897,7 @@ generateRuleTests({
               "source": "{{#if foo}}
           {{/if}}",
             },
-            Object {
+            {
               "column": 7,
               "endColumn": 7,
               "endLine": 2,
@@ -920,8 +920,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 14,
               "endColumn": 7,
               "endLine": 3,
@@ -935,7 +935,7 @@ generateRuleTests({
             bar
           {{/if}}",
             },
-            Object {
+            {
               "column": 11,
               "endColumn": 7,
               "endLine": 3,
@@ -959,8 +959,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 7,
               "endLine": 5,
@@ -1004,8 +1004,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 7,
               "endLine": 7,
@@ -1033,8 +1033,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 17,
               "endLine": 2,
@@ -1057,8 +1057,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 8,
               "endLine": 2,
@@ -1091,8 +1091,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 8,
               "endLine": 4,
@@ -1107,7 +1107,7 @@ generateRuleTests({
              {{foobar.baz}}
           {{/foo}}",
             },
-            Object {
+            {
               "column": 3,
               "endColumn": 8,
               "endLine": 4,
@@ -1131,8 +1131,8 @@ generateRuleTests({
       fixedTemplate: ['<div>', '  <!-- Comment -->', '</div>'].join('\n'),
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 3,
@@ -1155,8 +1155,8 @@ generateRuleTests({
       fixedTemplate: ['<div>', '  {{! Comment }}', '</div>'].join('\n'),
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 3,
@@ -1182,8 +1182,8 @@ generateRuleTests({
       },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 3,
@@ -1207,8 +1207,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 9,
               "endLine": 4,
@@ -1231,8 +1231,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 22,
               "endLine": 1,
@@ -1244,7 +1244,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<title>Title</title>",
             },
-            Object {
+            {
               "column": 2,
               "endColumn": 6,
               "endLine": 3,
@@ -1267,8 +1267,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 9,
               "endLine": 6,
@@ -1293,8 +1293,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 11,
               "endLine": 1,
@@ -1306,7 +1306,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<h3></h3>",
             },
-            Object {
+            {
               "column": 2,
               "endColumn": 8,
               "endLine": 7,

--- a/test/unit/rules/builtin-component-arguments-test.js
+++ b/test/unit/rules/builtin-component-arguments-test.js
@@ -18,8 +18,8 @@ generateRuleTests({
       template: '<Input type="text" size="10" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 18,
               "endLine": 1,
@@ -38,8 +38,8 @@ generateRuleTests({
       template: '<Input @type="checkbox" checked />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 24,
               "endColumn": 31,
               "endLine": 1,
@@ -58,8 +58,8 @@ generateRuleTests({
       template: '<Textarea value="Tomster" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 25,
               "endLine": 1,

--- a/test/unit/rules/deprecated-inline-view-helper-test.js
+++ b/test/unit/rules/deprecated-inline-view-helper-test.js
@@ -28,13 +28,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 27,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "{{awful-fishsticks}}",
               },
               "line": 1,
@@ -52,13 +52,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 23,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "{{bad-fishsticks}}",
               },
               "line": 1,
@@ -76,13 +76,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 28,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "{{terrible.fishsticks}}",
               },
               "line": 1,
@@ -100,13 +100,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 35,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "{{foo-bar baz=qux.qaz}}",
               },
               "line": 1,
@@ -124,13 +124,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 69,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<div data-foo={{hallo}}></div>",
               },
               "line": 1,
@@ -148,13 +148,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 27,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "{{#foo-bar derp=whoops}}{{/foo-bar}}",
               },
               "line": 1,

--- a/test/unit/rules/deprecated-render-helper-test.js
+++ b/test/unit/rules/deprecated-render-helper-test.js
@@ -23,13 +23,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 24,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "{{ken-griffey}}",
               },
               "line": 1,
@@ -47,13 +47,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 36,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "{{baseball-player model=pitcher}}",
               },
               "line": 1,

--- a/test/unit/rules/eol-last-test.js
+++ b/test/unit/rules/eol-last-test.js
@@ -53,8 +53,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 4,
               "endLine": 1,
@@ -77,8 +77,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 5,
               "endLine": 1,
@@ -101,8 +101,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 2,
@@ -126,8 +126,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 2,
@@ -212,8 +212,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 4,

--- a/test/unit/rules/inline-link-to-test.js
+++ b/test/unit/rules/inline-link-to-test.js
@@ -17,8 +17,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 35,
               "endLine": 1,
@@ -40,8 +40,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 43,
               "endLine": 1,
@@ -63,8 +63,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 58,
               "endLine": 1,
@@ -85,8 +85,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 36,
               "endLine": 1,

--- a/test/unit/rules/linebreak-style-test.js
+++ b/test/unit/rules/linebreak-style-test.js
@@ -38,8 +38,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 0,
               "endLine": 3,
@@ -61,8 +61,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 2,
@@ -84,8 +84,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 0,
               "endLine": 2,
@@ -107,8 +107,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 0,
               "endLine": 2,
@@ -130,8 +130,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 0,
               "endLine": 2,
@@ -153,8 +153,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 3,
               "endLine": 2,
@@ -176,8 +176,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 0,
               "endLine": 2,
@@ -199,8 +199,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 2,

--- a/test/unit/rules/link-href-attributes-test.js
+++ b/test/unit/rules/link-href-attributes-test.js
@@ -18,8 +18,8 @@ generateRuleTests({
       template: '<a></a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,

--- a/test/unit/rules/link-rel-noopener-test.js
+++ b/test/unit/rules/link-rel-noopener-test.js
@@ -28,8 +28,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 42,
               "endLine": 1,
@@ -52,8 +52,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 57,
               "endLine": 1,
@@ -75,8 +75,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 57,
               "endLine": 1,
@@ -98,8 +98,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 59,
               "endLine": 1,

--- a/test/unit/rules/modifier-name-case-test.js
+++ b/test/unit/rules/modifier-name-case-test.js
@@ -21,8 +21,8 @@ generateRuleTests({
       template: '<div {{didInsert}}></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 16,
               "endLine": 1,
@@ -41,8 +41,8 @@ generateRuleTests({
       template: '<div class="monkey" {{didInsert "something" with="somethingElse"}}></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 22,
               "endColumn": 31,
               "endLine": 1,
@@ -61,8 +61,8 @@ generateRuleTests({
       template: '<a href="#" onclick={{amazingActionThing "foo"}} {{doSomething}}></a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 51,
               "endColumn": 62,
               "endLine": 1,

--- a/test/unit/rules/no-abstract-roles-test.js
+++ b/test/unit/rules/no-abstract-roles-test.js
@@ -16,8 +16,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 1,
@@ -37,8 +37,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -58,8 +58,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 1,
@@ -79,8 +79,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 21,
               "endLine": 1,
@@ -100,8 +100,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 1,
@@ -121,8 +121,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 21,
               "endLine": 1,
@@ -142,8 +142,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 1,
@@ -163,8 +163,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 24,
               "endLine": 1,
@@ -184,8 +184,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 31,
               "endLine": 1,
@@ -205,8 +205,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 28,
               "endLine": 1,
@@ -226,8 +226,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 19,
               "endLine": 1,
@@ -247,8 +247,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 19,
               "endLine": 1,

--- a/test/unit/rules/no-accesskey-attribute-test.js
+++ b/test/unit/rules/no-accesskey-attribute-test.js
@@ -13,8 +13,8 @@ generateRuleTests({
       fixedTemplate: '<button></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 21,
               "endLine": 1,
@@ -35,8 +35,8 @@ generateRuleTests({
       fixedTemplate: '<button></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 17,
               "endLine": 1,
@@ -57,8 +57,8 @@ generateRuleTests({
       fixedTemplate: '<button></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 30,
               "endLine": 1,
@@ -79,8 +79,8 @@ generateRuleTests({
       fixedTemplate: '<button></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 32,
               "endLine": 1,

--- a/test/unit/rules/no-action-modifiers-test.js
+++ b/test/unit/rules/no-action-modifiers-test.js
@@ -24,8 +24,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 24,
               "endLine": 1,
@@ -45,8 +45,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 28,
               "endLine": 1,
@@ -67,8 +67,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 28,
               "endLine": 1,

--- a/test/unit/rules/no-action-test.js
+++ b/test/unit/rules/no-action-test.js
@@ -24,8 +24,8 @@ generateRuleTests({
       template: '<button onclick={{action "foo"}}></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 32,
               "endLine": 1,
@@ -44,8 +44,8 @@ generateRuleTests({
       template: '<button {{action "submit"}}>Submit</button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 27,
               "endLine": 1,
@@ -64,8 +64,8 @@ generateRuleTests({
       template: '<FooBar @baz={{action "submit"}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 32,
               "endLine": 1,
@@ -84,8 +84,8 @@ generateRuleTests({
       template: '{{yield (action "foo")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 22,
               "endLine": 1,
@@ -104,8 +104,8 @@ generateRuleTests({
       template: '{{yield (action this.foo)}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 25,
               "endLine": 1,

--- a/test/unit/rules/no-args-paths-test.js
+++ b/test/unit/rules/no-args-paths-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
       template: '{{hello (format value=args.foo)}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 22,
               "endColumn": 30,
               "endLine": 1,
@@ -39,8 +39,8 @@ generateRuleTests({
       template: '{{hello value=args.foo}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 14,
               "endColumn": 22,
               "endLine": 1,
@@ -59,8 +59,8 @@ generateRuleTests({
       template: '{{hello (format args.foo.bar)}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 28,
               "endLine": 1,
@@ -79,8 +79,8 @@ generateRuleTests({
       template: '<br {{hello args.foo.bar}}>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 24,
               "endLine": 1,
@@ -99,8 +99,8 @@ generateRuleTests({
       template: '{{hello args.foo.bar}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 20,
               "endLine": 1,
@@ -119,8 +119,8 @@ generateRuleTests({
       template: '{{args.foo.bar}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 14,
               "endLine": 1,
@@ -139,8 +139,8 @@ generateRuleTests({
       template: '{{args.foo}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 10,
               "endLine": 1,
@@ -159,8 +159,8 @@ generateRuleTests({
       template: '{{this.args.foo}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 15,
               "endLine": 1,

--- a/test/unit/rules/no-arguments-for-html-elements-test.js
+++ b/test/unit/rules/no-arguments-for-html-elements-test.js
@@ -23,8 +23,8 @@ generateRuleTests({
       template: '<div @value="1"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 15,
               "endLine": 1,
@@ -43,8 +43,8 @@ generateRuleTests({
       template: '<div @value></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 11,
               "endLine": 1,
@@ -63,8 +63,8 @@ generateRuleTests({
       template: '<img @src="12">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 14,
               "endLine": 1,

--- a/test/unit/rules/no-aria-hidden-body-test.js
+++ b/test/unit/rules/no-aria-hidden-body-test.js
@@ -17,8 +17,8 @@ generateRuleTests({
       fixedTemplate: '<body></body>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 32,
               "endLine": 1,
@@ -39,8 +39,8 @@ generateRuleTests({
       fixedTemplate: '<body></body>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 25,
               "endLine": 1,

--- a/test/unit/rules/no-attrs-in-components-test.js
+++ b/test/unit/rules/no-attrs-in-components-test.js
@@ -20,8 +20,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 11,
               "endLine": 1,
@@ -45,8 +45,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 22,
               "endLine": 1,
@@ -70,8 +70,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 15,
               "endLine": 1,
@@ -95,8 +95,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 19,
               "endLine": 1,
@@ -120,8 +120,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 21,
               "endLine": 1,
@@ -145,8 +145,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 20,
               "endColumn": 29,
               "endLine": 1,
@@ -170,8 +170,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 11,
               "endLine": 1,

--- a/test/unit/rules/no-autofocus-attribute-test.js
+++ b/test/unit/rules/no-autofocus-attribute-test.js
@@ -24,8 +24,8 @@ generateRuleTests({
       template: '<input autofocus />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 16,
               "endLine": 1,
@@ -45,8 +45,8 @@ generateRuleTests({
       template: '<input type="text" autofocus="autofocus" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 40,
               "endLine": 1,
@@ -66,8 +66,8 @@ generateRuleTests({
       template: '<input autofocus={{this.foo}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 29,
               "endLine": 1,
@@ -87,8 +87,8 @@ generateRuleTests({
       template: '{{input type="text" autofocus=true}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 20,
               "endColumn": 34,
               "endLine": 1,
@@ -108,8 +108,8 @@ generateRuleTests({
       template: '{{component "input" type="text" autofocus=true}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 32,
               "endColumn": 46,
               "endLine": 1,
@@ -129,8 +129,8 @@ generateRuleTests({
       template: '<div autofocus="true"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 21,
               "endLine": 1,
@@ -150,8 +150,8 @@ generateRuleTests({
       template: '<h1 autofocus="autofocus"><span>Valid Heading</span></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 25,
               "endLine": 1,
@@ -171,8 +171,8 @@ generateRuleTests({
       template: '<CustomComponent autofocus={{this.foo}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 17,
               "endColumn": 39,
               "endLine": 1,

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -119,8 +119,8 @@ generateRuleTests({
       template: '<p>{{"Hello!"}}</p>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 13,
               "endLine": 1,
@@ -140,8 +140,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 2,
@@ -162,8 +162,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 0,
               "endLine": 3,
@@ -186,8 +186,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 23,
               "endLine": 1,
@@ -208,8 +208,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 26,
               "endLine": 1,
@@ -230,8 +230,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 40,
               "endLine": 1,
@@ -252,8 +252,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 40,
               "endLine": 1,
@@ -274,8 +274,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 43,
               "endLine": 1,
@@ -296,8 +296,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 41,
               "endLine": 1,
@@ -318,8 +318,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 44,
               "endLine": 1,
@@ -340,8 +340,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 24,
               "endColumn": 63,
               "endLine": 1,
@@ -362,8 +362,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 38,
               "endColumn": 73,
               "endLine": 1,
@@ -384,8 +384,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 46,
               "endLine": 1,
@@ -407,8 +407,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 38,
               "endLine": 1,
@@ -430,8 +430,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 20,
               "endLine": 1,
@@ -453,8 +453,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 34,
               "endLine": 1,
@@ -475,8 +475,8 @@ generateRuleTests({
       template: '<div>Bady\n  <input placeholder="trolol">\n</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 2,
               "endLine": 2,
@@ -488,7 +488,7 @@ generateRuleTests({
               "source": "Bady
             ",
             },
-            Object {
+            {
               "column": 9,
               "endColumn": 28,
               "endLine": 2,
@@ -537,8 +537,8 @@ generateRuleTests({
       template: '{{t "foo"}} / error / &lpar;"{{name}}"&rpar;',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 29,
               "endLine": 1,
@@ -560,8 +560,8 @@ generateRuleTests({
       template: '<a title="hahaha trolol"></a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 23,
               "endLine": 1,
@@ -583,8 +583,8 @@ generateRuleTests({
       template: '<input placeholder="hahaha">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 26,
               "endLine": 1,

--- a/test/unit/rules/no-block-params-for-html-elements-test.js
+++ b/test/unit/rules/no-block-params-for-html-elements-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
       template: '<div as |blockName|></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 26,
               "endLine": 1,
@@ -39,8 +39,8 @@ generateRuleTests({
       template: '<div as |a b c|></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,

--- a/test/unit/rules/no-capital-arguments-test.js
+++ b/test/unit/rules/no-capital-arguments-test.js
@@ -13,8 +13,8 @@ generateRuleTests({
       template: '<Foo @Name="bar" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 16,
               "endLine": 1,
@@ -33,8 +33,8 @@ generateRuleTests({
       template: '<Foo @_ame="bar" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 16,
               "endLine": 1,
@@ -53,8 +53,8 @@ generateRuleTests({
       template: '{{@Name}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 7,
               "endLine": 1,
@@ -73,8 +73,8 @@ generateRuleTests({
       template: '{{@_Name}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 8,
               "endLine": 1,

--- a/test/unit/rules/no-class-bindings-test.js
+++ b/test/unit/rules/no-class-bindings-test.js
@@ -13,8 +13,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 35,
               "endLine": 1,
@@ -34,8 +34,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 34,
               "endLine": 1,
@@ -55,8 +55,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 44,
               "endLine": 1,
@@ -76,8 +76,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 43,
               "endLine": 1,

--- a/test/unit/rules/no-debugger-test.js
+++ b/test/unit/rules/no-debugger-test.js
@@ -13,8 +13,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 12,
               "endLine": 1,
@@ -34,8 +34,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 34,
               "endLine": 1,

--- a/test/unit/rules/no-down-event-binding-test.js
+++ b/test/unit/rules/no-down-event-binding-test.js
@@ -21,8 +21,8 @@ generateRuleTests({
       template: "<div {{on 'keydown' this.doSomething}}></div>",
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 19,
               "endLine": 1,
@@ -41,8 +41,8 @@ generateRuleTests({
       template: "<div {{action this.doSomething on='keydown'}}></div>",
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 34,
               "endColumn": 43,
               "endLine": 1,
@@ -62,8 +62,8 @@ generateRuleTests({
       template: "<div {{action this.doSomething preventDefault=true on='keydown'}}></div>",
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 54,
               "endColumn": 63,
               "endLine": 1,
@@ -83,8 +83,8 @@ generateRuleTests({
       template: '<input type="text" onkeydown="myFunction()">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 43,
               "endLine": 1,

--- a/test/unit/rules/no-duplicate-attributes-test.js
+++ b/test/unit/rules/no-duplicate-attributes-test.js
@@ -27,8 +27,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 53,
               "endColumn": 72,
               "endLine": 1,
@@ -52,8 +52,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 55,
               "endColumn": 74,
               "endLine": 1,
@@ -74,8 +74,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 26,
               "endLine": 1,
@@ -97,8 +97,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 80,
               "endColumn": 99,
               "endLine": 1,
@@ -120,8 +120,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 87,
               "endColumn": 106,
               "endLine": 1,

--- a/test/unit/rules/no-duplicate-id-test.js
+++ b/test/unit/rules/no-duplicate-id-test.js
@@ -141,8 +141,8 @@ generateRuleTests({
       template: '<div id="id-00"></div><div id="id-00"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 27,
               "endColumn": 37,
               "endLine": 1,
@@ -161,8 +161,8 @@ generateRuleTests({
       template: '<div><div id="id-01"></div></div><div><div id="id-01"></div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 43,
               "endColumn": 53,
               "endLine": 1,
@@ -181,8 +181,8 @@ generateRuleTests({
       template: '<div id="id-00"></div><div id={{"id-00"}}></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 27,
               "endColumn": 41,
               "endLine": 1,
@@ -201,8 +201,8 @@ generateRuleTests({
       template: '<div id={{"id-00"}}></div><div id="id-00"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 31,
               "endColumn": 41,
               "endLine": 1,
@@ -221,8 +221,8 @@ generateRuleTests({
       template: '<div id="id-00"></div><div id="id-{{"00"}}"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 27,
               "endColumn": 43,
               "endLine": 1,
@@ -241,8 +241,8 @@ generateRuleTests({
       template: '<div id="id-00"></div><div id="{{"id"}}-00"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 27,
               "endColumn": 43,
               "endLine": 1,
@@ -261,8 +261,8 @@ generateRuleTests({
       template: '<div id="id-00"></div>{{#foo elementId="id-00"}}{{/foo}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 22,
               "endColumn": 56,
               "endLine": 1,
@@ -281,8 +281,8 @@ generateRuleTests({
       template: '{{#foo elementId="id-00"}}{{/foo}}<div id="id-00"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 39,
               "endColumn": 49,
               "endLine": 1,
@@ -301,8 +301,8 @@ generateRuleTests({
       template: '<div id={{"id-00"}}></div>{{#foo elementId="id-00"}}{{/foo}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 26,
               "endColumn": 60,
               "endLine": 1,
@@ -321,8 +321,8 @@ generateRuleTests({
       template: '{{#foo elementId="id-00"}}{{/foo}}<div id={{"id-00"}}></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 39,
               "endColumn": 53,
               "endLine": 1,
@@ -341,8 +341,8 @@ generateRuleTests({
       template: '<div id="id-{{"00"}}"></div>{{#foo elementId="id-00"}}{{/foo}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 28,
               "endColumn": 62,
               "endLine": 1,
@@ -361,8 +361,8 @@ generateRuleTests({
       template: '{{#foo elementId="id-00"}}{{/foo}}<div id="id-{{"00"}}"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 39,
               "endColumn": 55,
               "endLine": 1,
@@ -381,8 +381,8 @@ generateRuleTests({
       template: '{{#foo elementId="id-00"}}{{/foo}}{{#bar elementId="id-00"}}{{/bar}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 34,
               "endColumn": 68,
               "endLine": 1,
@@ -401,8 +401,8 @@ generateRuleTests({
       template: '{{foo id="id-00"}}{{foo id="id-00"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 36,
               "endLine": 1,
@@ -421,8 +421,8 @@ generateRuleTests({
       template: '<div id={{1234}}></div><div id={{1234}}></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 28,
               "endColumn": 39,
               "endLine": 1,
@@ -441,8 +441,8 @@ generateRuleTests({
       template: '<div id={{this.divId00}}></div><div id={{this.divId00}}></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 36,
               "endColumn": 55,
               "endLine": 1,
@@ -462,8 +462,8 @@ generateRuleTests({
         '<div id="partA{{partB}}{{"partC"}}"></div><div id="{{"partA"}}{{partB}}partC"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 47,
               "endColumn": 77,
               "endLine": 1,
@@ -482,8 +482,8 @@ generateRuleTests({
       template: '{{#foo elementId="id-00"}}{{/foo}}{{bar elementId="id-00"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 34,
               "endColumn": 59,
               "endLine": 1,
@@ -502,8 +502,8 @@ generateRuleTests({
       template: '{{#foo id="id-00"}}{{/foo}}{{bar id="id-00"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 27,
               "endColumn": 45,
               "endLine": 1,
@@ -522,8 +522,8 @@ generateRuleTests({
       template: '{{#foo id="id-00"}}{{/foo}}<Bar id="id-00" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 32,
               "endColumn": 42,
               "endLine": 1,
@@ -542,8 +542,8 @@ generateRuleTests({
       template: '{{#foo id="id-00"}}{{/foo}}<Bar @id="id-00" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 32,
               "endColumn": 43,
               "endLine": 1,
@@ -562,8 +562,8 @@ generateRuleTests({
       template: '{{#foo id="id-00"}}{{/foo}}<Bar @elementId="id-00" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 32,
               "endColumn": 50,
               "endLine": 1,
@@ -589,8 +589,8 @@ generateRuleTests({
     `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 32,
               "endLine": 4,
@@ -614,8 +614,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 25,
               "endLine": 4,
@@ -641,8 +641,8 @@ generateRuleTests({
     `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 32,
               "endLine": 4,
@@ -653,7 +653,7 @@ generateRuleTests({
               "severity": 2,
               "source": "id={{this.divId00}}",
             },
-            Object {
+            {
               "column": 13,
               "endColumn": 32,
               "endLine": 6,
@@ -679,8 +679,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 26,
               "endLine": 7,
@@ -708,8 +708,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 24,
               "endLine": 9,
@@ -733,8 +733,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 17,
               "endColumn": 42,
               "endLine": 4,

--- a/test/unit/rules/no-duplicate-landmark-elements-test.js
+++ b/test/unit/rules/no-duplicate-landmark-elements-test.js
@@ -23,8 +23,8 @@ generateRuleTests({
       template: '<nav></nav><nav></nav>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 22,
               "endLine": 1,
@@ -43,8 +43,8 @@ generateRuleTests({
       template: '<nav></nav><div role="navigation"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 40,
               "endLine": 1,
@@ -63,8 +63,8 @@ generateRuleTests({
       template: '<nav></nav><nav aria-label="secondary navigation"></nav>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 11,
               "endLine": 1,
@@ -83,8 +83,8 @@ generateRuleTests({
       template: '<main></main><div role="main"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 36,
               "endLine": 1,
@@ -103,8 +103,8 @@ generateRuleTests({
       template: '<nav aria-label="site navigation"></nav><nav aria-label="site navigation"></nav>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 40,
               "endColumn": 80,
               "endLine": 1,
@@ -123,8 +123,8 @@ generateRuleTests({
       template: '<form aria-label="search-form"></form><form aria-label="search-form"></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 38,
               "endColumn": 76,
               "endLine": 1,
@@ -144,8 +144,8 @@ generateRuleTests({
         '<form aria-labelledby="form-title"></form><form aria-labelledby="form-title"></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 42,
               "endColumn": 84,
               "endLine": 1,

--- a/test/unit/rules/no-dynamic-subexpression-invocations-test.js
+++ b/test/unit/rules/no-dynamic-subexpression-invocations-test.js
@@ -31,8 +31,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 31,
               "endLine": 1,
@@ -52,8 +52,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 17,
               "endLine": 1,
@@ -73,8 +73,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 13,
               "endLine": 1,
@@ -94,8 +94,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 16,
               "endLine": 1,
@@ -115,8 +115,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 37,
               "endLine": 1,
@@ -137,8 +137,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 46,
               "endColumn": 66,
               "endLine": 1,
@@ -158,8 +158,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 41,
               "endLine": 1,
@@ -179,8 +179,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 45,
               "endLine": 1,
@@ -200,8 +200,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 15,
               "endLine": 1,
@@ -221,8 +221,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 31,
               "endLine": 1,
@@ -242,8 +242,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 34,
               "endLine": 1,

--- a/test/unit/rules/no-element-event-actions-test.js
+++ b/test/unit/rules/no-element-event-actions-test.js
@@ -30,8 +30,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 37,
               "endLine": 1,
@@ -42,7 +42,7 @@ generateRuleTests({
               "severity": 2,
               "source": "onclick={{action \\"myAction\\"}}",
             },
-            Object {
+            {
               "column": 38,
               "endColumn": 67,
               "endLine": 1,
@@ -63,8 +63,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 41,
               "endLine": 1,
@@ -86,8 +86,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 22,
               "endColumn": 47,
               "endLine": 1,
@@ -107,8 +107,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 22,
               "endColumn": 47,
               "endLine": 1,

--- a/test/unit/rules/no-empty-headings-test.js
+++ b/test/unit/rules/no-empty-headings-test.js
@@ -39,8 +39,8 @@ generateRuleTests({
       template: '<h1></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 9,
               "endLine": 1,
@@ -59,8 +59,8 @@ generateRuleTests({
       template: '<h1> \n &nbsp;</h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 12,
               "endLine": 2,
@@ -80,8 +80,8 @@ generateRuleTests({
       template: '<h1><span></span></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -100,8 +100,8 @@ generateRuleTests({
       template: '<h1><span> \n &nbsp;</span></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 19,
               "endLine": 2,
@@ -121,8 +121,8 @@ generateRuleTests({
       template: '<h1><div><span></span></div></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 33,
               "endLine": 1,
@@ -141,8 +141,8 @@ generateRuleTests({
       template: '<h1><span></span><span></span></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 35,
               "endLine": 1,
@@ -161,8 +161,8 @@ generateRuleTests({
       template: '<h1> &nbsp; <div aria-hidden="true">Some hidden text</div></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 63,
               "endLine": 1,
@@ -181,8 +181,8 @@ generateRuleTests({
       template: '<h1><span aria-hidden="true">Inaccessible text</span></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 58,
               "endLine": 1,
@@ -201,8 +201,8 @@ generateRuleTests({
       template: '<h1><span hidden>Inaccessible text</span></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 46,
               "endLine": 1,
@@ -221,8 +221,8 @@ generateRuleTests({
       template: '<h1><span hidden>{{@title}}</span></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 39,
               "endLine": 1,
@@ -241,8 +241,8 @@ generateRuleTests({
       template: '<h1><span hidden>{{#component}}Inaccessible text{{/component}}</span></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 74,
               "endLine": 1,
@@ -261,8 +261,8 @@ generateRuleTests({
       template: '<h1><span hidden><CustomComponent>Inaccessible text</CustomComponent></span></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 81,
               "endLine": 1,
@@ -282,8 +282,8 @@ generateRuleTests({
         '<h1><span aria-hidden="true">Hidden text</span><span aria-hidden="true">Hidden text</span></h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 95,
               "endLine": 1,
@@ -302,8 +302,8 @@ generateRuleTests({
       template: '<div role="heading" aria-level="1"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 41,
               "endLine": 1,
@@ -323,8 +323,8 @@ generateRuleTests({
         '<div role="heading" aria-level="1"><span aria-hidden="true">Inaccessible text</span></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 90,
               "endLine": 1,
@@ -343,8 +343,8 @@ generateRuleTests({
       template: '<div role="heading" aria-level="1"><span hidden>Inaccessible text</span></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 78,
               "endLine": 1,

--- a/test/unit/rules/no-extra-mut-helper-argument-test.js
+++ b/test/unit/rules/no-extra-mut-helper-argument-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 29,
               "endColumn": 49,
               "endLine": 1,
@@ -40,8 +40,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 32,
               "endColumn": 52,
               "endLine": 1,
@@ -61,8 +61,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 17,
               "endColumn": 37,
               "endLine": 1,

--- a/test/unit/rules/no-forbidden-elements-test.js
+++ b/test/unit/rules/no-forbidden-elements-test.js
@@ -27,8 +27,8 @@ generateRuleTests({
       template: '<script></script>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 17,
               "endLine": 1,
@@ -47,8 +47,8 @@ generateRuleTests({
       template: '<html></html>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 13,
               "endLine": 1,
@@ -67,8 +67,8 @@ generateRuleTests({
       template: '<style></style>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 15,
               "endLine": 1,
@@ -87,8 +87,8 @@ generateRuleTests({
       template: '<meta charset="utf-8">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -110,8 +110,8 @@ generateRuleTests({
       },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 11,
               "endLine": 1,
@@ -131,8 +131,8 @@ generateRuleTests({
       config: ['div'],
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 11,
               "endLine": 1,
@@ -152,8 +152,8 @@ generateRuleTests({
       config: ['Foo'],
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
@@ -175,8 +175,8 @@ generateRuleTests({
       },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 17,
               "endLine": 1,
@@ -198,8 +198,8 @@ generateRuleTests({
       },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 13,
               "endLine": 1,
@@ -218,8 +218,8 @@ generateRuleTests({
       template: '<head><html></html></head>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 19,
               "endLine": 1,

--- a/test/unit/rules/no-heading-inside-button-test.js
+++ b/test/unit/rules/no-heading-inside-button-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
       template: '<button><h1>Page Title</h1></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 27,
               "endLine": 1,
@@ -39,8 +39,8 @@ generateRuleTests({
       template: '<button><h2>Heading Title</h2></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 30,
               "endLine": 1,
@@ -59,8 +59,8 @@ generateRuleTests({
       template: '<button><h3>Heading Title</h3></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 30,
               "endLine": 1,
@@ -79,8 +79,8 @@ generateRuleTests({
       template: '<button><h4>Heading Title</h4></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 30,
               "endLine": 1,
@@ -99,8 +99,8 @@ generateRuleTests({
       template: '<button><h5>Heading Title</h5></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 30,
               "endLine": 1,
@@ -119,8 +119,8 @@ generateRuleTests({
       template: '<button><div><h1>Heading Title</h1></div></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 35,
               "endLine": 1,
@@ -139,8 +139,8 @@ generateRuleTests({
       template: '<button><h6>Heading Title</h6></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 30,
               "endLine": 1,
@@ -159,8 +159,8 @@ generateRuleTests({
       template: '<div role="button"><h6>Heading in a div with a role of button</h6></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 66,
               "endLine": 1,

--- a/test/unit/rules/no-html-comments-test.js
+++ b/test/unit/rules/no-html-comments-test.js
@@ -19,13 +19,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 21,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "{{! comment here }}",
               },
               "line": 1,
@@ -43,13 +43,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 19,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "{{!comment here}}",
               },
               "line": 1,

--- a/test/unit/rules/no-implicit-this-test.js
+++ b/test/unit/rules/no-implicit-this-test.js
@@ -53,8 +53,8 @@ generateRuleTests({
       template: '{{book}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 6,
               "endLine": 1,
@@ -73,8 +73,8 @@ generateRuleTests({
       template: '{{book-details}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 14,
               "endLine": 1,
@@ -93,8 +93,8 @@ generateRuleTests({
       template: '{{book.author}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 13,
               "endLine": 1,
@@ -113,8 +113,8 @@ generateRuleTests({
       template: '{{helper book}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 13,
               "endLine": 1,
@@ -133,8 +133,8 @@ generateRuleTests({
       template: '{{#helper book}}{{/helper}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 14,
               "endLine": 1,
@@ -153,8 +153,8 @@ generateRuleTests({
       template: '<MyComponent @prop={{can.do}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 27,
               "endLine": 1,
@@ -174,8 +174,8 @@ generateRuleTests({
       config: { allow: ['can'] },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 27,
               "endLine": 1,
@@ -194,8 +194,8 @@ generateRuleTests({
       template: '{{session.user.name}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 19,
               "endLine": 1,
@@ -214,8 +214,8 @@ generateRuleTests({
       template: '<MyComponent @prop={{session.user.name}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 38,
               "endLine": 1,

--- a/test/unit/rules/no-index-component-invocation-test.js
+++ b/test/unit/rules/no-index-component-invocation-test.js
@@ -24,8 +24,8 @@ generateRuleTests({
       template: '{{foo/index}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 11,
               "endLine": 1,
@@ -44,8 +44,8 @@ generateRuleTests({
       template: '{{component "foo/index"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 23,
               "endLine": 1,
@@ -64,8 +64,8 @@ generateRuleTests({
       template: '{{#foo/index}}{{/foo/index}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 12,
               "endLine": 1,
@@ -84,8 +84,8 @@ generateRuleTests({
       template: '{{#component "foo/index"}}{{/component}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 24,
               "endLine": 1,
@@ -104,8 +104,8 @@ generateRuleTests({
       template: '{{foo/bar (component "foo/index")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 32,
               "endLine": 1,
@@ -124,8 +124,8 @@ generateRuleTests({
       template: '{{foo/bar name=(component "foo/index")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 26,
               "endColumn": 37,
               "endLine": 1,
@@ -144,8 +144,8 @@ generateRuleTests({
       template: '<Foo::Index />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 14,
               "endLine": 1,
@@ -164,8 +164,8 @@ generateRuleTests({
       template: '<Foo::Bar::Index />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 19,
               "endLine": 1,
@@ -184,8 +184,8 @@ generateRuleTests({
       template: '<Foo::Index></Foo::Index>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 25,
               "endLine": 1,

--- a/test/unit/rules/no-input-block-test.js
+++ b/test/unit/rules/no-input-block-test.js
@@ -13,8 +13,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 1,

--- a/test/unit/rules/no-input-tagname-test.js
+++ b/test/unit/rules/no-input-tagname-test.js
@@ -17,8 +17,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 23,
               "endLine": 1,
@@ -38,8 +38,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 21,
               "endLine": 1,
@@ -59,8 +59,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 35,
               "endLine": 1,
@@ -80,8 +80,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 33,
               "endLine": 1,
@@ -101,8 +101,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 41,
               "endLine": 1,
@@ -122,8 +122,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 39,
               "endLine": 1,

--- a/test/unit/rules/no-invalid-aria-attributes-test.js
+++ b/test/unit/rules/no-invalid-aria-attributes-test.js
@@ -25,8 +25,8 @@ generateRuleTests({
       template: '<input aria-text="inaccessible text" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 39,
               "endLine": 1,
@@ -46,8 +46,8 @@ generateRuleTests({
         '<div role="slider" aria-valuenow={{this.foo}} aria-valuemax={{this.bar}} aria-value-min={{this.baz}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 103,
               "endLine": 1,
@@ -66,8 +66,8 @@ generateRuleTests({
       template: '<h1 aria--hidden="true">Broken heading</h1>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 43,
               "endLine": 1,
@@ -86,8 +86,8 @@ generateRuleTests({
       template: '<CustomComponent role="region" aria-alert="polite" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 53,
               "endLine": 1,
@@ -107,8 +107,8 @@ generateRuleTests({
         '<span role="checkbox" aria-checked="bad-value" tabindex="0" aria-label="Forget me"></span>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 90,
               "endLine": 1,
@@ -127,8 +127,8 @@ generateRuleTests({
       template: '<button type="submit" disabled="true" aria-disabled="123">Submit</button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 73,
               "endLine": 1,
@@ -147,8 +147,8 @@ generateRuleTests({
       template: '<input type="text" disabled="true" aria-errormessage="false" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 63,
               "endLine": 1,
@@ -167,8 +167,8 @@ generateRuleTests({
       template: '<input type="password" required="true" aria-errormessage={{0}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 65,
               "endLine": 1,
@@ -188,8 +188,8 @@ generateRuleTests({
         '<button type="submit" aria-describedby="blah false">Continue at your own risk</button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 86,
               "endLine": 1,
@@ -208,8 +208,8 @@ generateRuleTests({
       template: '<button type="submit" aria-describedby={{false}} >broken button</button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 72,
               "endLine": 1,
@@ -228,8 +228,8 @@ generateRuleTests({
       template: '<div role="heading" aria-level="bogus">Inaccessible heading</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 65,
               "endLine": 1,
@@ -248,8 +248,8 @@ generateRuleTests({
       template: '<div role="heading" aria-level="true">Another inaccessible heading</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 72,
               "endLine": 1,
@@ -268,8 +268,8 @@ generateRuleTests({
       template: '<div role="heading" aria-level={{"blah"}}>Broken heading</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 62,
               "endLine": 1,
@@ -289,8 +289,8 @@ generateRuleTests({
         '<div role="slider" aria-valuenow=(2*2)  aria-valuemax="100" aria-valuemin="30">Broken slider</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 98,
               "endLine": 1,
@@ -309,8 +309,8 @@ generateRuleTests({
       template: '<div role="region" aria-live="no-such-value">Inaccessible live region</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 75,
               "endLine": 1,
@@ -330,8 +330,8 @@ generateRuleTests({
         '<div role="region" aria-live="polite" aria-relevant="additions errors">Inaccessible live region</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 101,
               "endLine": 1,
@@ -350,8 +350,8 @@ generateRuleTests({
       template: '<input type="text" aria-required={{if this.foo "true" "woosh"}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 66,
               "endLine": 1,
@@ -370,8 +370,8 @@ generateRuleTests({
       template: '<input type="text" aria-required="undefined" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 47,
               "endLine": 1,

--- a/test/unit/rules/no-invalid-interactive-test.js
+++ b/test/unit/rules/no-invalid-interactive-test.js
@@ -60,8 +60,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 35,
               "endLine": 1,
@@ -81,8 +81,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 21,
               "endLine": 1,
@@ -103,8 +103,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 29,
               "endLine": 1,
@@ -126,8 +126,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 34,
               "endLine": 1,
@@ -148,8 +148,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 30,
               "endLine": 1,
@@ -171,8 +171,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 37,
               "endLine": 1,
@@ -193,8 +193,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 33,
               "endLine": 1,
@@ -215,8 +215,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 33,
               "endLine": 1,

--- a/test/unit/rules/no-invalid-link-text-test.js
+++ b/test/unit/rules/no-invalid-link-text-test.js
@@ -25,8 +25,8 @@ generateRuleTests({
       template: '<a href="https://myurl.com">click here</a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 42,
               "endLine": 1,
@@ -45,8 +45,8 @@ generateRuleTests({
       template: '<LinkTo>click here</LinkTo>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 27,
               "endLine": 1,
@@ -65,8 +65,8 @@ generateRuleTests({
       template: '{{#link-to}}click here{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 34,
               "endLine": 1,
@@ -85,8 +85,8 @@ generateRuleTests({
       template: '<a href="https://myurl.com"></a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 32,
               "endLine": 1,
@@ -105,8 +105,8 @@ generateRuleTests({
       template: '<a href="https://myurl.com"> </a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 33,
               "endLine": 1,
@@ -125,8 +125,8 @@ generateRuleTests({
       template: '<a href="https://myurl.com"> &nbsp; \n</a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 4,
               "endLine": 2,
@@ -146,8 +146,8 @@ generateRuleTests({
       template: '<a aria-labelledby="" href="https://myurl.com">Click here</a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 61,
               "endLine": 1,
@@ -166,8 +166,8 @@ generateRuleTests({
       template: '<a aria-labelledby=" " href="https://myurl.com">Click here</a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 62,
               "endLine": 1,
@@ -186,8 +186,8 @@ generateRuleTests({
       template: '<a aria-label="Click here" href="https://myurl.com">Click here</a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 66,
               "endLine": 1,
@@ -206,8 +206,8 @@ generateRuleTests({
       template: '<LinkTo></LinkTo>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 17,
               "endLine": 1,
@@ -226,8 +226,8 @@ generateRuleTests({
       template: '<LinkTo> &nbsp; \n</LinkTo>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 9,
               "endLine": 2,
@@ -247,8 +247,8 @@ generateRuleTests({
       template: '{{#link-to}}{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 24,
               "endLine": 1,
@@ -267,8 +267,8 @@ generateRuleTests({
       template: '{{#link-to}} &nbsp; \n{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 12,
               "endLine": 2,
@@ -289,8 +289,8 @@ generateRuleTests({
       template: '{{#link-to}} &nbsp; \n{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 12,
               "endLine": 2,

--- a/test/unit/rules/no-invalid-link-title-test.js
+++ b/test/unit/rules/no-invalid-link-title-test.js
@@ -28,8 +28,8 @@ generateRuleTests({
       template: '<a href="https://myurl.com" title="read the tutorial">Read the Tutorial</a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 75,
               "endLine": 1,
@@ -48,8 +48,8 @@ generateRuleTests({
       template: '<LinkTo title="quickstart">Quickstart</LinkTo>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 46,
               "endLine": 1,
@@ -68,8 +68,8 @@ generateRuleTests({
       template: '<LinkTo @title="foo" title="blah">derp</LinkTo>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 47,
               "endLine": 1,
@@ -88,8 +88,8 @@ generateRuleTests({
       template: '{{#link-to title="Do the things"}}Do the things{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 59,
               "endLine": 1,
@@ -108,8 +108,8 @@ generateRuleTests({
       template: '<LinkTo @route="some.route" @title="Do the things">Do the things</LinkTo>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 73,
               "endLine": 1,
@@ -128,8 +128,8 @@ generateRuleTests({
       template: '<a href="https://myurl.com" title="Tutorial">Read the Tutorial</a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 66,
               "endLine": 1,
@@ -148,8 +148,8 @@ generateRuleTests({
       template: '<LinkTo title="Tutorial">Read the Tutorial</LinkTo>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 51,
               "endLine": 1,
@@ -168,8 +168,8 @@ generateRuleTests({
       template: '{{#link-to title="Tutorial"}}Read the Tutorial{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 58,
               "endLine": 1,

--- a/test/unit/rules/no-invalid-meta-test.js
+++ b/test/unit/rules/no-invalid-meta-test.js
@@ -29,8 +29,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 67,
               "endLine": 1,
@@ -50,8 +50,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 43,
               "endLine": 1,
@@ -71,8 +71,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 49,
               "endLine": 1,
@@ -92,8 +92,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 51,
               "endLine": 1,
@@ -113,8 +113,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 50,
               "endLine": 1,
@@ -135,8 +135,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 89,
               "endLine": 1,
@@ -157,8 +157,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -178,8 +178,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 25,
               "endLine": 1,
@@ -199,8 +199,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -220,8 +220,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 27,
               "endLine": 1,
@@ -241,8 +241,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,

--- a/test/unit/rules/no-invalid-role-test.js
+++ b/test/unit/rules/no-invalid-role-test.js
@@ -35,8 +35,8 @@ generateRuleTests({
       template: '<ul role="presentation"></ul>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 29,
               "endLine": 1,
@@ -55,8 +55,8 @@ generateRuleTests({
       template: '<ol role="presentation"></ol>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 29,
               "endLine": 1,
@@ -75,8 +75,8 @@ generateRuleTests({
       template: '<li role="presentation"></li>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 29,
               "endLine": 1,
@@ -95,8 +95,8 @@ generateRuleTests({
       template: '<table role="presentation"></table>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 35,
               "endLine": 1,
@@ -115,8 +115,8 @@ generateRuleTests({
       template: '<table role="none"></table>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 27,
               "endLine": 1,
@@ -135,8 +135,8 @@ generateRuleTests({
       template: '<button role="presentation"></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 37,
               "endLine": 1,
@@ -155,8 +155,8 @@ generateRuleTests({
       template: '<button role="none"></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 29,
               "endLine": 1,
@@ -175,8 +175,8 @@ generateRuleTests({
       template: '<label role="presentation"></label>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 35,
               "endLine": 1,
@@ -195,8 +195,8 @@ generateRuleTests({
       template: '<label role="none"></label>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 27,
               "endLine": 1,
@@ -215,8 +215,8 @@ generateRuleTests({
       template: '<div role="command interface"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 36,
               "endLine": 1,
@@ -238,8 +238,8 @@ generateRuleTests({
       },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 36,
               "endLine": 1,
@@ -258,8 +258,8 @@ generateRuleTests({
       template: '<div role="COMMAND INTERFACE"></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 36,
               "endLine": 1,

--- a/test/unit/rules/no-link-to-positional-params-test.js
+++ b/test/unit/rules/no-link-to-positional-params-test.js
@@ -29,8 +29,8 @@ generateRuleTests({
       template: '{{link-to "About Us" "about"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 30,
               "endLine": 1,
@@ -49,8 +49,8 @@ generateRuleTests({
       template: '{{link-to "About Us" (if this.showNewAboutPage "about-us" "about")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 68,
               "endLine": 1,
@@ -69,8 +69,8 @@ generateRuleTests({
       template: '{{link-to (t "about") "about"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 31,
               "endLine": 1,
@@ -89,8 +89,8 @@ generateRuleTests({
       template: '{{link-to (t "about") this.aboutRoute}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 39,
               "endLine": 1,
@@ -109,8 +109,8 @@ generateRuleTests({
       template: '{{link-to (t "about") this.aboutRoute "foo"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 45,
               "endLine": 1,
@@ -129,8 +129,8 @@ generateRuleTests({
       template: '{{link-to (t "about") this.aboutRoute "foo" "bar"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 51,
               "endLine": 1,
@@ -149,8 +149,8 @@ generateRuleTests({
       template: '{{link-to (t "about") this.aboutRoute "foo" "bar" (query-params foo="bar")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 76,
               "endLine": 1,
@@ -170,8 +170,8 @@ generateRuleTests({
       template: '{{#link-to (if this.showNewAboutPage "about-us" "about")}}About Us{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 78,
               "endLine": 1,
@@ -190,8 +190,8 @@ generateRuleTests({
       template: '{{#link-to "about"}}About Us{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 40,
               "endLine": 1,
@@ -210,8 +210,8 @@ generateRuleTests({
       template: '{{#link-to this.aboutRoute}}About Us{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 48,
               "endLine": 1,
@@ -230,8 +230,8 @@ generateRuleTests({
       template: '{{#link-to this.aboutRoute "foo"}}About Us{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 54,
               "endLine": 1,
@@ -250,8 +250,8 @@ generateRuleTests({
       template: '{{#link-to this.aboutRoute "foo" "bar"}}About Us{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 60,
               "endLine": 1,
@@ -271,8 +271,8 @@ generateRuleTests({
         '{{#link-to this.aboutRoute "foo" "bar" (query-params foo="bar")}}About Us{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 85,
               "endLine": 1,
@@ -291,8 +291,8 @@ generateRuleTests({
       template: '{{#link-to "post" @post}}Read {{@post.title}}...{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 60,
               "endLine": 1,
@@ -313,8 +313,8 @@ generateRuleTests({
       {{/link-to}}`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 18,
               "endLine": 3,
@@ -337,8 +337,8 @@ generateRuleTests({
       {{/link-to}}`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 18,
               "endLine": 3,

--- a/test/unit/rules/no-link-to-tagname-test.js
+++ b/test/unit/rules/no-link-to-tagname-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
       template: '<LinkTo @route="routeName" @tagName="button">Link text</LinkTo>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 27,
               "endColumn": 44,
               "endLine": 1,
@@ -39,8 +39,8 @@ generateRuleTests({
       template: '{{#link-to "routeName" tagName="button"}}Link text{{/link-to}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 23,
               "endColumn": 39,
               "endLine": 1,
@@ -59,8 +59,8 @@ generateRuleTests({
       template: '{{link-to "Link text" "routeName" tagName="button"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 34,
               "endColumn": 50,
               "endLine": 1,

--- a/test/unit/rules/no-log-test.js
+++ b/test/unit/rules/no-log-test.js
@@ -21,8 +21,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
@@ -42,8 +42,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 38,
               "endLine": 1,
@@ -63,8 +63,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -84,8 +84,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -105,8 +105,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 36,
               "endColumn": 51,
               "endLine": 1,
@@ -126,8 +126,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 34,
               "endColumn": 49,
               "endLine": 1,
@@ -148,8 +148,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 51,
               "endColumn": 78,
               "endLine": 1,

--- a/test/unit/rules/no-model-argument-in-route-templates-test.js
+++ b/test/unit/rules/no-model-argument-in-route-templates-test.js
@@ -35,8 +35,8 @@ generateRuleTests({
       fixedTemplate: '{{this.model}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 8,
               "endLine": 1,
@@ -57,8 +57,8 @@ generateRuleTests({
       fixedTemplate: '{{this.model.foo}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 12,
               "endLine": 1,
@@ -79,8 +79,8 @@ generateRuleTests({
       fixedTemplate: '{{this.model.foo.bar}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 16,
               "endLine": 1,

--- a/test/unit/rules/no-multiple-empty-lines-test.js
+++ b/test/unit/rules/no-multiple-empty-lines-test.js
@@ -29,8 +29,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 14,
               "endLine": 4,
@@ -52,8 +52,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 14,
               "endLine": 6,
@@ -79,8 +79,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 14,
               "endLine": 6,

--- a/test/unit/rules/no-mut-helper-test.js
+++ b/test/unit/rules/no-mut-helper-test.js
@@ -33,8 +33,8 @@ generateRuleTests({
       template: '<MyComponent @toggled={{mut this.showAggregatedLine}}/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 22,
               "endColumn": 53,
               "endLine": 1,
@@ -53,8 +53,8 @@ generateRuleTests({
       template: '{{my-component value=(mut this.secondaryProfileHeadline)}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 56,
               "endLine": 1,
@@ -73,8 +73,8 @@ generateRuleTests({
       template: '<MyComponent {{action (mut this.isDropdownOpen) false}}/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 22,
               "endColumn": 47,
               "endLine": 1,
@@ -94,8 +94,8 @@ generateRuleTests({
         '<MyComponent @dismissModal={{action (mut this.isRequestExpiredModalOpen) false}}/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 36,
               "endColumn": 72,
               "endLine": 1,
@@ -115,8 +115,8 @@ generateRuleTests({
         '<MyComponent @click={{action (mut this.isCardCollapsed) (if this.isCardCollapsed false true)}}/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 29,
               "endColumn": 55,
               "endLine": 1,
@@ -135,8 +135,8 @@ generateRuleTests({
       template: '<MyComponent onclick={{fn (mut this.expandVoluntarySelfIdHelpText) true}}/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 26,
               "endColumn": 66,
               "endLine": 1,
@@ -155,8 +155,8 @@ generateRuleTests({
       template: '<MyComponent @onVisibilityChange={{fn (mut this.isDropdownOpen)}}/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 38,
               "endColumn": 63,
               "endLine": 1,
@@ -175,8 +175,8 @@ generateRuleTests({
       template: '{{my-component click=(action (mut this.isOpen) false)}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 29,
               "endColumn": 46,
               "endLine": 1,
@@ -196,8 +196,8 @@ generateRuleTests({
         '{{my-component click=(action (mut this.isLegalTextExpanded) (not this.isLegalTextExpanded))}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 29,
               "endColumn": 59,
               "endLine": 1,
@@ -216,8 +216,8 @@ generateRuleTests({
       template: '{{my-component onVisibilityChange=(action (mut this.isDropdownOpen))}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 42,
               "endColumn": 67,
               "endLine": 1,
@@ -236,8 +236,8 @@ generateRuleTests({
       template: '{{my-component click=(fn (mut this.showManageEventsModal) true)}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 25,
               "endColumn": 57,
               "endLine": 1,
@@ -260,8 +260,8 @@ generateRuleTests({
         />`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 49,
               "endLine": 3,
@@ -285,8 +285,8 @@ generateRuleTests({
         />`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 59,
               "endLine": 3,
@@ -306,8 +306,8 @@ generateRuleTests({
         '<MyComponent onchange={{action (mut this.contactUsSection.description) value="target.value"}}/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 31,
               "endColumn": 70,
               "endLine": 1,
@@ -330,8 +330,8 @@ generateRuleTests({
         '<MyComponent onchange={{action (mut this.contactUsSection.description) value="target.value"}}/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 31,
               "endColumn": 70,
               "endLine": 1,

--- a/test/unit/rules/no-negated-condition-test.js
+++ b/test/unit/rules/no-negated-condition-test.js
@@ -99,8 +99,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 35,
               "endLine": 1,
@@ -124,8 +124,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 50,
               "endLine": 1,
@@ -149,8 +149,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 43,
               "endLine": 1,
@@ -174,8 +174,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 58,
               "endLine": 1,
@@ -199,8 +199,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 77,
               "endLine": 1,
@@ -225,8 +225,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 89,
               "endLine": 1,
@@ -252,8 +252,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 44,
               "endColumn": 79,
               "endLine": 1,
@@ -277,8 +277,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 25,
               "endColumn": 60,
               "endLine": 1,
@@ -306,8 +306,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 46,
               "endLine": 1,
@@ -331,8 +331,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 60,
               "endLine": 1,
@@ -356,8 +356,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 50,
               "endLine": 1,
@@ -381,8 +381,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 64,
               "endLine": 1,
@@ -410,8 +410,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 14,
               "endColumn": 47,
               "endLine": 1,
@@ -435,8 +435,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 14,
               "endColumn": 61,
               "endLine": 1,
@@ -460,8 +460,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 14,
               "endColumn": 51,
               "endLine": 1,
@@ -485,8 +485,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 14,
               "endColumn": 65,
               "endLine": 1,

--- a/test/unit/rules/no-nested-interactive-test.js
+++ b/test/unit/rules/no-nested-interactive-test.js
@@ -43,8 +43,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 35,
               "endLine": 1,
@@ -64,8 +64,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 36,
               "endLine": 1,
@@ -85,8 +85,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 14,
               "endColumn": 31,
               "endLine": 1,
@@ -106,8 +106,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 14,
               "endColumn": 32,
               "endLine": 1,
@@ -127,8 +127,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 27,
               "endLine": 1,
@@ -148,8 +148,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 66,
               "endLine": 1,
@@ -170,8 +170,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 79,
               "endLine": 1,
@@ -191,8 +191,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 68,
               "endLine": 1,
@@ -212,8 +212,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 25,
               "endLine": 1,
@@ -233,8 +233,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 29,
               "endLine": 1,
@@ -254,8 +254,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 32,
               "endLine": 1,
@@ -275,8 +275,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 23,
               "endLine": 1,
@@ -296,8 +296,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 35,
               "endLine": 1,
@@ -320,8 +320,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 45,
               "endLine": 1,
@@ -342,8 +342,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 14,
               "endColumn": 21,
               "endLine": 1,
@@ -369,8 +369,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 9,
               "endLine": 3,

--- a/test/unit/rules/no-nested-landmark-test.js
+++ b/test/unit/rules/no-nested-landmark-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
       template: '<main><main></main></main>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 19,
               "endLine": 1,
@@ -39,8 +39,8 @@ generateRuleTests({
       template: '<main><div><main></main></div></main>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 24,
               "endLine": 1,
@@ -60,8 +60,8 @@ generateRuleTests({
       template: '<div role="main"><main></main></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 17,
               "endColumn": 30,
               "endLine": 1,
@@ -80,8 +80,8 @@ generateRuleTests({
       template: '<div role="main"><div><main></main></div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 22,
               "endColumn": 35,
               "endLine": 1,
@@ -101,8 +101,8 @@ generateRuleTests({
       template: '<main><div role="main"></div></main>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 29,
               "endLine": 1,
@@ -121,8 +121,8 @@ generateRuleTests({
       template: '<main><div><div role="main"></div></div></main>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 34,
               "endLine": 1,
@@ -141,8 +141,8 @@ generateRuleTests({
       template: '<nav><nav></nav></nav>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 16,
               "endLine": 1,
@@ -161,8 +161,8 @@ generateRuleTests({
       template: '<header><header></header></header>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 25,
               "endLine": 1,
@@ -181,8 +181,8 @@ generateRuleTests({
       template: '<header><div role="banner"></div></header>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 33,
               "endLine": 1,
@@ -201,8 +201,8 @@ generateRuleTests({
       template: '<div role="contentinfo"><footer></footer></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 24,
               "endColumn": 41,
               "endLine": 1,

--- a/test/unit/rules/no-nested-splattributes-test.js
+++ b/test/unit/rules/no-nested-splattributes-test.js
@@ -22,8 +22,8 @@ generateRuleTests({
         '</div>\n',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 20,
               "endLine": 2,
@@ -49,8 +49,8 @@ generateRuleTests({
         '</div>\n',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 22,
               "endLine": 3,

--- a/test/unit/rules/no-outlet-outside-routes-test.js
+++ b/test/unit/rules/no-outlet-outside-routes-test.js
@@ -55,8 +55,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 10,
               "endLine": 1,
@@ -80,8 +80,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 10,
               "endLine": 1,
@@ -105,8 +105,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 10,
               "endLine": 1,

--- a/test/unit/rules/no-partial-test.js
+++ b/test/unit/rules/no-partial-test.js
@@ -13,8 +13,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 17,
               "endLine": 1,

--- a/test/unit/rules/no-passed-in-event-handlers-test.js
+++ b/test/unit/rules/no-passed-in-event-handlers-test.js
@@ -65,8 +65,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 32,
               "endLine": 1,
@@ -86,8 +86,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 35,
               "endLine": 1,
@@ -107,8 +107,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 33,
               "endLine": 1,
@@ -128,8 +128,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 28,
               "endLine": 1,
@@ -149,8 +149,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 31,
               "endLine": 1,
@@ -170,8 +170,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 29,
               "endLine": 1,

--- a/test/unit/rules/no-positional-data-test-selectors-test.js
+++ b/test/unit/rules/no-positional-data-test-selectors-test.js
@@ -74,8 +74,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 10,
               "endLine": 6,

--- a/test/unit/rules/no-positive-tabindex-test.js
+++ b/test/unit/rules/no-positive-tabindex-test.js
@@ -26,8 +26,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 43,
               "endLine": 1,
@@ -47,8 +47,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 30,
               "endLine": 1,
@@ -68,8 +68,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 33,
               "endLine": 1,
@@ -89,8 +89,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 35,
               "endLine": 1,
@@ -110,8 +110,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 38,
               "endLine": 1,
@@ -131,8 +131,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 34,
               "endLine": 1,
@@ -152,8 +152,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 42,
               "endLine": 1,
@@ -173,8 +173,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 42,
               "endLine": 1,
@@ -194,8 +194,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 39,
               "endLine": 1,
@@ -215,8 +215,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 45,
               "endLine": 1,
@@ -236,8 +236,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 43,
               "endLine": 1,
@@ -257,8 +257,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 46,
               "endLine": 1,

--- a/test/unit/rules/no-potential-path-strings-test.js
+++ b/test/unit/rules/no-potential-path-strings-test.js
@@ -18,8 +18,8 @@ generateRuleTests({
       template: '<img src="this.picture">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 22,
               "endLine": 1,
@@ -38,8 +38,8 @@ generateRuleTests({
       template: '<img src=this.picture>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 21,
               "endLine": 1,
@@ -58,8 +58,8 @@ generateRuleTests({
       template: '<img src="@img">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 14,
               "endLine": 1,
@@ -78,8 +78,8 @@ generateRuleTests({
       template: '<img src=@img>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 13,
               "endLine": 1,
@@ -98,8 +98,8 @@ generateRuleTests({
       template: '<SomeComponent @foo=@bar />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 20,
               "endColumn": 24,
               "endLine": 1,
@@ -118,8 +118,8 @@ generateRuleTests({
       template: '<SomeComponent @foo=this.bar />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 20,
               "endColumn": 28,
               "endLine": 1,

--- a/test/unit/rules/no-quoteless-attributes-test.js
+++ b/test/unit/rules/no-quoteless-attributes-test.js
@@ -23,8 +23,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 14,
               "endColumn": 18,
               "endLine": 1,
@@ -44,8 +44,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 17,
               "endColumn": 21,
               "endLine": 1,

--- a/test/unit/rules/no-redundant-fn-test.js
+++ b/test/unit/rules/no-redundant-fn-test.js
@@ -20,8 +20,8 @@ generateRuleTests({
       fixedTemplate: '<button {{on "click" this.handleClick}}>Click Me</button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 42,
               "endLine": 1,
@@ -42,8 +42,8 @@ generateRuleTests({
       fixedTemplate: '<SomeComponent @onClick={{this.handleClick}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 24,
               "endColumn": 47,
               "endLine": 1,
@@ -64,8 +64,8 @@ generateRuleTests({
       fixedTemplate: '{{foo bar=this.handleClick}}>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 31,
               "endLine": 1,

--- a/test/unit/rules/no-redundant-landmark-role-test.js
+++ b/test/unit/rules/no-redundant-landmark-role-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 31,
               "endLine": 1,
@@ -42,8 +42,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 25,
               "endLine": 1,
@@ -65,8 +65,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 36,
               "endLine": 1,
@@ -88,8 +88,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 29,
               "endLine": 1,
@@ -111,8 +111,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 25,
               "endLine": 1,
@@ -134,8 +134,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 51,
               "endLine": 1,
@@ -157,8 +157,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 59,
               "endLine": 1,

--- a/test/unit/rules/no-restricted-invocations-test.js
+++ b/test/unit/rules/no-restricted-invocations-test.js
@@ -53,8 +53,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
@@ -74,8 +74,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
@@ -95,8 +95,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 15,
               "endLine": 1,
@@ -116,8 +116,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 17,
               "endLine": 1,
@@ -137,8 +137,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 16,
               "endLine": 1,
@@ -158,8 +158,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 24,
               "endLine": 1,
@@ -179,8 +179,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 26,
               "endLine": 1,
@@ -200,8 +200,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 19,
               "endLine": 1,
@@ -221,8 +221,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 27,
               "endLine": 1,
@@ -242,8 +242,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 29,
               "endLine": 1,
@@ -263,8 +263,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 34,
               "endLine": 1,
@@ -284,8 +284,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 42,
               "endLine": 1,
@@ -305,8 +305,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 44,
               "endLine": 1,
@@ -326,8 +326,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 25,
               "endLine": 1,
@@ -347,8 +347,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 33,
               "endLine": 1,
@@ -368,8 +368,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 35,
               "endLine": 1,
@@ -389,8 +389,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 13,
               "endColumn": 28,
               "endLine": 1,
@@ -410,8 +410,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 24,
               "endColumn": 29,
               "endLine": 1,
@@ -431,8 +431,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 28,
               "endColumn": 33,
               "endLine": 1,
@@ -452,8 +452,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 27,
               "endColumn": 32,
               "endLine": 1,
@@ -473,8 +473,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 24,
               "endLine": 1,
@@ -494,8 +494,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -515,8 +515,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 24,
               "endLine": 1,

--- a/test/unit/rules/no-route-action-test.js
+++ b/test/unit/rules/no-route-action-test.js
@@ -33,8 +33,8 @@ generateRuleTests({
       template: `<CustomComponent @onUpdate={{if true (route-action 'updateFoo' 'bar')}} />`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 37,
               "endColumn": 69,
               "endLine": 1,
@@ -53,8 +53,8 @@ generateRuleTests({
       template: `{{custom-component onUpdate=(route-action 'updateFoo' 'bar')}}`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 28,
               "endColumn": 60,
               "endLine": 1,
@@ -76,8 +76,8 @@ generateRuleTests({
       )}}`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 44,
               "endLine": 3,
@@ -100,8 +100,8 @@ generateRuleTests({
       />`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 46,
               "endLine": 2,
@@ -120,8 +120,8 @@ generateRuleTests({
       template: `<CustomComponent @onUpdate={{route-action 'updateFoo' 'bar'}} />`,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 27,
               "endColumn": 61,
               "endLine": 1,

--- a/test/unit/rules/no-shadowed-elements-test.js
+++ b/test/unit/rules/no-shadowed-elements-test.js
@@ -18,8 +18,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 17,
               "endColumn": 28,
               "endLine": 1,

--- a/test/unit/rules/no-this-in-template-only-components-test.js
+++ b/test/unit/rules/no-this-in-template-only-components-test.js
@@ -25,8 +25,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 31,
               "endLine": 1,
@@ -48,8 +48,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 30,
               "endColumn": 43,
               "endLine": 1,
@@ -71,8 +71,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 32,
               "endColumn": 42,
               "endLine": 1,
@@ -92,8 +92,8 @@ generateRuleTests({
       template: '{{input id=(concat this.elementId "-username")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 33,
               "endLine": 1,
@@ -117,8 +117,8 @@ generateRuleTests({
       },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 31,
               "endLine": 1,

--- a/test/unit/rules/no-trailing-spaces-test.js
+++ b/test/unit/rules/no-trailing-spaces-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 5,
               "endLine": 1,
@@ -40,8 +40,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 0,
               "endLine": 2,
@@ -61,8 +61,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 3,
@@ -84,8 +84,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 17,
               "endLine": 3,

--- a/test/unit/rules/no-triple-curlies-test.js
+++ b/test/unit/rules/no-triple-curlies-test.js
@@ -18,8 +18,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 1,
               "endColumn": 10,
               "endLine": 2,

--- a/test/unit/rules/no-unbalanced-curlies-test.js
+++ b/test/unit/rules/no-unbalanced-curlies-test.js
@@ -21,8 +21,8 @@ generateRuleTests({
       template: 'foo}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 5,
               "endLine": 1,
@@ -41,8 +41,8 @@ generateRuleTests({
       template: '{foo}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 6,
               "endLine": 1,
@@ -61,8 +61,8 @@ generateRuleTests({
       template: 'foo}}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 3,
               "endColumn": 6,
               "endLine": 1,
@@ -81,8 +81,8 @@ generateRuleTests({
       template: '{foo}}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 7,
               "endLine": 1,
@@ -101,8 +101,8 @@ generateRuleTests({
       template: '{foo\n}}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 1,
               "endColumn": 3,
               "endLine": 2,
@@ -122,8 +122,8 @@ generateRuleTests({
       template: '{foo\n}}}\nbar',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 1,
               "endColumn": 3,
               "endLine": 3,
@@ -144,8 +144,8 @@ generateRuleTests({
       template: '{foo\r\nbar\r\n\r\nbaz}}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 6,
               "endLine": 4,
@@ -167,8 +167,8 @@ generateRuleTests({
       template: '{foo\rbar\r\rbaz}}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 4,
               "endColumn": 6,
               "endLine": 4,

--- a/test/unit/rules/no-unbound-test.js
+++ b/test/unit/rules/no-unbound-test.js
@@ -13,8 +13,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 15,
               "endLine": 1,
@@ -34,8 +34,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 28,
               "endLine": 1,

--- a/test/unit/rules/no-unknown-arguments-for-builtin-components-test.js
+++ b/test/unit/rules/no-unknown-arguments-for-builtin-components-test.js
@@ -18,8 +18,8 @@ generateRuleTests({
       template: '<Input @valuee={{this.content}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 31,
               "endLine": 1,
@@ -39,8 +39,8 @@ generateRuleTests({
       template: '<Textarea @valuee={{this.content}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 34,
               "endLine": 1,
@@ -60,8 +60,8 @@ generateRuleTests({
       template: '<LinkTo @route="foo" @valuee={{this.content}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 45,
               "endLine": 1,
@@ -82,8 +82,8 @@ generateRuleTests({
       template: '<LinkTo @route="foo" @madel={{this.content}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 44,
               "endLine": 1,
@@ -104,8 +104,8 @@ generateRuleTests({
       template: '<LinkTo @model={{this.model}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 1,
               "endColumn": 32,
               "endLine": 1,
@@ -125,8 +125,8 @@ generateRuleTests({
       template: '<LinkTo @route="info" @model={{this.model}} @models={{this.models}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 22,
               "endColumn": 43,
               "endLine": 1,
@@ -137,7 +137,7 @@ generateRuleTests({
               "severity": 2,
               "source": "@model",
             },
-            Object {
+            {
               "column": 44,
               "endColumn": 67,
               "endLine": 1,
@@ -159,8 +159,8 @@ generateRuleTests({
       template: '<LinkTo @route="info" @model={{this.model}} @tagName="button" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 44,
               "endColumn": 61,
               "endLine": 1,
@@ -182,8 +182,8 @@ generateRuleTests({
       fixedTemplate: '<LinkTo @route="info" @model={{this.model}} id="superstar" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 44,
               "endColumn": 66,
               "endLine": 1,
@@ -209,8 +209,8 @@ generateRuleTests({
         '<LinkTo @route="info" @model={{this.model}} {{on "dblclick" (action this.click)}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 44,
               "endColumn": 78,
               "endLine": 1,
@@ -234,8 +234,8 @@ generateRuleTests({
       template: '<Input @value="1" @bubbles={{false}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 36,
               "endLine": 1,
@@ -257,8 +257,8 @@ generateRuleTests({
       fixedTemplate: '<Input @value="1" id="42" disabled="disabled" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 33,
               "endLine": 1,
@@ -271,7 +271,7 @@ generateRuleTests({
               "severity": 2,
               "source": "@elementId",
             },
-            Object {
+            {
               "column": 34,
               "endColumn": 54,
               "endLine": 1,
@@ -296,8 +296,8 @@ generateRuleTests({
       fixedTemplate: '<Input @value="1" {{on "keyup" ths.onKeyUp}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 41,
               "endLine": 1,
@@ -320,8 +320,8 @@ generateRuleTests({
       template: '<Textarea @value="1" @bubbles={{false}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 39,
               "endLine": 1,
@@ -343,8 +343,8 @@ generateRuleTests({
       fixedTemplate: '<Textarea @value="1" id="42" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 36,
               "endLine": 1,
@@ -368,8 +368,8 @@ generateRuleTests({
       fixedTemplate: '<Textarea @value="1" {{on "keyup" ths.onKeyUp}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 44,
               "endLine": 1,
@@ -394,8 +394,8 @@ generateRuleTests({
         ' <LinkTo class="auk-search-results-list__item" @route={{@route}} @models={{this.models}} @random="test" @query={{@query}} ...attributes >Hello</LinkTo>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 89,
               "endColumn": 103,
               "endLine": 1,

--- a/test/unit/rules/no-unnecessary-component-helper-test.js
+++ b/test/unit/rules/no-unnecessary-component-helper-test.js
@@ -55,8 +55,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 33,
               "endLine": 1,
@@ -77,8 +77,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 48,
               "endLine": 1,
@@ -99,8 +99,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 44,
               "endColumn": 79,
               "endLine": 1,

--- a/test/unit/rules/no-unnecessary-concat-test.js
+++ b/test/unit/rules/no-unnecessary-concat-test.js
@@ -13,8 +13,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 22,
               "endLine": 1,
@@ -34,8 +34,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 18,
               "endLine": 1,
@@ -46,7 +46,7 @@ generateRuleTests({
               "severity": 2,
               "source": "\\"{{url}}\\"",
             },
-            Object {
+            {
               "column": 23,
               "endColumn": 47,
               "endLine": 1,

--- a/test/unit/rules/no-unused-block-params-test.js
+++ b/test/unit/rules/no-unused-block-params-test.js
@@ -90,8 +90,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 23,
               "endColumn": 27,
               "endLine": 1,
@@ -110,8 +110,8 @@ generateRuleTests({
       template: '{{#each cats as |cat index|}}{{cat}}{{/each}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 29,
               "endColumn": 36,
               "endLine": 1,
@@ -135,8 +135,8 @@ generateRuleTests({
         '{{/each}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 29,
               "endColumn": 92,
               "endLine": 1,
@@ -159,8 +159,8 @@ generateRuleTests({
         '{{/each}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 75,
               "endColumn": 79,
               "endLine": 1,

--- a/test/unit/rules/no-valueless-arguments-test.js
+++ b/test/unit/rules/no-valueless-arguments-test.js
@@ -15,8 +15,8 @@ generateRuleTests({
       template: '<SomeComponent @valueless />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 25,
               "endLine": 1,
@@ -35,8 +35,8 @@ generateRuleTests({
       template: '<SomeComponent @valuelessByAccident{{this.canBeAModifier}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 35,
               "endLine": 1,
@@ -55,8 +55,8 @@ generateRuleTests({
       template: '<SomeComponent @valuelessByAccident{{@canBeAModifier}} />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 35,
               "endLine": 1,

--- a/test/unit/rules/no-whitespace-for-layout-test.js
+++ b/test/unit/rules/no-whitespace-for-layout-test.js
@@ -20,8 +20,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 13,
               "endLine": 1,
@@ -40,8 +40,8 @@ generateRuleTests({
       template: 'START&nbsp;&nbsp;FINISH',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 23,
               "endLine": 1,
@@ -60,8 +60,8 @@ generateRuleTests({
       template: 'START&nbsp; FINISH',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 18,
               "endLine": 1,
@@ -80,8 +80,8 @@ generateRuleTests({
       template: 'START &nbsp;FINISH',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 18,
               "endLine": 1,

--- a/test/unit/rules/no-whitespace-within-word-test.js
+++ b/test/unit/rules/no-whitespace-within-word-test.js
@@ -25,8 +25,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 13,
               "endLine": 1,
@@ -45,8 +45,8 @@ generateRuleTests({
       template: 'W&nbsp;e&nbsp;l&nbsp;c&nbsp;o&nbsp;m&nbsp;e',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 43,
               "endLine": 1,
@@ -65,8 +65,8 @@ generateRuleTests({
       template: 'Wel c o me',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 10,
               "endLine": 1,
@@ -85,8 +85,8 @@ generateRuleTests({
       template: 'Wel&nbsp;c&emsp;o&nbsp;me',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 25,
               "endLine": 1,
@@ -105,8 +105,8 @@ generateRuleTests({
       template: '<div>W e l c o m e</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 18,
               "endLine": 1,
@@ -125,8 +125,8 @@ generateRuleTests({
       template: '<div>Wel c o me</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 15,
               "endLine": 1,

--- a/test/unit/rules/no-with-test.js
+++ b/test/unit/rules/no-with-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 43,
               "endLine": 1,
@@ -41,8 +41,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 103,
               "endLine": 1,

--- a/test/unit/rules/no-yield-only-test.js
+++ b/test/unit/rules/no-yield-only-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 9,
               "endLine": 1,
@@ -40,8 +40,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 14,
               "endLine": 1,
@@ -61,8 +61,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 11,
               "endLine": 2,

--- a/test/unit/rules/no-yield-to-default-test.js
+++ b/test/unit/rules/no-yield-to-default-test.js
@@ -23,8 +23,8 @@ generateRuleTests({
       template: '{{yield to="default"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 20,
               "endLine": 1,
@@ -43,8 +43,8 @@ generateRuleTests({
       template: '{{has-block "default"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 21,
               "endLine": 1,
@@ -63,8 +63,8 @@ generateRuleTests({
       template: '{{has-block-params "default"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 28,
               "endLine": 1,
@@ -83,8 +83,8 @@ generateRuleTests({
       template: '{{hasBlock "default"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 11,
               "endColumn": 20,
               "endLine": 1,
@@ -103,8 +103,8 @@ generateRuleTests({
       template: '{{hasBlockParams "default"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 17,
               "endColumn": 26,
               "endLine": 1,
@@ -123,8 +123,8 @@ generateRuleTests({
       template: '{{if (has-block "default")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 25,
               "endLine": 1,
@@ -143,8 +143,8 @@ generateRuleTests({
       template: '{{#if (has-block "default")}}{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 17,
               "endColumn": 26,
               "endLine": 1,
@@ -163,8 +163,8 @@ generateRuleTests({
       template: '{{if (has-block-params "default")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 23,
               "endColumn": 32,
               "endLine": 1,
@@ -183,8 +183,8 @@ generateRuleTests({
       template: '{{#if (has-block-params "default")}}{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 24,
               "endColumn": 33,
               "endLine": 1,
@@ -203,8 +203,8 @@ generateRuleTests({
       template: '{{if (hasBlock "default")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 24,
               "endLine": 1,
@@ -223,8 +223,8 @@ generateRuleTests({
       template: '{{#if (hasBlock "default")}}{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 25,
               "endLine": 1,
@@ -243,8 +243,8 @@ generateRuleTests({
       template: '{{if (hasBlockParams "default")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 30,
               "endLine": 1,
@@ -263,8 +263,8 @@ generateRuleTests({
       template: '{{#if (hasBlockParams "default")}}{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 22,
               "endColumn": 31,
               "endLine": 1,

--- a/test/unit/rules/quotes-test.js
+++ b/test/unit/rules/quotes-test.js
@@ -38,8 +38,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 31,
               "endLine": 1,
@@ -62,8 +62,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 18,
               "endLine": 1,
@@ -86,8 +86,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 16,
               "endLine": 1,
@@ -110,8 +110,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 22,
               "endLine": 1,
@@ -134,8 +134,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 18,
               "endLine": 1,
@@ -158,8 +158,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 16,
               "endLine": 1,
@@ -182,8 +182,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 22,
               "endLine": 1,
@@ -206,8 +206,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 24,
               "endLine": 1,
@@ -229,8 +229,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 50,
               "endLine": 1,
@@ -252,8 +252,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 24,
               "endLine": 1,

--- a/test/unit/rules/require-button-type-test.js
+++ b/test/unit/rules/require-button-type-test.js
@@ -28,8 +28,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 9,
               "endLine": 1,
@@ -51,8 +51,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -74,8 +74,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 18,
               "endLine": 1,
@@ -97,8 +97,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 21,
               "endLine": 1,
@@ -120,8 +120,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 18,
               "endLine": 1,

--- a/test/unit/rules/require-context-role-test.js
+++ b/test/unit/rules/require-context-role-test.js
@@ -41,8 +41,8 @@ generateRuleTests({
       template: '<div role="tablist"><div role="treeitem">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 25,
               "endColumn": 40,
               "endLine": 1,
@@ -61,8 +61,8 @@ generateRuleTests({
       template: '<div><div role="columnheader">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 29,
               "endLine": 1,
@@ -81,8 +81,8 @@ generateRuleTests({
       template: '<div><div role="gridcell">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 25,
               "endLine": 1,
@@ -101,8 +101,8 @@ generateRuleTests({
       template: '<div><div role="listitem">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 25,
               "endLine": 1,
@@ -121,8 +121,8 @@ generateRuleTests({
       template: '<div><div role="menuitem">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 25,
               "endLine": 1,
@@ -141,8 +141,8 @@ generateRuleTests({
       template: '<div><div role="menuitemcheckbox">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 33,
               "endLine": 1,
@@ -161,8 +161,8 @@ generateRuleTests({
       template: '<div><div role="menuitemradio">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 30,
               "endLine": 1,
@@ -181,8 +181,8 @@ generateRuleTests({
       template: '<div><div role="option">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 23,
               "endLine": 1,
@@ -201,8 +201,8 @@ generateRuleTests({
       template: '<div><div role="row">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 20,
               "endLine": 1,
@@ -221,8 +221,8 @@ generateRuleTests({
       template: '<div><div role="rowgroup">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 25,
               "endLine": 1,
@@ -241,8 +241,8 @@ generateRuleTests({
       template: '<div><div role="rowheader">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 26,
               "endLine": 1,
@@ -261,8 +261,8 @@ generateRuleTests({
       template: '<div><div role="tab">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 20,
               "endLine": 1,
@@ -281,8 +281,8 @@ generateRuleTests({
       template: '<div><div role="treeitem">Item One</div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 25,
               "endLine": 1,

--- a/test/unit/rules/require-each-key-test.js
+++ b/test/unit/rules/require-each-key-test.js
@@ -18,8 +18,8 @@ generateRuleTests({
       template: '{{#each this.items as |item|}} {{item.name}} {{/each}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 54,
               "endLine": 1,
@@ -38,8 +38,8 @@ generateRuleTests({
       template: '{{#each this.items key="@invalid" as |item|}} {{item.name}} {{/each}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 69,
               "endLine": 1,
@@ -58,8 +58,8 @@ generateRuleTests({
       template: '{{#each this.items key="" as |item|}} {{item.name}} {{/each}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 61,
               "endLine": 1,

--- a/test/unit/rules/require-form-method-test.js
+++ b/test/unit/rules/require-form-method-test.js
@@ -37,8 +37,8 @@ generateRuleTests({
       template: '<form method="POST"></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 27,
               "endLine": 1,
@@ -61,8 +61,8 @@ generateRuleTests({
       template: '<form method="GET"></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 26,
               "endLine": 1,
@@ -82,8 +82,8 @@ generateRuleTests({
       template: '<form></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 13,
               "endLine": 1,
@@ -103,8 +103,8 @@ generateRuleTests({
       template: '<form method=""></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 23,
               "endLine": 1,
@@ -124,8 +124,8 @@ generateRuleTests({
       template: '<form method=42></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 23,
               "endLine": 1,
@@ -145,8 +145,8 @@ generateRuleTests({
       template: '<form method=" ge t "></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 29,
               "endLine": 1,
@@ -166,8 +166,8 @@ generateRuleTests({
       template: '<form method=" pos t "></form>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 30,
               "endLine": 1,

--- a/test/unit/rules/require-has-block-helper-test.js
+++ b/test/unit/rules/require-has-block-helper-test.js
@@ -23,8 +23,8 @@ generateRuleTests({
       fixedTemplate: '{{has-block}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 10,
               "endLine": 1,
@@ -45,8 +45,8 @@ generateRuleTests({
       fixedTemplate: '{{has-block-params}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 2,
               "endColumn": 16,
               "endLine": 1,
@@ -67,8 +67,8 @@ generateRuleTests({
       fixedTemplate: '{{if (has-block) "true" "false"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 13,
               "endLine": 1,
@@ -89,8 +89,8 @@ generateRuleTests({
       fixedTemplate: '{{if (has-block-params) "true" "false"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 19,
               "endLine": 1,
@@ -111,8 +111,8 @@ generateRuleTests({
       fixedTemplate: '{{if (has-block) "true" "false"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 1,
@@ -133,8 +133,8 @@ generateRuleTests({
       fixedTemplate: '{{if (has-block-params) "true" "false"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 20,
               "endLine": 1,
@@ -155,8 +155,8 @@ generateRuleTests({
       fixedTemplate: '{{if (has-block "inverse") "true" "false"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 1,
@@ -177,8 +177,8 @@ generateRuleTests({
       fixedTemplate: '{{if (has-block-params "inverse") "true" "false"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 20,
               "endLine": 1,
@@ -199,8 +199,8 @@ generateRuleTests({
       fixedTemplate: '{{component test=(if (has-block) "true")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 29,
               "endLine": 1,
@@ -221,8 +221,8 @@ generateRuleTests({
       fixedTemplate: '{{component test=(if (has-block-params) "true")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 35,
               "endLine": 1,
@@ -243,8 +243,8 @@ generateRuleTests({
       fixedTemplate: '{{#if (has-block)}}{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 1,
@@ -265,8 +265,8 @@ generateRuleTests({
       fixedTemplate: '{{#if (has-block-params)}}{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 20,
               "endLine": 1,
@@ -287,8 +287,8 @@ generateRuleTests({
       fixedTemplate: '{{#if (has-block)}}{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 15,
               "endLine": 1,
@@ -309,8 +309,8 @@ generateRuleTests({
       fixedTemplate: '{{#if (has-block-params)}}{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 21,
               "endLine": 1,
@@ -331,8 +331,8 @@ generateRuleTests({
       fixedTemplate: '{{#if (has-block "inverse")}}{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 15,
               "endLine": 1,
@@ -353,8 +353,8 @@ generateRuleTests({
       fixedTemplate: '{{#if (has-block-params "inverse")}}{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 21,
               "endLine": 1,
@@ -375,8 +375,8 @@ generateRuleTests({
       fixedTemplate: '<button name={{has-block}}></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 23,
               "endLine": 1,
@@ -397,8 +397,8 @@ generateRuleTests({
       fixedTemplate: '<button name={{has-block-params}}></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 29,
               "endLine": 1,
@@ -419,8 +419,8 @@ generateRuleTests({
       fixedTemplate: '<button name={{has-block "inverse"}}></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 23,
               "endLine": 1,
@@ -441,8 +441,8 @@ generateRuleTests({
       fixedTemplate: '<button name={{has-block-params "inverse"}}></button>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 29,
               "endLine": 1,
@@ -463,8 +463,8 @@ generateRuleTests({
       fixedTemplate: '{{#if (or isLoading hasLoadFailed (has-block))}}...{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 34,
               "endColumn": 42,
               "endLine": 1,
@@ -485,8 +485,8 @@ generateRuleTests({
       fixedTemplate: '{{#if (or isLoading hasLoadFailed (has-block-params))}}...{{/if}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 34,
               "endColumn": 48,
               "endLine": 1,

--- a/test/unit/rules/require-iframe-title-test.js
+++ b/test/unit/rules/require-iframe-title-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 19,
               "endLine": 1,
@@ -31,7 +31,7 @@ generateRuleTests({
               "severity": 2,
               "source": "title=\\"foo\\"",
             },
-            Object {
+            {
               "column": 22,
               "endColumn": 44,
               "endLine": 1,
@@ -51,8 +51,8 @@ generateRuleTests({
         '<iframe title="foo" /><iframe title="boo" /><iframe title="foo" /><iframe title="boo" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 19,
               "endLine": 1,
@@ -63,7 +63,7 @@ generateRuleTests({
               "severity": 2,
               "source": "title=\\"foo\\"",
             },
-            Object {
+            {
               "column": 44,
               "endColumn": 66,
               "endLine": 1,
@@ -74,7 +74,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<iframe title=\\"foo\\" />",
             },
-            Object {
+            {
               "column": 30,
               "endColumn": 41,
               "endLine": 1,
@@ -85,7 +85,7 @@ generateRuleTests({
               "severity": 2,
               "source": "title=\\"boo\\"",
             },
-            Object {
+            {
               "column": 66,
               "endColumn": 88,
               "endLine": 1,
@@ -105,8 +105,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 19,
               "endLine": 1,
@@ -126,8 +126,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 35,
               "endLine": 1,
@@ -147,8 +147,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 37,
               "endLine": 1,
@@ -168,8 +168,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 28,
               "endLine": 1,

--- a/test/unit/rules/require-input-label-test.js
+++ b/test/unit/rules/require-input-label-test.js
@@ -74,8 +74,8 @@ generateRuleTests({
       template: '<my-label><input /></my-label>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 19,
               "endLine": 1,
@@ -94,8 +94,8 @@ generateRuleTests({
       template: '<div><input /></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 14,
               "endLine": 1,
@@ -114,8 +114,8 @@ generateRuleTests({
       template: '<input />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 9,
               "endLine": 1,
@@ -134,8 +134,8 @@ generateRuleTests({
       template: '<input title="some title value" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 34,
               "endLine": 1,
@@ -154,8 +154,8 @@ generateRuleTests({
       template: '<label><input></label>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 14,
               "endLine": 1,
@@ -174,8 +174,8 @@ generateRuleTests({
       template: '<div>{{input}}</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 14,
               "endLine": 1,
@@ -194,8 +194,8 @@ generateRuleTests({
       template: '<Input/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 8,
               "endLine": 1,
@@ -214,8 +214,8 @@ generateRuleTests({
       template: '<input aria-label="first label" aria-labelledby="second label">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 63,
               "endLine": 1,
@@ -234,8 +234,8 @@ generateRuleTests({
       template: '<input id="label-input" aria-label="second label">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 50,
               "endLine": 1,
@@ -254,8 +254,8 @@ generateRuleTests({
       template: '<label>Input label<input aria-label="Custom label"></label>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 18,
               "endColumn": 51,
               "endLine": 1,
@@ -274,8 +274,8 @@ generateRuleTests({
       template: '{{input type="button"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 23,
               "endLine": 1,
@@ -294,8 +294,8 @@ generateRuleTests({
       template: '{{input type=myType}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 21,
               "endLine": 1,
@@ -314,8 +314,8 @@ generateRuleTests({
       template: '<input type="button"/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -334,8 +334,8 @@ generateRuleTests({
       template: '<input type={{myType}}/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 24,
               "endLine": 1,
@@ -354,8 +354,8 @@ generateRuleTests({
       template: '<Input type="button"/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -374,8 +374,8 @@ generateRuleTests({
       template: '<Input type={{myType}}/>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 24,
               "endLine": 1,
@@ -394,8 +394,8 @@ generateRuleTests({
       template: '<div><textarea /></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 17,
               "endLine": 1,
@@ -414,8 +414,8 @@ generateRuleTests({
       template: '<textarea />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 12,
               "endLine": 1,
@@ -434,8 +434,8 @@ generateRuleTests({
       template: '<textarea title="some title value" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 37,
               "endLine": 1,
@@ -454,8 +454,8 @@ generateRuleTests({
       template: '<label><textarea /></label>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 19,
               "endLine": 1,
@@ -474,8 +474,8 @@ generateRuleTests({
       template: '<div>{{textarea}}</div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 17,
               "endLine": 1,
@@ -494,8 +494,8 @@ generateRuleTests({
       template: '<Textarea />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 12,
               "endLine": 1,
@@ -514,8 +514,8 @@ generateRuleTests({
       template: '<textarea aria-label="first label" aria-labelledby="second label" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 68,
               "endLine": 1,
@@ -534,8 +534,8 @@ generateRuleTests({
       template: '<textarea id="label-input" aria-label="second label" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 55,
               "endLine": 1,
@@ -554,8 +554,8 @@ generateRuleTests({
       template: '<label>Textarea label<textarea aria-label="Custom label" /></label>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 21,
               "endColumn": 59,
               "endLine": 1,
@@ -574,8 +574,8 @@ generateRuleTests({
       template: '<div><select></select></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 22,
               "endLine": 1,
@@ -594,8 +594,8 @@ generateRuleTests({
       template: '<select></select>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 17,
               "endLine": 1,
@@ -614,8 +614,8 @@ generateRuleTests({
       template: '<select title="some title value" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 35,
               "endLine": 1,
@@ -634,8 +634,8 @@ generateRuleTests({
       template: '<label><select></select></label>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 7,
               "endColumn": 24,
               "endLine": 1,
@@ -654,8 +654,8 @@ generateRuleTests({
       template: '<select aria-label="first label" aria-labelledby="second label" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 66,
               "endLine": 1,
@@ -674,8 +674,8 @@ generateRuleTests({
       template: '<select id="label-input" aria-label="second label" />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 53,
               "endLine": 1,
@@ -694,8 +694,8 @@ generateRuleTests({
       template: '<label>Select label<select aria-label="Custom label" /></label>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 55,
               "endLine": 1,

--- a/test/unit/rules/require-lang-attribute-test.js
+++ b/test/unit/rules/require-lang-attribute-test.js
@@ -12,8 +12,8 @@ generateRuleTests({
       template: '<html></html>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 13,
               "endLine": 1,
@@ -32,8 +32,8 @@ generateRuleTests({
       template: '<html lang=""></html>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 21,
               "endLine": 1,

--- a/test/unit/rules/require-presentational-children-test.js
+++ b/test/unit/rules/require-presentational-children-test.js
@@ -32,8 +32,8 @@ generateRuleTests({
       template: '<div role="button"><h2>Test</h2></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 38,
               "endLine": 1,
@@ -52,8 +52,8 @@ generateRuleTests({
       template: '<div role="button"><h2 role="presentation"><img /></h2></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 61,
               "endLine": 1,
@@ -74,8 +74,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 82,
               "endLine": 1,
@@ -86,7 +86,7 @@ generateRuleTests({
               "severity": 2,
               "source": "<div role=\\"button\\"><h2 role=\\"presentation\\"><button>Test <img/></button></h2></div>",
             },
-            Object {
+            {
               "column": 0,
               "endColumn": 82,
               "endLine": 1,

--- a/test/unit/rules/require-splattributes-test.js
+++ b/test/unit/rules/require-splattributes-test.js
@@ -19,8 +19,8 @@ generateRuleTests({
       template: '<div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 11,
               "endLine": 1,
@@ -39,8 +39,8 @@ generateRuleTests({
       template: '<Foo></Foo>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 11,
               "endLine": 1,
@@ -59,8 +59,8 @@ generateRuleTests({
       template: '<div></div><div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 22,
               "endLine": 1,
@@ -79,8 +79,8 @@ generateRuleTests({
       template: '<div/>\n\n',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 1,

--- a/test/unit/rules/require-valid-alt-text-test.js
+++ b/test/unit/rules/require-valid-alt-text-test.js
@@ -59,8 +59,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 5,
               "endLine": 1,
@@ -80,8 +80,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 1,
@@ -101,8 +101,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 27,
               "endLine": 1,
@@ -122,8 +122,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 24,
               "endLine": 1,
@@ -142,8 +142,8 @@ generateRuleTests({
       template: '<img alt="path/to/zoey.jpg" src="path/to/zoey.jpg">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 51,
               "endLine": 1,
@@ -163,8 +163,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 1,
@@ -183,8 +183,8 @@ generateRuleTests({
       template: '<object></object>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 17,
               "endLine": 1,
@@ -203,8 +203,8 @@ generateRuleTests({
       template: '<object />',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 10,
               "endLine": 1,
@@ -223,8 +223,8 @@ generateRuleTests({
       template: '<area>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 1,
@@ -244,8 +244,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 19,
               "endLine": 1,
@@ -265,8 +265,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 17,
               "endLine": 1,
@@ -286,8 +286,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 17,
               "endLine": 1,
@@ -307,8 +307,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 20,
               "endLine": 1,
@@ -328,8 +328,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 41,
               "endLine": 1,
@@ -349,8 +349,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 28,
               "endLine": 1,
@@ -369,8 +369,8 @@ generateRuleTests({
       template: '<img alt="not-null-alt" src="zoey.jpg" role="none">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 51,
               "endLine": 1,
@@ -389,8 +389,8 @@ generateRuleTests({
       template: '<img alt="not-null-alt" src="zoey.jpg" role="presentation">',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 59,
               "endLine": 1,

--- a/test/unit/rules/require-valid-named-block-naming-format-test.js
+++ b/test/unit/rules/require-valid-named-block-naming-format-test.js
@@ -74,8 +74,8 @@ generateRuleTests({
       template: '{{yield to="foo-bar"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 20,
               "endLine": 1,
@@ -94,8 +94,8 @@ generateRuleTests({
       template: '{{has-block "foo-bar"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 21,
               "endLine": 1,
@@ -114,8 +114,8 @@ generateRuleTests({
       template: '{{if (has-block "foo-bar")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 25,
               "endLine": 1,
@@ -134,8 +134,8 @@ generateRuleTests({
       template: '{{has-block-params "foo-bar"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 28,
               "endLine": 1,
@@ -154,8 +154,8 @@ generateRuleTests({
       template: '{{if (has-block-params "foo-bar")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 23,
               "endColumn": 32,
               "endLine": 1,
@@ -177,8 +177,8 @@ generateRuleTests({
       template: '{{yield to="foo-bar"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 20,
               "endLine": 1,
@@ -198,8 +198,8 @@ generateRuleTests({
       template: '{{has-block "foo-bar"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 21,
               "endLine": 1,
@@ -219,8 +219,8 @@ generateRuleTests({
       template: '{{if (has-block "foo-bar")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 25,
               "endLine": 1,
@@ -240,8 +240,8 @@ generateRuleTests({
       template: '{{has-block-params "foo-bar"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 28,
               "endLine": 1,
@@ -261,8 +261,8 @@ generateRuleTests({
       template: '{{if (has-block-params "foo-bar")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 23,
               "endColumn": 32,
               "endLine": 1,
@@ -284,8 +284,8 @@ generateRuleTests({
       template: '{{yield to="fooBar"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 19,
               "endLine": 1,
@@ -305,8 +305,8 @@ generateRuleTests({
       template: '{{has-block "fooBar"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 12,
               "endColumn": 20,
               "endLine": 1,
@@ -326,8 +326,8 @@ generateRuleTests({
       template: '{{if (has-block "fooBar")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 16,
               "endColumn": 24,
               "endLine": 1,
@@ -347,8 +347,8 @@ generateRuleTests({
       template: '{{has-block-params "fooBar"}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 19,
               "endColumn": 27,
               "endLine": 1,
@@ -368,8 +368,8 @@ generateRuleTests({
       template: '{{if (has-block-params "fooBar")}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 23,
               "endColumn": 31,
               "endLine": 1,

--- a/test/unit/rules/self-closing-void-elements-test.js
+++ b/test/unit/rules/self-closing-void-elements-test.js
@@ -94,13 +94,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<area>",
               },
               "line": 1,
@@ -118,13 +118,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<base>",
               },
               "line": 1,
@@ -142,13 +142,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 5,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<br>",
               },
               "line": 1,
@@ -166,13 +166,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<col>",
               },
               "line": 1,
@@ -190,13 +190,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 10,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<command>",
               },
               "line": 1,
@@ -214,13 +214,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 8,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<embed>",
               },
               "line": 1,
@@ -238,13 +238,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 5,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<hr>",
               },
               "line": 1,
@@ -262,13 +262,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<img>",
               },
               "line": 1,
@@ -286,13 +286,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 8,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<input>",
               },
               "line": 1,
@@ -310,13 +310,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 9,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<keygen>",
               },
               "line": 1,
@@ -334,13 +334,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<link>",
               },
               "line": 1,
@@ -358,13 +358,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<meta>",
               },
               "line": 1,
@@ -382,13 +382,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 8,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<param>",
               },
               "line": 1,
@@ -406,13 +406,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 9,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<source>",
               },
               "line": 1,
@@ -430,13 +430,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 8,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<track>",
               },
               "line": 1,
@@ -455,13 +455,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<wbr>",
               },
               "line": 1,
@@ -480,13 +480,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<area/>",
               },
               "line": 1,
@@ -505,13 +505,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<base/>",
               },
               "line": 1,
@@ -530,13 +530,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 4,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<br/>",
               },
               "line": 1,
@@ -555,13 +555,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 5,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<col/>",
               },
               "line": 1,
@@ -580,13 +580,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 9,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<command/>",
               },
               "line": 1,
@@ -605,13 +605,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<embed/>",
               },
               "line": 1,
@@ -630,13 +630,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 4,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<hr/>",
               },
               "line": 1,
@@ -655,13 +655,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 5,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<img/>",
               },
               "line": 1,
@@ -680,13 +680,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<input/>",
               },
               "line": 1,
@@ -705,13 +705,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 8,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<keygen/>",
               },
               "line": 1,
@@ -730,13 +730,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<link/>",
               },
               "line": 1,
@@ -755,13 +755,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 6,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<meta/>",
               },
               "line": 1,
@@ -780,13 +780,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<param/>",
               },
               "line": 1,
@@ -805,13 +805,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 8,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<source/>",
               },
               "line": 1,
@@ -830,13 +830,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 7,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<track/>",
               },
               "line": 1,
@@ -855,13 +855,13 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 5,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "fix": Object {
+              "fix": {
                 "text": "<wbr/>",
               },
               "line": 1,

--- a/test/unit/rules/simple-unless-test.js
+++ b/test/unit/rules/simple-unless-test.js
@@ -74,8 +74,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 23,
               "endLine": 1,
@@ -95,8 +95,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 18,
               "endLine": 1,
@@ -116,8 +116,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 9,
               "endColumn": 28,
               "endLine": 1,
@@ -143,8 +143,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 3,
@@ -164,8 +164,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 2,
@@ -191,8 +191,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 2,
@@ -218,8 +218,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 3,
@@ -247,8 +247,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 3,
@@ -276,8 +276,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 3,
@@ -299,8 +299,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 5,
@@ -324,8 +324,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 32,
               "endLine": 1,
@@ -349,8 +349,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 32,
               "endLine": 1,
@@ -376,8 +376,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 3,
@@ -401,8 +401,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 27,
               "endColumn": 46,
               "endLine": 1,
@@ -427,8 +427,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 31,
               "endLine": 1,
@@ -456,8 +456,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 10,
               "endColumn": 32,
               "endLine": 1,
@@ -468,7 +468,7 @@ generateRuleTests({
               "severity": 2,
               "source": "{{unless (one ...",
             },
-            Object {
+            {
               "column": 15,
               "endColumn": 27,
               "endLine": 1,
@@ -496,8 +496,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 27,
               "endColumn": 38,
               "endLine": 1,
@@ -525,8 +525,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 26,
               "endLine": 1,
@@ -554,8 +554,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 15,
               "endColumn": 26,
               "endLine": 1,
@@ -566,7 +566,7 @@ generateRuleTests({
               "severity": 2,
               "source": "{{unless (... (two ...",
             },
-            Object {
+            {
               "column": 27,
               "endColumn": 38,
               "endLine": 1,

--- a/test/unit/rules/splat-attributes-only-test.js
+++ b/test/unit/rules/splat-attributes-only-test.js
@@ -18,8 +18,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 17,
               "endLine": 1,

--- a/test/unit/rules/style-concatenation-test.js
+++ b/test/unit/rules/style-concatenation-test.js
@@ -20,8 +20,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 24,
               "endLine": 1,
@@ -41,8 +41,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 38,
               "endLine": 1,
@@ -62,8 +62,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 37,
               "endLine": 1,
@@ -83,8 +83,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 5,
               "endColumn": 57,
               "endLine": 1,

--- a/test/unit/rules/table-groups-test.js
+++ b/test/unit/rules/table-groups-test.js
@@ -230,8 +230,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 12,
@@ -272,8 +272,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 12,
@@ -309,8 +309,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 7,
@@ -342,8 +342,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 8,
@@ -376,8 +376,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 8,
@@ -408,8 +408,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 6,
@@ -438,8 +438,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 6,
@@ -463,8 +463,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 36,
               "endLine": 1,
@@ -484,8 +484,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 33,
               "endLine": 1,
@@ -505,8 +505,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 53,
               "endLine": 1,
@@ -526,8 +526,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 60,
               "endLine": 1,
@@ -547,8 +547,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 41,
               "endLine": 1,
@@ -567,8 +567,8 @@ generateRuleTests({
       template: '<table>{{some-component tagName="div"}}</table>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 47,
               "endLine": 1,
@@ -587,8 +587,8 @@ generateRuleTests({
       template: '<table>{{some-component otherProp="tbody"}}</table>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 51,
               "endLine": 1,
@@ -607,8 +607,8 @@ generateRuleTests({
       template: '<table><SomeComponent @tagName="div" /></table>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 47,
               "endLine": 1,
@@ -627,8 +627,8 @@ generateRuleTests({
       template: '<table><SomeComponent @otherProp="tbody" /></table>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 51,
               "endLine": 1,
@@ -647,8 +647,8 @@ generateRuleTests({
       template: '<table>some text</table>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 24,
               "endLine": 1,
@@ -667,8 +667,8 @@ generateRuleTests({
       template: '<table><tfoot /><thead /></table>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 33,
               "endLine": 1,
@@ -687,8 +687,8 @@ generateRuleTests({
       template: '<table><tbody /><caption /></table>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 35,
               "endLine": 1,
@@ -712,8 +712,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 8,
               "endColumn": 16,
               "endLine": 5,
@@ -742,8 +742,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 4,
@@ -773,8 +773,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 5,
@@ -808,8 +808,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 7,
@@ -842,8 +842,8 @@ generateRuleTests({
       `,
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 6,
               "endColumn": 14,
               "endLine": 6,

--- a/test/unit/rules/template-length-test.js
+++ b/test/unit/rules/template-length-test.js
@@ -28,8 +28,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 3,
@@ -52,8 +52,8 @@ generateRuleTests({
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
-          Array [
-            Object {
+          [
+            {
               "column": 0,
               "endColumn": 0,
               "endLine": 5,


### PR DESCRIPTION
Jest's snapshots allow for configuring them to not include the extraneous object prototype information. This makes snapshots (arguably) more readable, but most importantly copyable. 

The following setting in the jest config disables this:

```json
{
  "jest": {
    "snapshotFormat": {
      "printBasicPrototype": false
    }
  }
}
```

It's probably more useful to view this PR via the [commits](https://github.com/ember-template-lint/ember-template-lint/pull/2361/commits). The first commit changes the config, and the second simply runs `yarn test:jest -u` to update the snapshots.