### PR TITLE
Adds new rule `require-aria-activedescendant-tabindex`

### DIFF
--- a/docs/rule/require-aria-activedescendant-tabindex.md
+++ b/docs/rule/require-aria-activedescendant-tabindex.md
@@ -1,0 +1,34 @@
+# require-aria-activedescendant-tabindex
+
+This rule requires all noninteractive HTML elements using the aria-activedescendant attribute to declare a tabindex of zero.
+
+The `aria-activedescendant` attribute identifies the active descendant element of a composite widget, textbox, group, or application with document focus. This attribute is placed on the container element of the input control, and its value is set to the ID of the active child element. This allows screen readers to communicate information about the currently active element as if it has focus, while actual focus of the DOM remains on the container element.
+
+Elements with `aria-activedescendant` must have a tabindex of zero in order to support keyboard navigation. Besides interactive elements, which are inherently keyboard-focusable, elements using the `aria-activedescendant` attribute must declare a `tabIndex` of zero with the `tabIndex` attribute.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<div aria-activedescendant="some-id" />
+<div aria-activedescendant="some-id" tabindex="-1" />
+<input aria-activedescendant={{some-id}} tabindex="-1" />
+```
+
+This rule **allows** the following:
+
+```hbs
+<CustomComponent />
+<CustomComponent aria-activedescendant={{some-id}} />
+<CustomComponent aria-activedescendant={{some-id}} tabindex={{0}} />
+<div aria-activedescendant="some-id" tabindex="0" />
+<input />
+<input aria-activedescendant={{some-id}} />
+<input aria-activedescendant={{some-id}} tabindex={{0}} />
+```
+
+## References
+
+- [MDN, Using the aria-activedescendant attribute(property)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-activedescendant_attribute)
+- [WAI-aria: aria-activedescendant(property](https://www.digitala11y.com/aria-activedescendant-properties/)

--- a/lib/config/a11y.js
+++ b/lib/config/a11y.js
@@ -24,6 +24,7 @@ export default {
     'no-redundant-landmark-role': 'error',
     'no-whitespace-for-layout': 'error',
     'no-whitespace-within-word': 'error',
+    'require-aria-activedescendant-tabindex': 'error',
     'require-context-role': 'error',
     'require-iframe-title': 'error',
     'require-input-label': 'error',

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -87,6 +87,7 @@ import nowith from './no-with.js';
 import noyieldonly from './no-yield-only.js';
 import noyieldtodefault from './no-yield-to-default.js';
 import quotes from './quotes.js';
+import requireariaactivedescendanttabindex from './require-aria-activedescendant-tabindex.js';
 import requirebuttontype from './require-button-type.js';
 import requirecontextrole from './require-context-role.js';
 import requireeachkey from './require-each-key.js';
@@ -194,6 +195,7 @@ export default {
   'no-yield-only': noyieldonly,
   'no-yield-to-default': noyieldtodefault,
   quotes,
+  'require-aria-activedescendant-tabindex': requireariaactivedescendanttabindex,
   'require-button-type': requirebuttontype,
   'require-context-role': requirecontextrole,
   'require-each-key': requireeachkey,

--- a/lib/rules/require-aria-activedescendant-tabindex.js
+++ b/lib/rules/require-aria-activedescendant-tabindex.js
@@ -1,0 +1,60 @@
+import { dom } from 'aria-query';
+
+import AstNodeInfo from '../helpers/ast-node-info.js';
+import isInteractiveElement from '../helpers/is-interactive-element.js';
+import Rule from './_base.js';
+
+const ERROR_MESSAGE =
+  'An element using the aria-activedescendant attribute must have a tabindex of zero';
+
+export default class RequireAriaActivedescendantTabindex extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        let hasAriaActivedescendant = AstNodeInfo.hasAttribute(node, 'aria-activedescendant');
+        if (!hasAriaActivedescendant) {
+          return;
+        }
+        // Bypass validation of Ember components, since we do not know what HTML tags they have
+        if (![...dom.keys()].includes(node.tag)) {
+          return;
+        }
+        let tabindex = AstNodeInfo.findAttribute(node, 'tabindex');
+        let tabindexValue = Number.naN;
+        if (!tabindex && isInteractiveElement(node)) {
+          return;
+        }
+        if (tabindex) {
+          switch (tabindex.value.type) {
+            case 'MustacheStatement': {
+              if (tabindex.value.path) {
+                if (
+                  ['BooleanLiteral', 'NumberLiteral', 'StringLiteral'].includes(
+                    tabindex.value.path.type
+                  )
+                ) {
+                  tabindexValue = tabindex.value.path.original;
+                }
+              }
+
+              break;
+            }
+            case 'TextNode': {
+              tabindexValue = Number.parseInt(tabindex.value.chars, 10);
+
+              break;
+            }
+            // No default
+          }
+        }
+
+        if (tabindexValue !== 0) {
+          this.log({
+            message: ERROR_MESSAGE,
+            node,
+          });
+        }
+      },
+    };
+  }
+}

--- a/test/unit/rules/require-aria-activedescendant-tabindex-test.js
+++ b/test/unit/rules/require-aria-activedescendant-tabindex-test.js
@@ -1,0 +1,119 @@
+import generateRuleTests from '../../helpers/rule-test-harness.js';
+
+generateRuleTests({
+  name: 'require-aria-activedescendant-tabindex',
+
+  config: true,
+
+  good: [
+    '<div tabindex="-1"></div>',
+    '<input aria-activedescendant="some-id" />',
+    '<input aria-activedescendant={{foo}} tabindex={{0}} />',
+    '<div aria-activedescendant="option0" tabindex="0"></div>',
+    '<CustomComponent aria-activedescendant="choice1" />',
+    '<CustomComponent aria-activedescendant="option1" tabIndex="-1" />',
+    '<CustomComponent aria-activedescendant={{foo}} tabindex={{bar}} />',
+  ],
+  bad: [
+    {
+      template: '<input aria-activedescendant="option0" tabindex="-2" />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 55,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "An element using the aria-activedescendant attribute must have a tabindex of zero",
+              "rule": "require-aria-activedescendant-tabindex",
+              "severity": 2,
+              "source": "<input aria-activedescendant=\\"option0\\" tabindex=\\"-2\\" />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<input aria-activedescendant="select" tabindex="2" />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 53,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "An element using the aria-activedescendant attribute must have a tabindex of zero",
+              "rule": "require-aria-activedescendant-tabindex",
+              "severity": 2,
+              "source": "<input aria-activedescendant=\\"select\\" tabindex=\\"2\\" />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<div aria-activedescendant="fixme" tabindex="500"></div>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 56,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "An element using the aria-activedescendant attribute must have a tabindex of zero",
+              "rule": "require-aria-activedescendant-tabindex",
+              "severity": 2,
+              "source": "<div aria-activedescendant=\\"fixme\\" tabindex=\\"500\\"></div>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<div aria-activedescendant={{bar}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 37,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "An element using the aria-activedescendant attribute must have a tabindex of zero",
+              "rule": "require-aria-activedescendant-tabindex",
+              "severity": 2,
+              "source": "<div aria-activedescendant={{bar}} />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<div aria-activedescendant={{foo}} tabindex={{-1}}></div>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 57,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "An element using the aria-activedescendant attribute must have a tabindex of zero",
+              "rule": "require-aria-activedescendant-tabindex",
+              "severity": 2,
+              "source": "<div aria-activedescendant={{foo}} tabindex={{-1}}></div>",
+            },
+          ]
+        `);
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds the new rule require-aria-activedescendant-tabindex which fixes #2364 .

### Background
The aria-activedescendant attribute identifies the active descendant element of a composite widget, textbox, group, or application with document focus. This attribute is placed on the container element of the input control, and its value is set to the ID of the active child element. This allows screen readers to communicate information about the currently active element as if it has focus, while actual focus of the DOM remains on the container element. Elements with aria-activedescendant must declare a tabindex of 0 in order to be accessible for keyboard users.

This proposes the authoring of a new rule that enforces that elements with an aria-activedescendant attribute declare a tab index of 0. This rule is analogous to JSXs A11y [aria-activedescendant-has-tabindex](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-activedescendant-has-tabindex.md) rule.
Reference: [MDN, Using the aria-activedescendant attribute(property)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-activedescendant_attribute) 

**Allowed**:

```
# examples
<CustomComponent />
<CustomComponent aria-activedescendant={{some-id}} />
<CustomComponent aria-activedescendant={{some-id}} tabindex={{0}} />
<div aria-activedescendant="some-id" tabindex="0" />
<input />
<input aria-activedescendant={{some-id}} />
<input aria-activedescendant={{some-id}} tabindex={{0}} />
```

**Forbidden**:

```
# examples
<div aria-activedescendant="some-id" />
<div aria-activedescendant="some-id" tabindex="-1" />
<input aria-activedescendant={{some-id}} tabindex="-1" />
```

### Testing
WIP