### PR TITLE
check for svg to extend the supportedExtensions

### DIFF
--- a/lib/helpers/cli.js
+++ b/lib/helpers/cli.js
@@ -221,6 +221,10 @@ export function getPossibleOptionNames(specifiedOptions) {
 function executeGlobby(workingDir, pattern, ignore) {
   let supportedExtensions = new Set(['.hbs', '.handlebars']);
 
+  if (path.extname(pattern) === '.svg') {
+    supportedExtensions.add('.svg');
+  }
+
   // `--no-ignore-pattern` results in `ignorePattern === [false]`
   let options =
     ignore[0] === false ? { cwd: workingDir } : { cwd: workingDir, gitignore: true, ignore };


### PR DESCRIPTION
We have relied for over a year on ember template lint to lint our svg files for certain issues(embedded images, text, etc). This is useful, since we can rely on the integration we already use for our template file lint.

We used to have our files only nested one deep, so no need for doing a glob search pattern. We reorganized our folder structure and will now have svgs nested in multiple folders deep.

When wrapping it in \"public/**/*.svg\", it does seem to do a recursive glob search, but in this case it executes the executeGlobby function and that hardcodes the supported extensions to be `let supportedExtensions = new Set(['.hbs', '.handlebars']);`

This change proposes to allow for linting of SVG files as well. I'm open to ideas and suggestions, one idea I had is to extend it with`.html` files as well for example.

ps. I was looking into adding a test scenario but I'm not sure where to best place this so any suggestion would be great!
