### PR TITLE
Crash in block indentation auto-fixer

### DIFF
--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -1327,5 +1327,9 @@ generateRuleTests({
         `);
       },
     },
+    {
+      template: '  <div>\n  </div>\n  <div>\n  </div>\n',
+      fixedTemplate: '<div>\n</div>\n<div>\n</div>\n',
+    },
   ],
 });


### PR DESCRIPTION
This provides a failing test that crashes the auto-fixer for the block indentation rule. 