### PR TITLE
Relax coverage thresholds to allow for some small drift

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 87,
-        "functions": 96,
-        "lines": 91,
-        "statements": 91
+        "branches": 82,
+        "functions": 91,
+        "lines": 86,
+        "statements": 86
       }
     },
     "setupFilesAfterEnv": [


### PR DESCRIPTION
Relaxes the code coverage threshold requirements so that PR's aren't blocked for minor changes.
We absolutely are not aiming for 100% coverage (so we don't want to incrementally increase this
as we improve coverage), the goal of these thresholds is to make sure we don't accidentally
**stop** running some subset of tests (e.g. someone commits `.only`).