### PR TITLE
New formatter: multi

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint require-atomic-updates:"off" */
 /* eslint node/shebang:"off" -- shebang needed so this script can be run directly */
 
 // Use V8's code cache to speed up instantiation time:
@@ -248,7 +249,7 @@ async function run() {
     process.exitCode = 1;
   }
 
-  printResults(results, { options, todoInfo });
+  printResults(results, { options, todoInfo, config: linter.config });
 }
 
 run();

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -249,7 +249,7 @@ async function run() {
     process.exitCode = 1;
   }
 
-  printResults(results, { options, todoInfo, config: linter.config });
+  await printResults(results, { options, todoInfo, config: linter.config });
 }
 
 run();

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -16,10 +16,9 @@ import path from 'node:path';
 import process from 'node:process';
 import { promisify } from 'node:util';
 
-import { loadFormatter } from '../lib/formatters/load-formatter.js';
 import { parseArgv, getFilesToLint } from '../lib/helpers/cli.js';
+import printResults from '../lib/helpers/print-results.js';
 import processResults from '../lib/helpers/process-results.js';
-import writeOutputFile from '../lib/helpers/write-output-file.js';
 import Linter from '../lib/linter.js';
 
 const readFile = promisify(fs.readFile);
@@ -250,32 +249,6 @@ async function run() {
   }
 
   printResults(results, { options, todoInfo });
-}
-
-function printResults(results, { options, todoInfo }) {
-  let hasErrors = results.errorCount > 0;
-  let hasWarnings = results.warningCount > 0;
-  let hasTodos = options.includeTodo && results.todoCount;
-  let hasUpdatedTodos = options.updateTodo;
-
-  let formatter = loadFormatter({
-    ...options,
-    hasResultData: hasErrors || hasWarnings || hasTodos || hasUpdatedTodos,
-  });
-
-  if (typeof formatter.format === 'function') {
-    let output = formatter.format(results, todoInfo);
-
-    if ('output-file' in options) {
-      let outputPath = writeOutputFile(output, formatter.defaultFileExtension || 'txt', options);
-      console.log(`Report written to ${outputPath}`);
-    } else {
-      console.log(output);
-    }
-  } else {
-    // support legacy formatters
-    formatter.print(results, todoInfo);
-  }
 }
 
 run();

--- a/lib/formatters/load-formatter.js
+++ b/lib/formatters/load-formatter.js
@@ -1,9 +1,10 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 
-import JsonPrinter from './json.js';
+import JsonFormatter from './json.js';
+import MultiFormatter from './multi.js';
 import PrettyFormatter from './pretty.js';
-import SarifPrinter from './sarif.js';
+import SarifFormatter from './sarif.js';
 
 export function loadFormatter(options) {
   let formatOptions = {
@@ -14,22 +15,25 @@ export function loadFormatter(options) {
     quiet: options.quiet,
     updateTodo: options.updateTodo,
     verbose: options.verbose,
-    workingDir: options.workingDirectory,
     hasResultData: options.hasResultData,
     config: options.config,
+    workingDirectory: options.workingDirectory,
     // backwards compatibility with old-style formatters
     console: options.console || console,
   };
 
   switch (options.format) {
     case 'json': {
-      return new JsonPrinter(formatOptions);
+      return new JsonFormatter(formatOptions);
     }
     case 'pretty': {
       return new PrettyFormatter(formatOptions);
     }
     case 'sarif': {
-      return new SarifPrinter(formatOptions);
+      return new SarifFormatter(formatOptions);
+    }
+    case 'multi': {
+      return new MultiFormatter(formatOptions);
     }
     default: {
       try {

--- a/lib/formatters/load-formatter.js
+++ b/lib/formatters/load-formatter.js
@@ -6,7 +6,7 @@ import PrettyFormatter from './pretty.js';
 import SarifPrinter from './sarif.js';
 
 export function loadFormatter(options) {
-  let printOptions = {
+  let formatOptions = {
     includeTodo: options.includeTodo,
     // env var is used to test output options via tests
     isInteractive: process.stdout.isTTY || process.env['IS_TTY'] === '1',
@@ -16,19 +16,20 @@ export function loadFormatter(options) {
     verbose: options.verbose,
     workingDir: options.workingDirectory,
     hasResultData: options.hasResultData,
+    config: options.config,
     // backwards compatibility with old-style formatters
     console: options.console || console,
   };
 
   switch (options.format) {
     case 'json': {
-      return new JsonPrinter(printOptions);
+      return new JsonPrinter(formatOptions);
     }
     case 'pretty': {
-      return new PrettyFormatter(printOptions);
+      return new PrettyFormatter(formatOptions);
     }
     case 'sarif': {
-      return new SarifPrinter(printOptions);
+      return new SarifPrinter(formatOptions);
     }
     default: {
       try {
@@ -36,7 +37,7 @@ export function loadFormatter(options) {
           path.join(options.workingDirectory, '__placeholder__.js')
         )(options.format);
 
-        return new CustomFormatter(printOptions);
+        return new CustomFormatter(formatOptions);
       } catch (error) {
         throw new Error(
           `There was a problem loading the formatter: Could not load "${options.format}"\n${error.message}`

--- a/lib/formatters/load-formatter.js
+++ b/lib/formatters/load-formatter.js
@@ -2,6 +2,9 @@ import { createRequire } from 'node:module';
 import path from 'node:path';
 
 import JsonFormatter from './json.js';
+// The following disable should be safe. This particular rule does not need to identify
+// cycles that are broken when using dynamic imports. See https://github.com/import-js/eslint-plugin-import/issues/2265
+// eslint-disable-next-line import/no-cycle
 import MultiFormatter from './multi.js';
 import PrettyFormatter from './pretty.js';
 import SarifFormatter from './sarif.js';

--- a/lib/formatters/multi.js
+++ b/lib/formatters/multi.js
@@ -1,0 +1,31 @@
+import printResults from '../helpers/print-results.js';
+
+export default class PrettyFormatter {
+  constructor(options = {}) {
+    this.options = options;
+  }
+
+  format(results, todoInfo) {
+    let formatConfig = this.options.config.format;
+
+    if (!formatConfig && !formatConfig.formatters) {
+      return '';
+    }
+
+    for (let formatter of formatConfig.formatters) {
+      let formatterOptions = {
+        options: Object.assign({}, this.options, {
+          format: formatter.name,
+        }),
+        todoInfo,
+        config: this.options.config,
+      };
+
+      if (formatter.outputFile) {
+        formatterOptions.options.outputFile = formatter.outputFile;
+      }
+
+      printResults(results, formatterOptions);
+    }
+  }
+}

--- a/lib/formatters/multi.js
+++ b/lib/formatters/multi.js
@@ -1,31 +1,33 @@
-import printResults from '../helpers/print-results.js';
-
-export default class PrettyFormatter {
+export default class MultiFormatter {
   constructor(options = {}) {
     this.options = options;
   }
 
-  format(results, todoInfo) {
+  async format(results, todoInfo) {
     let formatConfig = this.options.config.format;
 
-    if (!formatConfig && !formatConfig.formatters) {
-      return '';
-    }
+    if (formatConfig && formatConfig.formatters) {
+      // The following disable should be safe. This particular rule does not need to identify
+      // cycles that are broken when using dynamic imports. See https://github.com/import-js/eslint-plugin-import/issues/2265
+      // eslint-disable-next-line import/no-cycle
+      const { default: printResults } = await import('../helpers/print-results.js');
+      for (let formatter of formatConfig.formatters) {
+        let formatterOptions = {
+          options: Object.assign({}, this.options, {
+            format: formatter.name,
+          }),
+          todoInfo,
+          config: this.options.config,
+        };
 
-    for (let formatter of formatConfig.formatters) {
-      let formatterOptions = {
-        options: Object.assign({}, this.options, {
-          format: formatter.name,
-        }),
-        todoInfo,
-        config: this.options.config,
-      };
+        if (formatter.outputFile) {
+          formatterOptions.options.outputFile = formatter.outputFile;
+        }
 
-      if (formatter.outputFile) {
-        formatterOptions.options.outputFile = formatter.outputFile;
+        await printResults(results, formatterOptions);
       }
-
-      printResults(results, formatterOptions);
     }
+
+    return '';
   }
 }

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -21,6 +21,7 @@ const KNOWN_ROOT_PROPERTIES = new Set([
   'format',
 ]);
 const SUPPORTED_OVERRIDE_KEYS = new Set(['files', 'rules']);
+const SUPPORTED_FORMAT_PROPS = new Set(['name', 'outputFile']);
 
 const CONFIG_FILE_NAME = '.template-lintrc.js';
 const ALLOWED_ERROR_CODES = new Set([
@@ -133,7 +134,7 @@ function ensureRootProperties(config, source) {
   config.overrides = [...(source.overrides || [])];
   config.ignore = [...(source.ignore || [])];
   config.extends = source.extends;
-  config.format = Object.assign({}, source.format, {});
+  config.format = Object.assign({}, source.format || {});
 }
 
 function validateRootProperties(source) {
@@ -363,6 +364,20 @@ function validateOverrides(config, options) {
   }
 }
 
+function validateFormat(config) {
+  if ('formatters' in config.format) {
+    for (let format of config.format.formatters) {
+      for (let formatProp of Object.keys(format)) {
+        if (!SUPPORTED_FORMAT_PROPS.has(formatProp)) {
+          throw new Error(
+            `An invalid \`format.formatter\` in \`.template-lintrc.js\` was provided. Unexpected property \`${formatProp}\``
+          );
+        }
+      }
+    }
+  }
+}
+
 /**
  * Sets the severity and config on the rule object.
  * Eg:
@@ -391,7 +406,7 @@ export function processRules(config) {
 export async function getProjectConfig(workingDir, options) {
   let source = options.config || (await resolveProjectConfig(workingDir, options));
   let config;
-
+  debugger;
   if (source._processed) {
     config = source;
   } else {
@@ -409,6 +424,7 @@ export async function getProjectConfig(workingDir, options) {
 
     validateRules(config.rules, config.loadedRules, options);
     validateOverrides(config, options);
+    validateFormat(config);
     config.rules = processRules(config);
 
     config._processed = true;

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -12,7 +12,14 @@ import defaultRules from './rules/index.js';
 
 const require = createRequire(import.meta.url);
 
-const KNOWN_ROOT_PROPERTIES = new Set(['extends', 'rules', 'ignore', 'plugins', 'overrides']);
+const KNOWN_ROOT_PROPERTIES = new Set([
+  'extends',
+  'rules',
+  'ignore',
+  'plugins',
+  'overrides',
+  'format',
+]);
 const SUPPORTED_OVERRIDE_KEYS = new Set(['files', 'rules']);
 
 const CONFIG_FILE_NAME = '.template-lintrc.js';
@@ -126,6 +133,7 @@ function ensureRootProperties(config, source) {
   config.overrides = [...(source.overrides || [])];
   config.ignore = [...(source.ignore || [])];
   config.extends = source.extends;
+  config.format = Object.assign({}, source.format, {});
 }
 
 function validateRootProperties(source) {

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -406,7 +406,7 @@ export function processRules(config) {
 export async function getProjectConfig(workingDir, options) {
   let source = options.config || (await resolveProjectConfig(workingDir, options));
   let config;
-  debugger;
+
   if (source._processed) {
     config = source;
   } else {

--- a/lib/helpers/print-results.js
+++ b/lib/helpers/print-results.js
@@ -1,0 +1,30 @@
+import { loadFormatter } from '../formatters/load-formatter.js';
+import writeOutputFile from './write-output-file.js';
+
+export default function printResults(results, { options, todoInfo }) {
+  let hasErrors = results.errorCount > 0;
+  let hasWarnings = results.warningCount > 0;
+  let hasTodos = options.includeTodo && results.todoCount;
+  let hasUpdatedTodos = options.updateTodo;
+
+  let formatter = loadFormatter({
+    ...options,
+    hasResultData: hasErrors || hasWarnings || hasTodos || hasUpdatedTodos,
+  });
+
+  if (typeof formatter.format === 'function') {
+    let output = formatter.format(results, todoInfo);
+
+    if ('output-file' in options) {
+      let outputPath = writeOutputFile(output, formatter.defaultFileExtension || 'txt', options);
+      // eslint-disable-next-line no-console
+      console.log(`Report written to ${outputPath}`);
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(output);
+    }
+  } else {
+    // support legacy formatters
+    formatter.print(results, todoInfo);
+  }
+}

--- a/lib/helpers/print-results.js
+++ b/lib/helpers/print-results.js
@@ -16,7 +16,7 @@ export default function printResults(results, { options, todoInfo, config }) {
   if (typeof formatter.format === 'function') {
     let output = formatter.format(results, todoInfo);
 
-    if ('output-file' in options) {
+    if ('outputFile' in options && typeof options.outputFile !== 'undefined') {
       let outputPath = writeOutputFile(output, formatter.defaultFileExtension || 'txt', options);
       // eslint-disable-next-line no-console
       console.log(`Report written to ${outputPath}`);

--- a/lib/helpers/print-results.js
+++ b/lib/helpers/print-results.js
@@ -1,7 +1,10 @@
+// The following disable should be safe. This particular rule does not need to identify
+// cycles that are broken when using dynamic imports. See https://github.com/import-js/eslint-plugin-import/issues/2265
+// eslint-disable-next-line import/no-cycle
 import { loadFormatter } from '../formatters/load-formatter.js';
 import writeOutputFile from './write-output-file.js';
 
-export default function printResults(results, { options, todoInfo, config }) {
+export default async function printResults(results, { options, todoInfo, config }) {
   let hasErrors = results.errorCount > 0;
   let hasWarnings = results.warningCount > 0;
   let hasTodos = options.includeTodo && results.todoCount;
@@ -14,7 +17,7 @@ export default function printResults(results, { options, todoInfo, config }) {
   });
 
   if (typeof formatter.format === 'function') {
-    let output = formatter.format(results, todoInfo);
+    let output = await formatter.format(results, todoInfo);
 
     if ('outputFile' in options && typeof options.outputFile !== 'undefined') {
       let outputPath = writeOutputFile(output, formatter.defaultFileExtension || 'txt', options);

--- a/lib/helpers/print-results.js
+++ b/lib/helpers/print-results.js
@@ -1,7 +1,7 @@
 import { loadFormatter } from '../formatters/load-formatter.js';
 import writeOutputFile from './write-output-file.js';
 
-export default function printResults(results, { options, todoInfo }) {
+export default function printResults(results, { options, todoInfo, config }) {
   let hasErrors = results.errorCount > 0;
   let hasWarnings = results.warningCount > 0;
   let hasTodos = options.includeTodo && results.todoCount;
@@ -9,6 +9,7 @@ export default function printResults(results, { options, todoInfo }) {
 
   let formatter = loadFormatter({
     ...options,
+    config,
     hasResultData: hasErrors || hasWarnings || hasTodos || hasUpdatedTodos,
   });
 

--- a/lib/helpers/write-output-file.js
+++ b/lib/helpers/write-output-file.js
@@ -15,9 +15,10 @@ export default function writeOutputFile(contents, extension, options) {
 }
 
 function getOutputPath(extension, options) {
-  let outputFile = !options.outputFile
-    ? `${DEFAULT_OUTPUT_FILENAME}.${extension}`
-    : options.outputFile;
+  let outputFile =
+    options.outputFile === true || !options.outputFile
+      ? `${DEFAULT_OUTPUT_FILENAME}.${extension}`
+      : options.outputFile;
 
   let outputPath = path.isAbsolute(outputFile)
     ? outputFile

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -32,13 +32,10 @@ function buildErrorMessage(filePath, error) {
 }
 
 export default class Linter {
-  constructor(_options) {
-    let options = _options || {};
-
+  constructor(options = {}) {
     this.options = options;
     this.console = options.console || console;
     this.workingDir = options.workingDir || process.cwd();
-    this.constructor = Linter;
   }
 
   /**

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1124,6 +1124,7 @@ describe('ember-template-lint executable', function () {
             },
             \\"overrides\\": [],
             \\"ignore\\": [],
+            \\"format\\": {},
             \\"plugins\\": {},
             \\"loadedRules\\": {}
           }"

--- a/test/acceptance/formatters/multi-test.js
+++ b/test/acceptance/formatters/multi-test.js
@@ -1,0 +1,412 @@
+import { Project, getOutputFileContents, run, setupEnvVar } from '../../helpers/index.js';
+
+const ROOT = process.cwd();
+
+describe('multi formatter', () => {
+  setupEnvVar('FORCE_COLOR', '0');
+
+  let project;
+  beforeEach(function () {
+    project = Project.defaultSetup();
+    project.chdir();
+  });
+
+  afterEach(function () {
+    process.chdir(ROOT);
+    project.dispose();
+  });
+
+  it('should format errors', async function () {
+    project.setConfig({
+      rules: {
+        'no-bare-strings': true,
+      },
+      format: {
+        formatters: [
+          {
+            name: 'pretty',
+          },
+          {
+            name: 'json',
+            outputFile: 'my-results.json',
+          },
+        ],
+      },
+    });
+    project.write({
+      app: {
+        templates: {
+          'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+          components: {
+            'foo.hbs': '{{fooData}}',
+          },
+        },
+      },
+    });
+
+    let result = await run(['.', '--format', 'multi']);
+
+    expect(result.exitCode).toEqual(1);
+    expect(result.stdout.replace(project.baseDir, '')).toMatchInlineSnapshot(`
+      "app/templates/application.hbs
+        1:4  error  Non-translated string used  no-bare-strings
+        1:25  error  Non-translated string used  no-bare-strings
+
+      ✖ 2 problems (2 errors, 0 warnings)
+      Report written to /my-results.json
+      "
+    `);
+    expect(getOutputFileContents(result.stdout)).toMatchInlineSnapshot(`
+      "{
+        \\"app/templates/application.hbs\\": [
+          {
+            \\"rule\\": \\"no-bare-strings\\",
+            \\"severity\\": 2,
+            \\"filePath\\": \\"app/templates/application.hbs\\",
+            \\"line\\": 1,
+            \\"column\\": 4,
+            \\"endLine\\": 1,
+            \\"endColumn\\": 14,
+            \\"source\\": \\"Here too!!\\",
+            \\"message\\": \\"Non-translated string used\\"
+          },
+          {
+            \\"rule\\": \\"no-bare-strings\\",
+            \\"severity\\": 2,
+            \\"filePath\\": \\"app/templates/application.hbs\\",
+            \\"line\\": 1,
+            \\"column\\": 25,
+            \\"endLine\\": 1,
+            \\"endColumn\\": 48,
+            \\"source\\": \\"Bare strings are bad...\\",
+            \\"message\\": \\"Non-translated string used\\"
+          }
+        ]
+      }"
+    `);
+    expect(result.stderr).toBeFalsy();
+  });
+
+  // it('should format errors and warnings', async function () {
+  //   project.setConfig({
+  //     rules: {
+  //       'no-bare-strings': true,
+  //       'no-html-comments': 'warn',
+  //     },
+  //   });
+  //   project.write({
+  //     app: {
+  //       templates: {
+  //         'application.hbs':
+  //           '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+  //       },
+  //     },
+  //   });
+
+  //   let result = await run(['.', '--format', 'json']);
+
+  //   expect(result.exitCode).toEqual(1);
+  //   expect(result.stdout).toMatchInlineSnapshot(`
+  //     "{
+  //       \\"app/templates/application.hbs\\": [
+  //         {
+  //           \\"rule\\": \\"no-bare-strings\\",
+  //           \\"severity\\": 2,
+  //           \\"filePath\\": \\"app/templates/application.hbs\\",
+  //           \\"line\\": 1,
+  //           \\"column\\": 4,
+  //           \\"endLine\\": 1,
+  //           \\"endColumn\\": 14,
+  //           \\"source\\": \\"Here too!!\\",
+  //           \\"message\\": \\"Non-translated string used\\"
+  //         },
+  //         {
+  //           \\"rule\\": \\"no-bare-strings\\",
+  //           \\"severity\\": 2,
+  //           \\"filePath\\": \\"app/templates/application.hbs\\",
+  //           \\"line\\": 1,
+  //           \\"column\\": 24,
+  //           \\"endLine\\": 1,
+  //           \\"endColumn\\": 47,
+  //           \\"source\\": \\"Bare strings are bad...\\",
+  //           \\"message\\": \\"Non-translated string used\\"
+  //         },
+  //         {
+  //           \\"rule\\": \\"no-html-comments\\",
+  //           \\"severity\\": 1,
+  //           \\"filePath\\": \\"app/templates/application.hbs\\",
+  //           \\"line\\": 1,
+  //           \\"column\\": 53,
+  //           \\"endLine\\": 1,
+  //           \\"endColumn\\": 79,
+  //           \\"source\\": \\"<!-- bad html comment! -->\\",
+  //           \\"message\\": \\"HTML comment detected\\",
+  //           \\"fix\\": {
+  //             \\"text\\": \\"{{! bad html comment! }}\\"
+  //           }
+  //         }
+  //       ]
+  //     }"
+  //   `);
+  //   expect(result.stderr).toBeFalsy();
+  // });
+
+  // it('should include information about available fixes', async function () {
+  //   project.setConfig({
+  //     rules: {
+  //       'require-button-type': true,
+  //     },
+  //   });
+
+  //   project.write({
+  //     app: {
+  //       components: {
+  //         'click-me-button.hbs': '<button>Click me!</button>',
+  //       },
+  //     },
+  //   });
+
+  //   let result = await run(['.', '--format', 'json']);
+
+  //   expect(result.exitCode).toEqual(1);
+  //   expect(result.stdout).toMatchInlineSnapshot(`
+  //     "{
+  //       \\"app/components/click-me-button.hbs\\": [
+  //         {
+  //           \\"rule\\": \\"require-button-type\\",
+  //           \\"severity\\": 2,
+  //           \\"filePath\\": \\"app/components/click-me-button.hbs\\",
+  //           \\"line\\": 1,
+  //           \\"column\\": 0,
+  //           \\"endLine\\": 1,
+  //           \\"endColumn\\": 26,
+  //           \\"source\\": \\"<button>Click me!</button>\\",
+  //           \\"message\\": \\"All \`<button>\` elements should have a valid \`type\` attribute\\",
+  //           \\"isFixable\\": true
+  //         }
+  //       ]
+  //     }"
+  //   `);
+  //   expect(result.stderr).toBeFalsy();
+  // });
+
+  // it('should output to a file using --output-file option using default filename', async () => {
+  //   project.setConfig({
+  //     rules: {
+  //       'no-bare-strings': true,
+  //       'no-html-comments': 'warn',
+  //     },
+  //   });
+  //   project.write({
+  //     app: {
+  //       templates: {
+  //         'application.hbs':
+  //           '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+  //       },
+  //     },
+  //   });
+
+  //   let result = await run(['.', '--format', 'json', '--output-file']);
+
+  //   expect(result.exitCode).toEqual(1);
+  //   expect(getOutputFileContents(result.stdout)).toMatchInlineSnapshot(`
+  //     "{
+  //       \\"app/templates/application.hbs\\": [
+  //         {
+  //           \\"rule\\": \\"no-bare-strings\\",
+  //           \\"severity\\": 2,
+  //           \\"filePath\\": \\"app/templates/application.hbs\\",
+  //           \\"line\\": 1,
+  //           \\"column\\": 4,
+  //           \\"endLine\\": 1,
+  //           \\"endColumn\\": 14,
+  //           \\"source\\": \\"Here too!!\\",
+  //           \\"message\\": \\"Non-translated string used\\"
+  //         },
+  //         {
+  //           \\"rule\\": \\"no-bare-strings\\",
+  //           \\"severity\\": 2,
+  //           \\"filePath\\": \\"app/templates/application.hbs\\",
+  //           \\"line\\": 1,
+  //           \\"column\\": 24,
+  //           \\"endLine\\": 1,
+  //           \\"endColumn\\": 47,
+  //           \\"source\\": \\"Bare strings are bad...\\",
+  //           \\"message\\": \\"Non-translated string used\\"
+  //         },
+  //         {
+  //           \\"rule\\": \\"no-html-comments\\",
+  //           \\"severity\\": 1,
+  //           \\"filePath\\": \\"app/templates/application.hbs\\",
+  //           \\"line\\": 1,
+  //           \\"column\\": 53,
+  //           \\"endLine\\": 1,
+  //           \\"endColumn\\": 79,
+  //           \\"source\\": \\"<!-- bad html comment! -->\\",
+  //           \\"message\\": \\"HTML comment detected\\",
+  //           \\"fix\\": {
+  //             \\"text\\": \\"{{! bad html comment! }}\\"
+  //           }
+  //         }
+  //       ]
+  //     }"
+  //   `);
+  //   expect(result.stderr).toBeFalsy();
+  // });
+
+  // it('should output to a file using --output-file option using custom filename', async () => {
+  //   project.setConfig({
+  //     rules: {
+  //       'no-bare-strings': true,
+  //       'no-html-comments': 'warn',
+  //     },
+  //   });
+  //   project.write({
+  //     app: {
+  //       templates: {
+  //         'application.hbs':
+  //           '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+  //       },
+  //     },
+  //   });
+
+  //   let result = await run(['.', '--format', 'json', '--output-file', 'json-output.json']);
+
+  //   expect(result.exitCode).toEqual(1);
+  //   expect(result.stdout).toMatch(/.*json-output\.json/);
+  //   expect(getOutputFileContents(result.stdout)).toMatchInlineSnapshot(`
+  //     "{
+  //       \\"app/templates/application.hbs\\": [
+  //         {
+  //           \\"rule\\": \\"no-bare-strings\\",
+  //           \\"severity\\": 2,
+  //           \\"filePath\\": \\"app/templates/application.hbs\\",
+  //           \\"line\\": 1,
+  //           \\"column\\": 4,
+  //           \\"endLine\\": 1,
+  //           \\"endColumn\\": 14,
+  //           \\"source\\": \\"Here too!!\\",
+  //           \\"message\\": \\"Non-translated string used\\"
+  //         },
+  //         {
+  //           \\"rule\\": \\"no-bare-strings\\",
+  //           \\"severity\\": 2,
+  //           \\"filePath\\": \\"app/templates/application.hbs\\",
+  //           \\"line\\": 1,
+  //           \\"column\\": 24,
+  //           \\"endLine\\": 1,
+  //           \\"endColumn\\": 47,
+  //           \\"source\\": \\"Bare strings are bad...\\",
+  //           \\"message\\": \\"Non-translated string used\\"
+  //         },
+  //         {
+  //           \\"rule\\": \\"no-html-comments\\",
+  //           \\"severity\\": 1,
+  //           \\"filePath\\": \\"app/templates/application.hbs\\",
+  //           \\"line\\": 1,
+  //           \\"column\\": 53,
+  //           \\"endLine\\": 1,
+  //           \\"endColumn\\": 79,
+  //           \\"source\\": \\"<!-- bad html comment! -->\\",
+  //           \\"message\\": \\"HTML comment detected\\",
+  //           \\"fix\\": {
+  //             \\"text\\": \\"{{! bad html comment! }}\\"
+  //           }
+  //         }
+  //       ]
+  //     }"
+  //   `);
+  //   expect(result.stderr).toBeFalsy();
+  // });
+
+  // describe('with --quiet option', function () {
+  //   it('should print valid JSON string with errors, omitting warnings', async function () {
+  //     project.setConfig({
+  //       rules: {
+  //         'no-bare-strings': true,
+  //         'no-html-comments': true,
+  //       },
+  //     });
+  //     project.write({
+  //       app: {
+  //         templates: {
+  //           'application.hbs':
+  //             '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+  //         },
+  //       },
+  //     });
+
+  //     let result = await run(['.', '--format', 'json', '--quiet']);
+
+  //     expect(result.exitCode).toEqual(1);
+  //     expect(result.stdout).toMatchInlineSnapshot(`
+  //       "{
+  //         \\"app/templates/application.hbs\\": [
+  //           {
+  //             \\"rule\\": \\"no-bare-strings\\",
+  //             \\"severity\\": 2,
+  //             \\"filePath\\": \\"app/templates/application.hbs\\",
+  //             \\"line\\": 1,
+  //             \\"column\\": 4,
+  //             \\"endLine\\": 1,
+  //             \\"endColumn\\": 14,
+  //             \\"source\\": \\"Here too!!\\",
+  //             \\"message\\": \\"Non-translated string used\\"
+  //           },
+  //           {
+  //             \\"rule\\": \\"no-bare-strings\\",
+  //             \\"severity\\": 2,
+  //             \\"filePath\\": \\"app/templates/application.hbs\\",
+  //             \\"line\\": 1,
+  //             \\"column\\": 24,
+  //             \\"endLine\\": 1,
+  //             \\"endColumn\\": 47,
+  //             \\"source\\": \\"Bare strings are bad...\\",
+  //             \\"message\\": \\"Non-translated string used\\"
+  //           },
+  //           {
+  //             \\"rule\\": \\"no-html-comments\\",
+  //             \\"severity\\": 2,
+  //             \\"filePath\\": \\"app/templates/application.hbs\\",
+  //             \\"line\\": 1,
+  //             \\"column\\": 53,
+  //             \\"endLine\\": 1,
+  //             \\"endColumn\\": 79,
+  //             \\"source\\": \\"<!-- bad html comment! -->\\",
+  //             \\"message\\": \\"HTML comment detected\\",
+  //             \\"fix\\": {
+  //               \\"text\\": \\"{{! bad html comment! }}\\"
+  //             }
+  //           }
+  //         ]
+  //       }"
+  //     `);
+  //     expect(result.stderr).toBeFalsy();
+  //   });
+
+  //   it('should exit without error and empty errors array', async function () {
+  //     project.setConfig({
+  //       rules: {
+  //         'no-html-comments': 'warn',
+  //       },
+  //     });
+  //     project.write({
+  //       app: {
+  //         templates: {
+  //           'application.hbs':
+  //             '<h2>Here too!!</h2><div>Bare strings are bad...</div><!-- bad html comment! -->',
+  //         },
+  //       },
+  //     });
+  //     let result = await run(['.', '--format', 'json', '--quiet']);
+
+  //     expect(result.exitCode).toEqual(0);
+  //     expect(result.stdout).toMatchInlineSnapshot(`
+  //       "{
+  //         \\"app/templates/application.hbs\\": []
+  //       }"
+  //     `);
+  //     expect(result.stderr).toBeFalsy();
+  //   });
+  // });
+});

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -203,6 +203,34 @@ describe('get-config', function () {
     );
   });
 
+  it('returns empty format object when no config.format is provided', async function () {
+    let actual = await getProjectConfig(project.baseDir, {
+      config: {},
+    });
+
+    expect(actual.format).toEqual({});
+  });
+
+  it('throws when invalid format property in config.format is provided', async function () {
+    await expect(
+      async () =>
+        await getProjectConfig(project.baseDir, {
+          config: {
+            format: {
+              formatters: [
+                {
+                  name: 'pretty',
+                  foo: 'bar',
+                },
+              ],
+            },
+          },
+        })
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `"An invalid \`format.formatter\` in \`.template-lintrc.js\` was provided. Unexpected property \`foo\`"`
+    );
+  });
+
   it('throws when providing wrong type for config.extends', async function () {
     await expect(
       async () =>


### PR DESCRIPTION
Creates a new multi formatter that allows you to configure, via `.template-lintrc.js`, the specific formatters you want to use.

```js
// .template-lintrc.js
{
  rules: {
    'no-bare-strings': true,
  },
  format: {
    formatters: [
      {
        name: 'pretty',
      },
      {
        name: 'json',
        outputFile: true, // outputs using default filename
      },
      {
        name: 'sarif',
        outputFile: 'my-results.sarif',
      },
    ],
  },
}
```

The format config allows you to specify the following parameters for each `formatters` entry:

- `name`: The name of the formatter. Should be either one of the default formatters (`pretty`, `json`, `sarif`) or a custom formatter (either path to a formatter, or a package name corresponding to a formatter)
- `outputFile` (optional): Either `true`, indicating the outputFile name should be auto-created, or a filename to use.