### PR TITLE
Use async `write()` instead of deprecated `writeSync()` in tests

### DIFF
--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -13,9 +13,9 @@ describe('ember-template-lint executable', function () {
 
   // Fake project
   let project;
-  beforeEach(function () {
-    project = Project.defaultSetup();
-    project.chdir();
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
+    await project.chdir();
   });
 
   afterEach(function () {
@@ -174,12 +174,12 @@ describe('ember-template-lint executable', function () {
   describe('reading files', function () {
     describe('given path to non-existing file', function () {
       it('should exit with error', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -202,12 +202,12 @@ describe('ember-template-lint executable', function () {
 
     describe('given path to single file with errors', function () {
       it('should print errors', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -226,15 +226,15 @@ describe('ember-template-lint executable', function () {
       });
 
       it('when using custom working directory', async function () {
-        process.chdir(ROOT);
+        await process.chdir(ROOT);
 
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
 
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -267,12 +267,12 @@ describe('ember-template-lint executable', function () {
 
     describe('given path to single file with custom extension with errors', function () {
       it('should print errors', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.fizzle': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -290,12 +290,12 @@ describe('ember-template-lint executable', function () {
 
     describe('given wildcard path resolving to single file', function () {
       it('should print errors', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -314,13 +314,13 @@ describe('ember-template-lint executable', function () {
       });
 
       it('when using custom working directory', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
 
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -384,12 +384,12 @@ describe('ember-template-lint executable', function () {
 
     describe('given directory path', function () {
       it('should print errors', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -416,12 +416,12 @@ describe('ember-template-lint executable', function () {
 
     describe('given path to single file without errors', function () {
       it('should exit without error and any console output', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': false,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs':
@@ -445,12 +445,12 @@ describe('ember-template-lint executable', function () {
       setupEnvVar('GITHUB_ACTIONS', null);
 
       it('should print errors', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -524,12 +524,12 @@ describe('ember-template-lint executable', function () {
 
     describe('given no path with --filename', function () {
       it('should print errors', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -558,12 +558,12 @@ describe('ember-template-lint executable', function () {
       }
 
       it('should print errors', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -591,12 +591,12 @@ describe('ember-template-lint executable', function () {
       }
 
       it('should print errors', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -620,13 +620,13 @@ describe('ember-template-lint executable', function () {
 
   describe('errors and warnings formatting', function () {
     it('should be able run a rule passed in (rule:warn)', async function () {
-      project.setConfig({
+      await project.setConfig({
         rules: {
           'no-bare-strings': true,
           'no-html-comments': true,
         },
       });
-      project.write({
+      await project.write({
         app: {
           templates: {
             'application.hbs':
@@ -648,13 +648,13 @@ describe('ember-template-lint executable', function () {
     });
 
     it('should be able run a rule passed in (rule:error)', async function () {
-      project.setConfig({
+      await project.setConfig({
         rules: {
           'no-bare-strings': true,
           'no-html-comments': true,
         },
       });
-      project.write({
+      await project.write({
         app: {
           templates: {
             'application.hbs':
@@ -676,13 +676,13 @@ describe('ember-template-lint executable', function () {
     });
 
     it('should be able run a rule passed in (rule:[warn, config])', async function () {
-      project.setConfig({
+      await project.setConfig({
         rules: {
           'no-bare-strings': true,
           'no-html-comments': true,
         },
       });
-      project.write({
+      await project.write({
         app: {
           templates: {
             'application.hbs':
@@ -709,13 +709,13 @@ describe('ember-template-lint executable', function () {
     });
 
     it('should be able run a rule passed in (rule:[error, config])', async function () {
-      project.setConfig({
+      await project.setConfig({
         rules: {
           'no-bare-strings': true,
           'no-html-comments': true,
         },
       });
-      project.write({
+      await project.write({
         app: {
           templates: {
             'application.hbs':
@@ -743,13 +743,13 @@ describe('ember-template-lint executable', function () {
 
     describe('with/without --ignore-pattern', function () {
       it('should respect dirs ignored by default', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
             'no-html-comments': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             dist: {
               'application.hbs':
@@ -767,13 +767,13 @@ describe('ember-template-lint executable', function () {
       });
 
       it('should allow to pass custom ignore pattern', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
             'no-html-comments': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             foo: {
               'application.hbs':
@@ -801,12 +801,12 @@ describe('ember-template-lint executable', function () {
       });
 
       it('should fail when no files match because of ignore pattern', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             foo: {
               'application.hbs': 'Bare strings are bad',
@@ -822,13 +822,13 @@ describe('ember-template-lint executable', function () {
       });
 
       it('should allow to disable dirs ignored by default', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': true,
             'no-html-comments': true,
           },
         });
-        project.write({
+        await project.write({
           app: {
             dist: {
               'application.hbs':
@@ -889,12 +889,12 @@ describe('ember-template-lint executable', function () {
 
       describe('given a working-directory with errors and a lintrc with rules', function () {
         it('should print properly formatted error messages', async function () {
-          project.setConfig({
+          await project.setConfig({
             rules: {
               'no-bare-strings': false,
             },
           });
-          project.write({
+          await project.write({
             app: {
               templates: {
                 'application.hbs':
@@ -932,12 +932,12 @@ describe('ember-template-lint executable', function () {
 
       describe('given a directory with errors and a lintrc with rules', function () {
         it('should print properly formatted error messages', async function () {
-          project.setConfig({
+          await project.setConfig({
             rules: {
               'no-bare-strings': false,
             },
           });
-          project.write({
+          await project.write({
             app: {
               templates: {
                 'application.hbs':
@@ -963,12 +963,12 @@ describe('ember-template-lint executable', function () {
 
       describe('given a directory with errors but a lintrc without any rules', function () {
         it('should exit without error and any console output', async function () {
-          project.setConfig({
+          await project.setConfig({
             rules: {
               'no-bare-strings': true,
             },
           });
-          project.write({
+          await project.write({
             app: {
               templates: {
                 'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
@@ -991,13 +991,13 @@ describe('ember-template-lint executable', function () {
 
     describe('with --max-warnings param', function () {
       it('should exit with error if warning count is greater than max-warnings', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': 'warn',
             'no-html-comments': 'warn',
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs':
@@ -1013,13 +1013,13 @@ describe('ember-template-lint executable', function () {
       });
 
       it('should exit without error if warning count is less or equal to max-warnings', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': 'warn',
             'no-html-comments': 'warn',
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs':
@@ -1043,13 +1043,13 @@ describe('ember-template-lint executable', function () {
       });
 
       it('should exit with error if error count is greater than zero regardless of max-warnings', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': 'warn',
             'no-html-comments': 'error',
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs':
@@ -1067,7 +1067,7 @@ describe('ember-template-lint executable', function () {
 
     describe('with --print-config option', function () {
       it('should error if more than one file passed to --print-config', async function () {
-        project.write({
+        await project.write({
           app: {
             templates: {
               components: {
@@ -1091,13 +1091,13 @@ describe('ember-template-lint executable', function () {
       });
 
       it('should print config for file', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': 'warn',
             'no-html-comments': 'error',
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs':
@@ -1133,12 +1133,12 @@ describe('ember-template-lint executable', function () {
 
     describe('with --max-warnings and --quiet param', function () {
       it('should exit without error if warning count is more than max-warnings', async function () {
-        project.setConfig({
+        await project.setConfig({
           rules: {
             'no-bare-strings': 'warn',
           },
         });
-        project.write({
+        await project.write({
           app: {
             templates: {
               'application.hbs': '<h2>Here too!!</h2><div>Bare strings are bad...</div>',
@@ -1158,8 +1158,8 @@ describe('ember-template-lint executable', function () {
   describe('autofixing files', function () {
     it('should write fixed file to fs', async function () {
       let config = { rules: { 'require-button-type': true } };
-      project.setConfig(config);
-      project.write({ 'require-button-type.hbs': '<button>Klikk</button>' });
+      await project.setConfig(config);
+      await project.write({ 'require-button-type.hbs': '<button>Klikk</button>' });
 
       let result = await run(['.', '--fix']);
 

--- a/test/acceptance/editors-integration-test.js
+++ b/test/acceptance/editors-integration-test.js
@@ -23,9 +23,9 @@ describe('editors integration', function () {
 
   // Fake project
   let project;
-  beforeEach(function () {
-    project = Project.defaultSetup();
-    project.chdir();
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
+    await project.chdir();
   });
 
   afterEach(function () {

--- a/test/acceptance/formatters/custom-formatters-test.js
+++ b/test/acceptance/formatters/custom-formatters-test.js
@@ -9,9 +9,9 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 describe('custom formatters', () => {
   let project;
-  beforeEach(function () {
-    project = Project.defaultSetup();
-    project.chdir();
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
+    await project.chdir();
   });
 
   afterEach(function () {

--- a/test/acceptance/formatters/json-test.js
+++ b/test/acceptance/formatters/json-test.js
@@ -4,13 +4,13 @@ const ROOT = process.cwd();
 
 describe('JSON formatter', () => {
   let project;
-  beforeEach(function () {
-    project = Project.defaultSetup();
-    project.chdir();
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
+    await project.chdir();
   });
 
-  afterEach(function () {
-    process.chdir(ROOT);
+  afterEach(async function () {
+    await process.chdir(ROOT);
     project.dispose();
   });
 

--- a/test/acceptance/formatters/multi-test.js
+++ b/test/acceptance/formatters/multi-test.js
@@ -6,13 +6,13 @@ describe('multi formatter', () => {
   setupEnvVar('FORCE_COLOR', '0');
 
   let project;
-  beforeEach(function () {
-    project = Project.defaultSetup();
-    project.chdir();
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
+    await project.chdir();
   });
 
-  afterEach(function () {
-    process.chdir(ROOT);
+  afterEach(async function () {
+    await process.chdir(ROOT);
     project.dispose();
   });
 

--- a/test/acceptance/formatters/pretty-test.js
+++ b/test/acceptance/formatters/pretty-test.js
@@ -10,13 +10,13 @@ describe('pretty formatter', () => {
   setupEnvVar('FORCE_COLOR', '0');
 
   let project;
-  beforeEach(function () {
-    project = Project.defaultSetup();
-    project.chdir();
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
+    await project.chdir();
   });
 
-  afterEach(function () {
-    process.chdir(ROOT);
+  afterEach(async function () {
+    await process.chdir(ROOT);
     project.dispose();
   });
 

--- a/test/acceptance/formatters/sarif-test.js
+++ b/test/acceptance/formatters/sarif-test.js
@@ -243,13 +243,13 @@ function getFixture(fixtureName) {
 describe('SARIF formatter', () => {
   let project;
 
-  beforeEach(function () {
-    project = Project.defaultSetup();
-    project.chdir();
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
+    await project.chdir();
   });
 
-  afterEach(function () {
-    process.chdir(ROOT);
+  afterEach(async function () {
+    await process.chdir(ROOT);
     project.dispose();
   });
 

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -103,7 +103,7 @@ describe('public api', function () {
       project.files['some-other-path.js'] = `module.exports = ${JSON.stringify(
         someOtherPathConfig
       )};`;
-      project.writeSync();
+      await project.write();
 
       let linter = new Linter({
         console: mockConsole,

--- a/test/acceptance/stdin-by-platform-test.js
+++ b/test/acceptance/stdin-by-platform-test.js
@@ -14,20 +14,20 @@ describe('ember-template-lint executable', function () {
 
   // Fake project
   let project;
-  beforeEach(function () {
-    project = Project.defaultSetup();
-    project.setConfig({
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
+    await project.setConfig({
       rules: {
         'no-bare-strings': true,
       },
     });
-    project.write({
+    await project.write({
       'template.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
       components: {
         'foo.hbs': '{{fooData}}',
       },
     });
-    project.chdir();
+    await project.chdir();
   });
 
   afterEach(function () {

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -19,9 +19,9 @@ describe('todo usage', () => {
 
   // Fake project
   let project;
-  beforeEach(function () {
-    project = Project.defaultSetup();
-    project.chdir();
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
+    await project.chdir();
   });
 
   afterEach(function () {

--- a/test/helpers/fake-project.js
+++ b/test/helpers/fake-project.js
@@ -38,7 +38,7 @@ module.exports = {
 `;
 
 export default class FakeProject extends Project {
-  static defaultSetup() {
+  static async defaultSetup() {
     let project = new this();
 
     project.files = {
@@ -46,15 +46,13 @@ export default class FakeProject extends Project {
       '.editorconfig': DEFAULT_EDITOR_CONFIG,
     };
 
-    project.writeSync();
+    await project.write();
 
     return project;
   }
 
   constructor(name = 'fake-project', ...args) {
     super(name, ...args);
-
-    this.writeSync();
   }
 
   setConfig(config) {
@@ -65,7 +63,7 @@ export default class FakeProject extends Project {
 
     this.files['.template-lintrc.js'] = configFileContents;
 
-    this.writeSync();
+    return this.write();
   }
 
   async getConfig() {
@@ -76,7 +74,7 @@ export default class FakeProject extends Project {
   setEditorConfig(value = DEFAULT_EDITOR_CONFIG) {
     this.files['.editorconfig'] = value;
 
-    this.writeSync();
+    return this.write();
   }
 
   path(subPath) {
@@ -86,7 +84,7 @@ export default class FakeProject extends Project {
   // behave like a TempDir from broccoli-test-helper
   write(dirJSON) {
     this.files = { ...this.files, ...dirJSON };
-    this.writeSync();
+    return super.write();
   }
 
   setShorthandPackageJsonTodoConfig(daysToDecay) {
@@ -96,7 +94,7 @@ export default class FakeProject extends Project {
       },
     });
 
-    this.writeSync();
+    return this.write();
   }
 
   setPackageJsonTodoConfig(daysToDecay, daysToDecayByRule) {
@@ -114,7 +112,7 @@ export default class FakeProject extends Project {
 
     this.pkg = Object.assign({}, this.pkg, todoConfig);
 
-    this.writeSync();
+    return this.write();
   }
 
   setLintTodorc(daysToDecay, daysToDecayByRule) {
@@ -133,11 +131,11 @@ export default class FakeProject extends Project {
     });
   }
 
-  chdir() {
+  async chdir() {
     this._dirChanged = true;
 
     // ensure the directory structure is created initially
-    this.writeSync();
+    await this.write();
 
     process.chdir(this.baseDir);
   }

--- a/test/unit/base-plugin-test.js
+++ b/test/unit/base-plugin-test.js
@@ -16,8 +16,8 @@ const ruleNames = Object.keys(rules);
 
 describe('base plugin', function () {
   let project, editorConfigResolver;
-  beforeEach(() => {
-    project = Project.defaultSetup();
+  beforeEach(async () => {
+    project = await Project.defaultSetup();
 
     editorConfigResolver = new EditorConfigResolver(project.baseDir);
     editorConfigResolver.resolveEditorConfigFiles();

--- a/test/unit/bin/expand-file-globs-test.js
+++ b/test/unit/bin/expand-file-globs-test.js
@@ -4,8 +4,8 @@ import Project from '../../helpers/fake-project.js';
 describe('expandFileGlobs', function () {
   let project = null;
 
-  beforeEach(function () {
-    project = Project.defaultSetup();
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
   });
 
   afterEach(function () {

--- a/test/unit/bin/get-files-to-lint-test.js
+++ b/test/unit/bin/get-files-to-lint-test.js
@@ -6,10 +6,10 @@ const STDIN = '/dev/stdin';
 describe('getFilesToLint', function () {
   let project = null;
 
-  beforeEach(function () {
-    project = Project.defaultSetup();
-    project.chdir();
-    project.write({ 'application.hbs': 'almost empty', 'other.hbs': 'ZOMG' });
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
+    await project.chdir();
+    await project.write({ 'application.hbs': 'almost empty', 'other.hbs': 'ZOMG' });
   });
 
   afterEach(function () {

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -11,8 +11,9 @@ import Project from '../helpers/fake-project.js';
 describe('get-config', function () {
   let project = null;
 
-  beforeEach(function () {
+  beforeEach(async function () {
     project = new Project();
+    await project.write();
   });
 
   afterEach(function () {
@@ -152,7 +153,7 @@ describe('get-config', function () {
     project.files['some-other-path.js'] = `module.exports = ${JSON.stringify(
       someOtherPathConfig
     )};`;
-    project.writeSync();
+    await project.write();
 
     let actual = await getProjectConfig(project.baseDir, {
       configPath: project.path('some-other-path.js'),
@@ -707,7 +708,7 @@ describe('determineRuleConfig', function () {
 
 describe('resolveProjectConfig', function () {
   it('should return an empty object when options.configPath is set explicitly false', async function () {
-    let project = Project.defaultSetup();
+    let project = await Project.defaultSetup();
 
     try {
       const config = await resolveProjectConfig(project.baseDir, { configPath: false });
@@ -719,12 +720,12 @@ describe('resolveProjectConfig', function () {
   });
 
   it('should search for config relative to the specified working directory', async function () {
-    let project1 = Project.defaultSetup();
-    let project2 = Project.defaultSetup();
+    let project1 = await Project.defaultSetup();
+    let project2 = await Project.defaultSetup();
 
-    project1.chdir();
+    await project1.chdir();
 
-    project2.setConfig({
+    await project2.setConfig({
       extends: 'foo',
     });
 
@@ -744,8 +745,8 @@ describe('resolveProjectConfig', function () {
 describe('getProjectConfig', function () {
   let project = null;
 
-  beforeEach(function () {
-    project = Project.defaultSetup();
+  beforeEach(async function () {
+    project = await Project.defaultSetup();
   });
 
   afterEach(function () {


### PR DESCRIPTION
Currently, when running tests you are flooded with deprecation warnings that `project.writeSync()` should not be used anymore.
This PR refactors all test usage to use async `project.write()` instead.

```
    console.warn
      this method is deprecated, please use write instead

      66 |     this.files['.template-lintrc.js'] = configFileContents;
      67 |
    > 68 |     this.writeSync();
         |          ^
      69 |   }
      70 |
      71 |   async getConfig() {

      at FakeProject.writeSync (node_modules/fixturify-project/index.js:203:17)
      at FakeProject.setConfig (test/helpers/fake-project.js:68:10)
      at Object.<anonymous> (test/acceptance/cli-test.js:1161:15)
```