### PR TITLE
Handle dashes in `no-whitespace-within-word` rule

### DIFF
--- a/lib/rules/no-whitespace-within-word.js
+++ b/lib/rules/no-whitespace-within-word.js
@@ -57,8 +57,10 @@ const whitespaceCharacterList = new Set([
   '&ic;',
 ]);
 
-function isWhitespace(char) {
-  return whitespaceCharacterList.has(char);
+const allowedSeparatorList = new Set(['-', '&#45;', '—', '&mdash;', '–', '&ndash;', '&minus;']);
+
+function isWhitespaceOrAllowedSeparator(char) {
+  return whitespaceCharacterList.has(char) || allowedSeparatorList.has(char);
 }
 
 function splitTextByEntity(input) {
@@ -123,8 +125,10 @@ export default class NoWhitespaceWithinWord extends Rule {
           let previousChar = i > 0 ? characters[i - 1] : undefined;
 
           if (
-            (isWhitespace(currentChar) && !isWhitespace(previousChar)) ||
-            (!isWhitespace(currentChar) && isWhitespace(previousChar))
+            (isWhitespaceOrAllowedSeparator(currentChar) &&
+              !isWhitespaceOrAllowedSeparator(previousChar)) ||
+            (!isWhitespaceOrAllowedSeparator(currentChar) &&
+              isWhitespaceOrAllowedSeparator(previousChar))
           ) {
             alternationCount++;
           } else {

--- a/test/unit/rules/no-whitespace-within-word-test.js
+++ b/test/unit/rules/no-whitespace-within-word-test.js
@@ -8,6 +8,7 @@ generateRuleTests({
 
   good: [
     'Welcome',
+    'Hey - I like this!',
     'It is possible to get some examples of in-word emph a sis past this rule.',
     'However, I do not want a rule that flags annoying false positives for correctly-used single-character words.',
     '<div>Welcome</div>',


### PR DESCRIPTION
This allows the following:

```
Hello - I like this
```

So basically, it considers dashes as "whitespace" for the purpose of this rule, instead of as characters/

Closes https://github.com/ember-template-lint/ember-template-lint/issues/2420