### PR TITLE
feat:  adds `allowHTMLCharacters` configuration property for `no-bare-strings` rule

### DIFF
--- a/docs/rule/no-bare-strings.md
+++ b/docs/rule/no-bare-strings.md
@@ -27,6 +27,7 @@ This rule **allows** the following:
   * `allowlist` -- An array of allowlisted strings (extends the default config)
   * `globalAttributes` -- An array of attributes to check on every element (extends the default config)
   * `elementAttributes` -- An object whose keys are tag names and value is an array of attributes to check for that tag name (extends the default config)
+  * `allowHTMLCharacters` -- A boolean to allow all characters defined by [`tildeio/simple-html-tokenizer`](https://github.com/tildeio/simple-html-tokenizer/blob/15b1d6e7a825e68fe7a68a7080e272c374adbc27/src/generated/html5-named-char-refs.ts) to extend the `DEFAULT_CONFIG.allowlist` and provided `allowlist`.
 
 When the config value of `true` is provided, the following default configuration is used:
 

--- a/lib/rules/no-bare-strings.js
+++ b/lib/rules/no-bare-strings.js
@@ -1,6 +1,10 @@
+import { HTML5NamedCharRefs } from 'simple-html-tokenizer';
+
 import createErrorMessage from '../helpers/create-error-message.js';
 import { match } from '../helpers/node-matcher.js';
 import Rule from './_base.js';
+
+const HTML_CHARACTERS = Object.values(HTML5NamedCharRefs);
 
 const DEFAULT_GLOBAL_ATTRIBUTES = [
   'title',
@@ -165,7 +169,11 @@ export default class NoBareStrings extends Rule {
           };
         } else if (isValidConfigObjectFormat(config)) {
           return {
-            allowlist: [...sanitizeConfigArray(config.allowlist), ...DEFAULT_ALLOWLIST],
+            allowlist: [
+              ...(config.allowHTMLCharacters ? HTML_CHARACTERS : []),
+              ...sanitizeConfigArray(config.allowlist),
+              ...DEFAULT_ALLOWLIST,
+            ],
             globalAttributes: [...(config.globalAttributes || []), ...DEFAULT_GLOBAL_ATTRIBUTES],
             elementAttributes: mergeObjects(config.elementAttributes, DEFAULT_ELEMENT_ATTRIBUTES),
           };

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "is-glob": "^4.0.3",
     "micromatch": "^4.0.4",
     "resolve": "^1.22.0",
+    "simple-html-tokenizer": "^0.5.11",
     "v8-compile-cache": "^2.3.0",
     "yargs": "^17.3.1"
   },

--- a/test/unit/rules/no-bare-strings-test.js
+++ b/test/unit/rules/no-bare-strings-test.js
@@ -37,6 +37,14 @@ generateRuleTests({
       template: '& &times;',
     },
     {
+      config: { allowHTMLCharacters: true },
+      template: '&times;',
+    },
+    {
+      config: { allowHTMLCharacters: true, allowlist: ['strange'] },
+      template: 'strange &times;',
+    },
+    {
       config: { allowlist: ['howdy'] },
       template: 'howdy',
     },


### PR DESCRIPTION
A more in-depth pass at #2422 implementing the functionality described in https://github.com/ember-template-lint/ember-template-lint/issues/1131.