### PR TITLE
Fixes require-presentational-children to return correct line/column of node

### DIFF
--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -95,11 +95,8 @@ export default class RequirePresentationalChildren extends Rule {
           // If it's not a non semantic tag, it's semantic
           if (!NON_SEMANTIC_TAGS.has(child.tag)) {
             this.log({
-              node,
+              node: child,
               message: createErrorMessage(node, roleAttrValue, child),
-              line: node.loc && node.loc.start.line,
-              column: node.loc && node.loc.start.column,
-              source: this.sourceForNode(node),
             });
           }
         }

--- a/test/unit/rules/require-presentational-children-test.js
+++ b/test/unit/rules/require-presentational-children-test.js
@@ -34,15 +34,15 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 38,
+              "column": 19,
+              "endColumn": 32,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
               "message": "<div> has a role of button, it cannot have semantic descendants like <h2>",
               "rule": "require-presentational-children",
               "severity": 2,
-              "source": "<div role=\\"button\\"><h2>Test</h2></div>",
+              "source": "<h2>Test</h2>",
             },
           ]
         `);
@@ -54,15 +54,15 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 61,
+              "column": 43,
+              "endColumn": 50,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
               "message": "<div> has a role of button, it cannot have semantic descendants like <img>",
               "rule": "require-presentational-children",
               "severity": 2,
-              "source": "<div role=\\"button\\"><h2 role=\\"presentation\\"><img /></h2></div>",
+              "source": "<img />",
             },
           ]
         `);
@@ -76,26 +76,26 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 82,
+              "column": 43,
+              "endColumn": 71,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
               "message": "<div> has a role of button, it cannot have semantic descendants like <button>",
               "rule": "require-presentational-children",
               "severity": 2,
-              "source": "<div role=\\"button\\"><h2 role=\\"presentation\\"><button>Test <img/></button></h2></div>",
+              "source": "<button>Test <img/></button>",
             },
             {
-              "column": 0,
-              "endColumn": 82,
+              "column": 56,
+              "endColumn": 62,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
               "message": "<div> has a role of button, it cannot have semantic descendants like <img>",
               "rule": "require-presentational-children",
               "severity": 2,
-              "source": "<div role=\\"button\\"><h2 role=\\"presentation\\"><button>Test <img/></button></h2></div>",
+              "source": "<img/>",
             },
           ]
         `);


### PR DESCRIPTION
Fixes: #2333 