### PR TITLE
Extract `hasParentTag` utility function

### DIFF
--- a/lib/helpers/has-parent-tag.js
+++ b/lib/helpers/has-parent-tag.js
@@ -1,0 +1,11 @@
+import { match } from './node-matcher.js';
+
+export default function hasParentTag(path, tag) {
+  let parents = [...path.parents()];
+  let refParentNode = {
+    tag,
+    type: 'ElementNode',
+  };
+  let hasHeadElementInParentPath = parents.some((parent) => match(parent.node, refParentNode));
+  return Boolean(hasHeadElementInParentPath);
+}

--- a/lib/rules/require-button-type.js
+++ b/lib/rules/require-button-type.js
@@ -5,11 +5,11 @@ import Rule from './_base.js';
 
 const ERROR_MESSAGE = 'All `<button>` elements should have a valid `type` attribute';
 
-function hasFormParent(path) {
+function hasParentTag(path, tag) {
   let parents = [...path.parents()];
   let refParentNode = {
+    tag,
     type: 'ElementNode',
-    tag: 'form',
   };
   let hasHeadElementInParentPath = parents.some((parent) => match(parent.node, refParentNode));
   return Boolean(hasHeadElementInParentPath);
@@ -35,7 +35,7 @@ export default class RequireButtonType extends Rule {
         let typeAttribute = attributes.find((it) => it.name === 'type');
         if (!typeAttribute) {
           if (this.mode === 'fix') {
-            if (hasFormParent(path)) {
+            if (hasParentTag(path, 'form')) {
               attributes.push(b.attr('type', b.text('submit')));
             } else {
               attributes.push(b.attr('type', b.text('button')));

--- a/lib/rules/require-button-type.js
+++ b/lib/rules/require-button-type.js
@@ -1,19 +1,10 @@
 import { builders as b } from 'ember-template-recast';
 
-import { match } from '../helpers/node-matcher.js';
+import hasParentTag from '../helpers/has-parent-tag.js';
 import Rule from './_base.js';
 
 const ERROR_MESSAGE = 'All `<button>` elements should have a valid `type` attribute';
 
-function hasParentTag(path, tag) {
-  let parents = [...path.parents()];
-  let refParentNode = {
-    tag,
-    type: 'ElementNode',
-  };
-  let hasHeadElementInParentPath = parents.some((parent) => match(parent.node, refParentNode));
-  return Boolean(hasHeadElementInParentPath);
-}
 export default class RequireButtonType extends Rule {
   logNode({ node, message }) {
     return this.log({


### PR DESCRIPTION
The `hasFormParent` function only exists in the `lib/rules/require-button-type.js` rule file.

We want to be able to reuse it in other rule, so we are extracting it in a more generic version.

_FYI it will soon be used to complete [this rule](https://github.com/ember-template-lint/ember-template-lint/pull/1931)._