### PR TITLE
Add CLI option `--no-error-on-unmatched-pattern`

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -173,9 +173,13 @@ async function run() {
   try {
     filePaths = getFilesToLint(options.workingDirectory, positional, options.ignorePattern);
   } catch (error) {
-    console.error(error.message);
-    process.exitCode = 1;
-    return;
+    if (error.name === 'NoMatchingFilesError' && options.errorOnUnmatchedPattern === false) {
+      return;
+    } else {
+      console.error(error.message);
+      process.exitCode = 1;
+      return;
+    }
   }
 
   if (options.printConfig) {

--- a/lib/helpers/cli.js
+++ b/lib/helpers/cli.js
@@ -12,6 +12,13 @@ import camelize from './camelize.js';
 
 const STDIN = '/dev/stdin';
 
+class NoMatchingFilesError extends Error {
+  constructor(...params) {
+    super(...params);
+    this.name = 'NoMatchingFilesError';
+  }
+}
+
 export function parseArgv(_argv) {
   const specifiedOptions = {
     'config-path': {
@@ -113,6 +120,10 @@ export function parseArgv(_argv) {
       describe: 'Number of warnings to trigger nonzero exit code',
       type: 'number',
     },
+    'no-error-on-unmatched-pattern': {
+      describe: 'Prevent errors when pattern is unmatched',
+      boolean: true,
+    },
   };
 
   let parser = yargs()
@@ -171,7 +182,7 @@ export function expandFileGlobs(workingDir, filePatterns, ignorePattern, glob = 
 
     const globResults = glob(workingDir, pattern, ignorePattern);
     if (!globResults || globResults.length === 0) {
-      throw new Error(`No files matching the pattern were found: "${pattern}"`);
+      throw new NoMatchingFilesError(`No files matching the pattern were found: "${pattern}"`);
     }
 
     for (const filePath of globResults) {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -35,52 +35,56 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path               Define a custom config path
+            --config-path                    Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config                    Define a custom configuration to be used - (e.g.
-                                        '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
-                                                                                  [string]
-            --quiet                     Ignore warnings and only show errors     [boolean]
-            --rule                      Specify a rule and its severity to add that rule t
-                                        o loaded rules - (e.g. \`no-implicit-this:error\` or
-                                         \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
-                                                                                  [string]
-            --filename                  Used to indicate the filename to be assumed for co
-                                        ntents from STDIN                         [string]
-            --fix                       Fix any errors that are reported as fixable
+            --config                         Define a custom configuration to be used - (
+                                             e.g. '{ \\"rules\\": { \\"no-implicit-this\\": \\"erro
+                                             r\\" } }')                             [string]
+            --quiet                          Ignore warnings and only show errors[boolean]
+            --rule                           Specify a rule and its severity to add that r
+                                             ule to loaded rules - (e.g. \`no-implicit-this
+                                             :error\` or \`rule:[\\"error\\", { \\"allow\\": [\\"some-
+                                             helper\\"] }]\`)                        [string]
+            --filename                       Used to indicate the filename to be assumed f
+                                             or contents from STDIN               [string]
+            --fix                            Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --format                    Specify format to be used in printing output
+            --format                         Specify format to be used in printing output
                                                               [string] [default: \\"pretty\\"]
-            --output-file               Specify file to write report to           [string]
-            --verbose                   Output errors with source description    [boolean]
-            --working-directory, --cwd  Path to a directory that should be considered as t
-                                        he current working directory.
+            --output-file                    Specify file to write report to      [string]
+            --verbose                        Output errors with source description
+                                                                                 [boolean]
+            --working-directory, --cwd       Path to a directory that should be considered
+                                              as the current working directory.
                                                                    [string] [default: \\".\\"]
-            --no-config-path            Does not use the local template-lintrc, will use a
-                                         blank template-lintrc instead           [boolean]
-            --update-todo               Update list of linting todos by transforming lint
-                                        errors to todos         [boolean] [default: false]
-            --include-todo              Include todos in the results
+            --no-config-path                 Does not use the local template-lintrc, will
+                                             use a blank template-lintrc instead [boolean]
+            --update-todo                    Update list of linting todos by transforming
+                                             lint errors to todos
                                                                 [boolean] [default: false]
-            --clean-todo                Remove expired and invalid todo files
+            --include-todo                   Include todos in the results
+                                                                [boolean] [default: false]
+            --clean-todo                     Remove expired and invalid todo files
                                                                  [boolean] [default: true]
-            --compact-todo              Compacts the .lint-todo storage file, removing ext
-                                        raneous todos                            [boolean]
-            --todo-days-to-warn         Number of days after its creation date that a todo
-                                         transitions into a warning               [number]
-            --todo-days-to-error        Number of days after its creation date that a todo
-                                         transitions into an error                [number]
-            --ignore-pattern            Specify custom ignore pattern (can be disabled wit
-                                        h --no-ignore-pattern)
+            --compact-todo                   Compacts the .lint-todo storage file, removin
+                                             g extraneous todos                  [boolean]
+            --todo-days-to-warn              Number of days after its creation date that a
+                                              todo transitions into a warning     [number]
+            --todo-days-to-error             Number of days after its creation date that a
+                                              todo transitions into an error      [number]
+            --ignore-pattern                 Specify custom ignore pattern (can be disable
+                                             d with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --no-inline-config          Prevent inline configuration comments from changin
-                                        g config or rules                        [boolean]
-            --print-config              Print the configuration for the given file
+            --no-inline-config               Prevent inline configuration comments from ch
+                                             anging config or rules              [boolean]
+            --print-config                   Print the configuration for the given file
                                                                 [boolean] [default: false]
-            --max-warnings              Number of warnings to trigger nonzero exit code
-                                                                                  [number]
-            --help                      Show help                                [boolean]
-            --version                   Show version number                      [boolean]"
+            --max-warnings                   Number of warnings to trigger nonzero exit co
+                                             de                                   [number]
+            --no-error-on-unmatched-pattern  Prevent errors when pattern is unmatched
+                                                                                 [boolean]
+            --help                           Show help                           [boolean]
+            --version                        Show version number                 [boolean]"
         `);
       });
     });
@@ -94,52 +98,56 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path               Define a custom config path
+            --config-path                    Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config                    Define a custom configuration to be used - (e.g.
-                                        '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
-                                                                                  [string]
-            --quiet                     Ignore warnings and only show errors     [boolean]
-            --rule                      Specify a rule and its severity to add that rule t
-                                        o loaded rules - (e.g. \`no-implicit-this:error\` or
-                                         \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
-                                                                                  [string]
-            --filename                  Used to indicate the filename to be assumed for co
-                                        ntents from STDIN                         [string]
-            --fix                       Fix any errors that are reported as fixable
+            --config                         Define a custom configuration to be used - (
+                                             e.g. '{ \\"rules\\": { \\"no-implicit-this\\": \\"erro
+                                             r\\" } }')                             [string]
+            --quiet                          Ignore warnings and only show errors[boolean]
+            --rule                           Specify a rule and its severity to add that r
+                                             ule to loaded rules - (e.g. \`no-implicit-this
+                                             :error\` or \`rule:[\\"error\\", { \\"allow\\": [\\"some-
+                                             helper\\"] }]\`)                        [string]
+            --filename                       Used to indicate the filename to be assumed f
+                                             or contents from STDIN               [string]
+            --fix                            Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --format                    Specify format to be used in printing output
+            --format                         Specify format to be used in printing output
                                                               [string] [default: \\"pretty\\"]
-            --output-file               Specify file to write report to           [string]
-            --verbose                   Output errors with source description    [boolean]
-            --working-directory, --cwd  Path to a directory that should be considered as t
-                                        he current working directory.
+            --output-file                    Specify file to write report to      [string]
+            --verbose                        Output errors with source description
+                                                                                 [boolean]
+            --working-directory, --cwd       Path to a directory that should be considered
+                                              as the current working directory.
                                                                    [string] [default: \\".\\"]
-            --no-config-path            Does not use the local template-lintrc, will use a
-                                         blank template-lintrc instead           [boolean]
-            --update-todo               Update list of linting todos by transforming lint
-                                        errors to todos         [boolean] [default: false]
-            --include-todo              Include todos in the results
+            --no-config-path                 Does not use the local template-lintrc, will
+                                             use a blank template-lintrc instead [boolean]
+            --update-todo                    Update list of linting todos by transforming
+                                             lint errors to todos
                                                                 [boolean] [default: false]
-            --clean-todo                Remove expired and invalid todo files
+            --include-todo                   Include todos in the results
+                                                                [boolean] [default: false]
+            --clean-todo                     Remove expired and invalid todo files
                                                                  [boolean] [default: true]
-            --compact-todo              Compacts the .lint-todo storage file, removing ext
-                                        raneous todos                            [boolean]
-            --todo-days-to-warn         Number of days after its creation date that a todo
-                                         transitions into a warning               [number]
-            --todo-days-to-error        Number of days after its creation date that a todo
-                                         transitions into an error                [number]
-            --ignore-pattern            Specify custom ignore pattern (can be disabled wit
-                                        h --no-ignore-pattern)
+            --compact-todo                   Compacts the .lint-todo storage file, removin
+                                             g extraneous todos                  [boolean]
+            --todo-days-to-warn              Number of days after its creation date that a
+                                              todo transitions into a warning     [number]
+            --todo-days-to-error             Number of days after its creation date that a
+                                              todo transitions into an error      [number]
+            --ignore-pattern                 Specify custom ignore pattern (can be disable
+                                             d with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --no-inline-config          Prevent inline configuration comments from changin
-                                        g config or rules                        [boolean]
-            --print-config              Print the configuration for the given file
+            --no-inline-config               Prevent inline configuration comments from ch
+                                             anging config or rules              [boolean]
+            --print-config                   Print the configuration for the given file
                                                                 [boolean] [default: false]
-            --max-warnings              Number of warnings to trigger nonzero exit code
-                                                                                  [number]
-            --help                      Show help                                [boolean]
-            --version                   Show version number                      [boolean]"
+            --max-warnings                   Number of warnings to trigger nonzero exit co
+                                             de                                   [number]
+            --no-error-on-unmatched-pattern  Prevent errors when pattern is unmatched
+                                                                                 [boolean]
+            --help                           Show help                           [boolean]
+            --version                        Show version number                 [boolean]"
         `);
       });
     });
@@ -197,6 +205,35 @@ describe('ember-template-lint executable', function () {
         expect(result.stderr).toEqual(
           'No files matching the pattern were found: "app/templates/application-1.hbs"'
         );
+      });
+    });
+
+    describe('given --no-error-on-unmatched-pattern flag and a path to non-existing file', function () {
+      it('should exit without an error', async function () {
+        await project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        await project.write({
+          app: {
+            templates: {
+              'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+              components: {
+                'foo.hbs': '{{fooData}}',
+              },
+            },
+          },
+        });
+
+        let result = await run([
+          '--no-error-on-unmatched-pattern',
+          'app/templates/application-1.hbs',
+        ]);
+
+        expect(result.exitCode).toEqual(0);
+        expect(result.stdout).toBeFalsy();
+        expect(result.stderr).toBeFalsy();
       });
     });
 
@@ -472,52 +509,56 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path               Define a custom config path
+            --config-path                    Define a custom config path
                                                  [string] [default: \\".template-lintrc.js\\"]
-            --config                    Define a custom configuration to be used - (e.g.
-                                        '{ \\"rules\\": { \\"no-implicit-this\\": \\"error\\" } }')
-                                                                                  [string]
-            --quiet                     Ignore warnings and only show errors     [boolean]
-            --rule                      Specify a rule and its severity to add that rule t
-                                        o loaded rules - (e.g. \`no-implicit-this:error\` or
-                                         \`rule:[\\"error\\", { \\"allow\\": [\\"some-helper\\"] }]\`)
-                                                                                  [string]
-            --filename                  Used to indicate the filename to be assumed for co
-                                        ntents from STDIN                         [string]
-            --fix                       Fix any errors that are reported as fixable
+            --config                         Define a custom configuration to be used - (
+                                             e.g. '{ \\"rules\\": { \\"no-implicit-this\\": \\"erro
+                                             r\\" } }')                             [string]
+            --quiet                          Ignore warnings and only show errors[boolean]
+            --rule                           Specify a rule and its severity to add that r
+                                             ule to loaded rules - (e.g. \`no-implicit-this
+                                             :error\` or \`rule:[\\"error\\", { \\"allow\\": [\\"some-
+                                             helper\\"] }]\`)                        [string]
+            --filename                       Used to indicate the filename to be assumed f
+                                             or contents from STDIN               [string]
+            --fix                            Fix any errors that are reported as fixable
                                                                 [boolean] [default: false]
-            --format                    Specify format to be used in printing output
+            --format                         Specify format to be used in printing output
                                                               [string] [default: \\"pretty\\"]
-            --output-file               Specify file to write report to           [string]
-            --verbose                   Output errors with source description    [boolean]
-            --working-directory, --cwd  Path to a directory that should be considered as t
-                                        he current working directory.
+            --output-file                    Specify file to write report to      [string]
+            --verbose                        Output errors with source description
+                                                                                 [boolean]
+            --working-directory, --cwd       Path to a directory that should be considered
+                                              as the current working directory.
                                                                    [string] [default: \\".\\"]
-            --no-config-path            Does not use the local template-lintrc, will use a
-                                         blank template-lintrc instead           [boolean]
-            --update-todo               Update list of linting todos by transforming lint
-                                        errors to todos         [boolean] [default: false]
-            --include-todo              Include todos in the results
+            --no-config-path                 Does not use the local template-lintrc, will
+                                             use a blank template-lintrc instead [boolean]
+            --update-todo                    Update list of linting todos by transforming
+                                             lint errors to todos
                                                                 [boolean] [default: false]
-            --clean-todo                Remove expired and invalid todo files
+            --include-todo                   Include todos in the results
+                                                                [boolean] [default: false]
+            --clean-todo                     Remove expired and invalid todo files
                                                                  [boolean] [default: true]
-            --compact-todo              Compacts the .lint-todo storage file, removing ext
-                                        raneous todos                            [boolean]
-            --todo-days-to-warn         Number of days after its creation date that a todo
-                                         transitions into a warning               [number]
-            --todo-days-to-error        Number of days after its creation date that a todo
-                                         transitions into an error                [number]
-            --ignore-pattern            Specify custom ignore pattern (can be disabled wit
-                                        h --no-ignore-pattern)
+            --compact-todo                   Compacts the .lint-todo storage file, removin
+                                             g extraneous todos                  [boolean]
+            --todo-days-to-warn              Number of days after its creation date that a
+                                              todo transitions into a warning     [number]
+            --todo-days-to-error             Number of days after its creation date that a
+                                              todo transitions into an error      [number]
+            --ignore-pattern                 Specify custom ignore pattern (can be disable
+                                             d with --no-ignore-pattern)
                         [array] [default: [\\"**/dist/**\\",\\"**/tmp/**\\",\\"**/node_modules/**\\"]]
-            --no-inline-config          Prevent inline configuration comments from changin
-                                        g config or rules                        [boolean]
-            --print-config              Print the configuration for the given file
+            --no-inline-config               Prevent inline configuration comments from ch
+                                             anging config or rules              [boolean]
+            --print-config                   Print the configuration for the given file
                                                                 [boolean] [default: false]
-            --max-warnings              Number of warnings to trigger nonzero exit code
-                                                                                  [number]
-            --help                      Show help                                [boolean]
-            --version                   Show version number                      [boolean]"
+            --max-warnings                   Number of warnings to trigger nonzero exit co
+                                             de                                   [number]
+            --no-error-on-unmatched-pattern  Prevent errors when pattern is unmatched
+                                                                                 [boolean]
+            --help                           Show help                           [boolean]
+            --version                        Show version number                 [boolean]"
         `);
       });
     });


### PR DESCRIPTION
#2245 added the behavior (inspired by eslint) to error out when no matching files are found.

This PR adds a related flag (also from eslint) `--no-error-on-unmatched-pattern` that can disable this behavior when needed.