### PR TITLE
Add new rule: `no-array-prototype-extensions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Each rule has emojis denoting:
 | [no-args-paths](./docs/rule/no-args-paths.md)                                                             | ✅  |     |     |     |
 | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)                           | ✅  |     |     |     |
 | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                                                 | ✅  |     | ⌨️  | 🔧  |
+| [no-array-prototype-extensions](./docs/rule/no-array-prototype-extensions.md)                             |     |     |     | 🔧  |
 | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                                           | ✅  |     |     |     |
 | [no-autofocus-attribute](./docs/rule/no-autofocus-attribute.md)                                           | ✅  |     | ⌨️  |     |
 | [no-bare-strings](./docs/rule/no-bare-strings.md)                                                         |     |     |     |     |

--- a/docs/rule/no-array-prototype-extensions.md
+++ b/docs/rule/no-array-prototype-extensions.md
@@ -1,0 +1,63 @@
+# no-array-prototype-extensions
+
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
+Using array prototype extension properties like `{{list.firstObject.name}}`, `{{list.lastObject}}` is discouraged and is likely to be deprecated soon.
+This rule recommends the use of Ember's `get` helper as an alternative for accessing array values.
+
+## Examples
+
+### firstObject
+
+This rule **forbids** the following:
+
+```hbs
+<Foo @bar={{@list.firstObject.name}} />
+```
+
+This rule **allows** the following:
+
+```hbs
+<Foo @bar={{get @list '0.name'}} />
+```
+
+### lastObject
+
+```hbs
+<Foo @bar={{@list.lastObject}} />
+```
+
+This rule **allows** the following:
+
+Use JS approach
+
+```js
+import Component from '@glimmer/component';
+
+export default class SampleComponent extends Component {
+  abc = ['x', 'y', 'z', 'x'];
+
+  get lastObj() {
+    return abc[abc.length - 1];
+  }
+}
+```
+
+Then in your template
+
+```hbs
+<Foo @bar={{this.lastObj}} />
+```
+
+Or if you have ember-math-helpers addon included:
+
+```hbs
+<!-- ember-math-helpers included-->
+<Foo @bar={{get @list (sub @list.length 1)}} />
+```
+
+## References
+
+- [Eslint rule: no-array-prototype-extensions](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-array-prototype-extensions.md)
+- [Ember math helpers](https://shipshapecode.github.io/ember-math-helpers/)
+- [Ember get helper documentation](https://guides.emberjs.com/release/components/helper-functions/#toc_the-get-helper)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -18,6 +18,7 @@ import noaction from './no-action.js';
 import noargspaths from './no-args-paths.js';
 import noargumentsforhtmlelements from './no-arguments-for-html-elements.js';
 import noariahiddenbody from './no-aria-hidden-body.js';
+import noarrayprototypeextensions from './no-array-prototype-extensions.js';
 import noattrsincomponents from './no-attrs-in-components.js';
 import noautofocusattribute from './no-autofocus-attribute.js';
 import nobarestrings from './no-bare-strings.js';
@@ -128,6 +129,7 @@ export default {
   'no-args-paths': noargspaths,
   'no-arguments-for-html-elements': noargumentsforhtmlelements,
   'no-aria-hidden-body': noariahiddenbody,
+  'no-array-prototype-extensions': noarrayprototypeextensions,
   'no-attrs-in-components': noattrsincomponents,
   'no-autofocus-attribute': noautofocusattribute,
   'no-bare-strings': nobarestrings,

--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -1,0 +1,160 @@
+import { builders } from 'ember-template-recast';
+
+import Rule from './_base.js';
+
+const FIRST_OBJECT_PROP_NAME = 'firstObject';
+const LAST_OBJECT_PROP_NAME = 'lastObject';
+
+const ERROR_MESSAGES = Object.freeze({
+  LAST_OBJECT: 'Array prototype extension property lastObject usage is disallowed.',
+  FIRST_OBJECT:
+    "Array prototype extension property firstObject usage is disallowed. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+});
+
+/**
+ * generate a tuple of pathExpression before `firstObject` and string of parts after `firstObject` index and replace `firstObject` with 0. e.g. [this.list, '0.name']
+ *
+ * @param {PathExpression} node The pathExpression node that should be wrapped in a get helper
+ * @returns a tuple of path parts before digit and path parts after digit index
+ * e.g. node.original - `this.list.firstObject.name` return -`[this.list, '0.name']`
+ */
+function getHelperParams(node) {
+  // use node.original instead of node.parts so the context isn't dropped
+  const originalParts = node.original.split('.');
+  // we don't handle optional chaining here as in hbs we don't need to `?.` and it's not a general practice
+  const firstObjectIndex = originalParts.indexOf(FIRST_OBJECT_PROP_NAME);
+
+  // mutate originalParts to use 0 instead of `firstObject`
+  originalParts.splice(firstObjectIndex, 1, '0');
+  return [
+    builders.path({ head: originalParts.slice(0, firstObjectIndex).join('.') }, node.loc),
+    builders.literal('StringLiteral', originalParts.slice(firstObjectIndex).join('.'), node.loc),
+  ];
+}
+
+/**
+ * generate new literal for firstObject literal. eg: `firstObject.name` => `0.name`;
+ * @param {Object} path
+ * @returns {String}
+ */
+function getFirstObjectFixerLiteral(path) {
+  return path.parentNode.params[1].original
+    .split('.')
+    .map((part) => {
+      if (part === FIRST_OBJECT_PROP_NAME) {
+        return 0;
+      }
+      return part;
+    })
+    .join('.');
+}
+
+/**
+ * Check if should disallow the path origin. `firstObject`, `@lastObject`, `this.firstObject.test` are allowed.
+ * @param {Object} node
+ * @param {matchString} to be matched string, firstObject or lastObject
+ * @returns {Boolean} indicating whether is a match
+ */
+function isAllowed(originalStr, matchedStr) {
+  // allow `@firstObject.test`, `@lastObject`
+  if (new RegExp(`@${matchedStr}`).test(originalStr)) {
+    return true;
+  }
+  const originalParts = originalStr.split('.');
+  const matchStrIndex = originalParts.indexOf(matchedStr);
+
+  // if not found
+  if (matchStrIndex === -1) {
+    return true;
+  }
+  // allow this.firstObject
+  return !matchStrIndex || originalParts[matchStrIndex - 1] === 'this';
+}
+
+/**
+ * Check if current node is a `get` helper and it's literals contains matchedStr
+ * For example `{{get this 'list.firstObject'}}` or `{{get this 'list.lastObject.name'}}` will return true
+ * `{{get this 'lastObject.name'}}` will return false
+ * @param {Object} node
+ * @param {matchString} to be matched string, firstObject or lastObject
+ * @returns {Boolean} indicating whether is a match
+ */
+function isGetHelperWithMatchedLiteral(node, path, matchedStr) {
+  if (node.original === 'get') {
+    if (
+      path.parentNode?.type === 'MustacheStatement' &&
+      path.parentNode?.params?.[1]?.type === 'StringLiteral'
+    ) {
+      const literal = path.parentNode.params[1].original;
+      const parts = literal.split('.');
+      const matchStrIndex = parts.indexOf(matchedStr);
+
+      // matchedStr is found and not the `{{get this 'firstObject'}}` case, then return true
+      return (
+        matchStrIndex !== -1 &&
+        !(matchStrIndex === 0 && path.parentNode?.params?.[0].original === 'this')
+      );
+    }
+    return false;
+  }
+}
+
+export default class NoArrayPrototypeExtensions extends Rule {
+  visitor() {
+    return {
+      PathExpression(node, path) {
+        if (!node.original) {
+          return;
+        }
+        // handle for `lastObject`, no fixer available
+        if (
+          !isAllowed(node.original, LAST_OBJECT_PROP_NAME) ||
+          isGetHelperWithMatchedLiteral(node, path, LAST_OBJECT_PROP_NAME)
+        ) {
+          this.log({
+            message: ERROR_MESSAGES.LAST_OBJECT,
+            source: `${node.original}`,
+            node,
+            isFixable: false,
+          });
+          return node;
+        }
+
+        // handle for `firstObject`, fixer available
+        // check if applies to format like {{get @list `firstObject.name`}}
+        const isGetWithFirstObjectInLiteral = isGetHelperWithMatchedLiteral(
+          node,
+          path,
+          FIRST_OBJECT_PROP_NAME
+        );
+
+        if (!isAllowed(node.original, FIRST_OBJECT_PROP_NAME) || isGetWithFirstObjectInLiteral) {
+          if (this.mode === 'fix') {
+            // for get path with disallowed literal format
+            if (isGetWithFirstObjectInLiteral) {
+              const newValue = getFirstObjectFixerLiteral(path);
+              path.parentNode.params[1].original = newValue;
+              path.parentNode.params[1].value = newValue;
+              // for paths with a MustacheStatement parentNode replace the pathExpression with a get helper pathExpression
+              // eg: `{{this.list.firstObject}}` => `{{get this.list "0"}}`
+            } else if (path.parentNode.type === 'MustacheStatement') {
+              path.parentNode[path.parentKey] = builders.path('get', node.loc);
+              path.parentNode.params = getHelperParams(node);
+            } else {
+              // replace the pathExpression with a get helper subExpression
+              node = builders.sexpr('get', getHelperParams(node));
+            }
+          } else {
+            this.log({
+              message: ERROR_MESSAGES.FIRST_OBJECT,
+              source: `${node.original}`,
+              node,
+              isFixable: true,
+            });
+          }
+        }
+        return node;
+      },
+    };
+  }
+}

--- a/test/unit/rules/no-array-prototype-extensions-test.js
+++ b/test/unit/rules/no-array-prototype-extensions-test.js
@@ -1,0 +1,269 @@
+import generateRuleTests from '../../helpers/rule-test-harness.js';
+
+const RULE_NAME = 'no-array-prototype-extensions';
+generateRuleTests({
+  name: RULE_NAME,
+
+  config: true,
+
+  good: [
+    "{{foo bar=(get this 'list.0' )}}",
+    "<Foo @bar={{get this 'list.0'}}",
+    "{{get this 'list.0.foo'}}",
+    "{{get this 'firstObject'}}",
+    "{{get this 'lastObject.name'}}",
+    '{{foo bar @list}}',
+    '{{this.firstObject}}',
+    '{{this.lastObject.name}}',
+    '{{firstObject}}',
+    '{{lastObject}}',
+    '{{notfirstObject}}',
+    '{{@firstObject}}',
+    '{{@lastObject}}',
+    '{{@lastObject.name}}',
+    '{{foo bar this.firstObject}}',
+    '{{foo bar this.lastObject.name}}',
+    '{{foo bar @lastObject}}',
+    '{{foo bar @firstObject}}',
+    '{{foo bar @lastObject.name}}',
+    '{{foo bar @list.notfirstObject}}',
+    '{{foo bar @list.lastObjectV2}}',
+    'Just a regular text in the template bar.firstObject bar.lastObject.foo',
+    '<Foo foo="bar.firstObject.baz" />',
+    '<Foo foo="lastObject" />',
+    `<FooBar
+     @subHeaderText={{if
+      this.isFooBarV2Enabled
+      "firstObject"
+    }}
+  />`,
+    `<FooBar
+     @subHeaderText={{if
+      this.isFooBarV2Enabled
+      "hi.lastObject.name"
+    }}
+  />`,
+  ],
+
+  bad: [
+    /** Non-fixable `lastObject` */
+    {
+      template: '{{foo bar=@list.lastObject.test}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 10,
+              "endColumn": 31,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": false,
+              "line": 1,
+              "message": "Array prototype extension property lastObject usage is disallowed.",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "@list.lastObject.test",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '{{this.list.lastObject}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 2,
+              "endColumn": 22,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": false,
+              "line": 1,
+              "message": "Array prototype extension property lastObject usage is disallowed.",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "this.list.lastObject",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: "<Foo @bar={{get this 'list.lastObject'}} />",
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 12,
+              "endColumn": 15,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": false,
+              "line": 1,
+              "message": "Array prototype extension property lastObject usage is disallowed.",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "get",
+            },
+          ]
+        `);
+      },
+    },
+    /** Fixable `firstObject` */
+    {
+      template: '{{foo bar=this.list.firstObject}}',
+      fixedTemplate: '{{foo bar=(get this.list "0")}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 10,
+              "endColumn": 31,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Array prototype extension property firstObject usage is disallowed. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "this.list.firstObject",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '{{this.list.firstObject}}',
+      fixedTemplate: '{{get this.list "0"}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 2,
+              "endColumn": 23,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Array prototype extension property firstObject usage is disallowed. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "this.list.firstObject",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '{{this.list.firstObject.name}}',
+      fixedTemplate: '{{get this.list "0.name"}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 2,
+              "endColumn": 28,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Array prototype extension property firstObject usage is disallowed. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "this.list.firstObject.name",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<Foo @bar={{@list.firstObject}} />',
+      fixedTemplate: '<Foo @bar={{get @list "0"}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 12,
+              "endColumn": 29,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Array prototype extension property firstObject usage is disallowed. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "@list.firstObject",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<Foo @bar={{this.list.firstObject.name.foo}} />',
+      fixedTemplate: '<Foo @bar={{get this.list "0.name.foo"}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 12,
+              "endColumn": 42,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Array prototype extension property firstObject usage is disallowed. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "this.list.firstObject.name.foo",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: "<Foo @bar={{get this 'list.firstObject'}} />",
+      fixedTemplate: "<Foo @bar={{get this 'list.0'}} />",
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 12,
+              "endColumn": 15,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Array prototype extension property firstObject usage is disallowed. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "get",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: "<Foo @bar={{get @list 'firstObject.name'}} />",
+      fixedTemplate: "<Foo @bar={{get @list '0.name'}} />",
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 12,
+              "endColumn": 15,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Array prototype extension property firstObject usage is disallowed. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "get",
+            },
+          ]
+        `);
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This PR addresses https://github.com/ember-template-lint/ember-template-lint/issues/2450

We are moving away from array prototype extensions in general. `firstObject`, `lastObject` should be disallowed in template usage.

Reference: [Eslint rule: no-array-prototype-extensions](https://github.com/ember-cli/eslint-plugin-ember/blob/master/docs/rules/no-array-prototype-extensions.md)