### PR TITLE
Better handling of dashes in `no-whitespace-within-word` rule

### DIFF
--- a/lib/rules/no-whitespace-within-word.js
+++ b/lib/rules/no-whitespace-within-word.js
@@ -2,9 +2,8 @@ import Rule from './_base.js';
 
 const ERROR_MESSAGE = 'Excess whitespace in layout detected.';
 
-const whitespaceCharacterList = new Set([
+const WHITESPACE_ENTITY_LIST = [
   '&#32;',
-  ' ',
   '&#160;',
   '&nbsp;',
   '&NonBreakingSpace;',
@@ -55,43 +54,9 @@ const whitespaceCharacterList = new Set([
   '&#8291;',
   '&InvisibleComma;',
   '&ic;',
-]);
+];
 
-const allowedSeparatorList = new Set(['-', '&#45;', '—', '&mdash;', '–', '&ndash;', '&minus;']);
-
-function isWhitespaceOrAllowedSeparator(char) {
-  return whitespaceCharacterList.has(char) || allowedSeparatorList.has(char);
-}
-
-function splitTextByEntity(input) {
-  let result = [];
-
-  for (let i = 0; i < input.length; i++) {
-    let current = input[i];
-
-    if (current === '&') {
-      let possibleEndIndex = input.indexOf(';', i);
-
-      // this is a stand alone `&`
-      if (possibleEndIndex === -1) {
-        result.push(current);
-      }
-
-      // now we know we have an "entity like thing"
-      let possibleEntity = input.slice(i, possibleEndIndex + 1);
-      if (whitespaceCharacterList.has(possibleEntity)) {
-        result.push(possibleEntity);
-        i += possibleEntity.length - 1;
-      } else {
-        result.push(current);
-      }
-    } else {
-      result.push(current);
-    }
-  }
-
-  return result;
-}
+const CHARACTER_REGEX = '[a-zA-Z]';
 
 // The goal here is to catch alternating non-whitespace/whitespace
 // characters, for example, in 'W e l c o m e'.
@@ -104,6 +69,19 @@ function splitTextByEntity(input) {
 // will return false positives and any more than this should not be
 // necessary in 99.99% of cases
 export default class NoWhitespaceWithinWord extends Rule {
+  constructor(...args) {
+    super(...args);
+
+    let whitespaceOrEntityRegex = `(?:\\s|${WHITESPACE_ENTITY_LIST.map(
+      (entity) => `\\${entity}`
+    ).join('|')})+`;
+    let characterRegex = CHARACTER_REGEX;
+
+    this.regex = new RegExp(
+      `${whitespaceOrEntityRegex}${characterRegex}${whitespaceOrEntityRegex}${characterRegex}${whitespaceOrEntityRegex}`
+    );
+  }
+
   visitor() {
     return {
       TextNode(node, path) {
@@ -116,35 +94,14 @@ export default class NoWhitespaceWithinWord extends Rule {
         ) {
           return;
         }
-        let alternationCount = 0;
         let source = this.sourceForNode(node);
-        let characters = splitTextByEntity(source);
 
-        for (let i = 0; i < characters.length; i++) {
-          let currentChar = characters[i];
-          let previousChar = i > 0 ? characters[i - 1] : undefined;
-
-          if (
-            (isWhitespaceOrAllowedSeparator(currentChar) &&
-              !isWhitespaceOrAllowedSeparator(previousChar)) ||
-            (!isWhitespaceOrAllowedSeparator(currentChar) &&
-              isWhitespaceOrAllowedSeparator(previousChar))
-          ) {
-            alternationCount++;
-          } else {
-            alternationCount = 0;
-          }
-
-          if (alternationCount >= 5) {
-            this.log({
-              message: ERROR_MESSAGE,
-              node,
-              source,
-            });
-
-            // no need to keep parsing, we've already reported
-            return;
-          }
+        if (this.regex.test(source)) {
+          this.log({
+            message: ERROR_MESSAGE,
+            node,
+            source,
+          });
         }
       },
     };

--- a/test/unit/rules/no-whitespace-within-word-test.js
+++ b/test/unit/rules/no-whitespace-within-word-test.js
@@ -9,6 +9,8 @@ generateRuleTests({
   good: [
     'Welcome',
     'Hey - I like this!',
+    'Expected: 5-10 guests',
+    'Expected: 5 - 10 guests',
     'It is possible to get some examples of in-word emph a sis past this rule.',
     'However, I do not want a rule that flags annoying false positives for correctly-used single-character words.',
     '<div>Welcome</div>',
@@ -137,6 +139,27 @@ generateRuleTests({
               "rule": "no-whitespace-within-word",
               "severity": 2,
               "source": "Wel c o me",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: 'A  B&nbsp;&nbsp; C ',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 19,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Excess whitespace in layout detected.",
+              "rule": "no-whitespace-within-word",
+              "severity": 2,
+              "source": "A  B&nbsp;&nbsp; C ",
             },
           ]
         `);


### PR DESCRIPTION
This should be more robust than the previous implementation.

This fixes https://github.com/ember-template-lint/ember-template-lint/issues/2464, and also handles multi-whitespace properly (e.g. `A&nbsp;&nbsp;B C`, for example). You can configure the regex for the single-character lookup (e.g. if you also want to handle some special characters etc.), by default we use `[a-zA-Z]`.

I am also not 100% sure if we _really_ need to include the full list of possible white-space characters here, or if it is good enough to just have the main ones (e.g. `&nbsp;`) in there - or maybe also make this configurable. Not sure if there _is_ a noticeable performance impact having a rather large regex, but I would imagine for most users/use cases this would be a _really_ rare scenario to run into `X&InvisibleComma;X&InvisibleComma;X&InvisibleComma;` or something like that.

I can either leave it as it is, or reduce the character set somewhat, or reduce it to a smaller subset and make it configurable for users who really need the full list? My feeling is a subset like this maybe:

```js
[
  '&nbsp;',
  '&NonBreakingSpace;',
  '&thinsp;',
  '&ThinSpace;',
  '&hairsp;',
  '&VeryThinSpace;',
  '&ThickSpace;',
  '&ZeroWidthSpace;',
  '&NegativeVeryThinSpace;',
  '&NegativeThinSpace;',
  '&NegativeMediumSpace;',
  '&NegativeThickSpace;',
  '&MediumSpace;',
  '&ThickSpace;',
]
```

So basically the "named" whitespace entites, may be enough? 