### PR TITLE
Remove validation of mustache statements in `no-invalid-aria-attributes` rule

### DIFF
--- a/docs/rule/no-invalid-aria-attributes.md
+++ b/docs/rule/no-invalid-aria-attributes.md
@@ -11,7 +11,7 @@ This rule **forbids** the following:
 ```hbs
 <input type="text" aria-not-real="true" />
 <div role="region" aria-live="bogus">Inaccessible live region</div>',
-<button type="submit" aria-invalid={{if this.foo "true" "woosh"}}>Submit</button>
+<button type="submit" disabled="true" aria-disabled="123">Submit</button>
 ```
 
 This rule **allows** the following:

--- a/lib/rules/no-invalid-aria-attributes.js
+++ b/lib/rules/no-invalid-aria-attributes.js
@@ -84,23 +84,6 @@ function validityCheck(expectedType, permittedValues, allowUndefined, value) {
   }
 }
 
-function getValuesFromMustache(mustacheNode) {
-  let valuesList = [];
-  if (['BooleanLiteral', 'NumberLiteral', 'StringLiteral'].includes(mustacheNode.path.type)) {
-    valuesList.push(mustacheNode.path.original);
-  } else if (mustacheNode.path.type === 'PathExpression') {
-    if (mustacheNode.path.original === 'if' || mustacheNode.path.original === 'unless') {
-      if (mustacheNode.params.length === 2 || mustacheNode.params.length === 3) {
-        valuesList.push(mustacheNode.params[1].value);
-      }
-      if (mustacheNode.params.length === 3) {
-        valuesList.push(mustacheNode.params[2].value);
-      }
-    }
-  }
-  return valuesList;
-}
-
 export default class NoInvalidAriaAttributes extends Rule {
   visitor() {
     return {
@@ -126,24 +109,11 @@ export default class NoInvalidAriaAttributes extends Rule {
           let allowUndefined = validAriaAttribute.allowundefined || false;
           let isValidValue;
           // Skip validation for interpolated string values
-          if (attribute.value.type === 'ConcatStatement') {
+          if (
+            attribute.value.type === 'MustacheStatement' ||
+            attribute.value.type === 'ConcatStatement'
+          ) {
             return;
-          } else if (attribute.value.type === 'MustacheStatement') {
-            if (attribute.value.path) {
-              let valuesList = getValuesFromMustache(attribute.value);
-              if (valuesList.length === 0) {
-                isValidValue = true;
-              } else {
-                for (let value of valuesList) {
-                  isValidValue = validityCheck(
-                    expectedType,
-                    permittedValues,
-                    allowUndefined,
-                    value
-                  );
-                }
-              }
-            }
           } else {
             isValidValue = validityCheck(
               expectedType,

--- a/test/unit/rules/no-invalid-aria-attributes-test.js
+++ b/test/unit/rules/no-invalid-aria-attributes-test.js
@@ -22,6 +22,7 @@ generateRuleTests({
     '<button type="submit" aria-disabled={{this.isDisabled}}>Submit</button>',
     '<div role="textbox" aria-sort={{if this.hasCustomSort "other" "ascending"}}></div>',
     '<div role="combobox" aria-expanded="undefined"></div>',
+    '<button aria-label={{if @isNew (t "actions.add") (t "actions.edit")}}></button>',
   ],
   bad: [
     {
@@ -167,26 +168,6 @@ generateRuleTests({
       },
     },
     {
-      template: '<input type="password" required="true" aria-errormessage={{0}} />',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 65,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "The value for aria-errormessage must be a string that represents a DOM element ID",
-              "rule": "no-invalid-aria-attributes",
-              "severity": 2,
-              "source": "<input type=\\"password\\" required=\\"true\\" aria-errormessage={{0}} />",
-            },
-          ]
-        `);
-      },
-    },
-    {
       template:
         '<button type="submit" aria-describedby="blah false">Continue at your own risk</button>',
       verifyResults(results) {
@@ -202,26 +183,6 @@ generateRuleTests({
               "rule": "no-invalid-aria-attributes",
               "severity": 2,
               "source": "<button type=\\"submit\\" aria-describedby=\\"blah false\\">Continue at your own risk</button>",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<button type="submit" aria-describedby={{false}} >broken button</button>',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 72,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "The value for aria-describedby must be a list of strings that represent DOM element IDs (idlist)",
-              "rule": "no-invalid-aria-attributes",
-              "severity": 2,
-              "source": "<button type=\\"submit\\" aria-describedby={{false}} >broken button</button>",
             },
           ]
         `);
@@ -262,26 +223,6 @@ generateRuleTests({
               "rule": "no-invalid-aria-attributes",
               "severity": 2,
               "source": "<div role=\\"heading\\" aria-level=\\"true\\">Another inaccessible heading</div>",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<div role="heading" aria-level={{"blah"}}>Broken heading</div>',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 62,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "The value for aria-level must be an integer.",
-              "rule": "no-invalid-aria-attributes",
-              "severity": 2,
-              "source": "<div role=\\"heading\\" aria-level={{\\"blah\\"}}>Broken heading</div>",
             },
           ]
         `);
@@ -344,26 +285,6 @@ generateRuleTests({
               "rule": "no-invalid-aria-attributes",
               "severity": 2,
               "source": "<div role=\\"region\\" aria-live=\\"polite\\" aria-relevant=\\"additions errors\\">Inaccessible live region</div>",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<input type="text" aria-required={{if this.foo "true" "woosh"}} />',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 66,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "The value for aria-required must be a boolean.",
-              "rule": "no-invalid-aria-attributes",
-              "severity": 2,
-              "source": "<input type=\\"text\\" aria-required={{if this.foo \\"true\\" \\"woosh\\"}} />",
             },
           ]
         `);


### PR DESCRIPTION
This PR fixes #2405 and fixes #2451.

Besides string, number, and boolean literals, mustache statements often also contains helpers, variables, and other nested statements. Since it is not possible to check what a given mustache statement evaluates to at the template level, this PR removes their validation to prevent valid ARIA attribute values in complex statements from failing the rule.

**Allowed**:
```
# examples
<div aria-label={{this.foo}} />
<div aria-label={{if @label @label @placeholder}} />
<button aria-label={{if @isNew (t "actions.add") (t "actions.edit")}}></button>
```

### Testing
Test Suites: 135 passed, 135 total
Tests:       5 skipped, 7459 passed, 7464 total
Snapshots:   969 passed, 969 total
Time:        96.051 s
Ran all test suites.
✨  Done in 107.73s.
