### PR TITLE
Ensure configuration can be resolved from a parent directory when no `--config-path` override is present (e.g. within a monorepo with `.template-lintrc.js` in the monorepo root).

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -67,11 +67,13 @@ function getTodoConfigFromCommandLineOptions(options) {
 }
 
 function _isOverridingConfig(options) {
+  let defaultArgs = parseArgv(['fake-file-to-get-default-options.hbs']);
+
   return Boolean(
-    options.config ||
-      options.rule ||
-      options.inlineConfig === false ||
-      options.configPath !== '.template-lintrc.js'
+    options.config !== defaultArgs.config ||
+      options.rule !== defaultArgs.rule ||
+      options.inlineConfig !== defaultArgs.inlineConfig ||
+      options.configPath !== defaultArgs.configPath
   );
 }
 

--- a/lib/helpers/cli.js
+++ b/lib/helpers/cli.js
@@ -22,8 +22,7 @@ class NoMatchingFilesError extends Error {
 export function parseArgv(_argv) {
   const specifiedOptions = {
     'config-path': {
-      describe: 'Define a custom config path',
-      default: '.template-lintrc.js',
+      describe: 'Define a custom config path (default: .template-lintrc.js)',
       type: 'string',
     },
     config: {

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -6,6 +7,8 @@ import run from '../helpers/run.js';
 import setupEnvVar from '../helpers/setup-env-var.js';
 
 const ROOT = process.cwd();
+
+jest.setTimeout(10_000);
 
 describe('ember-template-lint executable', function () {
   setupEnvVar('FORCE_COLOR', '0');
@@ -35,8 +38,8 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path                    Define a custom config path
-                                                 [string] [default: \\".template-lintrc.js\\"]
+            --config-path                    Define a custom config path (default: .templa
+                                             te-lintrc.js)                        [string]
             --config                         Define a custom configuration to be used - (
                                              e.g. '{ \\"rules\\": { \\"no-implicit-this\\": \\"erro
                                              r\\" } }')                             [string]
@@ -98,8 +101,8 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path                    Define a custom config path
-                                                 [string] [default: \\".template-lintrc.js\\"]
+            --config-path                    Define a custom config path (default: .templa
+                                             te-lintrc.js)                        [string]
             --config                         Define a custom configuration to be used - (
                                              e.g. '{ \\"rules\\": { \\"no-implicit-this\\": \\"erro
                                              r\\" } }')                             [string]
@@ -509,8 +512,8 @@ describe('ember-template-lint executable', function () {
           "ember-template-lint [options] [files..]
 
           Options:
-            --config-path                    Define a custom config path
-                                                 [string] [default: \\".template-lintrc.js\\"]
+            --config-path                    Define a custom config path (default: .templa
+                                             te-lintrc.js)                        [string]
             --config                         Define a custom configuration to be used - (
                                              e.g. '{ \\"rules\\": { \\"no-implicit-this\\": \\"erro
                                              r\\" } }')                             [string]

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -6,8 +6,6 @@ import Project from '../helpers/fake-project.js';
 import run from '../helpers/run.js';
 import setupEnvVar from '../helpers/setup-env-var.js';
 
-const ROOT = process.cwd();
-
 jest.setTimeout(10_000);
 
 function buildReadOptions() {
@@ -25,7 +23,6 @@ describe('todo usage', () => {
   });
 
   afterEach(function () {
-    process.chdir(ROOT);
     project.dispose();
   });
 


### PR DESCRIPTION
Enhance config discovery to allow configs to be in parent directories. This is particularly useful for monorepos, where subpackages invoke ember-template-lint, but it's desirable to have a single config file in the root.

Fixes #2467 

/cc @NullVoxPopuli 