### PR TITLE
Ensure `--compact-todo` functions properly 

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -131,9 +131,7 @@ async function run() {
   }
 
   if (options.compactTodo) {
-    let { compacted } = compactTodoStorageFile(options.workingDirectory, {
-      engine: 'ember-template-lint',
-    });
+    let { compacted } = compactTodoStorageFile(options.workingDirectory);
     _console.log(`Removed ${compacted} todos in .lint-todo storage file`);
     process.exitCode = 0;
     return;

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -131,7 +131,9 @@ async function run() {
   }
 
   if (options.compactTodo) {
-    let { compacted } = compactTodoStorageFile(options.workingDirectory);
+    let { compacted } = compactTodoStorageFile(options.workingDirectory, {
+      engine: 'ember-template-lint',
+    });
     _console.log(`Removed ${compacted} todos in .lint-todo storage file`);
     process.exitCode = 0;
     return;

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@lint-todo/utils": "^12.0.1",
+    "@lint-todo/utils": "^13.0.2",
     "aria-query": "^5.0.0",
     "chalk": "^4.1.2",
     "ci-info": "^3.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,12 +684,13 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@lint-todo/utils@^12.0.1":
-  version "12.0.1"
-  resolved "https://registry.yarnpkg.com/@lint-todo/utils/-/utils-12.0.1.tgz#d61ef329f9f6c7332adee7b1f68651f190d53a7f"
-  integrity sha512-Xiy5wN+ns95gEHepJ55TXEBAZrkZlzrF9wTjqoTgv+RYOYL3+qQ+v0RtPH2n/UwPJEFuXJ6QKiT99RnUOt1pzw==
+"@lint-todo/utils@^13.0.2":
+  version "13.0.2"
+  resolved "https://registry.yarnpkg.com/@lint-todo/utils/-/utils-13.0.2.tgz#0d2fc6cc24452564dd2ee97be01437aa92b4c1a8"
+  integrity sha512-tLZfEjU5i7KThQbWZ4u5dLUJx9+euGnytz402uAH4VRa0jMxyc2HNXw+h6qPdKxM/wGAvwEQGn7l1j2kyLI7rQ==
   dependencies:
     "@types/eslint" "^7.2.13"
+    find-up "^5.0.0"
     fs-extra "^9.1.0"
     proper-lockfile "^4.1.2"
     slash "^3.0.0"


### PR DESCRIPTION
The compacting code in `@lint-todo/utils` had a bug, which was fixed (https://github.com/lint-todo/utils/pull/376). This PR bumps the minimum version to this new release.