### PR TITLE
Add `validateValues` option to `require-lang-attribute` rule

### DIFF
--- a/docs/rule/require-lang-attribute.md
+++ b/docs/rule/require-lang-attribute.md
@@ -14,11 +14,11 @@ When the language of the page cannot be identified, the integrity of the above i
 
 Consider any of the following use cases:
 
-* the application developer is unaware that Ember now includes the lang attribute
-* the application does not require internationalization
-* the application's content is in a language that is not English
-* an end-user with a screen reader turned on, whose operating system (OS) is set to a different language, navigates to that page with their screen reader turned on
-* the screen reader would attempt to read the page in the language that is defined by the lang attribute on the page, but the supporting element information ("button", "link", etc) is read out in the language that is set by the operating system.
+- the application developer is unaware that Ember now includes the lang attribute
+- the application does not require internationalization
+- the application's content is in a language that is not English
+- an end-user with a screen reader turned on, whose operating system (OS) is set to a different language, navigates to that page with their screen reader turned on
+- the screen reader would attempt to read the page in the language that is defined by the lang attribute on the page, but the supporting element information ("button", "link", etc) is read out in the language that is set by the operating system.
 
 ## Examples
 
@@ -29,7 +29,7 @@ This rule **forbids** the following:
 ```
 
 ```hbs
-<html lang=""></html>
+<html lang=''></html>
 ```
 
 ```hbs
@@ -39,11 +39,11 @@ This rule **forbids** the following:
 This rule **allows** the following:
 
 ```hbs
-<html lang="en"></html>
+<html lang='en'></html>
 ```
 
 ```hbs
-<html lang="en-US"></html>
+<html lang='en-US'></html>
 ```
 
 ```hbs
@@ -54,6 +54,15 @@ This rule **allows** the following:
 
 Add the `lang` attribute to the `app/index.html` file in your Ember app. If you use an internationalization addon like `ember-intl`, note that this will not conflict with that addon.
 
+## Configuration
+
+- boolean -- if `true`, default configuration is applied
+  (`validateValues: false`), see below for details
+
+- object -- containing the following property:
+  - boolean -- `validateValues` -- if `true`, the rule checks whether the value in the `lang` attribute is a known IETF's BCP 47 language tag
+    (default: `false`)
+
 ## References
 
-* [WCAG Success Criterion 3.1.1: Language of Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html)
+- [WCAG Success Criterion 3.1.1: Language of Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html)

--- a/docs/rule/require-lang-attribute.md
+++ b/docs/rule/require-lang-attribute.md
@@ -29,7 +29,7 @@ This rule **forbids** the following:
 ```
 
 ```hbs
-<html lang=''></html>
+<html lang=""></html>
 ```
 
 ```hbs
@@ -39,11 +39,11 @@ This rule **forbids** the following:
 This rule **allows** the following:
 
 ```hbs
-<html lang='en'></html>
+<html lang="en"></html>
 ```
 
 ```hbs
-<html lang='en-US'></html>
+<html lang="en-US"></html>
 ```
 
 ```hbs
@@ -57,11 +57,10 @@ Add the `lang` attribute to the `app/index.html` file in your Ember app. If you 
 ## Configuration
 
 - boolean -- if `true`, default configuration is applied
-  (`validateValues: false`), see below for details
 
 - object -- containing the following property:
   - boolean -- `validateValues` -- if `true`, the rule checks whether the value in the `lang` attribute is a known IETF's BCP 47 language tag
-    (default: `false`)
+    (default: `false`) (TODO: enable by default in next major release)
 
 ## References
 

--- a/docs/rule/require-lang-attribute.md
+++ b/docs/rule/require-lang-attribute.md
@@ -2,9 +2,9 @@
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
-A missing `lang` attribute can cause an application to fail legal conformance for digital accessibility requirements.
+A missing or invalid `lang` attribute can cause an application to fail legal conformance for digital accessibility requirements.
 
-This rule's objective is to ensure that Ember applications achieve [WCAG Success Criterion 3.1.1: Language of Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html). The state of the `lang` attribute has a usability impact on the experience of users that require screen-reading assistive technology. When the attribute is properly assigned:
+This rule's objective is to ensure that Ember applications achieve [WCAG Success Criterion 3.1.1: Language of Page](https://www.w3.org/WAI/WCAG21/Understanding/language-of-page.html), by declaring a valid IETF's BCP 47 language tag for the `lang` attribute. The state of the `lang` attribute has a usability impact on the experience of users that require screen-reading assistive technology. When the attribute is properly assigned:
 
 > "Both assistive technologies and conventional user agents can render text more accurately when the language of the Web page is identified. Screen readers can load the correct pronunciation rules. Visual browsers can display characters and scripts correctly. Media players can show captions correctly. **As a result, users with disabilities will be better able to understand the content.**"
 >
@@ -30,6 +30,10 @@ This rule **forbids** the following:
 
 ```hbs
 <html lang=""></html>
+```
+
+```hbs
+<html lang="abracadabra"></Html>
 ```
 
 This rule **allows** the following:

--- a/lib/rules/require-lang-attribute.js
+++ b/lib/rules/require-lang-attribute.js
@@ -3,7 +3,21 @@ import tags from 'language-tags';
 import AstNodeInfo from '../helpers/ast-node-info.js';
 import Rule from './_base.js';
 
+const DEFAULT_CONFIG = {
+  validateValues: false,
+};
+
 const ERROR_MESSAGE = 'The `<html>` element must have the `lang` attribute with a valid value';
+
+function hasValue(langAttrNode) {
+  let langAttributeValue;
+  if (langAttrNode.value.type === 'TextNode') {
+    langAttributeValue = langAttrNode.value.chars;
+  } else {
+    langAttributeValue = langAttrNode.value;
+  }
+  return langAttributeValue;
+}
 
 function hasValidValue(langAttrNode) {
   if (langAttrNode.value.type === 'TextNode') {
@@ -14,6 +28,10 @@ function hasValidValue(langAttrNode) {
 }
 
 export default class RequireLangAttribute extends Rule {
+  parseConfig(config) {
+    return parseConfig(config);
+  }
+
   visitor() {
     return {
       ElementNode(node) {
@@ -28,13 +46,31 @@ export default class RequireLangAttribute extends Rule {
         if (hasLangAttribute) {
           langAttrNode = AstNodeInfo.findAttribute(node, 'lang');
         }
-        if (node.tag === 'html' && hasLangAttribute && !hasValidValue(langAttrNode)) {
-          this.log({
-            message: ERROR_MESSAGE,
-            node,
-          });
+        if (node.tag === 'html' && hasLangAttribute) {
+          let isValidValue = this.config.validateValues
+            ? hasValidValue(langAttrNode)
+            : hasValue(langAttrNode);
+          if (!isValidValue) {
+            this.log({
+              message: ERROR_MESSAGE,
+              node,
+            });
+          }
         }
       },
+    };
+  }
+}
+
+export function parseConfig(config) {
+  if (config === true) {
+    return DEFAULT_CONFIG;
+  }
+
+  if (config && typeof config === 'object') {
+    return {
+      validateValues:
+        'validateValues' in config ? config.validateValues : DEFAULT_CONFIG.validateValues,
     };
   }
 }

--- a/lib/rules/require-lang-attribute.js
+++ b/lib/rules/require-lang-attribute.js
@@ -1,7 +1,17 @@
+import tags from 'language-tags';
+
 import AstNodeInfo from '../helpers/ast-node-info.js';
 import Rule from './_base.js';
 
-const ERROR_MESSAGE = 'The `<html>` element must have the `lang` attribute with a non-null value';
+const ERROR_MESSAGE = 'The `<html>` element must have the `lang` attribute with a valid value';
+
+function hasValidValue(langAttrNode) {
+  if (langAttrNode.value.type === 'TextNode') {
+    return tags.check(langAttrNode.value.chars);
+  } else {
+    return langAttrNode.value !== undefined;
+  }
+}
 
 export default class RequireLangAttribute extends Rule {
   visitor() {
@@ -14,17 +24,11 @@ export default class RequireLangAttribute extends Rule {
           });
         }
         const hasLangAttribute = AstNodeInfo.hasAttribute(node, 'lang');
-        let langAttrNode, langAttributeValue;
+        let langAttrNode;
         if (hasLangAttribute) {
           langAttrNode = AstNodeInfo.findAttribute(node, 'lang');
-          if (langAttrNode.value.type === 'TextNode') {
-            langAttributeValue = langAttrNode.value.chars;
-          } else {
-            langAttributeValue = langAttrNode.value;
-          }
         }
-
-        if (node.tag === 'html' && hasLangAttribute && !langAttributeValue) {
+        if (node.tag === 'html' && hasLangAttribute && !hasValidValue(langAttrNode)) {
           this.log({
             message: ERROR_MESSAGE,
             node,

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "get-stdin": "^9.0.0",
     "globby": "^13.1.1",
     "is-glob": "^4.0.3",
+    "language-tags": "^1.0.5",
     "micromatch": "^4.0.5",
     "resolve": "^1.22.0",
     "v8-compile-cache": "^2.3.0",

--- a/test/unit/rules/require-lang-attribute-test.js
+++ b/test/unit/rules/require-lang-attribute-test.js
@@ -19,7 +19,7 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "The \`<html>\` element must have the \`lang\` attribute with a non-null value",
+              "message": "The \`<html>\` element must have the \`lang\` attribute with a valid value",
               "rule": "require-lang-attribute",
               "severity": 2,
               "source": "<html></html>",
@@ -39,10 +39,30 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "The \`<html>\` element must have the \`lang\` attribute with a non-null value",
+              "message": "The \`<html>\` element must have the \`lang\` attribute with a valid value",
               "rule": "require-lang-attribute",
               "severity": 2,
               "source": "<html lang=\\"\\"></html>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<html lang="gibberish"></html>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 30,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "The \`<html>\` element must have the \`lang\` attribute with a valid value",
+              "rule": "require-lang-attribute",
+              "severity": 2,
+              "source": "<html lang=\\"gibberish\\"></html>",
             },
           ]
         `);

--- a/test/unit/rules/require-lang-attribute-test.js
+++ b/test/unit/rules/require-lang-attribute-test.js
@@ -8,6 +8,7 @@ generateRuleTests({
     '<html lang="en"></html>',
     '<html lang="en-US"></html>',
     '<html lang={{lang}}></html>',
+    '<html lang="hurrah"></html>', // allows invalid value when `validateValues` option defaults to `false`
     {
       config: {
         validateValues: true,

--- a/test/unit/rules/require-lang-attribute-test.js
+++ b/test/unit/rules/require-lang-attribute-test.js
@@ -3,7 +3,62 @@ import generateRuleTests from '../../helpers/rule-test-harness.js';
 generateRuleTests({
   name: 'require-lang-attribute',
 
-  config: true,
+  config: {
+    validateValues: false,
+  },
+
+  good: ['<html lang="en"></html>', '<html lang="en-US"></html>', '<html lang={{lang}}></html>'],
+
+  bad: [
+    {
+      template: '<html></html>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 13,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "The \`<html>\` element must have the \`lang\` attribute with a valid value",
+              "rule": "require-lang-attribute",
+              "severity": 2,
+              "source": "<html></html>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<html lang=""></html>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 21,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "The \`<html>\` element must have the \`lang\` attribute with a valid value",
+              "rule": "require-lang-attribute",
+              "severity": 2,
+              "source": "<html lang=\\"\\"></html>",
+            },
+          ]
+        `);
+      },
+    },
+  ],
+});
+
+generateRuleTests({
+  name: 'require-lang-attribute',
+
+  config: {
+    validateValues: true,
+  },
 
   good: ['<html lang="en"></html>', '<html lang="en-US"></html>', '<html lang={{lang}}></html>'],
 

--- a/test/unit/rules/require-lang-attribute-test.js
+++ b/test/unit/rules/require-lang-attribute-test.js
@@ -3,11 +3,36 @@ import generateRuleTests from '../../helpers/rule-test-harness.js';
 generateRuleTests({
   name: 'require-lang-attribute',
 
-  config: {
-    validateValues: false,
-  },
-
-  good: ['<html lang="en"></html>', '<html lang="en-US"></html>', '<html lang={{lang}}></html>'],
+  config: true,
+  good: [
+    '<html lang="en"></html>',
+    '<html lang="en-US"></html>',
+    '<html lang={{lang}}></html>',
+    {
+      config: {
+        validateValues: true,
+      },
+      template: '<html lang="de"></html>',
+    },
+    {
+      config: {
+        validateValues: true,
+      },
+      template: '<html lang={{this.language}}></html>',
+    },
+    {
+      config: {
+        validateValues: false,
+      },
+      template: '<html lang="hurrah"></html>',
+    },
+    {
+      config: {
+        validateValues: false,
+      },
+      template: '<html lang={{this.blah}}></html>',
+    },
+  ],
 
   bad: [
     {
@@ -50,21 +75,11 @@ generateRuleTests({
         `);
       },
     },
-  ],
-});
-
-generateRuleTests({
-  name: 'require-lang-attribute',
-
-  config: {
-    validateValues: true,
-  },
-
-  good: ['<html lang="en"></html>', '<html lang="en-US"></html>', '<html lang={{lang}}></html>'],
-
-  bad: [
     {
       template: '<html></html>',
+      config: {
+        validateValues: true,
+      },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -85,6 +100,9 @@ generateRuleTests({
     },
     {
       template: '<html lang=""></html>',
+      config: {
+        validateValues: true,
+      },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -105,6 +123,9 @@ generateRuleTests({
     },
     {
       template: '<html lang="gibberish"></html>',
+      config: {
+        validateValues: true,
+      },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -118,6 +139,52 @@ generateRuleTests({
               "rule": "require-lang-attribute",
               "severity": 2,
               "source": "<html lang=\\"gibberish\\"></html>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<html></html>',
+      config: {
+        validateValues: false,
+      },
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 13,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "The \`<html>\` element must have the \`lang\` attribute with a valid value",
+              "rule": "require-lang-attribute",
+              "severity": 2,
+              "source": "<html></html>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<html lang=""></html>',
+      config: {
+        validateValues: false,
+      },
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 21,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "The \`<html>\` element must have the \`lang\` attribute with a valid value",
+              "rule": "require-lang-attribute",
+              "severity": 2,
+              "source": "<html lang=\\"\\"></html>",
             },
           ]
         `);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4516,6 +4516,18 @@ kleur@^4.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.4.tgz#8c202987d7e577766d039a8cd461934c01cda04d"
   integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
 
+language-subtag-registry@~0.3.2:
+  version "0.3.21"
+  resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz#04ac218bea46f04cb039084602c6da9e788dd45a"
+  integrity sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==
+
+language-tags@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/language-tags/-/language-tags-1.0.5.tgz#d321dbc4da30ba8bf3024e040fa5c14661f9193a"
+  integrity sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=
+  dependencies:
+    language-subtag-registry "~0.3.2"
+
 latest-version@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/latest-version/-/latest-version-5.1.0.tgz#119dfe908fe38d15dfa43ecd13fa12ec8832face"


### PR DESCRIPTION
This PR fixes #2477.

### Background
Currently, the `require-lang-attribute` rule checks for the presence of the `lang` attribute but not whether its value is valid. This issue proposes updating the rule so that, if the `lang` attribute contains a text value, check that its value is a known [IETF's BCP 47 language tag](https://tools.ietf.org/search/bcp47). When this attribute is properly assigned, both assistive technologies and conventional user agents will be able to render text more accurately. 

Reference: [lang - HTML: HyperText Markup Language - MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang)

**Allowed**:
```
# examples
<html lang="en"></html>
<html lang="en-US"></html>
<html lang={{lang}}></html>
```

**Forbidden**:
```
# examples
<html></html>
<html lang=""></html>
<html lang="abracadabra"></Html>
```

### Testing
Test Suites: 136 passed, 136 total
Tests:       5 skipped, 7478 passed, 7483 total
Snapshots:   981 passed, 981 total
Time:        95.504 s
Ran all test suites.
✨  Done in 101.16s.
