### PR TITLE
Add `checkAllHTMLElements` option to `no-redundant-landmark-role` rule to lint against all HTML elements with default ARIA roles

### DIFF
--- a/docs/rule/no-redundant-landmark-role.md
+++ b/docs/rule/no-redundant-landmark-role.md
@@ -6,7 +6,10 @@
 
 If a landmark element is used, any role provided will either be redundant or incorrect.
 This rule adds support for landmark elements, to ensure that no role attribute is placed on any of
-the landmark elements, with a few exceptions.
+the landmark elements, with the following exceptions:
+
+- a `nav` element with the `navigation` role to [make the structure of the page more accessible to user agents](/https://www.w3.org/WAI/GL/wiki/Using_HTML5_nav_element#Example:The_.3Cnav.3E_element)s
+- a `form` element with the `search` role to [identify the form's search functionality](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/search_role#examples)
 
 ## Examples
 
@@ -25,7 +28,7 @@ This rule **forbids** the following:
 ```
 
 ```hbs
-<nav role="navigation"></nav>
+<footer role="contentinfo"></footer>
 ```
 
 ```hbs
@@ -39,11 +42,20 @@ This rule **allows** the following:
 ```
 
 ```hbs
-<footer role="contentinfo"></footer>
+<nav role="navigation"></nav>
 ```
+
+## Configuration
+
+- boolean -- if `true`, default configuration is applied
+
+- object -- containing the following property:
+  - boolean -- `checkAllElementRoles` -- if `true`, the rule checks for redundancy between any semantic HTML element with a default/implicit ARIA role and the role provided
+    (default: `false`) (TODO: enable by default in next major release)
 
 ## References
 
 - [Landmark Roles (WAI-ARIA spec)](https://www.w3.org/WAI/PF/aria/roles#landmark_roles)
 - [Using ARIA landmarks to identify regions of a page](https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA11)
 - [Document conformance requirements for use of ARIA attributes in HTML](https://www.w3.org/TR/html-aria/#docconformance)
+- [ARIA Spec, ARIA Adds Nothing to Default Semantics of Most HTML Elements](https://www.w3.org/TR/using-aria/#aria-does-nothing)

--- a/docs/rule/no-redundant-landmark-role.md
+++ b/docs/rule/no-redundant-landmark-role.md
@@ -50,7 +50,7 @@ This rule **allows** the following:
 - boolean -- if `true`, default configuration is applied
 
 - object -- containing the following property:
-  - boolean -- `checkAllElementRoles` -- if `true`, the rule checks for redundancy between any semantic HTML element with a default/implicit ARIA role and the role provided
+  - boolean -- `checkAllHTMLElements` -- if `true`, the rule checks for redundancy between any semantic HTML element with a default/implicit ARIA role and the role provided
     (default: `false`) (TODO: enable by default in next major release)
 
 ## References

--- a/lib/rules/no-redundant-landmark-role.js
+++ b/lib/rules/no-redundant-landmark-role.js
@@ -1,45 +1,46 @@
+import { roleElements } from 'aria-query';
+
 import AstNodeInfo from '../helpers/ast-node-info.js';
 import Rule from './_base.js';
 
-function createErrorMessage(element, role) {
+const DEFAULT_CONFIG = {
+  checkAllElementRoles: false,
+};
+
+function createErrorMessageLandmarkElement(element, role) {
   return `Use of redundant or invalid role: ${role} on <${element}> detected. If a landmark element is used, any role provided will either be redundant or incorrect.`;
 }
 
+function createErrorMessageAnyElement(element, role) {
+  return `Use of redundant or invalid role: ${role} on <${element}> detected.`;
+}
+
 // https://www.w3.org/TR/html-aria/#docconformance
-const LANDMARK_ROLES = [
-  {
-    name: 'header',
-    role: 'banner',
-  },
-  {
-    name: 'main',
-    role: 'main',
-  },
-  {
-    name: 'aside',
-    role: 'complementary',
-  },
-  {
-    name: 'form',
-    role: 'search',
-    allow: true,
-  },
-  {
-    name: 'form',
-    role: 'form',
-  },
+const LANDMARK_ROLES = new Set([
+  'banner',
+  'main',
+  'complementary',
+  'search',
+  'form',
+  'navigation',
+  'contentinfo',
+]);
+const allowedElementRoles = [
   {
     name: 'nav',
     role: 'navigation',
   },
   {
-    name: 'footer',
-    role: 'contentinfo',
-    allow: true,
+    name: 'form',
+    role: 'search',
   },
 ];
 
 export default class NoRedundantLandmarkRole extends Rule {
+  parseConfig(config) {
+    return parseConfig(config);
+  }
+
   visitor() {
     return {
       ElementNode(node) {
@@ -49,34 +50,56 @@ export default class NoRedundantLandmarkRole extends Rule {
           return;
         }
 
-        const landmarkElements = LANDMARK_ROLES.map((e) => e.name);
-        if (!landmarkElements.includes(node.tag)) {
-          return;
-        }
-
         let roleAttrNode = AstNodeInfo.findAttribute(node, 'role');
         let roleValue;
         if (roleAttrNode.value.type === 'TextNode') {
           roleValue = roleAttrNode.value.chars || '';
         }
 
-        const invalidLandmark = LANDMARK_ROLES.find((e) => {
-          return e.name === node.tag && e.role === roleValue && !e.allow;
-        });
+        let isLandmarkRole = LANDMARK_ROLES.has(roleValue);
+        if (!this.config.checkAllElementRoles && !isLandmarkRole) {
+          return;
+        }
 
-        if (invalidLandmark) {
+        let roleElementInfo = roleElements.get(roleValue);
+        if (!roleElementInfo) {
+          return;
+        }
+
+        const isRedundant =
+          roleElementInfo.find((prop) => prop.name === node.tag) &&
+          !allowedElementRoles.some((e) => e.name === node.tag && e.role === roleValue);
+        if (isRedundant) {
           if (this.mode === 'fix') {
             let roleAttrNode = AstNodeInfo.findAttribute(node, 'role');
             node.attributes = node.attributes.filter((attrNode) => attrNode !== roleAttrNode);
           } else {
+            let errorMessage = isLandmarkRole
+              ? createErrorMessageLandmarkElement(node.tag, roleValue)
+              : createErrorMessageAnyElement(node.tag, roleValue);
             this.log({
-              message: createErrorMessage(node.tag, roleValue),
+              message: errorMessage,
               node,
               isFixable: true,
             });
           }
         }
       },
+    };
+  }
+}
+
+export function parseConfig(config) {
+  if (config === true) {
+    return DEFAULT_CONFIG;
+  }
+
+  if (config && typeof config === 'object') {
+    return {
+      checkAllElementRoles:
+        'checkAllElementRoles' in config
+          ? config.checkAllElementRoles
+          : DEFAULT_CONFIG.checkAllElementRoles,
     };
   }
 }

--- a/lib/rules/no-redundant-landmark-role.js
+++ b/lib/rules/no-redundant-landmark-role.js
@@ -4,7 +4,7 @@ import AstNodeInfo from '../helpers/ast-node-info.js';
 import Rule from './_base.js';
 
 const DEFAULT_CONFIG = {
-  checkAllElementRoles: false,
+  checkAllHTMLElements: false,
 };
 
 function createErrorMessageLandmarkElement(element, role) {
@@ -57,7 +57,7 @@ export default class NoRedundantLandmarkRole extends Rule {
         }
 
         let isLandmarkRole = LANDMARK_ROLES.has(roleValue);
-        if (!this.config.checkAllElementRoles && !isLandmarkRole) {
+        if (!this.config.checkAllHTMLElements && !isLandmarkRole) {
           return;
         }
 
@@ -96,10 +96,10 @@ export function parseConfig(config) {
 
   if (config && typeof config === 'object') {
     return {
-      checkAllElementRoles:
-        'checkAllElementRoles' in config
-          ? config.checkAllElementRoles
-          : DEFAULT_CONFIG.checkAllElementRoles,
+      checkAllHTMLElements:
+        'checkAllHTMLElements' in config
+          ? config.checkAllHTMLElements
+          : DEFAULT_CONFIG.checkAllHTMLElements,
     };
   }
 }

--- a/test/unit/rules/no-redundant-landmark-role-test.js
+++ b/test/unit/rules/no-redundant-landmark-role-test.js
@@ -7,9 +7,46 @@ generateRuleTests({
 
   good: [
     '<form role="search"></form>',
-    '<footer role="contentinfo"></footer>',
     '<footer role={{this.foo}}></footer>',
     '<footer role="{{this.stuff}}{{this.foo}}"></footer>',
+    '<nav role="navigation"></nav>',
+    '<body role="document"></body>',
+    {
+      config: {
+        checkAllElementRoles: true,
+      },
+      template: '<button role="link"></button>',
+    },
+    {
+      config: {
+        checkAllElementRoles: true,
+      },
+      template: '<input type="checkbox" value="yes" checked />',
+    },
+    {
+      config: {
+        checkAllElementRoles: true,
+      },
+      template: '<nav class="navigation" role="navigation></nav>',
+    },
+    {
+      config: {
+        checkAllElementRoles: false,
+      },
+      template: '<input type="range" />',
+    },
+    {
+      config: {
+        checkAllElementRoles: false,
+      },
+      template: '<dialog role="dialog" />',
+    },
+    {
+      config: {
+        checkAllElementRoles: false,
+      },
+      template: '<ul class="list" role="combobox"></ul>',
+    },
   ],
 
   bad: [
@@ -31,6 +68,29 @@ generateRuleTests({
               "rule": "no-redundant-landmark-role",
               "severity": 2,
               "source": "<header role=\\"banner\\"></header>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<footer role="contentinfo"></footer>',
+      fixedTemplate: '<footer></footer>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 36,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Use of redundant or invalid role: contentinfo on <footer> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
+              "rule": "no-redundant-landmark-role",
+              "severity": 2,
+              "source": "<footer role=\\"contentinfo\\"></footer>",
             },
           ]
         `);
@@ -83,29 +143,6 @@ generateRuleTests({
       },
     },
     {
-      template: '<nav role="navigation"></nav>',
-      fixedTemplate: '<nav></nav>',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 29,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "isFixable": true,
-              "line": 1,
-              "message": "Use of redundant or invalid role: navigation on <nav> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
-              "rule": "no-redundant-landmark-role",
-              "severity": 2,
-              "source": "<nav role=\\"navigation\\"></nav>",
-            },
-          ]
-        `);
-      },
-    },
-    {
       template: '<form role="form"></form>',
       fixedTemplate: '<form></form>',
 
@@ -152,23 +189,146 @@ generateRuleTests({
       },
     },
     {
-      template: '<nav role="navigation" class="crumbs" id="id-nav-00"></nav>',
-      fixedTemplate: '<nav class="crumbs" id="id-nav-00"></nav>',
+      config: { checkAllElementRoles: true },
+      template: '<button role="button"></button>',
+      fixedTemplate: '<button></button>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
               "column": 0,
-              "endColumn": 59,
+              "endColumn": 31,
               "endLine": 1,
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "Use of redundant or invalid role: navigation on <nav> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
+              "message": "Use of redundant or invalid role: button on <button> detected.",
               "rule": "no-redundant-landmark-role",
               "severity": 2,
-              "source": "<nav role=\\"navigation\\" class=\\"crumbs\\" id=\\"id-nav-00\\"></nav>",
+              "source": "<button role=\\"button\\"></button>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: { checkAllElementRoles: true },
+      template: '<input type="checkbox" name="agree" value="checkbox1" role="checkbox" />',
+      fixedTemplate: '<input type="checkbox" name="agree" value="checkbox1" />',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 72,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Use of redundant or invalid role: checkbox on <input> detected.",
+              "rule": "no-redundant-landmark-role",
+              "severity": 2,
+              "source": "<input type=\\"checkbox\\" name=\\"agree\\" value=\\"checkbox1\\" role=\\"checkbox\\" />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: { checkAllElementRoles: true },
+      template: '<table><th role="columnheader">Some heading</th><td>cell1</td></table>',
+      fixedTemplate: '<table><th>Some heading</th><td>cell1</td></table>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 7,
+              "endColumn": 48,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Use of redundant or invalid role: columnheader on <th> detected.",
+              "rule": "no-redundant-landmark-role",
+              "severity": 2,
+              "source": "<th role=\\"columnheader\\">Some heading</th>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: { checkAllElementRoles: true },
+      template:
+        '<select name="color" id="color" role="listbox" multiple><option value="default-color">black</option></select>',
+      fixedTemplate:
+        '<select name="color" id="color" multiple><option value="default-color">black</option></select>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 109,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Use of redundant or invalid role: listbox on <select> detected.",
+              "rule": "no-redundant-landmark-role",
+              "severity": 2,
+              "source": "<select name=\\"color\\" id=\\"color\\" role=\\"listbox\\" multiple><option value=\\"default-color\\">black</option></select>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: { checkAllElementRoles: false },
+      template: '<main role="main"></main>',
+      fixedTemplate: '<main></main>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 25,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Use of redundant or invalid role: main on <main> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
+              "rule": "no-redundant-landmark-role",
+              "severity": 2,
+              "source": "<main role=\\"main\\"></main>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: { checkAllElementRoles: false },
+      template: '<aside role="complementary"></aside>',
+      fixedTemplate: '<aside></aside>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 36,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Use of redundant or invalid role: complementary on <aside> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
+              "rule": "no-redundant-landmark-role",
+              "severity": 2,
+              "source": "<aside role=\\"complementary\\"></aside>",
             },
           ]
         `);

--- a/test/unit/rules/no-redundant-landmark-role-test.js
+++ b/test/unit/rules/no-redundant-landmark-role-test.js
@@ -10,40 +10,45 @@ generateRuleTests({
     '<footer role={{this.foo}}></footer>',
     '<footer role="{{this.stuff}}{{this.foo}}"></footer>',
     '<nav role="navigation"></nav>',
-    '<body role="document"></body>',
+    '<body role="document"></body>', // allows redundant non-landmark role when `checkAllHTMLElements` option defaults to `false`
+
     {
-      config: {
-        checkAllElementRoles: true,
-      },
-      template: '<button role="link"></button>',
+      config: { checkAllHTMLElements: true },
+      template: '<footer role={{this.bar}}></footer>',
     },
     {
       config: {
-        checkAllElementRoles: true,
-      },
-      template: '<input type="checkbox" value="yes" checked />',
-    },
-    {
-      config: {
-        checkAllElementRoles: true,
+        checkAllHTMLElements: true,
       },
       template: '<nav class="navigation" role="navigation></nav>',
     },
     {
       config: {
-        checkAllElementRoles: false,
+        checkAllHTMLElements: true,
+      },
+      template: '<button role="link"></button>',
+    },
+    {
+      config: {
+        checkAllHTMLElements: true,
+      },
+      template: '<input type="checkbox" value="yes" checked />',
+    },
+    {
+      config: {
+        checkAllHTMLElements: false,
       },
       template: '<input type="range" />',
     },
     {
       config: {
-        checkAllElementRoles: false,
+        checkAllHTMLElements: false,
       },
       template: '<dialog role="dialog" />',
     },
     {
       config: {
-        checkAllElementRoles: false,
+        checkAllHTMLElements: false,
       },
       template: '<ul class="list" role="combobox"></ul>',
     },
@@ -189,7 +194,7 @@ generateRuleTests({
       },
     },
     {
-      config: { checkAllElementRoles: true },
+      config: { checkAllHTMLElements: true },
       template: '<button role="button"></button>',
       fixedTemplate: '<button></button>',
 
@@ -213,7 +218,7 @@ generateRuleTests({
       },
     },
     {
-      config: { checkAllElementRoles: true },
+      config: { checkAllHTMLElements: true },
       template: '<input type="checkbox" name="agree" value="checkbox1" role="checkbox" />',
       fixedTemplate: '<input type="checkbox" name="agree" value="checkbox1" />',
 
@@ -237,7 +242,7 @@ generateRuleTests({
       },
     },
     {
-      config: { checkAllElementRoles: true },
+      config: { checkAllHTMLElements: true },
       template: '<table><th role="columnheader">Some heading</th><td>cell1</td></table>',
       fixedTemplate: '<table><th>Some heading</th><td>cell1</td></table>',
 
@@ -261,7 +266,7 @@ generateRuleTests({
       },
     },
     {
-      config: { checkAllElementRoles: true },
+      config: { checkAllHTMLElements: true },
       template:
         '<select name="color" id="color" role="listbox" multiple><option value="default-color">black</option></select>',
       fixedTemplate:
@@ -287,7 +292,7 @@ generateRuleTests({
       },
     },
     {
-      config: { checkAllElementRoles: false },
+      config: { checkAllHTMLElements: false },
       template: '<main role="main"></main>',
       fixedTemplate: '<main></main>',
 
@@ -311,7 +316,7 @@ generateRuleTests({
       },
     },
     {
-      config: { checkAllElementRoles: false },
+      config: { checkAllHTMLElements: false },
       template: '<aside role="complementary"></aside>',
       fixedTemplate: '<aside></aside>',
 


### PR DESCRIPTION
This PR fixes #2485.

### Background
Most HTML elements have default/implicit ARIA roles, and setting a role that matches an element's default has no effect. 

This PR adds an option, `checkAllElementRoles`, in the config for the existing `no-redundant-landmark-role` rule to expand its coverage to lint against all HTML elements with default roles.
This PR also adds the `nav` element and the `navigation` role to the list of allowed element-role pairings, as [advised by the W3 for accessibility]((/https://www.w3.org/WAI/GL/wiki/Using_HTML5_nav_element#Example:The_.3Cnav.3E_element)), and the `footer` element and `contentinfo` role are removed due to [redundancy in their functions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/contentinfo_role#description).

References:
- - [ARIA Spec, ARIA Adds Nothing to Default Semantics of Most HTML Elements](https://www.w3.org/TR/using-aria/#aria-does-nothing)
- [JSX `no-redundant-roles` rule](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-redundant-roles.md)

**Allowed**:

```
# examples
<nav role="navigation"></nav>
<form role="search"></form>
<input type="text" />
```

**Forbidden**:

```
# examples
<footer role="contentinfo"></footer>
<input type="checkbox" name="agree" value="checkbox1" role="checkbox" />
<select name="color" id="color" role="listbox" multiple><option value="default-color">black</option></select>
```

### Testing
Tests:       5 skipped, 7545 passed, 7550 total
Snapshots:   990 passed, 990 total
Time:        139.005 s, estimated 159 s
Ran all test suites.
✨  Done in 152.69s.
