### PR TITLE
Add Option to Print Full File Paths

### DIFF
--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -102,6 +102,12 @@ Specify a configuration to override the normally loaded config file:
 ember-template-lint . --config='{"extends": "a11y"}'
 ```
 
+Specify to print full file paths (may be needed for CI build annotations in monorepos)
+
+```bash
+ember-template-lint --print-full-path
+```
+
 Provide a custom formatter from a relative path
 
 ```bash

--- a/lib/formatters/load-formatter.js
+++ b/lib/formatters/load-formatter.js
@@ -12,6 +12,7 @@ import SarifFormatter from './sarif.js';
 
 export function loadFormatter(options) {
   let formatOptions = {
+    printFullPath: options.printFullPath,
     includeTodo: options.includeTodo,
     // env var is used to test output options via tests
     isInteractive: process.stdout.isTTY || process.env['IS_TTY'] === '1',

--- a/lib/formatters/pretty.js
+++ b/lib/formatters/pretty.js
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import path from 'node:path';
 
 import { WARNING_SEVERITY, TODO_SEVERITY } from '../helpers/severity.js';
 
@@ -94,6 +95,10 @@ export default class PrettyFormatter {
 
     if (!options.includeTodo) {
       errors = errors.filter((error) => error.severity !== TODO_SEVERITY);
+    }
+
+    if (options.printFullPath) {
+      filePath = path.resolve(options.workingDirectory, filePath);
     }
 
     if (errors.length === 0) {

--- a/lib/helpers/cli.js
+++ b/lib/helpers/cli.js
@@ -64,6 +64,10 @@ export function parseArgv(_argv) {
       type: 'string',
       default: 'pretty',
     },
+    'print-full-path': {
+      describe: 'Prints full file paths in error messages',
+      boolean: true,
+    },
     'output-file': {
       describe: 'Specify file to write report to',
       type: 'string',

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -55,7 +55,7 @@ describe('ember-template-lint executable', function () {
             --format                            Specify format to be used in printing outp
                                                 ut            [string] [default: "pretty"]
             --print-full-path                   Prints full file paths in error messages
-                                                                                  [boolean]
+                                                                                 [boolean]
             --output-file                       Specify file to write report to   [string]
             --verbose                           Output errors with source description
                                                                                  [boolean]
@@ -124,7 +124,7 @@ describe('ember-template-lint executable', function () {
             --format                            Specify format to be used in printing outp
                                                 ut            [string] [default: "pretty"]
             --print-full-path                   Prints full file paths in error messages
-                                                                                  [boolean]
+                                                                                 [boolean]
             --output-file                       Specify file to write report to   [string]
             --verbose                           Output errors with source description
                                                                                  [boolean]
@@ -698,7 +698,7 @@ describe('ember-template-lint executable', function () {
             --format                            Specify format to be used in printing outp
                                                 ut            [string] [default: "pretty"]
             --print-full-path                   Prints full file paths in error messages
-                                                                                  [boolean]
+                                                                                 [boolean]
             --output-file                       Specify file to write report to   [string]
             --verbose                           Output errors with source description
                                                                                  [boolean]

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -54,6 +54,8 @@ describe('ember-template-lint executable', function () {
                                                 e               [boolean] [default: false]
             --format                            Specify format to be used in printing outp
                                                 ut            [string] [default: "pretty"]
+            --print-full-path                   Prints full file paths in error messages
+                                                                                  [boolean]
             --output-file                       Specify file to write report to   [string]
             --verbose                           Output errors with source description
                                                                                  [boolean]
@@ -121,6 +123,8 @@ describe('ember-template-lint executable', function () {
                                                 e               [boolean] [default: false]
             --format                            Specify format to be used in printing outp
                                                 ut            [string] [default: "pretty"]
+            --print-full-path                   Prints full file paths in error messages
+                                                                                  [boolean]
             --output-file                       Specify file to write report to   [string]
             --verbose                           Output errors with source description
                                                                                  [boolean]
@@ -693,6 +697,8 @@ describe('ember-template-lint executable', function () {
                                                 e               [boolean] [default: false]
             --format                            Specify format to be used in printing outp
                                                 ut            [string] [default: "pretty"]
+            --print-full-path                   Prints full file paths in error messages
+                                                                                  [boolean]
             --output-file                       Specify file to write report to   [string]
             --verbose                           Output errors with source description
                                                                                  [boolean]

--- a/test/acceptance/formatters/pretty-test.js
+++ b/test/acceptance/formatters/pretty-test.js
@@ -186,6 +186,38 @@ describe('pretty formatter', () => {
     expect(result.stderr).toBeFalsy();
   });
 
+  describe('with --print-full-path option', function () {
+    it('should print properly formatted error messages, with full path printed', async function () {
+      await project.setConfig({
+        rules: {
+          'no-bare-strings': true,
+        },
+      });
+      await project.write({
+        app: {
+          templates: {
+            'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+            components: {
+              'foo.hbs': '{{fooData}}',
+            },
+          },
+        },
+      });
+
+      let result = await runBin('.', '--print-full-path');
+
+      expect(result.exitCode).toEqual(1);
+      expect(result.stdout.split('\n')).toEqual([
+        `${project.baseDir}/app/templates/application.hbs`,
+        '  1:4  error  Non-translated string used  no-bare-strings',
+        '  1:25  error  Non-translated string used  no-bare-strings',
+        '',
+        '✖ 2 problems (2 errors, 0 warnings)',
+      ]);
+      expect(result.stderr).toBeFalsy();
+    });
+  });
+
   describe('with --quiet option', function () {
     it('should print properly formatted error messages, omitting any warnings', async function () {
       await project.setConfig({

--- a/test/acceptance/formatters/pretty-test.js
+++ b/test/acceptance/formatters/pretty-test.js
@@ -208,6 +208,9 @@ describe('pretty formatter', () => {
 
       expect(result.exitCode).toEqual(1);
       expect(result.stdout.split('\n')).toEqual([
+        `Linting 2 Total Files with TemplateLint`,
+        `	.hbs: 2`,
+        ``,
         `${project.baseDir}/app/templates/application.hbs`,
         '  1:4  error  Non-translated string used  no-bare-strings',
         '  1:25  error  Non-translated string used  no-bare-strings',

--- a/test/acceptance/formatters/pretty-test.js
+++ b/test/acceptance/formatters/pretty-test.js
@@ -4,6 +4,7 @@ import PrettyFormatter from '../../../lib/formatters/pretty.js';
 import { TODO_SEVERITY } from '../../../lib/helpers/severity.js';
 import { setupProject, teardownProject, runBin } from '../../helpers/bin-tester.js';
 import { getOutputFileContents, setupEnvVar } from '../../helpers/index.js';
+import path from 'node:path';
 
 describe('pretty formatter', () => {
   setupEnvVar('FORCE_COLOR', '0');
@@ -211,7 +212,7 @@ describe('pretty formatter', () => {
         `Linting 2 Total Files with TemplateLint`,
         `	.hbs: 2`,
         ``,
-        `${project.baseDir}/app/templates/application.hbs`,
+        `${project.baseDir}${path.sep}${['app', 'templates', 'application.hbs'].join(path.sep)}`,
         '  1:4  error  Non-translated string used  no-bare-strings',
         '  1:25  error  Non-translated string used  no-bare-strings',
         '',


### PR DESCRIPTION
This is a possible solution to #2488.

The new added `--print-full-path` option will set the pretty printer (I was unsure if this should also impact serif and JSON printers) to print the full directory path.

A more complicated option would be to have some way of defining a git root which would give a cleaner output though still allowing nested annotations to be discoverable. Since GH and most annotation/lint readers have support for full path, I went with the option to print full path. Doing a relative path or print git root would add more complexity to the CLI and would require a bit more to clean up output and things.

If requested, I can add the full path to also change the JSON and serif formatters along with associated tests.