### PR TITLE
Add new rule `require-media-caption`

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Each rule has emojis denoting:
 | [require-iframe-title](./docs/rule/require-iframe-title.md)                                               | ✅  |     | ⌨️  |     |
 | [require-input-label](./docs/rule/require-input-label.md)                                                 | ✅  |     | ⌨️  |     |
 | [require-lang-attribute](./docs/rule/require-lang-attribute.md)                                           | ✅  |     | ⌨️  |     |
+| [require-media-caption](./docs/rule/require-media-caption.md)                                             |     |     | ⌨️  |     |
 | [require-presentational-children](./docs/rule/require-presentational-children.md)                         | ✅  |     | ⌨️  |     |
 | [require-splattributes](./docs/rule/require-splattributes.md)                                             |     |     |     |     |
 | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                                           | ✅  |     | ⌨️  |     |

--- a/docs/rule/require-media-caption.md
+++ b/docs/rule/require-media-caption.md
@@ -1,0 +1,41 @@
+# require-media-caption
+
+Captions provide a text version of the spoken and non-spoken audio information for media. They are essential for making audio and video content accessible for users who are deaf as well as those for whom the media is unavailable (similar to `alt` text on an image when it is unable to load).
+
+Captions should contain all relevant information needed to help users understand the media content, which may include a transcription of the dialogue and descriptions of meaningful sound effects. They are synchronized with the media to allow users access to the portion of the content conveyed via the audio track. Note that when audio or video components include the `muted` attribute, however, captions are *not* necessary.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<audio></audio>
+```
+
+```hbs
+<video><track /></video>
+```
+
+```hbs
+<video><track kind="descriptions" /></video>
+```
+
+This rule **allows** the following:
+
+```hbs
+<audio><track kind="captions"></audio>
+```
+
+```hbs
+<video muted="true"></video>
+```
+
+```hbs
+<video muted></video>
+```
+
+## References
+
+- [Captions_Subtitles _ Web Accessibility Initiative (WAI) _ W3C](https://www.w3.org/WAI/media/av/captions/)
+- [Understanding Success Criterion 1.2.2: Captions (Prerecorded)](https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html)
+- [media-has-caption - eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/media-has-caption.md)

--- a/docs/rule/require-media-caption.md
+++ b/docs/rule/require-media-caption.md
@@ -31,7 +31,7 @@ This rule **allows** the following:
 ```
 
 ```hbs
-<video muted></video>
+<video><track kind="captions" /><track kind="descriptions" /></video>
 ```
 
 ## References

--- a/lib/config/a11y.js
+++ b/lib/config/a11y.js
@@ -30,6 +30,7 @@ export default {
     'require-iframe-title': 'error',
     'require-input-label': 'error',
     'require-lang-attribute': 'error',
+    'require-media-caption': 'error',
     'require-presentational-children': 'error',
     'require-valid-alt-text': 'error',
     'table-groups': 'error',

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -99,6 +99,7 @@ import requirehasblockhelper from './require-has-block-helper.js';
 import requireiframetitle from './require-iframe-title.js';
 import requireinputlabel from './require-input-label.js';
 import requirelangattribute from './require-lang-attribute.js';
+import requiremediacaption from './require-media-caption.js';
 import requirepresentationalchildren from './require-presentational-children.js';
 import requiresplattributes from './require-splattributes.js';
 import requirevalidalttext from './require-valid-alt-text.js';
@@ -210,6 +211,7 @@ export default {
   'require-iframe-title': requireiframetitle,
   'require-input-label': requireinputlabel,
   'require-lang-attribute': requirelangattribute,
+  'require-media-caption': requiremediacaption,
   'require-presentational-children': requirepresentationalchildren,
   'require-splattributes': requiresplattributes,
   'require-valid-alt-text': requirevalidalttext,

--- a/lib/rules/require-media-caption.js
+++ b/lib/rules/require-media-caption.js
@@ -1,0 +1,50 @@
+import AstNodeInfo from '../helpers/ast-node-info.js';
+import Rule from './_base.js';
+
+const ERROR_MESSAGE =
+  'Media elements such as <audio> and <video> must have a <track> for captions.';
+
+const mediaTypes = new Set(['audio', 'video']);
+
+function hasTrackWithCaptions(nodes) {
+  for (let node of nodes) {
+    if (node.tag === 'track') {
+      let kindAttribute = AstNodeInfo.findAttribute(node, 'kind');
+      if (kindAttribute && kindAttribute.value.chars === 'captions') {
+        return true;
+      }
+    }
+  }
+}
+
+export default class RequireMediaCaption extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        if (!mediaTypes.has(node.tag)) {
+          return;
+        }
+
+        const mutedAttribute = AstNodeInfo.findAttribute(node, 'muted');
+        if (mutedAttribute) {
+          if (
+            ['MustacheStatement', 'BlockStatement'].includes(mutedAttribute.value.type) ||
+            ![false, 'false'].includes(mutedAttribute.value.chars)
+          ) {
+            return;
+          }
+        }
+
+        if (
+          !AstNodeInfo.hasChildren(node) ||
+          !hasTrackWithCaptions(AstNodeInfo.childrenFor(node))
+        ) {
+          this.log({
+            message: ERROR_MESSAGE,
+            node,
+          });
+        }
+      },
+    };
+  }
+}

--- a/test/unit/rules/require-media-caption-test.js
+++ b/test/unit/rules/require-media-caption-test.js
@@ -16,47 +16,122 @@ generateRuleTests({
   bad: [
     {
       template: '<video></video>',
-      result: {
-        message: 'Media elements such as <audio> and <video> must have a <track> for captions.',
-        line: 1,
-        column: 0,
-        source: '<video></video>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 15,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Media elements such as <audio> and <video> must have a <track> for captions.",
+              "rule": "require-media-caption",
+              "severity": 2,
+              "source": "<video></video>",
+            },
+          ]
+        `);
       },
     },
     {
       template: '<audio><track /></audio>',
-      result: {
-        message: 'Media elements such as <audio> and <video> must have a <track> for captions.',
-        line: 1,
-        column: 0,
-        source: '<audio><track /></audio>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 24,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Media elements such as <audio> and <video> must have a <track> for captions.",
+              "rule": "require-media-caption",
+              "severity": 2,
+              "source": "<audio><track /></audio>",
+            },
+          ]
+        `);
       },
     },
     {
       template: '<video><track kind="subtitles" /></video>',
-      result: {
-        message: 'Media elements such as <audio> and <video> must have a <track> for captions.',
-        line: 1,
-        column: 0,
-        source: '<video><track kind="subtitles" /></video>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 41,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Media elements such as <audio> and <video> must have a <track> for captions.",
+              "rule": "require-media-caption",
+              "severity": 2,
+              "source": "<video><track kind=\\"subtitles\\" /></video>",
+            },
+          ]
+        `);
       },
     },
     {
       template: '<audio muted="false"></audio>',
-      result: {
-        message: 'Media elements such as <audio> and <video> must have a <track> for captions.',
-        line: 1,
-        column: 0,
-        source: '<audio muted="false"></audio>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 29,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Media elements such as <audio> and <video> must have a <track> for captions.",
+              "rule": "require-media-caption",
+              "severity": 2,
+              "source": "<audio muted=\\"false\\"></audio>",
+            },
+          ]
+        `);
       },
     },
     {
       template: '<audio muted="false"><track kind="descriptions" /></audio>',
-      result: {
-        message: 'Media elements such as <audio> and <video> must have a <track> for captions.',
-        line: 1,
-        column: 0,
-        source: '<audio muted="false"><track kind="descriptions" /></audio>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 58,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Media elements such as <audio> and <video> must have a <track> for captions.",
+              "rule": "require-media-caption",
+              "severity": 2,
+              "source": "<audio muted=\\"false\\"><track kind=\\"descriptions\\" /></audio>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<video muted=false></video>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 27,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Media elements such as <audio> and <video> must have a <track> for captions.",
+              "rule": "require-media-caption",
+              "severity": 2,
+              "source": "<video muted=false></video>",
+            },
+          ]
+        `);
       },
     },
   ],

--- a/test/unit/rules/require-media-caption-test.js
+++ b/test/unit/rules/require-media-caption-test.js
@@ -1,0 +1,63 @@
+import generateRuleTests from '../../helpers/rule-test-harness.js';
+
+generateRuleTests({
+  name: 'require-media-caption',
+
+  config: true,
+
+  good: [
+    '<video><track kind="captions" /></video>',
+    '<audio muted="true"></audio>',
+    '<video muted></video>',
+    '<audio muted={{this.muted}}></audio>',
+    '<video><track kind="captions" /><track kind="descriptions" /></video>',
+  ],
+
+  bad: [
+    {
+      template: '<video></video>',
+      result: {
+        message: 'Media elements such as <audio> and <video> must have a <track> for captions.',
+        line: 1,
+        column: 0,
+        source: '<video></video>',
+      },
+    },
+    {
+      template: '<audio><track /></audio>',
+      result: {
+        message: 'Media elements such as <audio> and <video> must have a <track> for captions.',
+        line: 1,
+        column: 0,
+        source: '<audio><track /></audio>',
+      },
+    },
+    {
+      template: '<video><track kind="subtitles" /></video>',
+      result: {
+        message: 'Media elements such as <audio> and <video> must have a <track> for captions.',
+        line: 1,
+        column: 0,
+        source: '<video><track kind="subtitles" /></video>',
+      },
+    },
+    {
+      template: '<audio muted="false"></audio>',
+      result: {
+        message: 'Media elements such as <audio> and <video> must have a <track> for captions.',
+        line: 1,
+        column: 0,
+        source: '<audio muted="false"></audio>',
+      },
+    },
+    {
+      template: '<audio muted="false"><track kind="descriptions" /></audio>',
+      result: {
+        message: 'Media elements such as <audio> and <video> must have a <track> for captions.',
+        line: 1,
+        column: 0,
+        source: '<audio muted="false"><track kind="descriptions" /></audio>',
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds the new rule require-media-caption which fixes #2496.

### background
Captions are essential for users who are deaf, as well as those for whom the media content is unavailable, to access synchronized media content. By providing a transcript of the spoken content as well as descriptions of other relevant non-speech information, captions allow users access to the information conveyed via the audio track.

Reference: - [Understanding Success Criterion 1.2.2: Captions (Prerecorded)](https://www.w3.org/WAI/WCAG21/Understanding/captions-prerecorded.html)

**Allowed**:
```
# examples
<audio><track kind="captions" /></audio>
<video muted="true"></video>
<video muted></video>
```
**Forbidden**:
```
# examples
<audio></audio>
<video><track /></video>
<video><track kind="descriptions" /></video>
<audio muted="false"></audio>
```

### Testing
Test Suites: 137 passed, 137 total
Tests:       5 skipped, 7534 passed, 7539 total
Snapshots:   985 passed, 985 total
Time:        109.104 s
Ran all test suites.
✨  Done in 115.11s.
