### PR TITLE
Fixes issue where lint-todos add blank lines in .lint-todo storage file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.7.0",
       "license": "MIT",
       "dependencies": {
-        "@lint-todo/utils": "^13.0.2",
+        "@lint-todo/utils": "^13.0.3",
         "aria-query": "^5.0.0",
         "chalk": "^4.1.2",
         "ci-info": "^3.3.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     ]
   },
   "dependencies": {
-    "@lint-todo/utils": "^13.0.2",
+    "@lint-todo/utils": "^13.0.3",
     "aria-query": "^5.0.0",
     "chalk": "^4.1.2",
     "ci-info": "^3.3.0",


### PR DESCRIPTION
Title is self explanatory. 