### PR TITLE
Fixes CI OOM issues in Windows for Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
     name: Node ${{ matrix.node-version }} - ${{ matrix.os }}
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
 
     strategy:
       matrix:


### PR DESCRIPTION
There seems to be fairly consistent OOM issues with Node 18 on Windows for our CI jobs. Example: https://github.com/ember-template-lint/ember-template-lint/runs/6409591432?check_suite_focus=true 

This change bumps the memory limit for CI.