### PR TITLE
Add new rule `no-aria-unsupported-elements`

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Each rule has emojis denoting:
 | [no-args-paths](./docs/rule/no-args-paths.md)                                                             | ✅  |     |     |     |
 | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)                           | ✅  |     |     |     |
 | [no-aria-hidden-body](./docs/rule/no-aria-hidden-body.md)                                                 | ✅  |     | ⌨️  | 🔧  |
+| [no-aria-unsupported-elements](./docs/rule/no-aria-unsupported-elements.md)                               |     |     | ⌨️  |     |
 | [no-array-prototype-extensions](./docs/rule/no-array-prototype-extensions.md)                             |     |     |     | 🔧  |
 | [no-attrs-in-components](./docs/rule/no-attrs-in-components.md)                                           | ✅  |     |     |     |
 | [no-autofocus-attribute](./docs/rule/no-autofocus-attribute.md)                                           | ✅  |     | ⌨️  |     |

--- a/docs/rule/no-aria-unsupported-elements.md
+++ b/docs/rule/no-aria-unsupported-elements.md
@@ -1,6 +1,15 @@
 # no-aria-unsupported-elements
 
-Certain reserved DOM elements like `meta`, `html`, `script`, `style` do not support ARIA roles, states and properties. This is often because they are not visible. This rule enforces that these DOM elements do not contain the `role` and/or `aria-*` props.
+Certain reserved DOM elements do not support ARIA roles, states and properties. This is often because they are not visible.
+
+These elements include:
+
+- `html`
+- `meta`
+- `script`
+- `style`
+
+This rule enforces that these DOM elements do not contain the `role` and/or `aria-*` props.
 
 ## Examples
 

--- a/docs/rule/no-aria-unsupported-elements.md
+++ b/docs/rule/no-aria-unsupported-elements.md
@@ -1,0 +1,38 @@
+# no-aria-unsupported-elements
+
+Certain reserved DOM elements like `meta`, `html`, `script`, `style` do not support ARIA roles, states and properties. This is often because they are not visible. This rule enforces that these DOM elements do not contain the `role` and/or `aria-*` props.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<meta charset="UTF-8" aria-hidden="false" />
+```
+
+```hbs
+<html lang="en" role="application"></html>
+```
+
+```hbs
+<script aria-hidden="false"></script>
+```
+
+This rule **allows** the following:
+
+```hbs
+<meta charset="UTF-8" />
+```
+
+```hbs
+<html lang="en"></html>
+```
+
+```hbs
+<script></script>
+```
+
+## References
+
+- [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)
+- [aria-unsupported-elements - eslint-plugin-jsx-a11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/aria-unsupported-elements.md)

--- a/lib/config/a11y.js
+++ b/lib/config/a11y.js
@@ -4,6 +4,7 @@ export default {
     'no-abstract-roles': 'error',
     'no-accesskey-attribute': 'error',
     'no-aria-hidden-body': 'error',
+    'no-aria-unsupported-elements': 'error',
     'no-autofocus-attribute': 'error',
     'no-down-event-binding': 'error',
     'no-duplicate-attributes': 'error',

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -18,6 +18,7 @@ import noaction from './no-action.js';
 import noargspaths from './no-args-paths.js';
 import noargumentsforhtmlelements from './no-arguments-for-html-elements.js';
 import noariahiddenbody from './no-aria-hidden-body.js';
+import noariaunsupportedelements from './no-aria-unsupported-elements.js';
 import noarrayprototypeextensions from './no-array-prototype-extensions.js';
 import noattrsincomponents from './no-attrs-in-components.js';
 import noautofocusattribute from './no-autofocus-attribute.js';
@@ -130,6 +131,7 @@ export default {
   'no-args-paths': noargspaths,
   'no-arguments-for-html-elements': noargumentsforhtmlelements,
   'no-aria-hidden-body': noariahiddenbody,
+  'no-aria-unsupported-elements': noariaunsupportedelements,
   'no-array-prototype-extensions': noarrayprototypeextensions,
   'no-attrs-in-components': noattrsincomponents,
   'no-autofocus-attribute': noautofocusattribute,

--- a/lib/rules/no-aria-unsupported-elements.js
+++ b/lib/rules/no-aria-unsupported-elements.js
@@ -1,0 +1,40 @@
+import AstNodeInfo from '../helpers/ast-node-info.js';
+import Rule from './_base.js';
+
+export function ERROR_MESSAGE_ARIA_UNSUPPORTED_PROPERTY(tag, name) {
+  return `The <${tag}> element does not support the use of ARIA roles, states, and properties such as ${name}`;
+}
+const RESERVED_ELEMENTS = new Set(['html', 'meta', 'script', 'style']);
+
+export default class NoAriaUnsupportedElements extends Rule {
+  isReserved(tag) {
+    return RESERVED_ELEMENTS.has(tag);
+  }
+  visitor() {
+    return {
+      ElementNode(node) {
+        const isReserved = this.isReserved(node.tag);
+        if (isReserved) {
+          // Detect `role` attribute
+          const hasRoleAttr = AstNodeInfo.findAttribute(node, 'role');
+          if (hasRoleAttr) {
+            this.log({
+              message: ERROR_MESSAGE_ARIA_UNSUPPORTED_PROPERTY(node.tag, 'role'),
+              node,
+            });
+          }
+
+          // Detect `aria-*` attributes
+          for (const attribute of node.attributes) {
+            if (attribute.name.startsWith('aria-')) {
+              this.log({
+                message: ERROR_MESSAGE_ARIA_UNSUPPORTED_PROPERTY(node.tag, attribute.name),
+                node,
+              });
+            }
+          }
+        }
+      },
+    };
+  }
+}

--- a/lib/rules/no-aria-unsupported-elements.js
+++ b/lib/rules/no-aria-unsupported-elements.js
@@ -2,18 +2,15 @@ import AstNodeInfo from '../helpers/ast-node-info.js';
 import Rule from './_base.js';
 
 export function ERROR_MESSAGE_ARIA_UNSUPPORTED_PROPERTY(tag, name) {
-  return `The <${tag}> element does not support the use of ARIA roles, states, and properties such as ${name}`;
+  return `The <${tag}> element does not support the use of ARIA roles, states, and properties such as "${name}"`;
 }
-const RESERVED_ELEMENTS = new Set(['html', 'meta', 'script', 'style']);
+const NON_ARIA_ELEMENTS = new Set(['html', 'meta', 'script', 'style']);
 
 export default class NoAriaUnsupportedElements extends Rule {
-  isReserved(tag) {
-    return RESERVED_ELEMENTS.has(tag);
-  }
   visitor() {
     return {
       ElementNode(node) {
-        const isReserved = this.isReserved(node.tag);
+        const isReserved = NON_ARIA_ELEMENTS.has(node.tag);
         if (isReserved) {
           // Detect `role` attribute
           const hasRoleAttr = AstNodeInfo.findAttribute(node, 'role');

--- a/test/unit/rules/no-aria-unsupported-elements-test.js
+++ b/test/unit/rules/no-aria-unsupported-elements-test.js
@@ -5,7 +5,14 @@ generateRuleTests({
 
   config: true,
 
-  good: ['<meta charset="UTF-8" />', '<html lang="en"></html>', '<script></script>'],
+  good: [
+    '<meta charset="UTF-8" />',
+    '<html lang="en"></html>',
+    '<script></script>',
+    '<div></div>',
+    '<div aria-foo="true"></div>',
+    '<div role="foo"></div>',
+  ],
 
   bad: [
     {
@@ -19,7 +26,7 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "The <meta> element does not support the use of ARIA roles, states, and properties such as aria-hidden",
+              "message": "The <meta> element does not support the use of ARIA roles, states, and properties such as \\"aria-hidden\\"",
               "rule": "no-aria-unsupported-elements",
               "severity": 2,
               "source": "<meta charset=\\"UTF-8\\" aria-hidden=\\"false\\" />",
@@ -39,7 +46,7 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "The <html> element does not support the use of ARIA roles, states, and properties such as role",
+              "message": "The <html> element does not support the use of ARIA roles, states, and properties such as \\"role\\"",
               "rule": "no-aria-unsupported-elements",
               "severity": 2,
               "source": "<html lang=\\"en\\" role=\\"application\\"></html>",
@@ -59,7 +66,7 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "The <script> element does not support the use of ARIA roles, states, and properties such as aria-hidden",
+              "message": "The <script> element does not support the use of ARIA roles, states, and properties such as \\"aria-hidden\\"",
               "rule": "no-aria-unsupported-elements",
               "severity": 2,
               "source": "<script aria-hidden=\\"false\\"></script>",

--- a/test/unit/rules/no-aria-unsupported-elements-test.js
+++ b/test/unit/rules/no-aria-unsupported-elements-test.js
@@ -1,0 +1,72 @@
+import generateRuleTests from '../../helpers/rule-test-harness.js';
+
+generateRuleTests({
+  name: 'no-aria-unsupported-elements',
+
+  config: true,
+
+  good: ['<meta charset="UTF-8" />', '<html lang="en"></html>', '<script></script>'],
+
+  bad: [
+    {
+      template: '<meta charset="UTF-8" aria-hidden="false" />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 44,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "The <meta> element does not support the use of ARIA roles, states, and properties such as aria-hidden",
+              "rule": "no-aria-unsupported-elements",
+              "severity": 2,
+              "source": "<meta charset=\\"UTF-8\\" aria-hidden=\\"false\\" />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<html lang="en" role="application"></html>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 42,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "The <html> element does not support the use of ARIA roles, states, and properties such as role",
+              "rule": "no-aria-unsupported-elements",
+              "severity": 2,
+              "source": "<html lang=\\"en\\" role=\\"application\\"></html>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<script aria-hidden="false"></script>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 37,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "The <script> element does not support the use of ARIA roles, states, and properties such as aria-hidden",
+              "rule": "no-aria-unsupported-elements",
+              "severity": 2,
+              "source": "<script aria-hidden=\\"false\\"></script>",
+            },
+          ]
+        `);
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds the new rule `no-aria-unsupported-elements` which fixes #2504.

# Background
Certain reserved DOM elements like `meta`, `html`, `script`, `style` do not support ARIA roles, states and properties. This is often because they are not visible. This rule enforces that these DOM elements do not contain the `role` and/or `aria-*` props.

Reference: [Understanding Success Criterion 4.1.2: Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value)

## Allowed

```
# examples
<meta charset="UTF-8" />
<html lang="en"></html>
<script></script>
```

## Forbidden:

```
# examples
<meta charset="UTF-8" aria-hidden="false" />
<html lang="en" role="application"></html>
<script aria-hidden="false"></script>
```

## Testing

```
Test Suites: 138 passed, 138 total
Tests:       5 skipped, 7601 passed, 7606 total
Snapshots:   999 passed, 999 total
Time:        114.355 s, estimated 124 s
Ran all test suites.
```