### PR TITLE
Update yargs to 17.5.1 to fix `--version`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "micromatch": "^4.0.5",
         "resolve": "^1.22.0",
         "v8-compile-cache": "^2.3.0",
-        "yargs": "^17.4.1"
+        "yargs": "^17.5.1"
       },
       "bin": {
         "ember-template-lint": "bin/ember-template-lint.js"
@@ -13877,9 +13877,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.0.tgz",
-      "integrity": "sha512-3sLxVhbAB5OC8qvVRebCLWuouhwh/rswsiDYx3WGxajUk/l4G20SKfrKKFeNIHboUFt2JFgv2yfn+5cgOr/t5A==",
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
       "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
@@ -24892,9 +24892,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.0.tgz",
-      "integrity": "sha512-3sLxVhbAB5OC8qvVRebCLWuouhwh/rswsiDYx3WGxajUk/l4G20SKfrKKFeNIHboUFt2JFgv2yfn+5cgOr/t5A==",
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.5.1.tgz",
+      "integrity": "sha512-t6YAJcxDkNX7NFYiVtKvWUz8l+PaKTLiL63mJYWR2GnHq2gjEWISzsLp9wg3aY36dY1j+gfIEL3pIF+XlJJfbA==",
       "requires": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "micromatch": "^4.0.5",
     "resolve": "^1.22.0",
     "v8-compile-cache": "^2.3.0",
-    "yargs": "^17.4.1"
+    "yargs": "^17.5.1"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.17.0",


### PR DESCRIPTION
fixes #2431

There was an [issue with yargs ](https://github.com/yargs/yargs/issues/2122) when used with ESM that caused `--version` to report the consuming app's version instead of `ember-template-lint`'s. This was fixed in https://github.com/yargs/yargs/pull/2123 and released in [yargs@17.5.1](https://github.com/yargs/yargs/releases/tag/v17.5.1).