### PR TITLE
Add new rule `no-unsupported-role-attributes`

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Each rule has emojis denoting:
 | [no-unknown-arguments-for-builtin-components](./docs/rule/no-unknown-arguments-for-builtin-components.md) | ✅  |     |     | 🔧  |
 | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)                         | ✅  |     |     |     |
 | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                                             |     | 💅  |     |     |
-| [no-unsupported-role-attributes](./docs/rule/no-unsupported-role-attributes.md)                           |     | 💅  |     |     |
+| [no-unsupported-role-attributes](./docs/rule/no-unsupported-role-attributes.md)                           |     |     | ⌨️  | 🔧  |
 | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                                           | ✅  |     |     |     |
 | [no-valueless-arguments](./docs/rule/no-valueless-arguments.md)                                           | ✅  |     |     |     |
 | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                                       | ✅  |     | ⌨️  |     |

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Each rule has emojis denoting:
 | [no-unknown-arguments-for-builtin-components](./docs/rule/no-unknown-arguments-for-builtin-components.md) | ✅  |     |     | 🔧  |
 | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)                         | ✅  |     |     |     |
 | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                                             |     | 💅  |     |     |
+| [no-unsupported-role-attributes](./docs/rule/no-unsupported-role-attributes.md)                                             |     | 💅  |     |     |
 | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                                           | ✅  |     |     |     |
 | [no-valueless-arguments](./docs/rule/no-valueless-arguments.md)                                           | ✅  |     |     |     |
 | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                                       | ✅  |     | ⌨️  |     |

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Each rule has emojis denoting:
 | [no-unknown-arguments-for-builtin-components](./docs/rule/no-unknown-arguments-for-builtin-components.md) | ✅  |     |     | 🔧  |
 | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)                         | ✅  |     |     |     |
 | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                                             |     | 💅  |     |     |
-| [no-unsupported-role-attributes](./docs/rule/no-unsupported-role-attributes.md)                                             |     | 💅  |     |     |
+| [no-unsupported-role-attributes](./docs/rule/no-unsupported-role-attributes.md)                           |     | 💅  |     |     |
 | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                                           | ✅  |     |     |     |
 | [no-valueless-arguments](./docs/rule/no-valueless-arguments.md)                                           | ✅  |     |     |     |
 | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                                       | ✅  |     | ⌨️  |     |

--- a/docs/rule/no-unsupported-role-attributes.md
+++ b/docs/rule/no-unsupported-role-attributes.md
@@ -1,0 +1,29 @@
+# no-unsupported-role-attributes
+
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
+Many ARIA states and properties are only available to elements with particular roles. This ensures that the appropriate information gets exposed to a browser's accessibility API for the given element.
+
+This rule disallows the use of ARIA properties unsupported by an element's defined role. An element's role may either be explicitly set by the `role` attribute, or it may be implicitly defined through the use of HTML elements with inherent roles. For example, `<input type="checkbox"` has the implicit role of `checkbox`.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<div role="link" href="#" aria-checked />
+<input type="checkbox" aria-invalid="grammar" />
+<CustomComponent role="listbox" aria-level="2" />
+```
+
+This rule **allows** the following:
+
+```hbs
+<div role="heading" aria-level="1" />
+<input type="image" aria-atomic />
+<CustomComponent role="textbox" aria-required="true" />
+```
+
+## References
+
+- [Using ARIA, Roles, States, and Properties](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques)

--- a/lib/config/a11y.js
+++ b/lib/config/a11y.js
@@ -24,6 +24,7 @@ export default {
     'no-positive-tabindex': 'error',
     'no-redundant-landmark-role': 'error',
     'no-scope-outside-table-headings': 'error',
+    'no-unsupported-role-attributes': 'error',
     'no-whitespace-for-layout': 'error',
     'no-whitespace-within-word': 'error',
     'require-aria-activedescendant-tabindex': 'error',

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -83,6 +83,7 @@ import nounbound from './no-unbound.js';
 import nounknownargumentsforbuiltincomponents from './no-unknown-arguments-for-builtin-components.js';
 import nounnecessarycomponenthelper from './no-unnecessary-component-helper.js';
 import nounnecessaryconcat from './no-unnecessary-concat.js';
+import nounsupportedroleattributes from './no-unsupported-role-attributes.js';
 import nounusedblockparams from './no-unused-block-params.js';
 import novaluelessarguments from './no-valueless-arguments.js';
 import nowhitespaceforlayout from './no-whitespace-for-layout.js';
@@ -196,6 +197,7 @@ export default {
   'no-unknown-arguments-for-builtin-components': nounknownargumentsforbuiltincomponents,
   'no-unnecessary-component-helper': nounnecessarycomponenthelper,
   'no-unnecessary-concat': nounnecessaryconcat,
+  'no-unsupported-role-attributes': nounsupportedroleattributes,
   'no-unused-block-params': nounusedblockparams,
   'no-valueless-arguments': novaluelessarguments,
   'no-whitespace-for-layout': nowhitespaceforlayout,

--- a/lib/rules/no-unsupported-role-attributes.js
+++ b/lib/rules/no-unsupported-role-attributes.js
@@ -83,6 +83,49 @@ export default class NoUnsupportedRoleAttributes extends Rule {
           }
         }
       },
+      MustacheStatement(node) {
+        const roleAttribute = node.hash.pairs.find((pair) => pair.key === 'role');
+        if (!roleAttribute) {
+          return;
+        }
+        if (!roleAttribute.value.type === 'StringLiteral') {
+          return;
+        }
+        let role = roleAttribute.value.original;
+
+        // Skip validation for elements with unknown ARIA roles
+        if (!role) {
+          return;
+        }
+        const roleDefinition = roles.get(role);
+        if (!roleDefinition) {
+          return;
+        }
+
+        // Get a list of the ARIA attributes defined for this element
+        let foundAriaAttributes = [];
+        for (const pair of node.hash.pairs) {
+          if (pair.key.startsWith('aria-')) {
+            foundAriaAttributes.push(pair);
+          }
+        }
+
+        // Check that each ARIA attribute found is within the supported property set for the role
+        const supportedProps = Object.keys(roleDefinition.props);
+        for (let attribute of foundAriaAttributes) {
+          if (!supportedProps.includes(attribute.key)) {
+            if (this.mode === 'fix') {
+              node.hash.pairs = node.hash.pairs.filter((pair) => pair !== attribute);
+            } else {
+              this.log({
+                message: createUnsupportedAttributeErrorMessage(attribute.key, role, undefined),
+                node,
+                isFixable: true,
+              });
+            }
+          }
+        }
+      },
     };
   }
 }

--- a/lib/rules/no-unsupported-role-attributes.js
+++ b/lib/rules/no-unsupported-role-attributes.js
@@ -1,0 +1,84 @@
+import { roles, elementRoles } from 'aria-query';
+
+import AstNodeInfo from '../helpers/ast-node-info.js';
+import Rule from './_base.js';
+
+function createUnsupportedAttributeErrorMessage(attr, role, element) {
+  if (element) {
+    return `The attribute ${attr} is not supported by the element ${element} with the implicit role of ${role}`;
+  } else {
+    return `The attribute ${attr} is not supported by the role ${role}`;
+  }
+}
+function getImplicitRole(element, typeAttribute) {
+  if (element === 'input') {
+    for (let key of elementRoles.keys()) {
+      if (key.name === element) {
+        let attributes = key.attributes;
+        for (let attribute of attributes) {
+          if (attribute.name === 'type' && attribute.value === typeAttribute) {
+            return elementRoles.get(key)[0];
+          }
+        }
+      }
+    }
+  } else {
+    return elementRoles.get(elementRoles.keys().find((key) => key.name === element))[0];
+  }
+}
+
+export default class NoUnsupportedRoleAttributes extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        let element, typeAttribute, role;
+        if (AstNodeInfo.hasAttribute(node, 'role')) {
+          let roleAttrNode = AstNodeInfo.findAttribute(node, 'role');
+          if (roleAttrNode.value.type === 'TextNode') {
+            role = roleAttrNode.value.chars || '';
+          }
+        } else {
+          element = node.tag;
+          if (AstNodeInfo.hasAttribute(node, 'type')) {
+            let typeAttrNode = AstNodeInfo.findAttribute(node, 'type');
+            if (typeAttrNode.value.type === 'TextNode') {
+              typeAttribute = typeAttrNode.value.chars || '';
+            }
+          }
+          role = getImplicitRole(element, typeAttribute);
+        }
+
+        // Skip validation for elements with unknown ARIA roles
+        if (!role) {
+          return;
+        }
+        const roleDefinition = roles.get(role);
+        if (roleDefinition === undefined) {
+          return;
+        }
+
+        let foundAriaAttributes = [];
+        for (const attribute of node.attributes) {
+          if (attribute.name.startsWith('aria-')) {
+            foundAriaAttributes.push(attribute);
+          }
+        }
+
+        const supportedProps = Object.keys(roleDefinition.props);
+        for (let attribute of foundAriaAttributes) {
+          if (!supportedProps.includes(attribute.name)) {
+            if (this.mode === 'fix') {
+              node.attributes = node.attributes.filter((attrNode) => attrNode !== attribute);
+            } else {
+              this.log({
+                message: createUnsupportedAttributeErrorMessage(attribute.name, role, element),
+                node,
+                isFixable: true,
+              });
+            }
+          }
+        }
+      },
+    };
+  }
+}

--- a/lib/rules/no-unsupported-role-attributes.js
+++ b/lib/rules/no-unsupported-role-attributes.js
@@ -22,9 +22,8 @@ function getImplicitRole(element, typeAttribute) {
         }
       }
     }
-  } else {
-    return elementRoles.get(elementRoles.keys().find((key) => key.name === element))[0];
   }
+  return elementRoles.get(elementRoles.keys().find((key) => key.name === element))[0];
 }
 
 export default class NoUnsupportedRoleAttributes extends Rule {
@@ -32,12 +31,15 @@ export default class NoUnsupportedRoleAttributes extends Rule {
     return {
       ElementNode(node) {
         let element, typeAttribute, role;
+        // Check if role is explicitly defined
         if (AstNodeInfo.hasAttribute(node, 'role')) {
           let roleAttrNode = AstNodeInfo.findAttribute(node, 'role');
           if (roleAttrNode.value.type === 'TextNode') {
-            role = roleAttrNode.value.chars || '';
+            role = roleAttrNode.value.chars || undefined;
           }
-        } else {
+        }
+        // Otherwise try and get implicit role
+        else {
           element = node.tag;
           if (AstNodeInfo.hasAttribute(node, 'type')) {
             let typeAttrNode = AstNodeInfo.findAttribute(node, 'type');
@@ -53,10 +55,11 @@ export default class NoUnsupportedRoleAttributes extends Rule {
           return;
         }
         const roleDefinition = roles.get(role);
-        if (roleDefinition === undefined) {
+        if (!roleDefinition) {
           return;
         }
 
+        // Get a list of the ARIA attributes defined for this element
         let foundAriaAttributes = [];
         for (const attribute of node.attributes) {
           if (attribute.name.startsWith('aria-')) {
@@ -64,6 +67,7 @@ export default class NoUnsupportedRoleAttributes extends Rule {
           }
         }
 
+        // Check that each ARIA attribute found is within the supported property set for the role
         const supportedProps = Object.keys(roleDefinition.props);
         for (let attribute of foundAriaAttributes) {
           if (!supportedProps.includes(attribute.name)) {

--- a/lib/rules/no-unsupported-role-attributes.js
+++ b/lib/rules/no-unsupported-role-attributes.js
@@ -67,7 +67,7 @@ export default class NoUnsupportedRoleAttributes extends Rule {
           }
         }
 
-        // Check that each ARIA attribute found is within the supported property set for the role
+        // Check that each ARIA attribute found is within the supported property set for its role
         const supportedProps = Object.keys(roleDefinition.props);
         for (let attribute of foundAriaAttributes) {
           if (!supportedProps.includes(attribute.name)) {
@@ -110,7 +110,7 @@ export default class NoUnsupportedRoleAttributes extends Rule {
           }
         }
 
-        // Check that each ARIA attribute found is within the supported property set for the role
+        // Check that each ARIA attribute found is within the supported property set for its role
         const supportedProps = Object.keys(roleDefinition.props);
         for (let attribute of foundAriaAttributes) {
           if (!supportedProps.includes(attribute.key)) {

--- a/test/unit/rules/no-unsupported-role-attributes-test.js
+++ b/test/unit/rules/no-unsupported-role-attributes-test.js
@@ -20,6 +20,8 @@ generateRuleTests({
     '<input type="submit" aria-disabled="true" />',
     '<select aria-expanded="false" aria-controls="ctrlID" />',
     '<div type="button" foo="true" />',
+    '{{some-component role="heading" aria-level="2"}}',
+    '{{other-component role=this.role aria-bogus="true"}}',
   ],
 
   bad: [
@@ -226,6 +228,29 @@ generateRuleTests({
               "rule": "no-unsupported-role-attributes",
               "severity": 2,
               "source": "<input type=\\"email\\" aria-level={{this.level}} />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '{{foo-component role="button" aria-valuetext="blahblahblah"}}',
+      fixedTemplate: '{{foo-component role="button"}}',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 61,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "The attribute aria-valuetext is not supported by the role button",
+              "rule": "no-unsupported-role-attributes",
+              "severity": 2,
+              "source": "{{foo-component role=\\"button\\" aria-valuetext=\\"blahblahblah\\"}}",
             },
           ]
         `);

--- a/test/unit/rules/no-unsupported-role-attributes-test.js
+++ b/test/unit/rules/no-unsupported-role-attributes-test.js
@@ -11,6 +11,7 @@ generateRuleTests({
     '<span role="checkbox" aria-checked={{this.checked}}></span>',
     '<CustomComponent role="banner" />',
     '<div role="textbox" aria-required={{this.required}} aria-errormessage={{this.error}}></div>',
+    '<div role="heading" foo="true" />',
     '<dialog />',
     '<a href="#" aria-describedby=""></a>',
     '<menu type="toolbar" aria-hidden="true" />',
@@ -18,6 +19,7 @@ generateRuleTests({
     '<input type="image" aria-atomic />',
     '<input type="submit" aria-disabled="true" />',
     '<select aria-expanded="false" aria-controls="ctrlID" />',
+    '<div type="button" foo="true" />',
   ],
 
   bad: [

--- a/test/unit/rules/no-unsupported-role-attributes-test.js
+++ b/test/unit/rules/no-unsupported-role-attributes-test.js
@@ -1,0 +1,233 @@
+import generateRuleTests from '../../helpers/rule-test-harness.js';
+
+generateRuleTests({
+  name: 'no-unsupported-role-attributes',
+
+  config: true,
+
+  good: [
+    '<div role="button" aria-disabled="true"></div>',
+    '<div role="heading" aria-level="1" />',
+    '<span role="checkbox" aria-checked={{this.checked}}></span>',
+    '<CustomComponent role="banner" />',
+    '<div role="textbox" aria-required={{this.required}} aria-errormessage={{this.error}}></div>',
+    '<dialog />',
+    '<a href="#" aria-describedby=""></a>',
+    '<menu type="toolbar" aria-hidden="true" />',
+    '<menuitem type="command" aria-labelledby={{this.label}} />',
+    '<input type="image" aria-atomic />',
+    '<input type="submit" aria-disabled="true" />',
+    '<select aria-expanded="false" aria-controls="ctrlID" />',
+  ],
+
+  bad: [
+    {
+      template: '<div role="link" href="#" aria-checked />',
+      fixedTemplate: '<div role="link" href="#" />',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 41,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "The attribute aria-checked is not supported by the role link",
+              "rule": "no-unsupported-role-attributes",
+              "severity": 2,
+              "source": "<div role=\\"link\\" href=\\"#\\" aria-checked />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<CustomComponent role="listbox" aria-level="2" />',
+      fixedTemplate: '<CustomComponent role="listbox" />',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 49,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "The attribute aria-level is not supported by the role listbox",
+              "rule": "no-unsupported-role-attributes",
+              "severity": 2,
+              "source": "<CustomComponent role=\\"listbox\\" aria-level=\\"2\\" />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<div role="option" aria-notreal="bogus" aria-selected="false" />',
+      fixedTemplate: '<div role="option" aria-selected="false" />',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 64,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "The attribute aria-notreal is not supported by the role option",
+              "rule": "no-unsupported-role-attributes",
+              "severity": 2,
+              "source": "<div role=\\"option\\" aria-notreal=\\"bogus\\" aria-selected=\\"false\\" />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template:
+        '<div role="combobox" aria-multiline="true" aria-expanded="false" aria-controls="someId" />',
+      fixedTemplate: '<div role="combobox" aria-expanded="false" aria-controls="someId" />',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 90,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "The attribute aria-multiline is not supported by the role combobox",
+              "rule": "no-unsupported-role-attributes",
+              "severity": 2,
+              "source": "<div role=\\"combobox\\" aria-multiline=\\"true\\" aria-expanded=\\"false\\" aria-controls=\\"someId\\" />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<button type="submit" aria-valuetext="woosh"></button>',
+      fixedTemplate: '<button type="submit"></button>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 54,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "The attribute aria-valuetext is not supported by the element button with the implicit role of button",
+              "rule": "no-unsupported-role-attributes",
+              "severity": 2,
+              "source": "<button type=\\"submit\\" aria-valuetext=\\"woosh\\"></button>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<menu type="toolbar" aria-expanded="true" />',
+      fixedTemplate: '<menu type="toolbar" />',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 44,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "The attribute aria-expanded is not supported by the element menu with the implicit role of list",
+              "rule": "no-unsupported-role-attributes",
+              "severity": 2,
+              "source": "<menu type=\\"toolbar\\" aria-expanded=\\"true\\" />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<menuitem type="command" aria-checked={{this.checked}} />',
+      fixedTemplate: '<menuitem type="command" />',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 57,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "The attribute aria-checked is not supported by the element menuitem with the implicit role of command",
+              "rule": "no-unsupported-role-attributes",
+              "severity": 2,
+              "source": "<menuitem type=\\"command\\" aria-checked={{this.checked}} />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<input type="checkbox" aria-invalid="grammar" />',
+      fixedTemplate: '<input type="checkbox" />',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 48,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "The attribute aria-invalid is not supported by the element input with the implicit role of button",
+              "rule": "no-unsupported-role-attributes",
+              "severity": 2,
+              "source": "<input type=\\"checkbox\\" aria-invalid=\\"grammar\\" />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<input type="email" aria-level={{this.level}} />',
+      fixedTemplate: '<input type="email" />',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 48,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "The attribute aria-level is not supported by the element input with the implicit role of combobox",
+              "rule": "no-unsupported-role-attributes",
+              "severity": 2,
+              "source": "<input type=\\"email\\" aria-level={{this.level}} />",
+            },
+          ]
+        `);
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This PR adds the new rule no-unsupported-role-attributes which fixes #510 .

### Background
Many ARIA states and properties are only available to elements with particular roles. This ensures that the appropriate information gets exposed to a browser's accessibility API for the given element.

This rule enforces that elements only contain ARIA attributes supported by its declared role. This is essentially a port of JSX's [role-supports-aria-props](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/role-supports-aria-props.md) rule.

**Allowed**:
```
# examples
<div role="heading" aria-level="1" />
<input type="image" aria-atomic />
<CustomComponent role="textbox" aria-required="true" />
```
**Forbidden**:
```
# examples
<div role="link" href="#" aria-checked />
<input type="checkbox" aria-invalid="grammar" />
<CustomComponent role="listbox" aria-level="2" />
```

Reference: [Using ARIA, Roles, States, and Properties](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques)

### Testing
Test Suites: 128 passed, 128 total
Tests:       6 skipped, 6842 passed, 6848 total
Snapshots:   86 passed, 86 total
Time:        62.737 s
Ran all test suites.
✨  Done in 80.92s.
