### PR TITLE
Update overrides example

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -12,7 +12,7 @@ This option takes an array of objects where each object would support 2 keys:
 - `files`: Array of glob patterns (that would either match the exact modules or glob-match multiple modules)
 - `rules`: An object of lint rules that the user wants to override for the specific files
 
-- **module** -- `'app/templates/exceptional-page'`
+- **module** -- `'app/templates/exceptional-page.hbs'`
 - **glob** -- `'app/templates/components/odd-ones/**'`
 
 ## Sample configuration

--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -4,15 +4,15 @@ You can tell the linter to override certain aspects for individual files or enti
 
 The overrides option would enable the user to do the following:
 
-- Allows the user to pass an array exact modules/glob patterns
+- Allows the user to pass an array exact file path/glob patterns
 - Enable overriding of rules for a specific set of files
 
 This option takes an array of objects where each object would support 2 keys:
 
-- `files`: Array of glob patterns (that would either match the exact modules or glob-match multiple modules)
+- `files`: Array of glob patterns (that would either match the exact file path or glob-match multiple files)
 - `rules`: An object of lint rules that the user wants to override for the specific files
 
-- **module** -- `'app/templates/exceptional-page.hbs'`
+- **file path** -- `'app/templates/exceptional-page.hbs'`
 - **glob** -- `'app/templates/components/odd-ones/**'`
 
 ## Sample configuration


### PR DESCRIPTION
Specifying overrides with a module name is not valid. This updates the docs to indicate a full file name with extension is required.