### PR TITLE
Clean up `moduleId`, add ability to specify `ignore` via file path with extension

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -20,6 +20,7 @@ import { promisify } from 'node:util';
 import { parseArgv, getFilesToLint } from '../lib/helpers/cli.js';
 import printResults from '../lib/helpers/print-results.js';
 import processResults from '../lib/helpers/process-results.js';
+import removeExt from '../lib/helpers/remove-ext.js';
 import Linter from '../lib/linter.js';
 
 const readFile = promisify(fs.readFile);
@@ -31,10 +32,6 @@ const NOOP_CONSOLE = {
   warn: () => {},
   error: () => {},
 };
-
-function removeExt(filePath) {
-  return filePath.slice(0, -path.extname(filePath).length);
-}
 
 async function buildLinterOptions(workingDir, filePath, filename = '', isReadingStdin) {
   if (isReadingStdin) {

--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -20,7 +20,6 @@ import { promisify } from 'node:util';
 import { parseArgv, getFilesToLint } from '../lib/helpers/cli.js';
 import printResults from '../lib/helpers/print-results.js';
 import processResults from '../lib/helpers/process-results.js';
-import removeExt from '../lib/helpers/remove-ext.js';
 import Linter from '../lib/linter.js';
 
 const readFile = promisify(fs.readFile);
@@ -36,16 +35,14 @@ const NOOP_CONSOLE = {
 async function buildLinterOptions(workingDir, filePath, filename = '', isReadingStdin) {
   if (isReadingStdin) {
     let filePath = filename;
-    let moduleId = removeExt(filePath);
     let source = await getStdin();
 
-    return { source, filePath, moduleId };
+    return { source, filePath };
   } else {
-    let moduleId = removeExt(filePath);
     let resolvedFilePath = path.resolve(workingDir, filePath);
     let source = await readFile(resolvedFilePath, { encoding: 'utf8' });
 
-    return { source, filePath, moduleId };
+    return { source, filePath };
   }
 }
 

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -2,9 +2,9 @@
 
 You can tell the linter to ignore individual files or entire directories with the `ignore` option.
 
-The ignore option takes an array of strings that either match exact modules or glob-match multiple modules.
+The ignore option takes an array of strings that either match an exact file path or glob-match multiple files.
 
-* **module** -- `'app/templates/exceptional-page'`
+* **file path** -- `'app/templates/exceptional-page.hbs'`
 * **glob** -- `'app/templates/components/odd-ones/**'`
 
 ## Sample configuration
@@ -14,9 +14,9 @@ module.exports = {
   extends: 'recommended',
 
   ignore: [
-    'project-name/templates/login',
+    'project-name/templates/login.hbs',
     'project-name/templates/components/odd-ones/**',
-    'app/templates/login',
+    'app/templates/login.hbs',
     'app/templates/components/odd-ones/**',
   ]
 };

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -183,7 +183,7 @@ generateRuleTests({
     {
       template: '{{#if condition}}<img>{{/if}}',
       config: {}, // Custom config for this test case.
-      meta: { moduleId: 'app/templates/index.hbs' }, // Custom filepath for this test case.
+      meta: { filePath: 'app/templates/index.hbs' }, // Custom filepath for this test case.
     },
   ],
 

--- a/lib/-private/module-status-cache.js
+++ b/lib/-private/module-status-cache.js
@@ -1,6 +1,8 @@
 import micromatch from 'micromatch';
 import path from 'node:path';
 
+import removeExt from '../helpers/remove-ext.js';
+
 export default class ModuleStatusCache {
   constructor(workingDir, config, configPath) {
     this.workingDir = workingDir;
@@ -28,11 +30,12 @@ export default class ModuleStatusCache {
 
   getConfigForFile(options) {
     let filePath = options.filePath;
+    let moduleId = filePath && removeExt(filePath);
     let configuredRules = this.config.rules;
     let overrides = this.config.overrides;
 
     let fileConfig = Object.assign({}, this.config, {
-      shouldIgnore: this.lookupIgnore(options.moduleId),
+      shouldIgnore: this.lookupIgnore(moduleId),
     });
 
     if (filePath && overrides) {

--- a/lib/-private/module-status-cache.js
+++ b/lib/-private/module-status-cache.js
@@ -21,13 +21,6 @@ export default class ModuleStatusCache {
     return Boolean(this.cache.ignore[moduleId]);
   }
 
-  resolveFullModuleId(moduleId) {
-    if (!this._baseDirBasedOnConfigPath) {
-      this._baseDirBasedOnConfigPath = path.resolve(this.workingDir, path.dirname(this.configPath));
-    }
-    return path.resolve(this._baseDirBasedOnConfigPath, moduleId);
-  }
-
   getConfigForFile(options) {
     let filePath = options.filePath;
     let moduleId = filePath && removeExt(filePath);

--- a/lib/-private/module-status-cache.js
+++ b/lib/-private/module-status-cache.js
@@ -1,7 +1,9 @@
 import micromatch from 'micromatch';
 import path from 'node:path';
 
-import removeExt from '../helpers/remove-ext.js';
+function removeExt(filePath) {
+  return filePath.slice(0, -path.extname(filePath).length);
+}
 
 export default class ModuleStatusCache {
   constructor(workingDir, config, configPath) {

--- a/lib/-private/module-status-cache.js
+++ b/lib/-private/module-status-cache.js
@@ -13,22 +13,35 @@ export default class ModuleStatusCache {
     };
   }
 
-  lookupIgnore(moduleId) {
-    if (!(moduleId in this.cache.ignore)) {
-      const ignores = this.config['ignore'] || [];
-      this.cache.ignore[moduleId] = ignores.find((match) => match(moduleId));
+  lookupIgnore(filePath) {
+    let moduleId = filePath && removeExt(filePath);
+    if (filePath in this.cache.ignore) {
+      return Boolean(this.cache.ignore[filePath]);
     }
-    return Boolean(this.cache.ignore[moduleId]);
+    if (moduleId in this.cache.ignore) {
+      return Boolean(this.cache.ignore[moduleId]);
+    }
+    const ignores = this.config['ignore'] || [];
+    const filePathIgnore = ignores.find((match) => match(filePath));
+    if (filePathIgnore) {
+      this.cache.ignore[filePath] = filePathIgnore;
+      return Boolean(this.cache.ignore[filePath]);
+    }
+    const moduleIdIgnore = ignores.find((match) => match(moduleId));
+    if (moduleIdIgnore) {
+      this.cache.ignore[moduleId] = moduleIdIgnore;
+      return Boolean(this.cache.ignore[moduleId]);
+    }
+    return false;
   }
 
   getConfigForFile(options) {
     let filePath = options.filePath;
-    let moduleId = filePath && removeExt(filePath);
     let configuredRules = this.config.rules;
     let overrides = this.config.overrides;
 
     let fileConfig = Object.assign({}, this.config, {
-      shouldIgnore: this.lookupIgnore(moduleId),
+      shouldIgnore: this.lookupIgnore(filePath),
     });
 
     if (filePath && overrides) {

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -41,7 +41,6 @@ export default class TodoHandler {
             rule: 'invalid-todo-violation-rule',
             message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`ember-template-lint ${todo.filePath} --clean-todo\` to remove this todo from the todo list.`,
             filePath: todo.filePath,
-            moduleId: todo.moduleId,
             severity: 2,
             isFixable: true,
           });

--- a/lib/helpers/process-results.js
+++ b/lib/helpers/process-results.js
@@ -8,7 +8,6 @@ import Linter from '../linter.js';
     rule: string;
     severity: -1 | 0 | 1 | 2;
     filePath?: string;
-    moduleId?: string;
     message: string;
     line: number;
     column: number;

--- a/lib/helpers/process-results.js
+++ b/lib/helpers/process-results.js
@@ -50,7 +50,7 @@ export default function (messages) {
   let files = {};
 
   for (let item of messages) {
-    let filePath = item.filePath || item.moduleId;
+    let filePath = item.filePath;
     let fileResults = files[filePath];
     if (fileResults === undefined) {
       fileResults = {

--- a/lib/helpers/remove-ext.js
+++ b/lib/helpers/remove-ext.js
@@ -1,0 +1,5 @@
+import path from 'node:path';
+
+export default function removeExt(filePath) {
+  return filePath.slice(0, -path.extname(filePath).length);
+}

--- a/lib/helpers/remove-ext.js
+++ b/lib/helpers/remove-ext.js
@@ -1,5 +1,0 @@
-import path from 'node:path';
-
-export default function removeExt(filePath) {
-  return filePath.slice(0, -path.extname(filePath).length);
-}

--- a/test/acceptance/formatters/pretty-test.js
+++ b/test/acceptance/formatters/pretty-test.js
@@ -226,7 +226,7 @@ describe('Linter.errorsToMessages', function () {
     chalk.level = 0;
   });
 
-  it('formats error with rule, message and moduleId', function () {
+  it('formats error with rule and message', function () {
     let result = PrettyFormatter.errorsToMessages('file/path', [
       { rule: 'some rule', message: 'some message' },
     ]);

--- a/test/acceptance/formatters/pretty-test.js
+++ b/test/acceptance/formatters/pretty-test.js
@@ -268,7 +268,6 @@ describe('Linter.errorsToMessages', function () {
       {
         rule: 'some rule2',
         message: 'some message2',
-        moduleId: 'some moduleId2',
         source: 'some source2',
       },
     ]);

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -757,12 +757,30 @@ describe('public api', function () {
       expect(result).toEqual([]);
     });
 
-    it('does not include errors when marked as ignored', async function () {
+    it('does not include errors when marked as ignored using a module ID', async function () {
       linter = new Linter({
         console: mockConsole,
         config: {
           rules: { 'no-bare-strings': 'error', 'block-indentation': 'error' },
           ignore: ['some/path/here'],
+        },
+      });
+
+      let template = '<div>bare string</div>';
+      let result = await linter.verify({
+        source: template,
+        filePath: 'some/path/here.hbs',
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it('does not include errors when marked as ignored using a file path', async function () {
+      linter = new Linter({
+        console: mockConsole,
+        config: {
+          rules: { 'no-bare-strings': 'error', 'block-indentation': 'error' },
+          ignore: ['some/path/here.hbs'],
         },
       });
 

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -1055,7 +1055,7 @@ describe('public api', function () {
       chalk.level = 0;
     });
 
-    it('formats error with rule, message and moduleId', function () {
+    it('formats error with rule and message', function () {
       let result = Linter.errorsToMessages('file/path', [
         { rule: 'some rule', message: 'some message' },
       ]);

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -320,7 +320,6 @@ describe('public api', function () {
       let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result).toMatchInlineSnapshot(
@@ -362,7 +361,6 @@ describe('public api', function () {
       let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result.messages.length).toEqual(1);
@@ -386,7 +384,6 @@ describe('public api', function () {
       let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result.messages).toEqual([]);
@@ -410,7 +407,6 @@ describe('public api', function () {
       let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result.messages).toEqual([]);
@@ -488,7 +484,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result).toEqual(expected);
@@ -516,7 +511,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
-        moduleId: 'some/path/here',
       });
 
       let expected = {
@@ -549,7 +543,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
-        moduleId: 'some/path/here',
       });
 
       let expected = {
@@ -574,7 +567,6 @@ describe('public api', function () {
 
       let result = await linter.verify({
         source: templateContents,
-        moduleId: templatePath.slice(0, -4),
         filePath: templatePath,
       });
 
@@ -616,7 +608,6 @@ describe('public api', function () {
 
       let result = await linter.verify({
         source: templateContents,
-        moduleId: templatePath.slice(0, -4),
         filePath: templatePath,
       });
 
@@ -654,7 +645,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
-        moduleId: 'some/path/here',
       });
 
       let expected = [
@@ -717,7 +707,6 @@ describe('public api', function () {
 
       let result = await linter.verify({
         source: templateContents,
-        moduleId: templatePath.slice(0, -4),
         filePath: templatePath,
       });
 
@@ -762,7 +751,6 @@ describe('public api', function () {
 
       let result = await linter.verify({
         source: templateContents,
-        moduleId: templatePath.slice(0, -4),
         filePath: templatePath,
       });
 
@@ -782,7 +770,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
-        moduleId: 'some/path/here',
       });
 
       expect(result).toEqual([]);
@@ -801,7 +788,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
-        moduleId: 'some/path/here',
       });
 
       expect(result).toEqual([]);
@@ -819,7 +805,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: template,
         filePath: 'some/path/here.hbs',
-        moduleId: 'some/path/here',
       });
 
       expect(result).toEqual([
@@ -863,7 +848,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result).toEqual(expected);
@@ -877,7 +861,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result).toEqual(expected);
@@ -915,7 +898,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result).toEqual(expected);
@@ -963,7 +945,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result).toEqual(expected);
@@ -1001,7 +982,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result).toEqual(expected);
@@ -1039,7 +1019,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result).toEqual(expected);
@@ -1065,7 +1044,6 @@ describe('public api', function () {
       let result = await linter.verify({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result).toEqual(expected);
@@ -1119,7 +1097,6 @@ describe('public api', function () {
         {
           rule: 'some rule2',
           message: 'some message2',
-          moduleId: 'some moduleId2',
           source: 'some source2',
         },
       ]);
@@ -1209,7 +1186,6 @@ describe('public api', function () {
       let results = await linter.verify({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(results).toEqual([]);
@@ -1264,7 +1240,6 @@ describe('public api', function () {
       let results = await linter.verify({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(results).toEqual([]);
@@ -1294,7 +1269,6 @@ describe('public api', function () {
       let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result).toMatchInlineSnapshot(
@@ -1336,7 +1310,6 @@ describe('public api', function () {
       let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result.messages.length).toEqual(1);
@@ -1360,7 +1333,6 @@ describe('public api', function () {
       let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result.messages).toEqual([]);
@@ -1384,7 +1356,6 @@ describe('public api', function () {
       let result = await linter.verifyAndFix({
         source: templateContents,
         filePath: templatePath,
-        moduleId: templatePath.slice(0, -4),
       });
 
       expect(result.messages).toEqual([]);

--- a/test/unit/recommended-config-test.js
+++ b/test/unit/recommended-config-test.js
@@ -27,7 +27,7 @@ describe('recommended config', function () {
         config,
       });
 
-      expect(await linter.verify({ source, moduleId: 'some/thing.hbs' })).toEqual([]);
+      expect(await linter.verify({ source, filePath: 'some/thing.hbs' })).toEqual([]);
     });
   }
 

--- a/test/unit/rules/no-model-argument-in-route-templates-test.js
+++ b/test/unit/rules/no-model-argument-in-route-templates-test.js
@@ -6,7 +6,6 @@ generateRuleTests({
   config: true,
   meta: {
     filePath: 'app/templates/foo.hbs',
-    moduleId: 'app/templates/foo',
   },
 
   good: [
@@ -17,14 +16,12 @@ generateRuleTests({
       template: '{{@model}}',
       meta: {
         filePath: 'app/components/foo.hbs',
-        moduleId: 'app/components/foo',
       },
     },
     {
       template: '{{@model}}',
       meta: {
         filePath: 'app/templates/components/foo.hbs',
-        moduleId: 'app/templates/components/foo',
       },
     },
   ],


### PR DESCRIPTION
As described in #2128, when `ignore` is configured, `moduleId` is still required when calling the node API's `verify()`  despite the [docs](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/node-api.md) making no mention of this. This remedies that by cleaning up usage of `moduleId` internally as proposed in #2128.

The one place I've left any reference to `moduleId` is within `lib/-private/module-status-cache` because configuration of `ignore` for specific files (non-glob) currently requires specification as a module instead of a file path with extension, e.g.

```js
// .template-lintrc.js
module.exports = {
  ignore: ['path/to/template'],
};
```

I have, though, added the ability to also specify specific files via path with extension, e.g.

```js
// .template-lintrc.js
module.exports = {
  ignore: ['path/to/template.hbs'],
};
```

This was motivated in part with wanting to have consistency with `overrides` (see #2513).

We may want to deprecate specifying by module and remove in next major version.