### PR TITLE
Prevent `no-unsupported-role-attributes` rule from failing if the element does not have an implicit role

### DIFF
--- a/lib/rules/no-unsupported-role-attributes.js
+++ b/lib/rules/no-unsupported-role-attributes.js
@@ -23,7 +23,8 @@ function getImplicitRole(element, typeAttribute) {
       }
     }
   }
-  return elementRoles.get(elementRoles.keys().find((key) => key.name === element))[0];
+  let implicitRoles = elementRoles.get(elementRoles.keys().find((key) => key.name === element));
+  return implicitRoles && implicitRoles[0];
 }
 
 export default class NoUnsupportedRoleAttributes extends Rule {

--- a/test/unit/rules/no-unsupported-role-attributes-test.js
+++ b/test/unit/rules/no-unsupported-role-attributes-test.js
@@ -22,6 +22,8 @@ generateRuleTests({
     '<div type="button" foo="true" />',
     '{{some-component role="heading" aria-level="2"}}',
     '{{other-component role=this.role aria-bogus="true"}}',
+    '<ItemCheckbox @model={{@model}} @checkable={{@checkable}} />',
+    '<some-custom-element />',
   ],
 
   bad: [


### PR DESCRIPTION
Closes #2514.