### PR TITLE
Fixes bug in `no-unsupported-role-attributes` that throws an error wh…en custom components with no roles are invoked

### DIFF
--- a/lib/rules/no-unsupported-role-attributes.js
+++ b/lib/rules/no-unsupported-role-attributes.js
@@ -23,7 +23,8 @@ function getImplicitRole(element, typeAttribute) {
       }
     }
   }
-  return elementRoles.get(elementRoles.keys().find((key) => key.name === element))[0];
+  let elementRoleInfo = elementRoles.get(elementRoles.keys().find((key) => key.name === element));
+  return elementRoleInfo ? elementRoleInfo[0] : undefined;
 }
 
 export default class NoUnsupportedRoleAttributes extends Rule {

--- a/test/unit/rules/no-unsupported-role-attributes-test.js
+++ b/test/unit/rules/no-unsupported-role-attributes-test.js
@@ -22,6 +22,8 @@ generateRuleTests({
     '<div type="button" foo="true" />',
     '{{some-component role="heading" aria-level="2"}}',
     '{{other-component role=this.role aria-bogus="true"}}',
+    '<CustomCheckbox @model={{@model}} @checkable={{@checkable}} />',
+    '<CustomInput @required={{@required}} @disabled={{this.disabled}} aria-disabled="true" />',
   ],
 
   bad: [


### PR DESCRIPTION
This PR fixes #2514.

### Background
Currently the `no-unsupported-role-attributes` rule throws the following error for custom component without a role attribute:
Cannot read properties of undefined (reading '0') undefined. 

This patch addresses this bug by checking that a key-value pair of element and role exists before attempting to retrieve the role from the value.

**Allowed**:
```
# examples
<CustomCheckbox @model={{@model}} @checkable={{@checkable}} />
<CustomInput @required={{@required}} @disabled={{this.disabled}} aria-disabled="true" />
```

### Testing
Test Suites: 139 passed, 139 total
Tests:       5 skipped, 7693 passed, 7698 total
Snapshots:   1009 passed, 1009 total
Time:        130.318 s
Ran all test suites.
✨  Done in 140.30s.
