### PR TITLE
Fix config documentation for `table-groups` rule

### DIFF
--- a/docs/rule/table-groups.md
+++ b/docs/rule/table-groups.md
@@ -83,7 +83,7 @@ allow it with your configuration.
 
 ```js
 'table-groups': {
-  'allowable-tbody-components': 'some-component-with-tag-name-tbody',
+  'allowed-tbody-components': ['some-component-with-tag-name-tbody'],
 }
 ```
 


### PR DESCRIPTION
There seem to be two bugs with one of the examples for `table-groups` rule:
1. misspelled name of the configuration key itself
2. configuration value should be array of strings