### PR TITLE
Fix helper used by several rules for dasherizing multi-level nested component names

### DIFF
--- a/lib/helpers/dasherize-component-name.js
+++ b/lib/helpers/dasherize-component-name.js
@@ -14,5 +14,5 @@ export default function (key) {
 
       return `-${char.toLowerCase()}`;
     })
-    .replace('::', '/');
+    .replace(/::/g, '/');
 }

--- a/test/unit/helpers/dasherize-component-name-test.js
+++ b/test/unit/helpers/dasherize-component-name-test.js
@@ -1,0 +1,13 @@
+import dasherizeComponentName from '../../../lib/helpers/dasherize-component-name.js';
+
+describe('dasherizeComponentName', function () {
+  it('it works as expected', function () {
+    expect(dasherizeComponentName('foo')).toEqual('foo');
+    expect(dasherizeComponentName('foo-bar')).toEqual('foo-bar');
+    expect(dasherizeComponentName('FooBar')).toEqual('foo-bar');
+    expect(dasherizeComponentName('foo/bar-baz')).toEqual('foo/bar-baz');
+    expect(dasherizeComponentName('Foo::BarBaz')).toEqual('foo/bar-baz');
+    expect(dasherizeComponentName('foo/bar-baz/bang')).toEqual('foo/bar-baz/bang');
+    expect(dasherizeComponentName('Foo::BarBaz::Bang')).toEqual('foo/bar-baz/bang');
+  });
+});


### PR DESCRIPTION
Fixing a bug where component that is more than 1 level nested would get dasherized incorrectly.

Example: `<Popup::List::SearchButton>` would get incorrectly dasherized as `popup/list::search-button`. 
Expected result: `popup/list/search-button`.