### PR TITLE
Add autofixer to `no-unnecessary-concat` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Each rule has emojis denoting:
 | [no-unbound](./docs/rule/no-unbound.md)                                                                   | ✅  |     |     |     |
 | [no-unknown-arguments-for-builtin-components](./docs/rule/no-unknown-arguments-for-builtin-components.md) | ✅  |     |     | 🔧  |
 | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)                         | ✅  |     |     |     |
-| [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                                             |     | 💅  |     |     |
+| [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                                             |     | 💅  |     | 🔧  |
 | [no-unsupported-role-attributes](./docs/rule/no-unsupported-role-attributes.md)                           |     |     | ⌨️  | 🔧  |
 | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                                           | ✅  |     |     |     |
 | [no-valueless-arguments](./docs/rule/no-valueless-arguments.md)                                           | ✅  |     |     |     |

--- a/docs/rule/no-unnecessary-concat.md
+++ b/docs/rule/no-unnecessary-concat.md
@@ -2,6 +2,8 @@
 
 💅 The `extends: 'stylistic'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 This rule forbids unnecessary use of quotes (`""`) around expressions like `{{myValue}}`.
 
 ## Examples

--- a/lib/rules/no-unnecessary-concat.js
+++ b/lib/rules/no-unnecessary-concat.js
@@ -5,15 +5,22 @@ export default class NoUnnecessaryConcat extends Rule {
     return {
       ConcatStatement(node) {
         if (node.parts.length === 1) {
+          let mustacheStatement = node.parts[0];
           let source = this.sourceForNode(node);
-          let innerSource = this.sourceForNode(node.parts[0]);
+          let innerSource = this.sourceForNode(mustacheStatement);
           let message = `Unnecessary string concatenation. Use ${innerSource} instead of ${source}.`;
+          let isFixable = true;
 
-          this.log({
-            message,
-            node,
-            source,
-          });
+          if (this.mode === 'fix') {
+            return mustacheStatement;
+          } else {
+            this.log({
+              message,
+              node,
+              source,
+              isFixable,
+            });
+          }
         }
       },
     };

--- a/test/unit/rules/no-unnecessary-concat-test.js
+++ b/test/unit/rules/no-unnecessary-concat-test.js
@@ -10,6 +10,7 @@ generateRuleTests({
   bad: [
     {
       template: '<div class="{{clazz}}"></div>',
+      fixedTemplate: '<div class={{clazz}}></div>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -19,6 +20,7 @@ generateRuleTests({
               "endColumn": 22,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Unnecessary string concatenation. Use {{clazz}} instead of \\"{{clazz}}\\".",
               "rule": "no-unnecessary-concat",
@@ -31,6 +33,7 @@ generateRuleTests({
     },
     {
       template: '<img src="{{url}}" alt="{{t "alternate-text"}}">',
+      fixedTemplate: '<img src={{url}} alt={{t "alternate-text"}}>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -40,6 +43,7 @@ generateRuleTests({
               "endColumn": 18,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Unnecessary string concatenation. Use {{url}} instead of \\"{{url}}\\".",
               "rule": "no-unnecessary-concat",
@@ -51,6 +55,7 @@ generateRuleTests({
               "endColumn": 47,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Unnecessary string concatenation. Use {{t \\"alternate-text\\"}} instead of \\"{{t \\"alternate-text\\"}}\\".",
               "rule": "no-unnecessary-concat",


### PR DESCRIPTION
Also tested on a production codebase.