### PR TITLE
Add failing tests for missing component structures in `no-this-in-template-only-components`

### DIFF
--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -23,11 +23,24 @@ function isTemplateOnlyComponent(hbsFilePath, validComponentExtensions) {
   function componentClassExists(pathWithoutExtension) {
     return validComponentExtensions.some((ext) => fs.existsSync(pathWithoutExtension + ext));
   }
+
+  /**
+   * These are valid component class locations:
+   * --component-structure=classic
+   *   app/templates/components/foo-classic.hbs => app/components/foo-classic.{js,ts}
+   * --component-structure=flat
+   *   app/components/foo-flat.hbs => app/components/foo-flat.{js,ts}
+   * --component-structure=nested
+   *   app/components/foo-nested/index.hbs => app/components/foo-nested/index.{js,ts}
+   * --pod, -pods
+   *   app/components/foo-pod/template.hbs => app/components/foo-pod/component.{js,ts}
+   */
+
   const paths = path.normalize(hbsFilePath).split(path.sep);
   if (paths[0] === 'app' || paths[0] === 'addon') {
     if (paths[1] === 'templates') {
       if (paths[2] === 'components') {
-        // classic structure: /app/templates/components/foo.hbs => /app/components/foo.js
+        // classic structure: app/templates/components/foo-classic.hbs =>  app/components/foo-classic.{js,ts}
         const moduleName = path.basename(hbsFilePath, '.hbs');
         const classFilePath = path.join(paths[0], 'components', ...paths.slice(3, -1), moduleName);
         return !componentClassExists(classFilePath);
@@ -36,9 +49,20 @@ function isTemplateOnlyComponent(hbsFilePath, validComponentExtensions) {
         return false;
       }
     } else if (paths[1] === 'components') {
-      // co-located structure: /app/components/foo.hbs => /app/components/foo.js
       const moduleName = path.basename(hbsFilePath, '.hbs');
-      const classFilePath = path.join(path.dirname(hbsFilePath), moduleName);
+      let classFilePath;
+
+      if (moduleName === 'index') {
+        // nested structure: app/components/foo-nested/index.hbs => app/components/foo-nested/index.{js,ts}
+        classFilePath = path.join(path.dirname(hbsFilePath), 'index');
+      } else if (moduleName === 'template') {
+        // pod structure: app/components/foo-pod/template.hbs => app/components/foo-pod/component.{js,ts}
+        classFilePath = path.join(path.dirname(hbsFilePath), 'component');
+      } else {
+        // flat structure: app/components/foo.hbs => app/components/foo.{js,ts}
+        classFilePath = path.join(path.dirname(hbsFilePath), moduleName);
+      }
+
       return !componentClassExists(classFilePath);
     }
   }

--- a/test/unit/rules/no-this-in-template-only-components-test.js
+++ b/test/unit/rules/no-this-in-template-only-components-test.js
@@ -16,6 +16,18 @@ generateRuleTests({
         filePath: 'app/templates/route-template.hbs',
       },
     },
+    {
+      template: '<button {{on "click" this.nested}}>Button</button>',
+      meta: {
+        filePath: 'app/components/foo/index.hbs',
+      },
+    },
+    {
+      template: '<button {{on "click" this.pod}}>Button</button>',
+      meta: {
+        filePath: 'app/components/foo/template.hbs',
+      },
+    },
   ],
 
   bad: [


### PR DESCRIPTION
This adds two failing test cases that should be allowed as valid component structures for the `no-this-in-template-only-components` rule:

- nested structure from `--component-structure=nested`
- legacy pod structure from `--pod` (is this still valid?)

This is related to https://github.com/ember-template-lint/ember-template-lint/issues/2321 and https://github.com/ember-template-lint/ember-template-lint/pull/2335.

Since this rule looks for external files I'm unsure how to proceed from here. For example, I've set the `meta.filePath` to mimic different component structure patterns but how can I setup the appropriate component class files to properly test the unique scenarios for this rule?

I've also added some initial logic to differentiate between the flat, nested, and pod component structures, but again, I'm unsure how to test this properly since it relies on the existence of external files.
