### PR TITLE
Add autofixer to `modifier-name-case` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Each rule has emojis denoting:
 | [linebreak-style](./docs/rule/linebreak-style.md)                                                         |     | 💅  |     |     |
 | [link-href-attributes](./docs/rule/link-href-attributes.md)                                               | ✅  |     | ⌨️  |     |
 | [link-rel-noopener](./docs/rule/link-rel-noopener.md)                                                     | ✅  |     |     | 🔧  |
-| [modifier-name-case](./docs/rule/modifier-name-case.md)                                                   |     | 💅  |     |     |
+| [modifier-name-case](./docs/rule/modifier-name-case.md)                                                   |     | 💅  |     | 🔧  |
 | [no-abstract-roles](./docs/rule/no-abstract-roles.md)                                                     | ✅  |     | ⌨️  |     |
 | [no-accesskey-attribute](./docs/rule/no-accesskey-attribute.md)                                           | ✅  |     | ⌨️  | 🔧  |
 | [no-action](./docs/rule/no-action.md)                                                                     | ✅  |     |     |     |

--- a/docs/rule/modifier-name-case.md
+++ b/docs/rule/modifier-name-case.md
@@ -2,6 +2,8 @@
 
 💅 The `extends: 'stylistic'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 It is currently possible to invoke a modifier with multiple words in its name
 using camelCase: `{{didInsert}}` or using dasherized-case: `{{did-insert}}`.
 This means that you can potentially have a lot of inconsistency throughout your

--- a/lib/rules/modifier-name-case.js
+++ b/lib/rules/modifier-name-case.js
@@ -35,10 +35,19 @@ export default class ModifierNameCase extends Rule {
       return;
     }
 
-    this.log({
-      message: generateErrorMessage(modifierName),
-      node,
-    });
+    if (this.mode === 'fix') {
+      if (node.type === 'StringLiteral') {
+        node.value = dasherize(modifierName);
+      } else {
+        node.original = dasherize(modifierName);
+      }
+    } else {
+      this.log({
+        message: generateErrorMessage(modifierName),
+        node,
+        isFixable: true,
+      });
+    }
   }
 }
 

--- a/test/unit/rules/modifier-name-case-test.js
+++ b/test/unit/rules/modifier-name-case-test.js
@@ -22,6 +22,7 @@ generateRuleTests({
   bad: [
     {
       template: '<div {{didInsert}}></div>',
+      fixedTemplate: '<div {{did-insert}}></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -30,6 +31,7 @@ generateRuleTests({
               "endColumn": 16,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Use dasherized names for modifier invocation. Please replace \`didInsert\` with \`did-insert\`.",
               "rule": "modifier-name-case",
@@ -42,6 +44,7 @@ generateRuleTests({
     },
     {
       template: '<div class="monkey" {{didInsert "something" with="somethingElse"}}></div>',
+      fixedTemplate: '<div class="monkey" {{did-insert "something" with="somethingElse"}}></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -50,6 +53,7 @@ generateRuleTests({
               "endColumn": 31,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Use dasherized names for modifier invocation. Please replace \`didInsert\` with \`did-insert\`.",
               "rule": "modifier-name-case",
@@ -62,6 +66,7 @@ generateRuleTests({
     },
     {
       template: '<a href="#" onclick={{amazingActionThing "foo"}} {{doSomething}}></a>',
+      fixedTemplate: '<a href="#" onclick={{amazingActionThing "foo"}} {{do-something}}></a>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -70,6 +75,7 @@ generateRuleTests({
               "endColumn": 62,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Use dasherized names for modifier invocation. Please replace \`doSomething\` with \`do-something\`.",
               "rule": "modifier-name-case",
@@ -82,6 +88,7 @@ generateRuleTests({
     },
     {
       template: '<div {{(modifier "fooBar")}}></div>',
+      fixedTemplate: '<div {{(modifier "foo-bar")}}></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -90,6 +97,7 @@ generateRuleTests({
               "endColumn": 25,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Use dasherized names for modifier invocation. Please replace \`fooBar\` with \`foo-bar\`.",
               "rule": "modifier-name-case",
@@ -102,6 +110,7 @@ generateRuleTests({
     },
     {
       template: '<div {{(if this.foo (modifier "fooBar"))}}></div>',
+      fixedTemplate: '<div {{(if this.foo (modifier "foo-bar"))}}></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -110,6 +119,7 @@ generateRuleTests({
               "endColumn": 38,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Use dasherized names for modifier invocation. Please replace \`fooBar\` with \`foo-bar\`.",
               "rule": "modifier-name-case",


### PR DESCRIPTION
Partially fixes #2571. Very similar to #2569.

CC: @locks

https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/modifier-name-case.md