### PR TITLE
Element attributes order

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Each rule has emojis denoting:
 | [builtin-component-arguments](./docs/rule/builtin-component-arguments.md)                                 | ✅  |     |     |     |
 | [deprecated-inline-view-helper](./docs/rule/deprecated-inline-view-helper.md)                             | ✅  |     |     |     |
 | [deprecated-render-helper](./docs/rule/deprecated-render-helper.md)                                       | ✅  |     |     |     |
+| [element-attributes-order](./docs/rule/element-attributes-order.md)                                       |     |     |     |     |
 | [eol-last](./docs/rule/eol-last.md)                                                                       |     | 💅  |     | 🔧  |
 | [inline-link-to](./docs/rule/inline-link-to.md)                                                           |     |     |     | 🔧  |
 | [linebreak-style](./docs/rule/linebreak-style.md)                                                         |     | 💅  |     |     |

--- a/docs/rule/element-attributes-order.md
+++ b/docs/rule/element-attributes-order.md
@@ -1,0 +1,48 @@
+# element-attributes-order
+
+Element attributes must be ordered, by default the order is:
+
+- arguments
+- attributes
+- element modifiers
+- ...attributes
+- ?attributes
+
+## Configuration
+
+The following values are valid configuration:
+
+- attributeOrder: [`arguments`, `attributes`, `modifiers`, `splattributes`]
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<MyComponent ...attributes @name='Hello' />
+```
+
+```hbs
+<MyComponent {{did-render this.someAction}} @name='Hello' />
+```
+
+```hbs
+<MyComponent ...attributes {{did-render this.someAction}} />
+```
+
+This rule **allows** the following:
+
+```hbs
+<MyComponent @name='1' bar='baz' {{did-render this.someAction}} ...attributes aria-role='button' />
+<MyComponent @name='1' aria-role='button' />
+```
+
+```hbs
+<MyComponent @name='1' ...attributes />
+<MyComponent @name='1' {{did-render this.someAction}} />
+<MyComponent @name='1' bar='baz' />
+```
+
+## References
+
+- [eslint-plugin-vue/rules/attributes-order](https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/attributes-order.md)

--- a/docs/rule/element-attributes-order.md
+++ b/docs/rule/element-attributes-order.md
@@ -12,7 +12,8 @@ Element attributes must be ordered, by default the order is:
 
 The following values are valid configuration:
 
-- attributeOrder: [`arguments`, `attributes`, `modifiers`, `splattributes`]
+- attributeOrder: default [`arguments`, `attributes`, `modifiers`, `splattributes`]
+- alphabetize: default `false`, `true` to enforce alphabetically ordered values within attributes
 
 ## Examples
 

--- a/lib/rules/element-attributes-order.js
+++ b/lib/rules/element-attributes-order.js
@@ -45,7 +45,7 @@ export default class ElementAttributesOrder extends Rule {
     const sourceForNode = this.sourceForNode.bind(this);
     const config = this.config;
 
-    function extractElementTokens(node, nodeText) {
+    function getTokens(node, nodeText) {
       const keys = [];
       for (const attr of node.attributes) {
         const source = sourceForNode(attr);
@@ -63,22 +63,18 @@ export default class ElementAttributesOrder extends Rule {
       return keys;
     }
 
-    function combineElementTokens(tokens) {
-      const result = {
-        modifiers: [],
-        attributes: [],
-        splattributes: [],
-        arguments: [],
-      };
-      // const result = Object.values(AttributeType).reduce((acc, attribute) => {
-      // }
+    function groupTokens(tokens) {
+      const result = Object.values(AttributeType).reduce((acc, attributeType) => {
+        acc[attributeType] = [];
+        return acc;
+      }, {});
       for (let [name, index, source, node] of tokens) {
         result[name].push([index, source, node]);
       }
       return result;
     }
 
-    function addMetaToCombinedTokens(tokens) {
+    function addMetadata(tokens) {
       for (const tokenName of Object.keys(tokens)) {
         const indexes = tokens[tokenName].map(([index]) => Number(index));
         const firstLetters = tokens[tokenName].map(([, names]) =>
@@ -89,13 +85,19 @@ export default class ElementAttributesOrder extends Rule {
           exists: tokens[tokenName].length !== 0,
           last_index: Math.max(...indexes),
           first_index: Math.min(...indexes),
-          ordered: firstLetters.every((b, i, { [i - 1]: a }) => !i || a <= b),
+          unalphabetized_item_pos: firstLetters.findIndex(
+            (e, idx) => idx > 0 && e < firstLetters[idx - 1]
+          ),
         };
       }
       return tokens;
     }
 
-    function findBadItem(attributeType, nodeTokens) {
+    function findUnalphabetizedElement(attributeType, nodeTokens) {
+      return nodeTokens[attributeType].items[nodeTokens[attributeType].unalphabetized_item_pos];
+    }
+
+    function findCurrentElement(attributeType, nodeTokens) {
       return nodeTokens[attributeType].items.find(
         ([index]) => index === nodeTokens[attributeType].last_index
       );
@@ -105,17 +107,18 @@ export default class ElementAttributesOrder extends Rule {
       return string[0].toUpperCase() + string.slice(1, -1);
     }
 
-    function createErrorMessage(attributeType, source) {
+    function createNotAlphabetizedErrorMessage(attributeType, source) {
+      return `${capitalizedAttribute(attributeType)} ${source} is not alphabetized`;
+    }
+
+    function createUnorderedErrorMessage(attributeType, source) {
       const attributeOrder = config.attributeOrder.indexOf(attributeType);
       if (attributeOrder === 0) {
         const otherAttributes = `${config.attributeOrder[1]}, ${config.attributeOrder[2]} and ${config.attributeOrder[3]}`;
 
-        return `${capitalizedAttribute(
-          attributeType,
-          true
-        )} ${source} must go before ${otherAttributes}`;
+        return `${capitalizedAttribute(attributeType)} ${source} must go before ${otherAttributes}`;
       }
-      return `${capitalizedAttribute(attributeType, true)} ${source} must go after ${
+      return `${capitalizedAttribute(attributeType)} ${source} must go after ${
         config.attributeOrder[attributeOrder - 1]
       }`;
     }
@@ -157,15 +160,23 @@ export default class ElementAttributesOrder extends Rule {
       if (!sourceForNode(node)) {
         return;
       }
-      const nodeTokens = addMetaToCombinedTokens(
-        combineElementTokens(extractElementTokens(node, sourceForNode(node)))
-      );
+      const nodeTokens = addMetadata(groupTokens(getTokens(node, sourceForNode(node))));
 
       for (const attributeType of config.attributeOrder) {
-        if (isAttributeUnordered(attributeType, nodeTokens)) {
-          const [, source, item] = findBadItem(attributeType, nodeTokens);
+        if (config.alphabetize && nodeTokens[attributeType].unalphabetized_item_pos >= 0) {
+          const [, source, item] = findUnalphabetizedElement(attributeType, nodeTokens);
           log({
-            message: createErrorMessage(attributeType, source),
+            message: createNotAlphabetizedErrorMessage(attributeType, source),
+            line: item.loc.start.line,
+            column: item.loc.start.column,
+            source,
+            node,
+          });
+        }
+        if (isAttributeUnordered(attributeType, nodeTokens)) {
+          const [, source, item] = findCurrentElement(attributeType, nodeTokens);
+          log({
+            message: createUnorderedErrorMessage(attributeType, source),
             line: item.loc.start.line,
             column: item.loc.start.column,
             source,

--- a/lib/rules/element-attributes-order.js
+++ b/lib/rules/element-attributes-order.js
@@ -1,0 +1,181 @@
+import createErrorMessage from '../helpers/create-error-message.js';
+import Rule from './_base.js';
+
+const AttributeType = {
+  ARGUMENTS: 'arguments',
+  ATTRIBUTES: 'attributes',
+  MODIFIERS: 'modifiers',
+  SPLATTRIBUTES: 'splattributes',
+};
+
+const AttributeOrder = [
+  AttributeType.ARGUMENTS,
+  AttributeType.ATTRIBUTES,
+  AttributeType.MODIFIERS,
+  AttributeType.SPLATTRIBUTES,
+];
+
+const DEFAULT_CONFIG = {
+  attributeOrder: AttributeOrder,
+};
+
+export default class ElementAttributesOrder extends Rule {
+  parseConfig(config) {
+    if (config === true) {
+      return DEFAULT_CONFIG;
+    }
+
+    if (config && typeof config === 'object') {
+      return { ...DEFAULT_CONFIG, ...config };
+    }
+
+    let errorMessage = createErrorMessage(
+      'element-attributes-order',
+      [
+        '  * boolean - `true` to enable / `false` to disable',
+        '  * object -- An object with the following keys:',
+        '  * `attributeOrder` -- array: order of attribute groups',
+      ],
+      config
+    );
+
+    throw new Error(errorMessage);
+  }
+
+  visitor() {
+    const log = this.log.bind(this);
+    const sourceForNode = this.sourceForNode.bind(this);
+
+    function extractElementTokens(node, nodeText) {
+      const keys = [];
+      for (const attr of node.attributes) {
+        const source = sourceForNode(attr);
+        const type = attr.name.startsWith('@')
+          ? AttributeType.ARGUMENTS
+          : attr.name.startsWith('...')
+          ? AttributeType.SPLATTRIBUTES
+          : AttributeType.ATTRIBUTES;
+        keys.push([type, nodeText.indexOf(source), source, attr]);
+      }
+      for (const modifier of node.modifiers) {
+        const source = sourceForNode(modifier);
+        keys.push([AttributeType.MODIFIERS, nodeText.indexOf(source), source, modifier]);
+      }
+      return keys;
+    }
+
+    function combineElementTokens(tokens) {
+      const result = {
+        modifiers: [],
+        attributes: [],
+        splattributes: [],
+        arguments: [],
+      };
+      // const result = Object.values(AttributeType).reduce((acc, attribute) => {
+      // }
+      for (let [name, index, source, node] of tokens) {
+        result[name].push([index, source, node]);
+      }
+      return result;
+    }
+
+    function addMetaToCombinedTokens(tokens) {
+      for (const tokenName of Object.keys(tokens)) {
+        const indexes = tokens[tokenName].map(([index]) => Number(index));
+        const firstLetters = tokens[tokenName].map(([, names]) =>
+          names.startsWith('@') ? names.charAt(1) : names.charAt(0)
+        );
+        tokens[tokenName] = {
+          items: tokens[tokenName],
+          exists: tokens[tokenName].length !== 0,
+          last_index: Math.max(...indexes),
+          first_index: Math.min(...indexes),
+          ordered: firstLetters.every((b, i, { [i - 1]: a }) => !i || a <= b),
+        };
+      }
+      return tokens;
+    }
+
+    function findBadItem(attributeType, nodeTokens) {
+      return nodeTokens[attributeType].items.find(
+        ([index]) => index === nodeTokens[attributeType].last_index
+      );
+    }
+
+    function capitalizedAttribute(string) {
+      return string[0].toUpperCase() + string.slice(1, -1);
+    }
+
+    function createErrorMessage(attributeType, source) {
+      const attributeOrder = AttributeOrder.indexOf(attributeType);
+      if (attributeOrder === 0) {
+        const otherAttributes = `${AttributeOrder[1]}, ${AttributeOrder[2]} and ${AttributeOrder[3]}`;
+
+        return `${capitalizedAttribute(
+          attributeType,
+          true
+        )} ${source} must go before ${otherAttributes}`;
+      }
+      return `${capitalizedAttribute(attributeType, true)} ${source} must go after ${
+        AttributeOrder[attributeOrder - 1]
+      }`;
+    }
+
+    function isAttributeUnordered(attributeType, nodeTokens) {
+      if (!nodeTokens[attributeType].exists) {
+        return false;
+      }
+      const attributeOrder = AttributeOrder.indexOf(attributeType);
+      const hasAttributesAfterSplattributes =
+        nodeTokens[AttributeType.SPLATTRIBUTES].exists &&
+        nodeTokens[AttributeType.SPLATTRIBUTES].last_index <
+          nodeTokens[AttributeType.ATTRIBUTES].last_index;
+
+      if (attributeOrder === 0) {
+        return (
+          nodeTokens[attributeType].last_index > nodeTokens[AttributeOrder[1]].first_index ||
+          nodeTokens[attributeType].last_index > nodeTokens[AttributeOrder[2]].first_index ||
+          nodeTokens[attributeType].last_index > nodeTokens[AttributeOrder[3]].first_index
+        );
+      }
+      if (attributeOrder === 2) {
+        if (attributeType !== AttributeType.MODIFIERS || !hasAttributesAfterSplattributes) {
+          return nodeTokens[attributeType].last_index < nodeTokens[AttributeOrder[1]].last_index;
+        }
+      }
+      if (attributeOrder === 3) {
+        if (attributeType !== AttributeType.MODIFIERS || !hasAttributesAfterSplattributes) {
+          return nodeTokens[attributeType].last_index < nodeTokens[AttributeOrder[2]].last_index;
+        }
+      }
+    }
+
+    function checkAttributesOrder(node) {
+      if (!sourceForNode(node)) {
+        return;
+      }
+      const nodeTokens = addMetaToCombinedTokens(
+        combineElementTokens(extractElementTokens(node, sourceForNode(node)))
+      );
+
+      for (const attributeType of AttributeOrder) {
+        if (isAttributeUnordered(attributeType, nodeTokens)) {
+          const [, source, item] = findBadItem(attributeType, nodeTokens);
+          log({
+            message: createErrorMessage(attributeType, source),
+            line: item.loc.start.line,
+            column: item.loc.start.column,
+            source,
+            node,
+          });
+        }
+      }
+    }
+
+    return {
+      ElementNode(node) {
+        checkAttributesOrder(node);
+      },
+    };
+  }
+}

--- a/lib/rules/element-attributes-order.js
+++ b/lib/rules/element-attributes-order.js
@@ -8,15 +8,13 @@ const AttributeType = {
   SPLATTRIBUTES: 'splattributes',
 };
 
-const AttributeOrder = [
-  AttributeType.ARGUMENTS,
-  AttributeType.ATTRIBUTES,
-  AttributeType.MODIFIERS,
-  AttributeType.SPLATTRIBUTES,
-];
-
 const DEFAULT_CONFIG = {
-  attributeOrder: AttributeOrder,
+  attributeOrder: [
+    AttributeType.ARGUMENTS,
+    AttributeType.ATTRIBUTES,
+    AttributeType.MODIFIERS,
+    AttributeType.SPLATTRIBUTES,
+  ],
 };
 
 export default class ElementAttributesOrder extends Rule {
@@ -45,6 +43,7 @@ export default class ElementAttributesOrder extends Rule {
   visitor() {
     const log = this.log.bind(this);
     const sourceForNode = this.sourceForNode.bind(this);
+    const config = this.config;
 
     function extractElementTokens(node, nodeText) {
       const keys = [];
@@ -107,9 +106,9 @@ export default class ElementAttributesOrder extends Rule {
     }
 
     function createErrorMessage(attributeType, source) {
-      const attributeOrder = AttributeOrder.indexOf(attributeType);
+      const attributeOrder = config.attributeOrder.indexOf(attributeType);
       if (attributeOrder === 0) {
-        const otherAttributes = `${AttributeOrder[1]}, ${AttributeOrder[2]} and ${AttributeOrder[3]}`;
+        const otherAttributes = `${config.attributeOrder[1]}, ${config.attributeOrder[2]} and ${config.attributeOrder[3]}`;
 
         return `${capitalizedAttribute(
           attributeType,
@@ -117,7 +116,7 @@ export default class ElementAttributesOrder extends Rule {
         )} ${source} must go before ${otherAttributes}`;
       }
       return `${capitalizedAttribute(attributeType, true)} ${source} must go after ${
-        AttributeOrder[attributeOrder - 1]
+        config.attributeOrder[attributeOrder - 1]
       }`;
     }
 
@@ -125,7 +124,7 @@ export default class ElementAttributesOrder extends Rule {
       if (!nodeTokens[attributeType].exists) {
         return false;
       }
-      const attributeOrder = AttributeOrder.indexOf(attributeType);
+      const attributeOrder = config.attributeOrder.indexOf(attributeType);
       const hasAttributesAfterSplattributes =
         nodeTokens[AttributeType.SPLATTRIBUTES].exists &&
         nodeTokens[AttributeType.SPLATTRIBUTES].last_index <
@@ -133,19 +132,23 @@ export default class ElementAttributesOrder extends Rule {
 
       if (attributeOrder === 0) {
         return (
-          nodeTokens[attributeType].last_index > nodeTokens[AttributeOrder[1]].first_index ||
-          nodeTokens[attributeType].last_index > nodeTokens[AttributeOrder[2]].first_index ||
-          nodeTokens[attributeType].last_index > nodeTokens[AttributeOrder[3]].first_index
+          nodeTokens[attributeType].last_index > nodeTokens[config.attributeOrder[1]].first_index ||
+          nodeTokens[attributeType].last_index > nodeTokens[config.attributeOrder[2]].first_index ||
+          nodeTokens[attributeType].last_index > nodeTokens[config.attributeOrder[3]].first_index
         );
       }
       if (attributeOrder === 2) {
         if (attributeType !== AttributeType.MODIFIERS || !hasAttributesAfterSplattributes) {
-          return nodeTokens[attributeType].last_index < nodeTokens[AttributeOrder[1]].last_index;
+          return (
+            nodeTokens[attributeType].last_index < nodeTokens[config.attributeOrder[1]].last_index
+          );
         }
       }
       if (attributeOrder === 3) {
         if (attributeType !== AttributeType.MODIFIERS || !hasAttributesAfterSplattributes) {
-          return nodeTokens[attributeType].last_index < nodeTokens[AttributeOrder[2]].last_index;
+          return (
+            nodeTokens[attributeType].last_index < nodeTokens[config.attributeOrder[2]].last_index
+          );
         }
       }
     }
@@ -158,7 +161,7 @@ export default class ElementAttributesOrder extends Rule {
         combineElementTokens(extractElementTokens(node, sourceForNode(node)))
       );
 
-      for (const attributeType of AttributeOrder) {
+      for (const attributeType of config.attributeOrder) {
         if (isAttributeUnordered(attributeType, nodeTokens)) {
           const [, source, item] = findBadItem(attributeType, nodeTokens);
           log({

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -5,6 +5,7 @@ import blockindentation from './block-indentation.js';
 import builtincomponentarguments from './builtin-component-arguments.js';
 import deprecatedinlineviewhelper from './deprecated-inline-view-helper.js';
 import deprecatedrenderhelper from './deprecated-render-helper.js';
+import elementattributesorder from './element-attributes-order.js';
 import eollast from './eol-last.js';
 import inlinelinkto from './inline-link-to.js';
 import linebreakstyle from './linebreak-style.js';
@@ -120,6 +121,7 @@ export default {
   'builtin-component-arguments': builtincomponentarguments,
   'deprecated-inline-view-helper': deprecatedinlineviewhelper,
   'deprecated-render-helper': deprecatedrenderhelper,
+  'element-attributes-order': elementattributesorder,
   'eol-last': eollast,
   'inline-link-to': inlinelinkto,
   'linebreak-style': linebreakstyle,

--- a/test/unit/rules/element-attributes-order-test.js
+++ b/test/unit/rules/element-attributes-order-test.js
@@ -79,5 +79,17 @@ generateRuleTests({
         column: 38,
       },
     },
+    {
+      config: {
+        attributeOrder: ['attributes', 'arguments', 'modifiers', 'splattributes'],
+      },
+      template: '<div @foo="1" {{did-render this.ok}} ...attributes aria-label="foo"></div>',
+      result: {
+        message: 'Attribute aria-label="foo" must go before arguments, modifiers and splattributes',
+        source: 'aria-label="foo"',
+        line: 1,
+        column: 51,
+      },
+    },
   ],
 });

--- a/test/unit/rules/element-attributes-order-test.js
+++ b/test/unit/rules/element-attributes-order-test.js
@@ -1,0 +1,83 @@
+import generateRuleTests from '../../helpers/rule-test-harness.js';
+
+generateRuleTests({
+  name: 'element-attributes-order',
+
+  config: true,
+
+  good: [
+    '<div @foo="1" bar="baz" {{did-render this.ok}} ...attributes aria-label="foo"></div>',
+    '<div @foo="1" aria-label="foo"></div>',
+    '<div @foo="1" ...attributes></div>',
+    '<div @foo="1" {{did-render this.ok}}></div>',
+    '<div @foo="1" bar="baz"></div>',
+    '<div bar="baz" {{did-render this.ok}} ...attributes aria-label="foo"></div>',
+    '<div bar="baz" aria-label="foo"></div>',
+    '<div bar="baz" ...attributes></div>',
+    '<div bar="baz" {{did-render this.ok}}></div>',
+    '<div {{did-render this.oks}} ...attributes aria-label="foo"></div>',
+    '<div {{did-render this.ok}} ...attributes></div>',
+    '<div ...attributes aria-label="foo"></div>',
+    '<div aria-label="foo"></div>',
+    '<MyComponent @value="5" @change={{this.foo}} local-class="foo" data-test-foo {{on "click" this.foo}} ...attributes as |sth|>content</MyComponent>',
+  ],
+
+  bad: [
+    {
+      template: '<div ...attributes @a="1"></div>',
+      result: {
+        message: 'Argument @a="1" must go before attributes, modifiers and splattributes',
+        source: '@a="1"',
+        line: 1,
+        column: 19,
+      },
+    },
+    {
+      template: '<div contenteditable @a="1"></div>',
+      result: {
+        message: 'Argument @a="1" must go before attributes, modifiers and splattributes',
+        source: '@a="1"',
+        line: 1,
+        column: 21,
+      },
+    },
+    {
+      template: '<div {{did-render this.someAction}} @a="1"></div>',
+      result: {
+        message: 'Argument @a="1" must go before attributes, modifiers and splattributes',
+        source: '@a="1"',
+        line: 1,
+        column: 36,
+      },
+    },
+    {
+      template: '<div ...attributes {{did-render this.someAction}}></div>',
+      result: {
+        message: 'Splattribute ...attributes must go after modifiers',
+        source: '...attributes',
+        line: 1,
+        column: 5,
+      },
+    },
+    {
+      template: '<div {{did-render this.someAction}} aria-label="button"></div>',
+      result: {
+        message: 'Modifier {{did-render this.someAction}} must go after attributes',
+        source: '{{did-render this.someAction}}',
+        line: 1,
+        column: 5,
+      },
+    },
+    {
+      template:
+        '<MyComponent @value="5" data-test-foo @change={{this.foo}} local-class="foo" {{on "click" this.foo}} ...attributes as |sth|>content</MyComponent>',
+      result: {
+        message:
+          'Argument @change={{this.foo}} must go before attributes, modifiers and splattributes',
+        source: '@change={{this.foo}}',
+        line: 1,
+        column: 38,
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This adds new rule `element-attributes-order` for issue https://github.com/ember-template-lint/ember-template-lint/issues/684.  It takes inspiration from the previous PR made by @lifeart but makes some large changes to:

a. allow configuration of the attribute order by `attributeOrder`
b. allows config of whether or not to alphabetize within the attribute groupings (defaults false)
