### PR TITLE
Add autofixer to `no-unused-block-params` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Each rule has emojis denoting:
 | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)                         | ✅  |     |     | 🔧  |
 | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                                             |     | 💅  |     | 🔧  |
 | [no-unsupported-role-attributes](./docs/rule/no-unsupported-role-attributes.md)                           |     |     | ⌨️  | 🔧  |
-| [no-unused-block-params](./docs/rule/no-unused-block-params.md)                                           | ✅  |     |     |     |
+| [no-unused-block-params](./docs/rule/no-unused-block-params.md)                                           | ✅  |     |     | 🔧  |
 | [no-valueless-arguments](./docs/rule/no-valueless-arguments.md)                                           | ✅  |     |     |     |
 | [no-whitespace-for-layout](./docs/rule/no-whitespace-for-layout.md)                                       | ✅  |     | ⌨️  |     |
 | [no-whitespace-within-word](./docs/rule/no-whitespace-within-word.md)                                     | ✅  |     | ⌨️  |     |

--- a/docs/rule/no-unused-block-params.md
+++ b/docs/rule/no-unused-block-params.md
@@ -2,6 +2,8 @@
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 This rule forbids unused block parameters except when they are needed to access a later parameter.
 
 ## Examples

--- a/lib/rules/no-unused-block-params.js
+++ b/lib/rules/no-unused-block-params.js
@@ -40,6 +40,27 @@
 
 import Rule from './_base.js';
 
+function usedParams(node, unusedLocal) {
+  let used = node.blockParams.filter((blockParam) => {
+    return !unusedLocal.includes(blockParam);
+  });
+  console.log(
+    '\nPARAMS',
+    node.blockParams,
+    '\nUNUSED',
+    unusedLocal,
+    '\nUSED',
+    used,
+    '\n< />',
+    node.selfClosing
+  );
+
+  if (used.length > 0 || node.selfClosing) {
+    console.log('do it');
+    node.blockParams = used;
+  }
+}
+
 export default class NoUnusedBlockParams extends Rule {
   visitor() {
     return {
@@ -47,10 +68,15 @@ export default class NoUnusedBlockParams extends Rule {
         exit(node) {
           let unusedLocal = this.scope.frameHasUnusedBlockParams();
           if (unusedLocal) {
-            this.log({
-              message: `'${unusedLocal}' is defined but never used`,
-              node,
-            });
+            if (this.mode === 'fix') {
+              usedParams(node, unusedLocal);
+            } else {
+              this.log({
+                message: `'${unusedLocal}' is defined but never used`,
+                node,
+                isFixable: true,
+              });
+            }
           }
         },
       },
@@ -61,10 +87,29 @@ export default class NoUnusedBlockParams extends Rule {
             exit(node) {
               let unusedLocal = this.scope.frameHasUnusedBlockParams();
               if (unusedLocal) {
-                this.log({
-                  message: `'${unusedLocal}' is defined but never used`,
-                  node,
-                });
+                if (this.mode === 'fix') {
+                  let used = node.blockParams.filter((blockParam) => {
+                    return !unusedLocal.includes(blockParam);
+                  });
+                  console.log(
+                    '\nPARAMS',
+                    node.blockParams,
+                    '\nUNUSED',
+                    unusedLocal,
+                    '\nUSED',
+                    used,
+                    '\n< />',
+                    node.selfClosing
+                  );
+
+                  node.blockParams = used;
+                } else {
+                  this.log({
+                    message: `'${unusedLocal}' is defined but never used`,
+                    node,
+                    isFixable: true,
+                  });
+                }
               }
             },
           },
@@ -73,6 +118,7 @@ export default class NoUnusedBlockParams extends Rule {
 
       MustacheStatement(node) {
         if (node.path.original === 'partial') {
+          console.log('MEOW');
           this.scope.usePartial();
         }
       },

--- a/test/unit/rules/no-unused-block-params-test.js
+++ b/test/unit/rules/no-unused-block-params-test.js
@@ -11,6 +11,7 @@ generateRuleTests({
     '{{#each cats as |cat|}}{{partial "cat"}}{{/each}}',
     '{{#each cats as |cat|}}{{cat.name}}{{/each}}',
     '{{#each cats as |cat|}}{{meow cat}}{{/each}}',
+    '{{#each cats as |ampere|}}{{meow}}{{/each}}',
     '{{#each cats as |cat index|}}{{index}}{{/each}}',
     '{{#each cats as |cat index|}}' +
       '{{#each cat.lives as |life|}}' +
@@ -86,28 +87,8 @@ generateRuleTests({
 
   bad: [
     {
-      template: '{{#each cats as |cat|}}Dogs{{/each}}',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 23,
-              "endColumn": 27,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "'cat' is defined but never used",
-              "rule": "no-unused-block-params",
-              "severity": 2,
-              "source": "Dogs",
-            },
-          ]
-        `);
-      },
-    },
-    {
       template: '{{#each cats as |cat index|}}{{cat}}{{/each}}',
+      fixedTemplate: '{{#each cats as |cat|}}{{cat}}{{/each}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -116,6 +97,7 @@ generateRuleTests({
               "endColumn": 36,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "'index' is defined but never used",
               "rule": "no-unused-block-params",
@@ -133,6 +115,12 @@ generateRuleTests({
         '{{index}}: {{life}}' +
         '{{/each}}' +
         '{{/each}}',
+      fixedTemplate:
+        '{{#each cats as |cat|}}' +
+        '{{#each cat.lives as |life index|}}' +
+        '{{index}}: {{life}}' +
+        '{{/each}}' +
+        '{{/each}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -141,6 +129,7 @@ generateRuleTests({
               "endColumn": 92,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "'index' is defined but never used",
               "rule": "no-unused-block-params",
@@ -157,6 +146,11 @@ generateRuleTests({
         '{{partial "cat"}}' +
         '{{#each cat.lives as |life|}}Life{{/each}}' +
         '{{/each}}',
+      fixedTemplate:
+        '{{#each cats as |cat|}}' +
+        '{{partial "cat"}}' +
+        '{{#each cat.lives as |life|}}Life{{/each}}' +
+        '{{/each}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -165,11 +159,56 @@ generateRuleTests({
               "endColumn": 79,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "'life' is defined but never used",
               "rule": "no-unused-block-params",
               "severity": 2,
               "source": "Life",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<BurgerMenu as |menu| />',
+      fixedTemplate: '<BurgerMenu />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 24,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "'menu' is defined but never used",
+              "rule": "no-unused-block-params",
+              "severity": 2,
+              "source": "<BurgerMenu as |menu| />",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<BurgerMenu as |menu|>Buns</BurgerMenu>',
+      fixedTemplate: '<BurgerMenu>Buns</BurgerMenu>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 39,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "'menu' is defined but never used",
+              "rule": "no-unused-block-params",
+              "severity": 2,
+              "source": "<BurgerMenu as |menu|>Buns</BurgerMenu>",
             },
           ]
         `);


### PR DESCRIPTION
Part of https://github.com/ember-template-lint/ember-template-lint/issues/2571. [no-unused-block-params](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-unused-block-params.md)

I'm having a bit of trouble with this one.

- for nested `{{each}}`, visitor only seems to trigger for innermost one?
- haven't figured out how not to remove block params if the params list would be empty
- haven't figuredd out how to remove block params completely for self-closing component tag