### PR TITLE
Add autofixer to `no-html-comments` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Each rule has emojis denoting:
 | [no-extra-mut-helper-argument](./docs/rule/no-extra-mut-helper-argument.md)                               | ✅  |     |     |     |
 | [no-forbidden-elements](./docs/rule/no-forbidden-elements.md)                                             | ✅  |     |     |     |
 | [no-heading-inside-button](./docs/rule/no-heading-inside-button.md)                                       | ✅  |     | ⌨️  |     |
-| [no-html-comments](./docs/rule/no-html-comments.md)                                                       | ✅  |     |     |     |
+| [no-html-comments](./docs/rule/no-html-comments.md)                                                       | ✅  |     |     | 🔧  |
 | [no-implicit-this](./docs/rule/no-implicit-this.md)                                                       | ✅  |     |     |     |
 | [no-index-component-invocation](./docs/rule/no-index-component-invocation.md)                             | ✅  |     |     |     |
 | [no-inline-styles](./docs/rule/no-inline-styles.md)                                                       | ✅  |     |     |     |

--- a/docs/rule/no-html-comments.md
+++ b/docs/rule/no-html-comments.md
@@ -2,6 +2,8 @@
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 HTML comments in your templates will get compiled and rendered into the DOM at runtime. This is undesirable in a production environment. Instead, you can annotate your templates using Handlebars comments, which will be stripped out when the template is compiled and have no effect at runtime.
 
 ## Examples

--- a/lib/rules/no-html-comments.js
+++ b/lib/rules/no-html-comments.js
@@ -1,3 +1,5 @@
+import { builders as b } from 'ember-template-recast';
+
 import AstNodeInfo from '../helpers/ast-node-info.js';
 import Rule from './_base.js';
 
@@ -6,14 +8,19 @@ export default class NoHtmlComments extends Rule {
     return {
       CommentStatement(node) {
         if (AstNodeInfo.isNonConfigurationHtmlComment(node)) {
-          this.log({
-            message: 'HTML comment detected',
-            node,
-            source: `<!--${node.value}-->`,
-            fix: {
-              text: `{{!${node.value}}}`,
-            },
-          });
+          if (this.mode === 'fix') {
+            return b.mustacheComment(node.value);
+          } else {
+            this.log({
+              message: 'HTML comment detected',
+              node,
+              source: `<!--${node.value}-->`,
+              fix: {
+                text: `{{!${node.value}}}`,
+              },
+              isFixable: true,
+            });
+          }
         }
       },
     };

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -683,12 +683,15 @@ describe('ember-template-lint executable', function () {
       let result = await runBin('.', '--no-config-path', '--rule', 'no-html-comments:warn');
 
       expect(result.exitCode).toEqual(0);
-      expect(result.stdout.split('\n')).toEqual([
-        'app/templates/application.hbs',
-        '  1:53  warning  HTML comment detected  no-html-comments',
-        '',
-        '✖ 1 problems (0 errors, 1 warnings)',
-      ]);
+      expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+        [
+          "app/templates/application.hbs",
+          "  1:53  warning  HTML comment detected  no-html-comments",
+          "",
+          "✖ 1 problems (0 errors, 1 warnings)",
+          "  0 errors and 1 warnings potentially fixable with the \`--fix\` option.",
+        ]
+      `);
       expect(result.stderr).toBeFalsy();
     });
 
@@ -711,12 +714,15 @@ describe('ember-template-lint executable', function () {
       let result = await runBin('.', '--no-config-path', '--rule', 'no-html-comments:error');
 
       expect(result.exitCode).toEqual(1);
-      expect(result.stdout.split('\n')).toEqual([
-        'app/templates/application.hbs',
-        '  1:53  error  HTML comment detected  no-html-comments',
-        '',
-        '✖ 1 problems (1 errors, 0 warnings)',
-      ]);
+      expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+        [
+          "app/templates/application.hbs",
+          "  1:53  error  HTML comment detected  no-html-comments",
+          "",
+          "✖ 1 problems (1 errors, 0 warnings)",
+          "  1 errors and 0 warnings potentially fixable with the \`--fix\` option.",
+        ]
+      `);
       expect(result.stderr).toBeFalsy();
     });
 
@@ -744,12 +750,15 @@ describe('ember-template-lint executable', function () {
       );
 
       expect(result.exitCode).toEqual(0);
-      expect(result.stdout.split('\n')).toEqual([
-        'app/templates/application.hbs',
-        '  1:53  warning  HTML comment detected  no-html-comments',
-        '',
-        '✖ 1 problems (0 errors, 1 warnings)',
-      ]);
+      expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+        [
+          "app/templates/application.hbs",
+          "  1:53  warning  HTML comment detected  no-html-comments",
+          "",
+          "✖ 1 problems (0 errors, 1 warnings)",
+          "  0 errors and 1 warnings potentially fixable with the \`--fix\` option.",
+        ]
+      `);
       expect(result.stderr).toBeFalsy();
     });
 
@@ -777,12 +786,15 @@ describe('ember-template-lint executable', function () {
       );
 
       expect(result.exitCode).toEqual(1);
-      expect(result.stdout.split('\n')).toEqual([
-        'app/templates/application.hbs',
-        '  1:53  error  HTML comment detected  no-html-comments',
-        '',
-        '✖ 1 problems (1 errors, 0 warnings)',
-      ]);
+      expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+        [
+          "app/templates/application.hbs",
+          "  1:53  error  HTML comment detected  no-html-comments",
+          "",
+          "✖ 1 problems (1 errors, 0 warnings)",
+          "  1 errors and 0 warnings potentially fixable with the \`--fix\` option.",
+        ]
+      `);
       expect(result.stderr).toBeFalsy();
     });
 
@@ -885,14 +897,15 @@ describe('ember-template-lint executable', function () {
         let result = await runBin('app/**/*', '--no-ignore-pattern');
 
         expect(result.exitCode).toEqual(1);
-        expect(result.stdout).toEqual(
-          `app/dist/application.hbs
-  1:4  error  Non-translated string used  no-bare-strings
-  1:24  error  Non-translated string used  no-bare-strings
-  1:53  error  HTML comment detected  no-html-comments
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "app/dist/application.hbs
+            1:4  error  Non-translated string used  no-bare-strings
+            1:24  error  Non-translated string used  no-bare-strings
+            1:53  error  HTML comment detected  no-html-comments
 
-✖ 3 problems (3 errors, 0 warnings)`
-        );
+          ✖ 3 problems (3 errors, 0 warnings)
+            1 errors and 0 warnings potentially fixable with the \`--fix\` option."
+        `);
 
         expect(result.stderr).toBeFalsy();
       });
@@ -922,12 +935,14 @@ describe('ember-template-lint executable', function () {
           let result = await runBin('.', '--config-path', 'temp-templatelint-rc.js');
 
           expect(result.exitCode).toEqual(1);
-          expect(result.stdout.split('\n')).toEqual([
-            'template.hbs',
-            '  1:23  error  Ambiguous element used (`div`)  no-shadowed-elements',
-            '',
-            '✖ 1 problems (1 errors, 0 warnings)',
-          ]);
+          expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+            [
+              "template.hbs",
+              "  1:23  error  Ambiguous element used (\`div\`)  no-shadowed-elements",
+              "",
+              "✖ 1 problems (1 errors, 0 warnings)",
+            ]
+          `);
           expect(result.stderr).toBeFalsy();
         });
       });
@@ -962,13 +977,15 @@ describe('ember-template-lint executable', function () {
           );
 
           expect(result.exitCode).toEqual(1);
-          expect(result.stdout.split('\n')).toEqual([
-            'app/templates/application.hbs',
-            '  1:4  error  Non-translated string used  no-bare-strings',
-            '  1:39  error  Non-translated string used  no-bare-strings',
-            '',
-            '✖ 2 problems (2 errors, 0 warnings)',
-          ]);
+          expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+            [
+              "app/templates/application.hbs",
+              "  1:4  error  Non-translated string used  no-bare-strings",
+              "  1:39  error  Non-translated string used  no-bare-strings",
+              "",
+              "✖ 2 problems (2 errors, 0 warnings)",
+            ]
+          `);
           expect(result.stderr).toBeFalsy();
         });
       });
@@ -993,13 +1010,15 @@ describe('ember-template-lint executable', function () {
           let result = await runBin('.', '--config-path', project.path('other-file.js'));
 
           expect(result.exitCode).toEqual(1);
-          expect(result.stdout.split('\n')).toEqual([
-            'app/templates/application.hbs',
-            '  1:4  error  Non-translated string used  no-bare-strings',
-            '  1:39  error  Non-translated string used  no-bare-strings',
-            '',
-            '✖ 2 problems (2 errors, 0 warnings)',
-          ]);
+          expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+            [
+              "app/templates/application.hbs",
+              "  1:4  error  Non-translated string used  no-bare-strings",
+              "  1:39  error  Non-translated string used  no-bare-strings",
+              "",
+              "✖ 2 problems (2 errors, 0 warnings)",
+            ]
+          `);
           expect(result.stderr).toBeFalsy();
         });
       });
@@ -1075,14 +1094,17 @@ describe('ember-template-lint executable', function () {
 
         expect(result.exitCode).toEqual(0);
         expect(result.stderr).toBeFalsy();
-        expect(result.stdout.split('\n')).toEqual([
-          'app/templates/application.hbs',
-          '  1:4  warning  Non-translated string used  no-bare-strings',
-          '  1:24  warning  Non-translated string used  no-bare-strings',
-          '  1:53  warning  HTML comment detected  no-html-comments',
-          '',
-          '✖ 3 problems (0 errors, 3 warnings)',
-        ]);
+        expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+          [
+            "app/templates/application.hbs",
+            "  1:4  warning  Non-translated string used  no-bare-strings",
+            "  1:24  warning  Non-translated string used  no-bare-strings",
+            "  1:53  warning  HTML comment detected  no-html-comments",
+            "",
+            "✖ 3 problems (0 errors, 3 warnings)",
+            "  0 errors and 1 warnings potentially fixable with the \`--fix\` option.",
+          ]
+        `);
       });
 
       it('should exit with error if error count is greater than zero regardless of max-warnings', async function () {

--- a/test/acceptance/formatters/custom-formatters-test.js
+++ b/test/acceptance/formatters/custom-formatters-test.js
@@ -59,7 +59,7 @@ describe('custom formatters', () => {
     expect(result.stdout).toMatchInlineSnapshot(`
       "errors: 3
       warnings: 0
-      fixable: 0"
+      fixable: 1"
     `);
     expect(result.stderr).toBeFalsy();
   });
@@ -105,7 +105,7 @@ describe('custom formatters', () => {
       "Custom Formatter Header
       errors: 3
       warnings: 0
-      fixable: 0"
+      fixable: 1"
     `);
     expect(result.stderr).toBeFalsy();
   });
@@ -147,7 +147,7 @@ describe('custom formatters', () => {
     expect(result.stdout).toMatchInlineSnapshot(`
       "errors: 3
       warnings: 0
-      fixable: 0"
+      fixable: 1"
     `);
     expect(result.stderr).toBeFalsy();
   });

--- a/test/acceptance/formatters/json-test.js
+++ b/test/acceptance/formatters/json-test.js
@@ -119,7 +119,8 @@ describe('JSON formatter', () => {
             \\"message\\": \\"HTML comment detected\\",
             \\"fix\\": {
               \\"text\\": \\"{{! bad html comment! }}\\"
-            }
+            },
+            \\"isFixable\\": true
           }
         ]
       }"
@@ -222,7 +223,8 @@ describe('JSON formatter', () => {
             \\"message\\": \\"HTML comment detected\\",
             \\"fix\\": {
               \\"text\\": \\"{{! bad html comment! }}\\"
-            }
+            },
+            \\"isFixable\\": true
           }
         ]
       }"
@@ -287,7 +289,8 @@ describe('JSON formatter', () => {
             \\"message\\": \\"HTML comment detected\\",
             \\"fix\\": {
               \\"text\\": \\"{{! bad html comment! }}\\"
-            }
+            },
+            \\"isFixable\\": true
           }
         ]
       }"
@@ -352,7 +355,8 @@ describe('JSON formatter', () => {
               \\"message\\": \\"HTML comment detected\\",
               \\"fix\\": {
                 \\"text\\": \\"{{! bad html comment! }}\\"
-              }
+              },
+              \\"isFixable\\": true
             }
           ]
         }"

--- a/test/acceptance/formatters/pretty-test.js
+++ b/test/acceptance/formatters/pretty-test.js
@@ -38,13 +38,15 @@ describe('pretty formatter', () => {
     let result = await runBin('.');
 
     expect(result.exitCode).toEqual(1);
-    expect(result.stdout.split('\n')).toEqual([
-      'app/templates/application.hbs',
-      '  1:4  error  Non-translated string used  no-bare-strings',
-      '  1:25  error  Non-translated string used  no-bare-strings',
-      '',
-      '✖ 2 problems (2 errors, 0 warnings)',
-    ]);
+    expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+      [
+        "app/templates/application.hbs",
+        "  1:4  error  Non-translated string used  no-bare-strings",
+        "  1:25  error  Non-translated string used  no-bare-strings",
+        "",
+        "✖ 2 problems (2 errors, 0 warnings)",
+      ]
+    `);
     expect(result.stderr).toBeFalsy();
   });
 
@@ -67,14 +69,17 @@ describe('pretty formatter', () => {
     let result = await runBin('.');
 
     expect(result.exitCode).toEqual(1);
-    expect(result.stdout.split('\n')).toEqual([
-      'app/templates/application.hbs',
-      '  1:4  error  Non-translated string used  no-bare-strings',
-      '  1:24  error  Non-translated string used  no-bare-strings',
-      '  1:53  warning  HTML comment detected  no-html-comments',
-      '',
-      '✖ 3 problems (2 errors, 1 warnings)',
-    ]);
+    expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+      [
+        "app/templates/application.hbs",
+        "  1:4  error  Non-translated string used  no-bare-strings",
+        "  1:24  error  Non-translated string used  no-bare-strings",
+        "  1:53  warning  HTML comment detected  no-html-comments",
+        "",
+        "✖ 3 problems (2 errors, 1 warnings)",
+        "  0 errors and 1 warnings potentially fixable with the \`--fix\` option.",
+      ]
+    `);
     expect(result.stderr).toBeFalsy();
   });
 
@@ -97,13 +102,24 @@ describe('pretty formatter', () => {
 
     expect(result.exitCode).toEqual(1);
 
-    expect(result.stdout.split('\n')).toEqual([
-      'app/components/click-me-button.hbs',
-      '  1:0  error  All `<button>` elements should have a valid `type` attribute  require-button-type',
-      '',
-      '✖ 1 problems (1 errors, 0 warnings)',
-      '  1 errors and 0 warnings potentially fixable with the `--fix` option.',
-    ]);
+    expect(result.stdout.split('\n')).toMatchInlineSnapshot(
+      [
+        'app/components/click-me-button.hbs',
+        '  1:0  error  All `<button>` elements should have a valid `type` attribute  require-button-type',
+        '',
+        '✖ 1 problems (1 errors, 0 warnings)',
+        '  1 errors and 0 warnings potentially fixable with the `--fix` option.',
+      ],
+      `
+      [
+        "app/components/click-me-button.hbs",
+        "  1:0  error  All \`<button>\` elements should have a valid \`type\` attribute  require-button-type",
+        "",
+        "✖ 1 problems (1 errors, 0 warnings)",
+        "  1 errors and 0 warnings potentially fixable with the \`--fix\` option.",
+      ]
+    `
+    );
     expect(result.stderr).toBeFalsy();
   });
 
@@ -132,7 +148,8 @@ describe('pretty formatter', () => {
         1:24  error  Non-translated string used  no-bare-strings
         1:53  warning  HTML comment detected  no-html-comments
 
-      ✖ 3 problems (2 errors, 1 warnings)"
+      ✖ 3 problems (2 errors, 1 warnings)
+        0 errors and 1 warnings potentially fixable with the \`--fix\` option."
     `);
     expect(result.stderr).toBeFalsy();
   });
@@ -163,7 +180,8 @@ describe('pretty formatter', () => {
         1:24  error  Non-translated string used  no-bare-strings
         1:53  warning  HTML comment detected  no-html-comments
 
-      ✖ 3 problems (2 errors, 1 warnings)"
+      ✖ 3 problems (2 errors, 1 warnings)
+        0 errors and 1 warnings potentially fixable with the \`--fix\` option."
     `);
     expect(result.stderr).toBeFalsy();
   });
@@ -188,13 +206,16 @@ describe('pretty formatter', () => {
       let result = await runBin('.', '--quiet');
 
       expect(result.exitCode).toEqual(1);
-      expect(result.stdout.split('\n')).toEqual([
-        'app/templates/application.hbs',
-        '  1:4  error  Non-translated string used  no-bare-strings',
-        '  1:24  error  Non-translated string used  no-bare-strings',
-        '',
-        '✖ 2 problems (2 errors, 0 warnings)',
-      ]);
+      expect(result.stdout.split('\n')).toMatchInlineSnapshot(`
+        [
+          "app/templates/application.hbs",
+          "  1:4  error  Non-translated string used  no-bare-strings",
+          "  1:24  error  Non-translated string used  no-bare-strings",
+          "",
+          "✖ 2 problems (2 errors, 0 warnings)",
+          "  0 errors and 1 warnings potentially fixable with the \`--fix\` option.",
+        ]
+      `);
       expect(result.stderr).toBeFalsy();
     });
 

--- a/test/unit/rules/no-html-comments-test.js
+++ b/test/unit/rules/no-html-comments-test.js
@@ -16,6 +16,7 @@ generateRuleTests({
   bad: [
     {
       template: '<!-- comment here -->',
+      fixedTemplate: '{{!-- comment here --}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -28,6 +29,7 @@ generateRuleTests({
               "fix": {
                 "text": "{{! comment here }}",
               },
+              "isFixable": true,
               "line": 1,
               "message": "HTML comment detected",
               "rule": "no-html-comments",
@@ -40,6 +42,7 @@ generateRuleTests({
     },
     {
       template: '<!--comment here-->',
+      fixedTemplate: '{{!--comment here--}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -52,6 +55,7 @@ generateRuleTests({
               "fix": {
                 "text": "{{!comment here}}",
               },
+              "isFixable": true,
               "line": 1,
               "message": "HTML comment detected",
               "rule": "no-html-comments",


### PR DESCRIPTION
Part of https://github.com/ember-template-lint/ember-template-lint/issues/2571. [no-html-comments](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-html-comments.md)