### PR TITLE
Add autofixer to `no-quoteless-attributes` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Each rule has emojis denoting:
 | [no-positional-data-test-selectors](./docs/rule/no-positional-data-test-selectors.md)                     | ✅  |     |     | 🔧  |
 | [no-positive-tabindex](./docs/rule/no-positive-tabindex.md)                                               | ✅  |     | ⌨️  |     |
 | [no-potential-path-strings](./docs/rule/no-potential-path-strings.md)                                     | ✅  |     |     |     |
-| [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md)                                         | ✅  |     |     |     |
+| [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md)                                         | ✅  |     |     | 🔧  |
 | [no-redundant-fn](./docs/rule/no-redundant-fn.md)                                                         | ✅  |     |     | 🔧  |
 | [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)                                   | ✅  |     | ⌨️  | 🔧  |
 | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md)                                     |     |     |     |     |

--- a/docs/rule/no-quoteless-attributes.md
+++ b/docs/rule/no-quoteless-attributes.md
@@ -2,6 +2,8 @@
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 In HTML, all attribute values are considered strings, regardless of whether they are quoted or not.
 
 The following two examples are _identical_ from the perspective of the browser:

--- a/lib/rules/no-quoteless-attributes.js
+++ b/lib/rules/no-quoteless-attributes.js
@@ -3,28 +3,29 @@ import Rule from './_base.js';
 export default class NoQuotelessAttributes extends Rule {
   visitor() {
     return {
-      TextNode(node, path) {
-        if (path.parentNode.type !== 'AttrNode') {
-          return;
-        }
-
-        let attribute = path.parentNode;
-        let element = path.parent.parentNode;
-
-        let { isValueless, quoteType } = attribute;
+      AttrNode(node) {
+        let { isValueless, name, quoteType, value } = node;
 
         if (isValueless) {
           return;
         }
+        if (value.type !== 'TextNode') {
+          return;
+        }
 
         if (quoteType === null) {
-          let type = attribute.name.startsWith('@') ? 'Argument' : 'Attribute';
+          let type = name.startsWith('@') ? 'Argument' : 'Attribute';
 
-          this.log({
-            message: `${type} ${attribute.name} should be either quoted or wrapped in mustaches`,
-            node,
-            source: this.sourceForNode(element),
-          });
+          if (this.mode === 'fix') {
+            node.quoteType = '"';
+          } else {
+            this.log({
+              message: `${type} ${name} should be either quoted or wrapped in mustaches`,
+              node,
+              source: this.sourceForNode(node),
+              isFixable: true,
+            });
+          }
         }
       },
     };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "release": "release-it",
     "test": "npm-run-all lint:* test:*",
     "test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage",
+    "test:jest:watch": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "update": "npm-run-all update:*",
     "update:indices": "node ./scripts/update-indices.js",
     "update:readme": "node ./scripts/update-readme.js"

--- a/test/unit/rules/no-quoteless-attributes-test.js
+++ b/test/unit/rules/no-quoteless-attributes-test.js
@@ -20,20 +20,22 @@ generateRuleTests({
   bad: [
     {
       template: '<div data-foo=asdf></div>',
+      fixedTemplate: '<div data-foo="asdf"></div>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 14,
+              "column": 5,
               "endColumn": 18,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Attribute data-foo should be either quoted or wrapped in mustaches",
               "rule": "no-quoteless-attributes",
               "severity": 2,
-              "source": "<div data-foo=asdf></div>",
+              "source": "data-foo=asdf",
             },
           ]
         `);
@@ -41,20 +43,22 @@ generateRuleTests({
     },
     {
       template: '<SomeThing @blah=asdf />',
+      fixedTemplate: '<SomeThing @blah="asdf" />',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 17,
+              "column": 11,
               "endColumn": 21,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Argument @blah should be either quoted or wrapped in mustaches",
               "rule": "no-quoteless-attributes",
               "severity": 2,
-              "source": "<SomeThing @blah=asdf />",
+              "source": "@blah=asdf",
             },
           ]
         `);


### PR DESCRIPTION
Part of https://github.com/ember-template-lint/ember-template-lint/issues/2571. [no-quoteless-attributes](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-quoteless-attributes.md)

I switched over from TextNode to AttrNode because it feels cleaner reach into the node than up the parent.