### PR TITLE
Add autofixer to `self-closing-void-elements` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Each rule has emojis denoting:
 | [require-splattributes](./docs/rule/require-splattributes.md)                                             |     |     |     |     |
 | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                                           | ✅  |     | ⌨️  |     |
 | [require-valid-named-block-naming-format](./docs/rule/require-valid-named-block-naming-format.md)         | ✅  |     |     | 🔧  |
-| [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)                                   |     | 💅  |     |     |
+| [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)                                   |     | 💅  |     | 🔧  |
 | [simple-unless](./docs/rule/simple-unless.md)                                                             | ✅  |     |     |     |
 | [splat-attributes-only](./docs/rule/splat-attributes-only.md)                                             | ✅  |     |     |     |
 | [style-concatenation](./docs/rule/style-concatenation.md)                                                 | ✅  |     |     |     |

--- a/docs/rule/self-closing-void-elements.md
+++ b/docs/rule/self-closing-void-elements.md
@@ -2,6 +2,8 @@
 
 💅 The `extends: 'stylistic'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 HTML has no self-closing tags. The HTML5 parser will ignore self-closing tag in the case of [void elements](https://www.w3.org/TR/html-markup/syntax.html#void-elements) (tags that shouldn't have a "closing tag"). Although the parser will ignore it, it's
 unnecessary and can lead to confusion with SVG/XML code.
 

--- a/lib/rules/self-closing-void-elements.js
+++ b/lib/rules/self-closing-void-elements.js
@@ -1,3 +1,5 @@
+import { builders } from 'ember-template-recast';
+
 import createErrorMessage from '../helpers/create-error-message.js';
 import Rule from './_base.js';
 
@@ -83,16 +85,30 @@ export default class SelfClosingVoidElements extends Rule {
               ? `${source.slice(0, -1)}/>`
               : `${source.slice(0, -2)}>`;
 
-            this.log({
-              message: isSelfClosingRequired
-                ? 'Self-closing a void element is required'
-                : 'Self-closing a void element is redundant',
-              node,
-              source,
-              fix: {
-                text: expected,
-              },
-            });
+            if (this.mode === 'fix') {
+              let editedNode = builders.element(node.tag, {
+                attrs: node.attributes,
+                modifiers: node.modifiers,
+                children: node.children,
+                comments: node.comments,
+                blockParams: node.blockParams,
+                loc: node.loc,
+              });
+              editedNode.selfClosing = isSelfClosingRequired;
+              return editedNode;
+            } else {
+              this.log({
+                message: isSelfClosingRequired
+                  ? 'Self-closing a void element is required'
+                  : 'Self-closing a void element is redundant',
+                node,
+                source,
+                fix: {
+                  text: expected,
+                },
+                isFixable: true,
+              });
+            }
           }
         }
       },

--- a/test/unit/rules/self-closing-void-elements-test.js
+++ b/test/unit/rules/self-closing-void-elements-test.js
@@ -938,5 +938,32 @@ generateRuleTests({
         `);
       },
     },
+    {
+      template: 'foo<wbr data-custom="50" {{my-modifier true "baz"}} as |paramA paramB|>bar',
+      fixedTemplate: 'foo<wbr data-custom="50" {{my-modifier true "baz"}} as |paramA paramB| />bar',
+      config: 'require',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 3,
+              "endColumn": 71,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "fix": {
+                "text": "<wbr data-custom=\\"50\\" {{my-modifier true \\"baz\\"}} as |paramA paramB|/>",
+              },
+              "isFixable": true,
+              "line": 1,
+              "message": "Self-closing a void element is required",
+              "rule": "self-closing-void-elements",
+              "severity": 2,
+              "source": "<wbr data-custom=\\"50\\" {{my-modifier true \\"baz\\"}} as |paramA paramB|>",
+            },
+          ]
+        `);
+      },
+    },
   ],
 });

--- a/test/unit/rules/self-closing-void-elements-test.js
+++ b/test/unit/rules/self-closing-void-elements-test.js
@@ -939,8 +939,10 @@ generateRuleTests({
       },
     },
     {
-      template: 'foo<wbr data-custom="50" {{my-modifier true "baz"}} as |paramA paramB|>bar',
-      fixedTemplate: 'foo<wbr data-custom="50" {{my-modifier true "baz"}} as |paramA paramB| />bar',
+      template:
+        'foo<wbr data-custom="50" {{my-modifier true "baz"}} {{!comment}} as |paramA paramB| >bar',
+      fixedTemplate:
+        'foo<wbr data-custom="50" {{my-modifier true "baz"}} {{!comment}} as |paramA paramB| />bar',
       config: 'require',
 
       verifyResults(results) {
@@ -948,18 +950,18 @@ generateRuleTests({
           [
             {
               "column": 3,
-              "endColumn": 71,
+              "endColumn": 85,
               "endLine": 1,
               "filePath": "layout.hbs",
               "fix": {
-                "text": "<wbr data-custom=\\"50\\" {{my-modifier true \\"baz\\"}} as |paramA paramB|/>",
+                "text": "<wbr data-custom=\\"50\\" {{my-modifier true \\"baz\\"}} {{!comment}} as |paramA paramB| />",
               },
               "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
               "severity": 2,
-              "source": "<wbr data-custom=\\"50\\" {{my-modifier true \\"baz\\"}} as |paramA paramB|>",
+              "source": "<wbr data-custom=\\"50\\" {{my-modifier true \\"baz\\"}} {{!comment}} as |paramA paramB| >",
             },
           ]
         `);

--- a/test/unit/rules/self-closing-void-elements-test.js
+++ b/test/unit/rules/self-closing-void-elements-test.js
@@ -91,6 +91,7 @@ generateRuleTests({
   bad: [
     {
       template: '<area/>',
+      fixedTemplate: '<area>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -103,6 +104,7 @@ generateRuleTests({
               "fix": {
                 "text": "<area>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -115,6 +117,7 @@ generateRuleTests({
     },
     {
       template: '<base/>',
+      fixedTemplate: '<base>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -127,6 +130,7 @@ generateRuleTests({
               "fix": {
                 "text": "<base>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -139,6 +143,7 @@ generateRuleTests({
     },
     {
       template: '<br/>',
+      fixedTemplate: '<br>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -151,6 +156,7 @@ generateRuleTests({
               "fix": {
                 "text": "<br>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -163,6 +169,7 @@ generateRuleTests({
     },
     {
       template: '<col/>',
+      fixedTemplate: '<col>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -175,6 +182,7 @@ generateRuleTests({
               "fix": {
                 "text": "<col>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -187,6 +195,7 @@ generateRuleTests({
     },
     {
       template: '<command/>',
+      fixedTemplate: '<command>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -199,6 +208,7 @@ generateRuleTests({
               "fix": {
                 "text": "<command>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -211,6 +221,7 @@ generateRuleTests({
     },
     {
       template: '<embed/>',
+      fixedTemplate: '<embed>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -223,6 +234,7 @@ generateRuleTests({
               "fix": {
                 "text": "<embed>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -235,6 +247,7 @@ generateRuleTests({
     },
     {
       template: '<hr/>',
+      fixedTemplate: '<hr>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -247,6 +260,7 @@ generateRuleTests({
               "fix": {
                 "text": "<hr>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -259,6 +273,7 @@ generateRuleTests({
     },
     {
       template: '<img/>',
+      fixedTemplate: '<img>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -271,6 +286,7 @@ generateRuleTests({
               "fix": {
                 "text": "<img>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -283,6 +299,7 @@ generateRuleTests({
     },
     {
       template: '<input/>',
+      fixedTemplate: '<input>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -295,6 +312,7 @@ generateRuleTests({
               "fix": {
                 "text": "<input>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -307,6 +325,7 @@ generateRuleTests({
     },
     {
       template: '<keygen/>',
+      fixedTemplate: '<keygen>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -319,6 +338,7 @@ generateRuleTests({
               "fix": {
                 "text": "<keygen>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -331,6 +351,7 @@ generateRuleTests({
     },
     {
       template: '<link/>',
+      fixedTemplate: '<link>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -343,6 +364,7 @@ generateRuleTests({
               "fix": {
                 "text": "<link>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -355,6 +377,7 @@ generateRuleTests({
     },
     {
       template: '<meta/>',
+      fixedTemplate: '<meta>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -367,6 +390,7 @@ generateRuleTests({
               "fix": {
                 "text": "<meta>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -379,6 +403,7 @@ generateRuleTests({
     },
     {
       template: '<param/>',
+      fixedTemplate: '<param>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -391,6 +416,7 @@ generateRuleTests({
               "fix": {
                 "text": "<param>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -403,6 +429,7 @@ generateRuleTests({
     },
     {
       template: '<source/>',
+      fixedTemplate: '<source>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -415,6 +442,7 @@ generateRuleTests({
               "fix": {
                 "text": "<source>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -427,6 +455,7 @@ generateRuleTests({
     },
     {
       template: '<track/>',
+      fixedTemplate: '<track>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -439,6 +468,7 @@ generateRuleTests({
               "fix": {
                 "text": "<track>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -451,6 +481,7 @@ generateRuleTests({
     },
     {
       template: '<wbr/>',
+      fixedTemplate: '<wbr>',
       config: true,
 
       verifyResults(results) {
@@ -464,6 +495,7 @@ generateRuleTests({
               "fix": {
                 "text": "<wbr>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is redundant",
               "rule": "self-closing-void-elements",
@@ -476,6 +508,7 @@ generateRuleTests({
     },
     {
       template: '<area>',
+      fixedTemplate: '<area />',
       config: 'require',
 
       verifyResults(results) {
@@ -489,6 +522,7 @@ generateRuleTests({
               "fix": {
                 "text": "<area/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -501,6 +535,7 @@ generateRuleTests({
     },
     {
       template: '<base>',
+      fixedTemplate: '<base />',
       config: 'require',
 
       verifyResults(results) {
@@ -514,6 +549,7 @@ generateRuleTests({
               "fix": {
                 "text": "<base/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -526,6 +562,7 @@ generateRuleTests({
     },
     {
       template: '<br>',
+      fixedTemplate: '<br />',
       config: 'require',
 
       verifyResults(results) {
@@ -539,6 +576,7 @@ generateRuleTests({
               "fix": {
                 "text": "<br/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -551,6 +589,7 @@ generateRuleTests({
     },
     {
       template: '<col>',
+      fixedTemplate: '<col />',
       config: 'require',
 
       verifyResults(results) {
@@ -564,6 +603,7 @@ generateRuleTests({
               "fix": {
                 "text": "<col/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -576,6 +616,7 @@ generateRuleTests({
     },
     {
       template: '<command>',
+      fixedTemplate: '<command />',
       config: 'require',
 
       verifyResults(results) {
@@ -589,6 +630,7 @@ generateRuleTests({
               "fix": {
                 "text": "<command/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -601,6 +643,7 @@ generateRuleTests({
     },
     {
       template: '<embed>',
+      fixedTemplate: '<embed />',
       config: 'require',
 
       verifyResults(results) {
@@ -614,6 +657,7 @@ generateRuleTests({
               "fix": {
                 "text": "<embed/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -626,6 +670,7 @@ generateRuleTests({
     },
     {
       template: '<hr>',
+      fixedTemplate: '<hr />',
       config: 'require',
 
       verifyResults(results) {
@@ -639,6 +684,7 @@ generateRuleTests({
               "fix": {
                 "text": "<hr/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -651,6 +697,7 @@ generateRuleTests({
     },
     {
       template: '<img>',
+      fixedTemplate: '<img />',
       config: 'require',
 
       verifyResults(results) {
@@ -664,6 +711,7 @@ generateRuleTests({
               "fix": {
                 "text": "<img/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -676,6 +724,7 @@ generateRuleTests({
     },
     {
       template: '<input>',
+      fixedTemplate: '<input />',
       config: 'require',
 
       verifyResults(results) {
@@ -689,6 +738,7 @@ generateRuleTests({
               "fix": {
                 "text": "<input/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -701,6 +751,7 @@ generateRuleTests({
     },
     {
       template: '<keygen>',
+      fixedTemplate: '<keygen />',
       config: 'require',
 
       verifyResults(results) {
@@ -714,6 +765,7 @@ generateRuleTests({
               "fix": {
                 "text": "<keygen/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -726,6 +778,7 @@ generateRuleTests({
     },
     {
       template: '<link>',
+      fixedTemplate: '<link />',
       config: 'require',
 
       verifyResults(results) {
@@ -739,6 +792,7 @@ generateRuleTests({
               "fix": {
                 "text": "<link/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -751,6 +805,7 @@ generateRuleTests({
     },
     {
       template: '<meta>',
+      fixedTemplate: '<meta />',
       config: 'require',
 
       verifyResults(results) {
@@ -764,6 +819,7 @@ generateRuleTests({
               "fix": {
                 "text": "<meta/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -776,6 +832,7 @@ generateRuleTests({
     },
     {
       template: '<param>',
+      fixedTemplate: '<param />',
       config: 'require',
 
       verifyResults(results) {
@@ -789,6 +846,7 @@ generateRuleTests({
               "fix": {
                 "text": "<param/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -801,6 +859,7 @@ generateRuleTests({
     },
     {
       template: '<source>',
+      fixedTemplate: '<source />',
       config: 'require',
 
       verifyResults(results) {
@@ -814,6 +873,7 @@ generateRuleTests({
               "fix": {
                 "text": "<source/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -826,6 +886,7 @@ generateRuleTests({
     },
     {
       template: '<track>',
+      fixedTemplate: '<track />',
       config: 'require',
 
       verifyResults(results) {
@@ -839,6 +900,7 @@ generateRuleTests({
               "fix": {
                 "text": "<track/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",
@@ -851,6 +913,7 @@ generateRuleTests({
     },
     {
       template: '<wbr>',
+      fixedTemplate: '<wbr />',
       config: 'require',
 
       verifyResults(results) {
@@ -864,6 +927,7 @@ generateRuleTests({
               "fix": {
                 "text": "<wbr/>",
               },
+              "isFixable": true,
               "line": 1,
               "message": "Self-closing a void element is required",
               "rule": "self-closing-void-elements",


### PR DESCRIPTION
Part of https://github.com/ember-template-lint/ember-template-lint/issues/2571. [self-closing-void-elements](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/self-closing-void-elements.md)