### PR TITLE
Add autofixer to `linebreak-style` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Each rule has emojis denoting:
 | [deprecated-render-helper](./docs/rule/deprecated-render-helper.md)                                       | ✅  |     |     |     |
 | [eol-last](./docs/rule/eol-last.md)                                                                       |     | 💅  |     | 🔧  |
 | [inline-link-to](./docs/rule/inline-link-to.md)                                                           |     |     |     | 🔧  |
-| [linebreak-style](./docs/rule/linebreak-style.md)                                                         |     | 💅  |     |     |
+| [linebreak-style](./docs/rule/linebreak-style.md)                                                         |     | 💅  |     | 🔧  |
 | [link-href-attributes](./docs/rule/link-href-attributes.md)                                               | ✅  |     | ⌨️  |     |
 | [link-rel-noopener](./docs/rule/link-rel-noopener.md)                                                     | ✅  |     |     | 🔧  |
 | [modifier-name-case](./docs/rule/modifier-name-case.md)                                                   |     | 💅  |     | 🔧  |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Each rule has emojis denoting:
 | [no-extra-mut-helper-argument](./docs/rule/no-extra-mut-helper-argument.md)                               | ✅  |     |     |     |
 | [no-forbidden-elements](./docs/rule/no-forbidden-elements.md)                                             | ✅  |     |     |     |
 | [no-heading-inside-button](./docs/rule/no-heading-inside-button.md)                                       | ✅  |     | ⌨️  |     |
-| [no-html-comments](./docs/rule/no-html-comments.md)                                                       | ✅  |     |     |     |
+| [no-html-comments](./docs/rule/no-html-comments.md)                                                       | ✅  |     |     | 🔧  |
 | [no-implicit-this](./docs/rule/no-implicit-this.md)                                                       | ✅  |     |     |     |
 | [no-index-component-invocation](./docs/rule/no-index-component-invocation.md)                             | ✅  |     |     |     |
 | [no-inline-styles](./docs/rule/no-inline-styles.md)                                                       | ✅  |     |     |     |

--- a/docs/rule/linebreak-style.md
+++ b/docs/rule/linebreak-style.md
@@ -2,6 +2,8 @@
 
 💅 The `extends: 'stylistic'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 Having consistent linebreaks is important to make sure that the source code is rendered correctly in editors.
 
 ## Examples

--- a/docs/rule/no-html-comments.md
+++ b/docs/rule/no-html-comments.md
@@ -2,6 +2,8 @@
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 HTML comments in your templates will get compiled and rendered into the DOM at runtime. This is undesirable in a production environment. Instead, you can annotate your templates using Handlebars comments, which will be stripped out when the template is compiled and have no effect at runtime.
 
 ## Examples

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -70,11 +70,9 @@ export default class LinebreakStyle extends Rule {
     return {
       TextNode(node) {
         let n = this._checkNodeAndLog(node, (wrong, correct) => {
-          let editedText = node.chars.replace(wrong, correct);
+          let editedText = node.chars.replace(new RegExp(wrong, 'g'), correct);
           return builders.text(editedText);
         });
-
-        // console.log("N1", node, "N2", n);
 
         return n;
       },
@@ -86,13 +84,13 @@ export default class LinebreakStyle extends Rule {
       },
       MustacheCommentStatement(node) {
         return this._checkNodeAndLog(node, (wrong, correct) => {
-          let editedText = node.value.replace(wrong, correct);
-          return builders.comment(editedText);
+          let editedText = node.value.replace(new RegExp(wrong, 'g'), correct);
+          return builders.mustacheComment(editedText);
         });
       },
       CommentStatement(node) {
         return this._checkNodeAndLog(node, (wrong, correct) => {
-          let editedText = node.value.replace(wrong, correct);
+          let editedText = node.value.replace(new RegExp(wrong, 'g'), correct);
           return builders.comment(editedText);
         });
       },
@@ -134,9 +132,7 @@ export default class LinebreakStyle extends Rule {
         let goodLineBreakForDisplay = toUserString(this.config);
         let isFixable = Boolean(generateNode);
 
-        console.log("M 1", this.mode)
         if (this.mode === 'fix' && isFixable) {
-          console.log("M 2", this.mode)
           return generateNode(wrongLineBreak, this.config);
         } else {
           this.log({

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -1,4 +1,3 @@
-import { isThisISOWeek } from 'date-fns';
 import { builders } from 'ember-template-recast';
 import os from 'node:os';
 
@@ -70,10 +69,14 @@ export default class LinebreakStyle extends Rule {
   visitor() {
     return {
       TextNode(node) {
-        return this._checkNodeAndLog(node, (wrong, correct) => {
+        let n = this._checkNodeAndLog(node, (wrong, correct) => {
           let editedText = node.chars.replace(wrong, correct);
           return builders.text(editedText);
         });
+
+        // console.log("N1", node, "N2", n);
+
+        return n;
       },
       MustacheStatement(node) {
         return this._checkNodeAndLog(node);
@@ -82,10 +85,16 @@ export default class LinebreakStyle extends Rule {
         return this._checkNodeAndLog(node);
       },
       MustacheCommentStatement(node) {
-        return this._checkNodeAndLog(node);
+        return this._checkNodeAndLog(node, (wrong, correct) => {
+          let editedText = node.value.replace(wrong, correct);
+          return builders.comment(editedText);
+        });
       },
       CommentStatement(node) {
-        return this._checkNodeAndLog(node);
+        return this._checkNodeAndLog(node, (wrong, correct) => {
+          let editedText = node.value.replace(wrong, correct);
+          return builders.comment(editedText);
+        });
       },
     };
   }
@@ -123,8 +132,11 @@ export default class LinebreakStyle extends Rule {
       if (wrongLineBreak) {
         let wrongLineBreakForDisplay = toUserString(wrongLineBreak);
         let goodLineBreakForDisplay = toUserString(this.config);
+        let isFixable = Boolean(generateNode);
 
-        if (this.mode === 'fix' && generateNode) {
+        console.log("M 1", this.mode)
+        if (this.mode === 'fix' && isFixable) {
+          console.log("M 2", this.mode)
           return generateNode(wrongLineBreak, this.config);
         } else {
           this.log({
@@ -134,7 +146,7 @@ export default class LinebreakStyle extends Rule {
             column:
               sourceLine.length - wrongLineBreak.length + (i === 0 ? node.loc.start.column : 0),
             source: wrongLineBreak,
-            isFixable: node.type === 'TextNode',
+            isFixable,
           });
         }
       }

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -1,3 +1,5 @@
+import { isThisISOWeek } from 'date-fns';
+import { builders } from 'ember-template-recast';
 import os from 'node:os';
 
 import createErrorMessage from '../helpers/create-error-message.js';
@@ -68,19 +70,22 @@ export default class LinebreakStyle extends Rule {
   visitor() {
     return {
       TextNode(node) {
-        this._checkNodeAndLog(node);
+        return this._checkNodeAndLog(node, (wrong, correct) => {
+          let editedText = node.chars.replace(wrong, correct);
+          return builders.text(editedText);
+        });
       },
       MustacheStatement(node) {
-        this._checkNodeAndLog(node);
+        return this._checkNodeAndLog(node);
       },
       PartialStatement(node) {
-        this._checkNodeAndLog(node);
+        return this._checkNodeAndLog(node);
       },
       MustacheCommentStatement(node) {
-        this._checkNodeAndLog(node);
+        return this._checkNodeAndLog(node);
       },
       CommentStatement(node) {
-        this._checkNodeAndLog(node);
+        return this._checkNodeAndLog(node);
       },
     };
   }
@@ -106,7 +111,7 @@ export default class LinebreakStyle extends Rule {
     return null;
   }
 
-  _checkNodeAndLog(node) {
+  _checkNodeAndLog(node, generateNode) {
     if (!node.loc) {
       return;
     }
@@ -119,13 +124,19 @@ export default class LinebreakStyle extends Rule {
         let wrongLineBreakForDisplay = toUserString(wrongLineBreak);
         let goodLineBreakForDisplay = toUserString(this.config);
 
-        this.log({
-          message: `Wrong linebreak used. Expected ${goodLineBreakForDisplay} but found ${wrongLineBreakForDisplay}`,
-          node,
-          line: i + node.loc.start.line,
-          column: sourceLine.length - wrongLineBreak.length + (i === 0 ? node.loc.start.column : 0),
-          source: wrongLineBreak,
-        });
+        if (this.mode === 'fix' && generateNode) {
+          return generateNode(wrongLineBreak, this.config);
+        } else {
+          this.log({
+            message: `Wrong linebreak used. Expected ${goodLineBreakForDisplay} but found ${wrongLineBreakForDisplay}`,
+            node,
+            line: i + node.loc.start.line,
+            column:
+              sourceLine.length - wrongLineBreak.length + (i === 0 ? node.loc.start.column : 0),
+            source: wrongLineBreak,
+            isFixable: node.type === 'TextNode',
+          });
+        }
       }
     }
   }

--- a/lib/rules/no-html-comments.js
+++ b/lib/rules/no-html-comments.js
@@ -1,3 +1,5 @@
+import { builders as b } from 'ember-template-recast';
+
 import AstNodeInfo from '../helpers/ast-node-info.js';
 import Rule from './_base.js';
 
@@ -6,14 +8,19 @@ export default class NoHtmlComments extends Rule {
     return {
       CommentStatement(node) {
         if (AstNodeInfo.isNonConfigurationHtmlComment(node)) {
-          this.log({
-            message: 'HTML comment detected',
-            node,
-            source: `<!--${node.value}-->`,
-            fix: {
-              text: `{{!${node.value}}}`,
-            },
-          });
+          if (this.mode === 'fix') {
+            return b.mustacheComment(node.value);
+          } else {
+            this.log({
+              message: 'HTML comment detected',
+              node,
+              source: `<!--${node.value}-->`,
+              fix: {
+                text: `{{!${node.value}}}`,
+              },
+              isFixable: true,
+            });
+          }
         }
       },
     };

--- a/test/unit/rules/linebreak-style-test.js
+++ b/test/unit/rules/linebreak-style-test.js
@@ -34,179 +34,179 @@ generateRuleTests({
   ],
 
   bad: [
-    // {
-    //   template: 'something\ngoes\r\n',
-    //   fixedTemplate: 'something\ngoes\n',
+    {
+      template: 'something\ngoes\r\n',
+      fixedTemplate: 'something\ngoes\n',
 
-    //   verifyResults(results) {
-    //     expect(results).toMatchInlineSnapshot(`
-    //       [
-    //         {
-    //           "column": 4,
-    //           "endColumn": 0,
-    //           "endLine": 3,
-    //           "filePath": "layout.hbs",
-    //           "isFixable": true,
-    //           "line": 2,
-    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
-    //           "rule": "linebreak-style",
-    //           "severity": 2,
-    //           "source": "
-    //       ",
-    //         },
-    //       ]
-    //     `);
-    //   },
-    // },
-    // {
-    //   config: 'unix',
-    //   template: '\r\n',
-    //   fixedTemplate: '\n',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 4,
+              "endColumn": 0,
+              "endLine": 3,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 2,
+              "message": "Wrong linebreak used. Expected LF but found CRLF",
+              "rule": "linebreak-style",
+              "severity": 2,
+              "source": "
+          ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'unix',
+      template: '\r\n',
+      fixedTemplate: '\n',
 
-    //   verifyResults(results) {
-    //     expect(results).toMatchInlineSnapshot(`
-    //       [
-    //         {
-    //           "column": 0,
-    //           "endColumn": 0,
-    //           "endLine": 2,
-    //           "filePath": "layout.hbs",
-    //           "isFixable": true,
-    //           "line": 1,
-    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
-    //           "rule": "linebreak-style",
-    //           "severity": 2,
-    //           "source": "
-    //       ",
-    //         },
-    //       ]
-    //     `);
-    //   },
-    // },
-    // {
-    //   config: 'unix',
-    //   template: '{{#if test}}\r\n{{/if}}',
-    //   fixedTemplate: '{{#if test}}\n{{/if}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 0,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Wrong linebreak used. Expected LF but found CRLF",
+              "rule": "linebreak-style",
+              "severity": 2,
+              "source": "
+          ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'unix',
+      template: '{{#if test}}\r\n{{/if}}',
+      fixedTemplate: '{{#if test}}\n{{/if}}',
 
-    //   verifyResults(results) {
-    //     expect(results).toMatchInlineSnapshot(`
-    //       [
-    //         {
-    //           "column": 12,
-    //           "endColumn": 0,
-    //           "endLine": 2,
-    //           "filePath": "layout.hbs",
-    //           "isFixable": true,
-    //           "line": 1,
-    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
-    //           "rule": "linebreak-style",
-    //           "severity": 2,
-    //           "source": "
-    //       ",
-    //         },
-    //       ]
-    //     `);
-    //   },
-    // },
-    // {
-    //   config: 'unix',
-    //   template: '{{blah}}\r\n{{blah}}',
-    //   fixedTemplate: '{{blah}}\n{{blah}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 12,
+              "endColumn": 0,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Wrong linebreak used. Expected LF but found CRLF",
+              "rule": "linebreak-style",
+              "severity": 2,
+              "source": "
+          ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'unix',
+      template: '{{blah}}\r\n{{blah}}',
+      fixedTemplate: '{{blah}}\n{{blah}}',
 
-    //   verifyResults(results) {
-    //     expect(results).toMatchInlineSnapshot(`
-    //       [
-    //         {
-    //           "column": 8,
-    //           "endColumn": 0,
-    //           "endLine": 2,
-    //           "filePath": "layout.hbs",
-    //           "isFixable": true,
-    //           "line": 1,
-    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
-    //           "rule": "linebreak-style",
-    //           "severity": 2,
-    //           "source": "
-    //       ",
-    //         },
-    //       ]
-    //     `);
-    //   },
-    // },
-    // {
-    //   config: 'unix',
-    //   template: '{{blah}}\r\n',
-    //   fixedTemplate: '{{blah}}\n',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 8,
+              "endColumn": 0,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Wrong linebreak used. Expected LF but found CRLF",
+              "rule": "linebreak-style",
+              "severity": 2,
+              "source": "
+          ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'unix',
+      template: '{{blah}}\r\n',
+      fixedTemplate: '{{blah}}\n',
 
-    //   verifyResults(results) {
-    //     expect(results).toMatchInlineSnapshot(`
-    //       [
-    //         {
-    //           "column": 8,
-    //           "endColumn": 0,
-    //           "endLine": 2,
-    //           "filePath": "layout.hbs",
-    //           "isFixable": true,
-    //           "line": 1,
-    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
-    //           "rule": "linebreak-style",
-    //           "severity": 2,
-    //           "source": "
-    //       ",
-    //         },
-    //       ]
-    //     `);
-    //   },
-    // },
-    // {
-    //   config: 'unix',
-    //   template: '{{blah arg="\r\n"}}',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 8,
+              "endColumn": 0,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Wrong linebreak used. Expected LF but found CRLF",
+              "rule": "linebreak-style",
+              "severity": 2,
+              "source": "
+          ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'unix',
+      template: '{{blah arg="\r\n"}}',
 
-    //   verifyResults(results) {
-    //     expect(results).toMatchInlineSnapshot(`
-    //       [
-    //         {
-    //           "column": 12,
-    //           "endColumn": 3,
-    //           "endLine": 2,
-    //           "filePath": "layout.hbs",
-    //           "isFixable": false,
-    //           "line": 1,
-    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
-    //           "rule": "linebreak-style",
-    //           "severity": 2,
-    //           "source": "
-    //       ",
-    //         },
-    //       ]
-    //     `);
-    //   },
-    // },
-    // {
-    //   config: 'unix',
-    //   template: '<blah arg="\r\n" />',
-    //   fixedTemplate: '<blah arg="\n" />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 12,
+              "endColumn": 3,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "isFixable": false,
+              "line": 1,
+              "message": "Wrong linebreak used. Expected LF but found CRLF",
+              "rule": "linebreak-style",
+              "severity": 2,
+              "source": "
+          ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'unix',
+      template: '<blah arg="\r\n" />',
+      fixedTemplate: '<blah arg="\n" />',
 
-    //   verifyResults(results) {
-    //     expect(results).toMatchInlineSnapshot(`
-    //       [
-    //         {
-    //           "column": 11,
-    //           "endColumn": 0,
-    //           "endLine": 2,
-    //           "filePath": "layout.hbs",
-    //           "isFixable": true,
-    //           "line": 1,
-    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
-    //           "rule": "linebreak-style",
-    //           "severity": 2,
-    //           "source": "
-    //       ",
-    //         },
-    //       ]
-    //     `);
-    //   },
-    // },
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 11,
+              "endColumn": 0,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Wrong linebreak used. Expected LF but found CRLF",
+              "rule": "linebreak-style",
+              "severity": 2,
+              "source": "
+          ",
+            },
+          ]
+        `);
+      },
+    },
     {
       config: 'windows',
       template: '1\n2',
@@ -259,6 +259,31 @@ generateRuleTests({
     },
     {
       config: 'unix',
+      template: '<!-- comment\r\nline -->',
+      fixedTemplate: '<!-- comment\nline -->',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 12,
+              "endColumn": 8,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Wrong linebreak used. Expected LF but found CRLF",
+              "rule": "linebreak-style",
+              "severity": 2,
+              "source": "
+          ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'unix',
       template: '{{!-- comment\r\nline --}}',
       fixedTemplate: '{{!-- comment\nline --}}',
 
@@ -273,6 +298,31 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Wrong linebreak used. Expected LF but found CRLF",
+              "rule": "linebreak-style",
+              "severity": 2,
+              "source": "
+          ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'windows',
+      template: '{{!-- comment\nline --}}',
+      fixedTemplate: '{{!-- comment\r\nline --}}',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 13,
+              "endColumn": 9,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Wrong linebreak used. Expected CRLF but found LF",
               "rule": "linebreak-style",
               "severity": 2,
               "source": "

--- a/test/unit/rules/linebreak-style-test.js
+++ b/test/unit/rules/linebreak-style-test.js
@@ -11,6 +11,7 @@ generateRuleTests({
     'testing this',
     'testing \n this',
     'testing \r\n this',
+    '<!-- comment \n here -->',
     {
       config: 'system',
       template: os.EOL === '\n' ? 'testing\nthis' : 'testing\r\nthis',
@@ -33,170 +34,195 @@ generateRuleTests({
   ],
 
   bad: [
+    // {
+    //   template: 'something\ngoes\r\n',
+    //   fixedTemplate: 'something\ngoes\n',
+
+    //   verifyResults(results) {
+    //     expect(results).toMatchInlineSnapshot(`
+    //       [
+    //         {
+    //           "column": 4,
+    //           "endColumn": 0,
+    //           "endLine": 3,
+    //           "filePath": "layout.hbs",
+    //           "isFixable": true,
+    //           "line": 2,
+    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
+    //           "rule": "linebreak-style",
+    //           "severity": 2,
+    //           "source": "
+    //       ",
+    //         },
+    //       ]
+    //     `);
+    //   },
+    // },
+    // {
+    //   config: 'unix',
+    //   template: '\r\n',
+    //   fixedTemplate: '\n',
+
+    //   verifyResults(results) {
+    //     expect(results).toMatchInlineSnapshot(`
+    //       [
+    //         {
+    //           "column": 0,
+    //           "endColumn": 0,
+    //           "endLine": 2,
+    //           "filePath": "layout.hbs",
+    //           "isFixable": true,
+    //           "line": 1,
+    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
+    //           "rule": "linebreak-style",
+    //           "severity": 2,
+    //           "source": "
+    //       ",
+    //         },
+    //       ]
+    //     `);
+    //   },
+    // },
+    // {
+    //   config: 'unix',
+    //   template: '{{#if test}}\r\n{{/if}}',
+    //   fixedTemplate: '{{#if test}}\n{{/if}}',
+
+    //   verifyResults(results) {
+    //     expect(results).toMatchInlineSnapshot(`
+    //       [
+    //         {
+    //           "column": 12,
+    //           "endColumn": 0,
+    //           "endLine": 2,
+    //           "filePath": "layout.hbs",
+    //           "isFixable": true,
+    //           "line": 1,
+    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
+    //           "rule": "linebreak-style",
+    //           "severity": 2,
+    //           "source": "
+    //       ",
+    //         },
+    //       ]
+    //     `);
+    //   },
+    // },
+    // {
+    //   config: 'unix',
+    //   template: '{{blah}}\r\n{{blah}}',
+    //   fixedTemplate: '{{blah}}\n{{blah}}',
+
+    //   verifyResults(results) {
+    //     expect(results).toMatchInlineSnapshot(`
+    //       [
+    //         {
+    //           "column": 8,
+    //           "endColumn": 0,
+    //           "endLine": 2,
+    //           "filePath": "layout.hbs",
+    //           "isFixable": true,
+    //           "line": 1,
+    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
+    //           "rule": "linebreak-style",
+    //           "severity": 2,
+    //           "source": "
+    //       ",
+    //         },
+    //       ]
+    //     `);
+    //   },
+    // },
+    // {
+    //   config: 'unix',
+    //   template: '{{blah}}\r\n',
+    //   fixedTemplate: '{{blah}}\n',
+
+    //   verifyResults(results) {
+    //     expect(results).toMatchInlineSnapshot(`
+    //       [
+    //         {
+    //           "column": 8,
+    //           "endColumn": 0,
+    //           "endLine": 2,
+    //           "filePath": "layout.hbs",
+    //           "isFixable": true,
+    //           "line": 1,
+    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
+    //           "rule": "linebreak-style",
+    //           "severity": 2,
+    //           "source": "
+    //       ",
+    //         },
+    //       ]
+    //     `);
+    //   },
+    // },
+    // {
+    //   config: 'unix',
+    //   template: '{{blah arg="\r\n"}}',
+
+    //   verifyResults(results) {
+    //     expect(results).toMatchInlineSnapshot(`
+    //       [
+    //         {
+    //           "column": 12,
+    //           "endColumn": 3,
+    //           "endLine": 2,
+    //           "filePath": "layout.hbs",
+    //           "isFixable": false,
+    //           "line": 1,
+    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
+    //           "rule": "linebreak-style",
+    //           "severity": 2,
+    //           "source": "
+    //       ",
+    //         },
+    //       ]
+    //     `);
+    //   },
+    // },
+    // {
+    //   config: 'unix',
+    //   template: '<blah arg="\r\n" />',
+    //   fixedTemplate: '<blah arg="\n" />',
+
+    //   verifyResults(results) {
+    //     expect(results).toMatchInlineSnapshot(`
+    //       [
+    //         {
+    //           "column": 11,
+    //           "endColumn": 0,
+    //           "endLine": 2,
+    //           "filePath": "layout.hbs",
+    //           "isFixable": true,
+    //           "line": 1,
+    //           "message": "Wrong linebreak used. Expected LF but found CRLF",
+    //           "rule": "linebreak-style",
+    //           "severity": 2,
+    //           "source": "
+    //       ",
+    //         },
+    //       ]
+    //     `);
+    //   },
+    // },
     {
-      template: 'something\ngoes\r\n',
-      fixedTemplate: 'something\ngoes\n',
+      config: 'windows',
+      template: '1\n2',
+      fixedTemplate: '1\r\n2',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 4,
-              "endColumn": 0,
-              "endLine": 3,
-              "filePath": "layout.hbs",
-              "isFixable": true,
-              "line": 2,
-              "message": "Wrong linebreak used. Expected LF but found CRLF",
-              "rule": "linebreak-style",
-              "severity": 2,
-              "source": "
-          ",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      config: 'unix',
-      template: '\r\n',
-      fixedTemplate: '\n',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 0,
+              "column": 1,
+              "endColumn": 1,
               "endLine": 2,
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "Wrong linebreak used. Expected LF but found CRLF",
-              "rule": "linebreak-style",
-              "severity": 2,
-              "source": "
-          ",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      config: 'unix',
-      template: '{{#if test}}\r\n{{/if}}',
-      fixedTemplate: '{{#if test}}\n{{/if}}',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 12,
-              "endColumn": 0,
-              "endLine": 2,
-              "filePath": "layout.hbs",
-              "isFixable": true,
-              "line": 1,
-              "message": "Wrong linebreak used. Expected LF but found CRLF",
-              "rule": "linebreak-style",
-              "severity": 2,
-              "source": "
-          ",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      config: 'unix',
-      template: '{{blah}}\r\n{{blah}}',
-      fixedTemplate: '{{blah}}\n{{blah}}',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 8,
-              "endColumn": 0,
-              "endLine": 2,
-              "filePath": "layout.hbs",
-              "isFixable": true,
-              "line": 1,
-              "message": "Wrong linebreak used. Expected LF but found CRLF",
-              "rule": "linebreak-style",
-              "severity": 2,
-              "source": "
-          ",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      config: 'unix',
-      template: '{{blah}}\r\n',
-      fixedTemplate: '{{blah}}\n',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 8,
-              "endColumn": 0,
-              "endLine": 2,
-              "filePath": "layout.hbs",
-              "isFixable": true,
-              "line": 1,
-              "message": "Wrong linebreak used. Expected LF but found CRLF",
-              "rule": "linebreak-style",
-              "severity": 2,
-              "source": "
-          ",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      config: 'unix',
-      template: '{{blah arg="\r\n"}}',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 12,
-              "endColumn": 3,
-              "endLine": 2,
-              "filePath": "layout.hbs",
-              "isFixable": false,
-              "line": 1,
-              "message": "Wrong linebreak used. Expected LF but found CRLF",
-              "rule": "linebreak-style",
-              "severity": 2,
-              "source": "
-          ",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      config: 'unix',
-      template: '<blah arg="\r\n" />',
-      fixedTemplate: '<blah arg="\n" />',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 11,
-              "endColumn": 0,
-              "endLine": 2,
-              "filePath": "layout.hbs",
-              "isFixable": true,
-              "line": 1,
-              "message": "Wrong linebreak used. Expected LF but found CRLF",
+              "message": "Wrong linebreak used. Expected CRLF but found LF",
               "rule": "linebreak-style",
               "severity": 2,
               "source": "
@@ -208,20 +234,45 @@ generateRuleTests({
     },
     {
       config: 'windows',
-      template: '\n',
-      fixedTemplate: '\r\n',
+      template: '<!-- comment\nline -->',
+      fixedTemplate: '<!-- comment\r\nline -->',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
-              "endColumn": 0,
+              "column": 12,
+              "endColumn": 8,
               "endLine": 2,
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
               "message": "Wrong linebreak used. Expected CRLF but found LF",
+              "rule": "linebreak-style",
+              "severity": 2,
+              "source": "
+          ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: 'unix',
+      template: '{{!-- comment\r\nline --}}',
+      fixedTemplate: '{{!-- comment\nline --}}',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 13,
+              "endColumn": 9,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Wrong linebreak used. Expected LF but found CRLF",
               "rule": "linebreak-style",
               "severity": 2,
               "source": "

--- a/test/unit/rules/linebreak-style-test.js
+++ b/test/unit/rules/linebreak-style-test.js
@@ -35,6 +35,7 @@ generateRuleTests({
   bad: [
     {
       template: 'something\ngoes\r\n',
+      fixedTemplate: 'something\ngoes\n',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -44,6 +45,7 @@ generateRuleTests({
               "endColumn": 0,
               "endLine": 3,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 2,
               "message": "Wrong linebreak used. Expected LF but found CRLF",
               "rule": "linebreak-style",
@@ -58,6 +60,7 @@ generateRuleTests({
     {
       config: 'unix',
       template: '\r\n',
+      fixedTemplate: '\n',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -67,6 +70,7 @@ generateRuleTests({
               "endColumn": 0,
               "endLine": 2,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Wrong linebreak used. Expected LF but found CRLF",
               "rule": "linebreak-style",
@@ -81,6 +85,7 @@ generateRuleTests({
     {
       config: 'unix',
       template: '{{#if test}}\r\n{{/if}}',
+      fixedTemplate: '{{#if test}}\n{{/if}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -90,6 +95,7 @@ generateRuleTests({
               "endColumn": 0,
               "endLine": 2,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Wrong linebreak used. Expected LF but found CRLF",
               "rule": "linebreak-style",
@@ -104,6 +110,7 @@ generateRuleTests({
     {
       config: 'unix',
       template: '{{blah}}\r\n{{blah}}',
+      fixedTemplate: '{{blah}}\n{{blah}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -113,6 +120,7 @@ generateRuleTests({
               "endColumn": 0,
               "endLine": 2,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Wrong linebreak used. Expected LF but found CRLF",
               "rule": "linebreak-style",
@@ -127,6 +135,7 @@ generateRuleTests({
     {
       config: 'unix',
       template: '{{blah}}\r\n',
+      fixedTemplate: '{{blah}}\n',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -136,6 +145,7 @@ generateRuleTests({
               "endColumn": 0,
               "endLine": 2,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Wrong linebreak used. Expected LF but found CRLF",
               "rule": "linebreak-style",
@@ -159,6 +169,7 @@ generateRuleTests({
               "endColumn": 3,
               "endLine": 2,
               "filePath": "layout.hbs",
+              "isFixable": false,
               "line": 1,
               "message": "Wrong linebreak used. Expected LF but found CRLF",
               "rule": "linebreak-style",
@@ -173,6 +184,7 @@ generateRuleTests({
     {
       config: 'unix',
       template: '<blah arg="\r\n" />',
+      fixedTemplate: '<blah arg="\n" />',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -182,6 +194,7 @@ generateRuleTests({
               "endColumn": 0,
               "endLine": 2,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Wrong linebreak used. Expected LF but found CRLF",
               "rule": "linebreak-style",
@@ -196,6 +209,7 @@ generateRuleTests({
     {
       config: 'windows',
       template: '\n',
+      fixedTemplate: '\r\n',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -205,6 +219,7 @@ generateRuleTests({
               "endColumn": 0,
               "endLine": 2,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Wrong linebreak used. Expected CRLF but found LF",
               "rule": "linebreak-style",

--- a/test/unit/rules/no-html-comments-test.js
+++ b/test/unit/rules/no-html-comments-test.js
@@ -16,6 +16,7 @@ generateRuleTests({
   bad: [
     {
       template: '<!-- comment here -->',
+      fixedTemplate: '{{!-- comment here --}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -28,6 +29,7 @@ generateRuleTests({
               "fix": {
                 "text": "{{! comment here }}",
               },
+              "isFixable": true,
               "line": 1,
               "message": "HTML comment detected",
               "rule": "no-html-comments",
@@ -40,6 +42,7 @@ generateRuleTests({
     },
     {
       template: '<!--comment here-->',
+      fixedTemplate: '{{!--comment here--}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -52,6 +55,7 @@ generateRuleTests({
               "fix": {
                 "text": "{{!comment here}}",
               },
+              "isFixable": true,
               "line": 1,
               "message": "HTML comment detected",
               "rule": "no-html-comments",


### PR DESCRIPTION
Part of https://github.com/ember-template-lint/ember-template-lint/issues/2571. [linebreak-style](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/linebreak-style.md)

I'm not sure how to implement all the fixes, so I thought I'd open a draft PR to track the work.
If you think you'd prefer, I can also open a PR per node type.

## Autofixers
- [ ] `TextNode`
- [ ] `MustacheStatement`
- [ ] `PartialStatement`
- [ ] `MustacheCommentStatement`
- [ ] `CommentStatement`