### PR TITLE
Add `unique-id` to allowed built-in helpers in `no-curly-component-invocation` and `no-implicit-this` rules

### DIFF
--- a/lib/rules/no-curly-component-invocation.js
+++ b/lib/rules/no-curly-component-invocation.js
@@ -39,6 +39,7 @@ const BUILT_INS = new Set([
   'query-params',
   'textarea',
   'unbound',
+  'unique-id',
   'unless',
   'with',
   '-in-element',

--- a/lib/rules/no-implicit-this.js
+++ b/lib/rules/no-implicit-this.js
@@ -41,6 +41,7 @@ export const ARGLESS_BUILTIN_HELPERS = [
   'query-params',
   'textarea',
   'yield',
+  'unique-id',
 ];
 
 // arg'less Components / Helpers in default ember-cli blueprint

--- a/test/unit/rules/no-curly-component-invocation-test.js
+++ b/test/unit/rules/no-curly-component-invocation-test.js
@@ -36,6 +36,7 @@ const SHARED_GOOD = [
   '{{hasBlock}}',
   '{{hash}}',
   '{{outlet}}',
+  '{{unique-id}}',
   '{{yield}}',
   '{{yield to="inverse"}}',
 


### PR DESCRIPTION
In Ember v4.4.0, a [`unique-id` helper](https://api.emberjs.com/ember/4.6/classes/Ember.Templates.helpers/methods/unique-id?anchor=unique-id) was added which generates a unique ID string suitable for use as an ID attribute in the DOM. When this helper is used as: `<p>{{unique-id}}</p>`, both the no-implicit-this and no-curly-component-invocation rules flag it as an issue.

Let's update the allowed-lists in both rules such that they no longer flag this usage.