### PR TITLE
Unblock CI failures with Node 18

### DIFF
--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -5,7 +5,7 @@ import { differenceInDays, subDays } from 'date-fns';
 import { setupProject, teardownProject, runBin } from '../helpers/bin-tester.js';
 import setupEnvVar from '../helpers/setup-env-var.js';
 
-jest.setTimeout(10_000);
+jest.setTimeout(100_000);
 
 function buildReadOptions() {
   return { engine: 'ember-template-lint' };


### PR DESCRIPTION
Unblocks PRs that are failing in Node 18 due to test timeout (fixes #2599).

STR
* Update volta config to use Node 18.8.0 (same as installed in CI)
* Run the jest tests, observe the test timeout and failure
* Increase the timeout
* Run jest tests again, observe they all pass.