### PR TITLE
Fix `--version` to actually give the right value

### DIFF
--- a/lib/helpers/cli.js
+++ b/lib/helpers/cli.js
@@ -20,6 +20,12 @@ class NoMatchingFilesError extends Error {
   }
 }
 
+function getVersion() {
+  const json = JSON.parse(fs.readFileSync(new URL('../../package.json', import.meta.url)));
+
+  return json.version;
+}
+
 export function parseArgv(_argv) {
   const specifiedOptions = {
     'config-path': {
@@ -136,7 +142,7 @@ export function parseArgv(_argv) {
     .usage('$0 [options] [files..]')
     .options(specifiedOptions)
     .help()
-    .version();
+    .version('version', getVersion());
 
   parser.parserConfiguration({
     'greedy-arrays': false,


### PR DESCRIPTION
The default implementation of `yargs.version()` is _basically_ always going to be wrong since it uses `pkg-up` to find the nearest `package.json` upwards from the `process.cwd()` ([implementation here](https://github.com/yargs/yargs/blob/561fc7a787228b226e0ba76ab674456cbd30cd37/lib/yargs-factory.ts#L1581-L1584)).

Fixes https://github.com/ember-template-lint/ember-template-lint/issues/2550
