### PR TITLE
Add `concurrency` setup to GH Actions workflow.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ on:
   schedule:
     - cron: '0 3 * * *' # daily, at 3am
 
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
This will kill any CI jobs that are running if a new job for the branch is kicked off.

This should reduce CI resources (as people push new commits to PR's it will cancel the now defunct CI runs)...
