### PR TITLE
Add autofix for case with helpers to `simple-unless` rule

### DIFF
--- a/lib/rules/simple-unless.js
+++ b/lib/rules/simple-unless.js
@@ -182,6 +182,17 @@ export default class SimpleUnless extends Rule {
     } while (containsSubExpression);
     if (fixMode && shouldFix) {
       node.path.original = 'if';
+      if (node.params[0].type === 'SubExpression' && node.params[0].path.original === 'not') {
+        // skip creating subexpression so we won't create `(not (not` chain
+        if (node.params[0].params.length > 1) {
+          node.params[0].path.original = 'or';
+          return;
+        }
+        const [nothelper, ...rest] = [...node.params];
+        node.params = nothelper.params;
+        node.params.push(...rest);
+        return;
+      }
       node.params[0] = b.sexpr('not', [node.params[0]]);
     }
   }

--- a/lib/rules/simple-unless.js
+++ b/lib/rules/simple-unless.js
@@ -1,3 +1,5 @@
+import { builders as b } from 'ember-template-recast';
+
 import AstNodeInfo from '../helpers/ast-node-info.js';
 import createErrorMessage from '../helpers/create-error-message.js';
 import Rule from './_base.js';
@@ -64,8 +66,9 @@ export default class SimpleUnless extends Rule {
   visitor() {
     return {
       MustacheStatement(node) {
+        const fixMode = this.mode === 'fix';
         if (node.path.original === 'unless' && node.params[0].path) {
-          this._withHelper(node);
+          this._withHelper(node, fixMode);
         }
       },
 
@@ -84,7 +87,7 @@ export default class SimpleUnless extends Rule {
             this._asElseUnlessBlock(node);
           }
         } else if (AstNodeInfo.isUnless(node) && node.params[0].path) {
-          this._withHelper(node);
+          this._withHelper(node, fixMode);
         }
       },
     };
@@ -124,12 +127,13 @@ export default class SimpleUnless extends Rule {
     this._logMessage(node, messages.asElseUnlessBlock, loc.line, loc.column, actual);
   }
 
-  _withHelper(node) {
+  _withHelper(node, fixMode) {
     let { allowlist = [], denylist = [], maxHelpers } = this.config;
     let params;
     let nextParams = node.params;
     let helperCount = 0;
     let containsSubExpression = false;
+    let shouldFix = false;
 
     do {
       params = nextParams;
@@ -142,7 +146,8 @@ export default class SimpleUnless extends Rule {
             let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
             let message = `${messages.withHelper} MaxHelpers: ${maxHelpers}`;
 
-            this._logMessage(param, message, loc.line, loc.column, actual);
+            this._logMessage(param, message, loc.line, loc.column, actual, true);
+            shouldFix = true;
           }
 
           if (allowlist.length > 0 && !allowlist.includes(param.path.original)) {
@@ -152,7 +157,8 @@ export default class SimpleUnless extends Rule {
               allowlist.length > 1 ? 's' : ''
             }: ${allowlist.toString()}`;
 
-            this._logMessage(param, message, loc.line, loc.column, actual);
+            this._logMessage(param, message, loc.line, loc.column, actual, true);
+            shouldFix = true;
           }
 
           if (denylist.length > 0 && denylist.includes(param.path.original)) {
@@ -162,7 +168,8 @@ export default class SimpleUnless extends Rule {
               denylist.length > 1 ? 's' : ''
             }: ${denylist.toString()}`;
 
-            this._logMessage(param, message, loc.line, loc.column, actual);
+            this._logMessage(param, message, loc.line, loc.column, actual, true);
+            shouldFix = true;
           }
 
           for (const p of param.params) {
@@ -173,6 +180,10 @@ export default class SimpleUnless extends Rule {
 
       containsSubExpression = nextParams.some((param) => param.type === 'SubExpression');
     } while (containsSubExpression);
+    if (fixMode && shouldFix) {
+      node.path.original = 'if';
+      node.params[0] = b.sexpr('not', [node.params[0]]);
+    }
   }
 
   _isElseUnlessBlock(node) {

--- a/test/unit/rules/simple-unless-test.js
+++ b/test/unit/rules/simple-unless-test.js
@@ -71,6 +71,7 @@ generateRuleTests({
         maxHelpers: 2,
       },
       template: "{{unless (if (or true))  'Please no'}}",
+      fixedTemplate: "{{if (not (if (or true)))  'Please no'}}",
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -80,7 +81,7 @@ generateRuleTests({
               "endColumn": 23,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. Allowed helpers: or,eq,not-eq",
               "rule": "simple-unless",
@@ -93,6 +94,7 @@ generateRuleTests({
     },
     {
       template: "{{unless (if true)  'Please no'}}",
+      fixedTemplate: "{{if (not (if true))  'Please no'}}",
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -102,7 +104,7 @@ generateRuleTests({
               "endColumn": 18,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. Allowed helpers: or,eq,not-eq",
               "rule": "simple-unless",
@@ -115,6 +117,7 @@ generateRuleTests({
     },
     {
       template: "{{unless (and isBad isAwful)  'notBadAndAwful'}}",
+      fixedTemplate: "{{if (not (and isBad isAwful))  'notBadAndAwful'}}",
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -124,7 +127,7 @@ generateRuleTests({
               "endColumn": 28,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. Allowed helpers: or,eq,not-eq",
               "rule": "simple-unless",
@@ -346,6 +349,11 @@ generateRuleTests({
         '  I am a green celery!',
         '{{/unless}}',
       ].join('\n'),
+      fixedTemplate: [
+        '{{#if (not (and isFruit isYellow))}}',
+        '  I am a green celery!',
+        '{{/if}}',
+      ].join('\n'),
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -355,7 +363,7 @@ generateRuleTests({
               "endColumn": 32,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. Allowed helpers: or,eq,not-eq",
               "rule": "simple-unless",
@@ -372,6 +380,11 @@ generateRuleTests({
         '  I think I am a brown stick',
         '{{/unless}}',
       ].join('\n'),
+      fixedTemplate: [
+        '{{#if (not (not isBrown isSticky))}}',
+        '  I think I am a brown stick',
+        '{{/if}}',
+      ].join('\n'),
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -381,7 +394,7 @@ generateRuleTests({
               "endColumn": 32,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. Allowed helpers: or,eq,not-eq",
               "rule": "simple-unless",
@@ -433,6 +446,11 @@ generateRuleTests({
         '  MUCH HELPERS, VERY BAD',
         '{{/unless}}',
       ].join('\n'),
+      fixedTemplate: [
+        '{{#if (not (or (eq foo bar) (not-eq baz "beer")))}}',
+        '  MUCH HELPERS, VERY BAD',
+        '{{/if}}',
+      ].join('\n'),
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -442,7 +460,7 @@ generateRuleTests({
               "endColumn": 46,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 2",
               "rule": "simple-unless",
@@ -460,6 +478,11 @@ generateRuleTests({
         '  I think I am a brown stick',
         '{{/unless}}',
       ].join('\n'),
+      fixedTemplate: [
+        '{{#if (not (concat "blue" "red"))}}',
+        '  I think I am a brown stick',
+        '{{/if}}',
+      ].join('\n'),
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -469,7 +492,7 @@ generateRuleTests({
               "endColumn": 31,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 0",
               "rule": "simple-unless",
@@ -490,6 +513,11 @@ generateRuleTests({
         '  I think I am a brown stick',
         '{{/unless}}',
       ].join('\n'),
+      fixedTemplate: [
+        '{{#if (not (one (test power) two))}}',
+        '  I think I am a brown stick',
+        '{{/if}}',
+      ].join('\n'),
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -499,7 +527,7 @@ generateRuleTests({
               "endColumn": 32,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. Allowed helper: test",
               "rule": "simple-unless",
@@ -511,7 +539,7 @@ generateRuleTests({
               "endColumn": 27,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 1",
               "rule": "simple-unless",
@@ -532,6 +560,11 @@ generateRuleTests({
         '  I think I am a brown stick',
         '{{/unless}}',
       ].join('\n'),
+      fixedTemplate: [
+        '{{#if (not (one (two three) (four five)))}}',
+        '  I think I am a brown stick',
+        '{{/if}}',
+      ].join('\n'),
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -541,7 +574,7 @@ generateRuleTests({
               "endColumn": 38,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. MaxHelpers: 2",
               "rule": "simple-unless",
@@ -562,6 +595,11 @@ generateRuleTests({
         '  I think I am a brown stick',
         '{{/unless}}',
       ].join('\n'),
+      fixedTemplate: [
+        '{{#if (not (one (two three) (four five)))}}',
+        '  I think I am a brown stick',
+        '{{/if}}',
+      ].join('\n'),
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -571,7 +609,7 @@ generateRuleTests({
               "endColumn": 26,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. Restricted helper: two",
               "rule": "simple-unless",
@@ -592,6 +630,11 @@ generateRuleTests({
         '  I think I am a brown stick',
         '{{/unless}}',
       ].join('\n'),
+      fixedTemplate: [
+        '{{#if (not (one (two three) (four five)))}}',
+        '  I think I am a brown stick',
+        '{{/if}}',
+      ].join('\n'),
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -601,7 +644,7 @@ generateRuleTests({
               "endColumn": 26,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. Restricted helpers: two,four",
               "rule": "simple-unless",
@@ -613,7 +656,7 @@ generateRuleTests({
               "endColumn": 38,
               "endLine": 1,
               "filePath": "layout.hbs",
-              "isFixable": false,
+              "isFixable": true,
               "line": 1,
               "message": "Using {{unless}} in combination with other helpers should be avoided. Restricted helpers: two,four",
               "rule": "simple-unless",

--- a/test/unit/rules/simple-unless-test.js
+++ b/test/unit/rules/simple-unless-test.js
@@ -381,7 +381,7 @@ generateRuleTests({
         '{{/unless}}',
       ].join('\n'),
       fixedTemplate: [
-        '{{#if (not (not isBrown isSticky))}}',
+        '{{#if (or isBrown isSticky)}}',
         '  I think I am a brown stick',
         '{{/if}}',
       ].join('\n'),
@@ -400,6 +400,75 @@ generateRuleTests({
               "rule": "simple-unless",
               "severity": 2,
               "source": "{{unless (not ...",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: ['{{#unless (not isBrown)}}', '  I think I am a brown', '{{/unless}}'].join('\n'),
+      fixedTemplate: ['{{#if isBrown}}', '  I think I am a brown', '{{/if}}'].join('\n'),
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 10,
+              "endColumn": 23,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Using {{unless}} in combination with other helpers should be avoided. Allowed helpers: or,eq,not-eq",
+              "rule": "simple-unless",
+              "severity": 2,
+              "source": "{{unless (not ...",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<img class={{unless (not condition) "some-class"}}>',
+      fixedTemplate: '<img class={{if condition "some-class"}}>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 20,
+              "endColumn": 35,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Using {{unless}} in combination with other helpers should be avoided. Allowed helpers: or,eq,not-eq",
+              "rule": "simple-unless",
+              "severity": 2,
+              "source": "{{unless (not ...",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<img class={{unless (one condition) "some-class" "other-class"}}>',
+      fixedTemplate: '<img class={{if (not (one condition)) "some-class" "other-class"}}>',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 20,
+              "endColumn": 35,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Using {{unless}} in combination with other helpers should be avoided. Allowed helpers: or,eq,not-eq",
+              "rule": "simple-unless",
+              "severity": 2,
+              "source": "{{unless (one ...",
             },
           ]
         `);


### PR DESCRIPTION
Part of https://github.com/ember-template-lint/ember-template-lint/issues/2571.

Replace `unless` with helpers with `if not` with helpers.
I'm not sure if result is good enough to be auto fixed, any ideas to improve that are welcome.