### PR TITLE
feat: utilize new contents data from ember-template-imports

### DIFF
--- a/lib/extract-templates.js
+++ b/lib/extract-templates.js
@@ -65,11 +65,9 @@ export function extractTemplates(moduleSource, relativePath) {
     let { start, end } = templateInfo;
     let templateStart = start.index + start[0].length;
 
-    let template = moduleSource.slice(templateStart, end.index);
-
     return makeTemplateInfo(
       coordinatesOf(moduleSource, templateStart, end.index),
-      template,
+      templateInfo.contents,
       templateInfo,
       true
     );

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "chalk": "^4.1.2",
         "ci-info": "^3.4.0",
         "date-fns": "^2.29.2",
-        "ember-template-imports": "^3.1.1",
+        "ember-template-imports": "^3.2.0",
         "ember-template-recast": "^6.1.3",
         "find-up": "^6.3.0",
         "fuse.js": "^6.5.3",
@@ -5114,9 +5114,9 @@
       "peer": true
     },
     "node_modules/ember-template-imports": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-3.1.1.tgz",
-      "integrity": "sha512-ZsujuOwaF6lWDDeKC0NleCUAC8f06CfxWQPmejNnxg5gUdqHFTfW9L++X9RLLV/pJZ6eCtax7L94XkXQJ1LfBA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-3.2.0.tgz",
+      "integrity": "sha512-+8BjuDyyWLxgfnbzk3HpmlCC/1heGwXPONpXgSoVqXMQdEGsjyQui2rL0sLepdQU98tWsHz+dSOPTKZnxt3phA==",
       "dependencies": {
         "babel-import-util": "^0.2.0",
         "broccoli-stew": "^3.0.0",
@@ -20385,9 +20385,9 @@
       "peer": true
     },
     "ember-template-imports": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-3.1.1.tgz",
-      "integrity": "sha512-ZsujuOwaF6lWDDeKC0NleCUAC8f06CfxWQPmejNnxg5gUdqHFTfW9L++X9RLLV/pJZ6eCtax7L94XkXQJ1LfBA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-3.2.0.tgz",
+      "integrity": "sha512-+8BjuDyyWLxgfnbzk3HpmlCC/1heGwXPONpXgSoVqXMQdEGsjyQui2rL0sLepdQU98tWsHz+dSOPTKZnxt3phA==",
       "requires": {
         "babel-import-util": "^0.2.0",
         "broccoli-stew": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "chalk": "^4.1.2",
     "ci-info": "^3.4.0",
     "date-fns": "^2.29.2",
-    "ember-template-imports": "^3.1.1",
+    "ember-template-imports": "^3.2.0",
     "ember-template-recast": "^6.1.3",
     "find-up": "^6.3.0",
     "fuse.js": "^6.5.3",


### PR DESCRIPTION
# Summary

in https://github.com/ember-template-imports/ember-template-imports/pull/74 we added the ability to get the contents from the parsed template code so we can utilize that instead of slicing data.