### PR TITLE
Remove eslint-plugin-import-helpers

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,15 +8,7 @@ module.exports = {
   env: {
     node: true,
   },
-  plugins: [
-    'eslint-comments',
-    'filenames',
-    'import',
-    'import-helpers',
-    'node',
-    'prettier',
-    'unicorn',
-  ],
+  plugins: ['eslint-comments', 'filenames', 'import', 'node', 'prettier', 'unicorn'],
   extends: [
     'eslint:recommended',
     'plugin:eslint-comments/recommended',
@@ -100,19 +92,6 @@ module.exports = {
     'import/no-useless-path-segments': 'error',
     'import/no-webpack-loader-syntax': 'error',
     'import/unambiguous': 'error',
-
-    'import-helpers/order-imports': [
-      'error',
-      {
-        newlinesBetween: 'always',
-        groups: [
-          '/^(assert|async_hooks|buffer|child_process|cluster|console|constants|crypto|dgram|dns|domain|events|fs|http|http2|https|inspector|module|net|os|path|perf_hooks|process|punycode|querystring|readline|repl|stream|string_decoder|timers|tls|trace_events|tty|url|util|v8|vm|zli)/',
-          ['module'],
-          ['parent', 'sibling', 'index'],
-        ],
-        alphabetize: { order: 'asc', ignoreCase: true },
-      },
-    ],
 
     // Jest rules:
     'jest/no-conditional-expect': 'off',

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,6 @@
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-import": "^2.26.0",
-        "eslint-plugin-import-helpers": "^1.3.0",
         "eslint-plugin-jest": "^26.0.0",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^4.2.1",
@@ -5815,18 +5814,6 @@
       },
       "peerDependencies": {
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
-      }
-    },
-    "node_modules/eslint-plugin-import-helpers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-helpers/-/eslint-plugin-import-helpers-1.3.0.tgz",
-      "integrity": "sha512-rOWH24tNMeb47NjwiQ2SPb7GFy0rgXT6LRsED9B58LcdOaU/jr/8zlpGh3LvrjhWxn8fJuRN4w8bka8Fgs8w2w==",
-      "dev": true,
-      "engines": {
-        "node": "> 14"
-      },
-      "peerDependencies": {
-        "eslint": "5.x - 8.x"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/debug": {
@@ -21055,13 +21042,6 @@
           "dev": true
         }
       }
-    },
-    "eslint-plugin-import-helpers": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import-helpers/-/eslint-plugin-import-helpers-1.3.0.tgz",
-      "integrity": "sha512-rOWH24tNMeb47NjwiQ2SPb7GFy0rgXT6LRsED9B58LcdOaU/jr/8zlpGh3LvrjhWxn8fJuRN4w8bka8Fgs8w2w==",
-      "dev": true,
-      "requires": {}
     },
     "eslint-plugin-jest": {
       "version": "26.9.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,6 @@
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-import-helpers": "^1.3.0",
     "eslint-plugin-jest": "^26.0.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^4.2.1",


### PR DESCRIPTION
eslint-plugin-import-helpers@1 requires Node 16 or higher, which is not compatible with our node support matrix. In version 1.3.0 they added an `engines` field documenting that requirement. When using `npm@8` the `--engines-strict` flag is on by default. Ultimately, this combination of events means that `npm ci` fails with:

```
❯ volta run --node=14.x --npm=8.10.0 npm ci
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: eslint-plugin-import-helpers@1.3.0
npm ERR! notsup Not compatible with your version of node/npm: eslint-plugin-import-helpers@1.3.0
npm ERR! notsup Required: {"node":"> 14"}
npm ERR! notsup Actual:   {"npm":"8.10.0","node":"v14.20.1"}

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/rjackson/.npm/_logs/2022-10-25T20_45_44_753Z-debug-0.log
```
