### PR TITLE
Remove usage of `cross-env`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
     name: Node 16.x - ubuntu
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+
 
     steps:
       - uses: actions/checkout@v3
@@ -74,6 +77,9 @@ jobs:
     name: Node 12
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
+
 
     strategy:
       matrix:
@@ -100,6 +106,8 @@ jobs:
     name: Floating Dependencies
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      NODE_OPTIONS: --max-old-space-size=4096
 
     steps:
       - uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "new:rule": "node dev/generate.js new-rule",
     "release": "release-it",
     "test": "npm-run-all lint:* test:*",
-    "test:jest": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --coverage",
-    "test:jest:watch": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --watch",
+    "test:jest": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --coverage",
+    "test:jest:watch": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js --watch",
     "update": "npm-run-all update:*",
     "update:indices": "node ./scripts/update-indices.js",
     "update:readme": "node ./scripts/update-readme.js"
@@ -90,7 +90,6 @@
     "@microsoft/jest-sarif": "^1.0.0-beta.0",
     "@scalvert/bin-tester": "^2.1.0",
     "common-tags": "^1.8.2",
-    "cross-env": "^7.0.3",
     "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-eslint-comments": "^3.2.0",


### PR DESCRIPTION
We were using `cross-env` in order to set the `--experimental-vm-modules` flag via `process.env.NODE_OPTIONS` to run
`jest`. Unfortunately, this means that the `NODE_OPTIONS` that was being set in our `.github/workflows/ci.yaml` (which increases `--max-old-space-size` to 4096) is completely clobbered.

This doesn't **fix** the memory issues that we are seeing with Node 18, but it does bring back a previously known good work around so that CI is "green again".