### PR TITLE
Change `validateValues` option default to `true` on `require-lang-attribute` rule

### DIFF
--- a/docs/rule/require-lang-attribute.md
+++ b/docs/rule/require-lang-attribute.md
@@ -60,7 +60,7 @@ Add the `lang` attribute to the `app/index.html` file in your Ember app. If you 
 
 - object -- containing the following property:
   - boolean -- `validateValues` -- if `true`, the rule checks whether the value in the `lang` attribute is a known IETF's BCP 47 language tag
-    (default: `false`) (TODO: enable by default in next major release)
+    (default: `true`)
 
 ## References
 

--- a/lib/rules/require-lang-attribute.js
+++ b/lib/rules/require-lang-attribute.js
@@ -4,7 +4,7 @@ import AstNodeInfo from '../helpers/ast-node-info.js';
 import Rule from './_base.js';
 
 const DEFAULT_CONFIG = {
-  validateValues: false,
+  validateValues: true,
 };
 
 const ERROR_MESSAGE = 'The `<html>` element must have the `lang` attribute with a valid value';

--- a/test/unit/rules/require-lang-attribute-test.js
+++ b/test/unit/rules/require-lang-attribute-test.js
@@ -8,7 +8,6 @@ generateRuleTests({
     '<html lang="en"></html>',
     '<html lang="en-US"></html>',
     '<html lang={{lang}}></html>',
-    '<html lang="hurrah"></html>', // allows invalid value when `validateValues` option defaults to `false`
     {
       config: {
         validateValues: true,
@@ -117,6 +116,27 @@ generateRuleTests({
               "rule": "require-lang-attribute",
               "severity": 2,
               "source": "<html lang=\\"\\"></html>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      // no config, allows validateValues to default to true
+      template: '<html lang="gibberish"></html>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 30,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "The \`<html>\` element must have the \`lang\` attribute with a valid value",
+              "rule": "require-lang-attribute",
+              "severity": 2,
+              "source": "<html lang=\\"gibberish\\"></html>",
             },
           ]
         `);


### PR DESCRIPTION

Part of v5 release (https://github.com/ember-template-lint/ember-template-lint/issues/2319).

Follow-up to https://github.com/ember-template-lint/ember-template-lint/pull/2478.

CC: @judithhinlung 