### PR TITLE
Rename `no-redundant-landmark-role` rule to `no-redundant-role` and change `checkAllHTMLElements` option default to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Each rule has emojis denoting:
 | [no-potential-path-strings](./docs/rule/no-potential-path-strings.md)                                     | ✅  |     |     |     |
 | [no-quoteless-attributes](./docs/rule/no-quoteless-attributes.md)                                         | ✅  |     |     | 🔧  |
 | [no-redundant-fn](./docs/rule/no-redundant-fn.md)                                                         | ✅  |     |     | 🔧  |
-| [no-redundant-landmark-role](./docs/rule/no-redundant-landmark-role.md)                                   | ✅  |     | ⌨️  | 🔧  |
+| [no-redundant-role](./docs/rule/no-redundant-role.md)                                                     | ✅  |     | ⌨️  | 🔧  |
 | [no-restricted-invocations](./docs/rule/no-restricted-invocations.md)                                     |     |     |     |     |
 | [no-route-action](./docs/rule/no-route-action.md)                                                         | ✅  |     |     |     |
 | [no-scope-outside-table-headings](./docs/rule/no-scope-outside-table-headings.md)                         | ✅  |     | ⌨️  |     |

--- a/docs/rule/no-redundant-role.md
+++ b/docs/rule/no-redundant-role.md
@@ -1,12 +1,12 @@
-# no-redundant-landmark-role
+# no-redundant-role
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
 🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
 
-If a landmark element is used, any role provided will either be redundant or incorrect.
-This rule adds support for landmark elements, to ensure that no role attribute is placed on any of
-the landmark elements, with the following exceptions:
+The rule checks for redundancy between any semantic HTML element with a default/implicit ARIA role and the role provided.
+
+For example, if a landmark element is used, any role provided will either be redundant or incorrect. This rule ensures that no role attribute is placed on any of the landmark elements, with the following exceptions:
 
 - a `nav` element with the `navigation` role to [make the structure of the page more accessible to user agents](/https://www.w3.org/WAI/GL/wiki/Using_HTML5_nav_element#Example:The_.3Cnav.3E_element)s
 - a `form` element with the `search` role to [identify the form's search functionality](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/search_role#examples)
@@ -50,8 +50,7 @@ This rule **allows** the following:
 - boolean -- if `true`, default configuration is applied
 
 - object -- containing the following property:
-  - boolean -- `checkAllHTMLElements` -- if `true`, the rule checks for redundancy between any semantic HTML element with a default/implicit ARIA role and the role provided
-    (default: `false`) (TODO: enable by default in next major release)
+  - boolean -- `checkAllHTMLElements` -- if `true`, the rule checks for redundancy between any semantic HTML element with a default/implicit ARIA role and the role provided, instead of just landmark roles (default: `true`)
 
 ## References
 

--- a/lib/config/3-x-recommended.js
+++ b/lib/config/3-x-recommended.js
@@ -48,7 +48,7 @@ export default {
     'no-potential-path-strings': 'error',
     'no-quoteless-attributes': 'error',
     'no-redundant-fn': 'error',
-    'no-redundant-landmark-role': 'error',
+    'no-redundant-role': 'error',
     'no-shadowed-elements': 'error',
     'no-triple-curlies': 'error',
     'no-unbalanced-curlies': 'error',

--- a/lib/config/a11y.js
+++ b/lib/config/a11y.js
@@ -22,7 +22,7 @@ export default {
     'no-obsolete-elements': 'error',
     'no-pointer-down-event-binding': 'error',
     'no-positive-tabindex': 'error',
-    'no-redundant-landmark-role': 'error',
+    'no-redundant-role': 'error',
     'no-scope-outside-table-headings': 'error',
     'no-unsupported-role-attributes': 'error',
     'no-whitespace-for-layout': 'error',

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -57,7 +57,7 @@ export default {
     'no-potential-path-strings': 'error',
     'no-quoteless-attributes': 'error',
     'no-redundant-fn': 'error',
-    'no-redundant-landmark-role': 'error',
+    'no-redundant-role': 'error',
     'no-route-action': 'error',
     'no-scope-outside-table-headings': 'error',
     'no-shadowed-elements': 'error',

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -70,7 +70,7 @@ import nopositivetabindex from './no-positive-tabindex.js';
 import nopotentialpathstrings from './no-potential-path-strings.js';
 import noquotelessattributes from './no-quoteless-attributes.js';
 import noredundantfn from './no-redundant-fn.js';
-import noredundantlandmarkrole from './no-redundant-landmark-role.js';
+import noredundantrole from './no-redundant-role.js';
 import norestrictedinvocations from './no-restricted-invocations.js';
 import norouteaction from './no-route-action.js';
 import noscopeoutsidetableheadings from './no-scope-outside-table-headings.js';
@@ -185,7 +185,7 @@ export default {
   'no-potential-path-strings': nopotentialpathstrings,
   'no-quoteless-attributes': noquotelessattributes,
   'no-redundant-fn': noredundantfn,
-  'no-redundant-landmark-role': noredundantlandmarkrole,
+  'no-redundant-role': noredundantrole,
   'no-restricted-invocations': norestrictedinvocations,
   'no-route-action': norouteaction,
   'no-scope-outside-table-headings': noscopeoutsidetableheadings,

--- a/lib/rules/no-redundant-role.js
+++ b/lib/rules/no-redundant-role.js
@@ -4,7 +4,7 @@ import AstNodeInfo from '../helpers/ast-node-info.js';
 import Rule from './_base.js';
 
 const DEFAULT_CONFIG = {
-  checkAllHTMLElements: false,
+  checkAllHTMLElements: true,
 };
 
 function createErrorMessageLandmarkElement(element, role) {
@@ -36,7 +36,7 @@ const allowedElementRoles = [
   },
 ];
 
-export default class NoRedundantLandmarkRole extends Rule {
+export default class NoRedundantRole extends Rule {
   parseConfig(config) {
     return parseConfig(config);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "yeoman-test": "^6.3.0"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^14.18.0 || ^16.0.0 || >= 18.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/test/unit/rules/no-redundant-role-test.js
+++ b/test/unit/rules/no-redundant-role-test.js
@@ -1,7 +1,7 @@
 import generateRuleTests from '../../helpers/rule-test-harness.js';
 
 generateRuleTests({
-  name: 'no-redundant-landmark-role',
+  name: 'no-redundant-role',
 
   config: true,
 
@@ -10,8 +10,10 @@ generateRuleTests({
     '<footer role={{this.foo}}></footer>',
     '<footer role="{{this.stuff}}{{this.foo}}"></footer>',
     '<nav role="navigation"></nav>',
-    '<body role="document"></body>', // allows redundant non-landmark role when `checkAllHTMLElements` option defaults to `false`
-
+    {
+      config: { checkAllHTMLElements: false },
+      template: '<body role="document"></body>',
+    },
     {
       config: { checkAllHTMLElements: true },
       template: '<footer role={{this.bar}}></footer>',
@@ -56,6 +58,29 @@ generateRuleTests({
 
   bad: [
     {
+      // with no config, checkAllHTMLElements defaults to true
+      template: '<dialog role="dialog" />',
+      fixedTemplate: '<dialog />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 24,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Use of redundant or invalid role: dialog on <dialog> detected.",
+              "rule": "no-redundant-role",
+              "severity": 2,
+              "source": "<dialog role=\\"dialog\\" />",
+            },
+          ]
+        `);
+      },
+    },
+    {
       template: '<header role="banner"></header>',
       fixedTemplate: '<header></header>',
 
@@ -70,7 +95,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: banner on <header> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<header role=\\"banner\\"></header>",
             },
@@ -93,7 +118,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: contentinfo on <footer> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<footer role=\\"contentinfo\\"></footer>",
             },
@@ -116,7 +141,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: main on <main> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<main role=\\"main\\"></main>",
             },
@@ -139,7 +164,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: complementary on <aside> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<aside role=\\"complementary\\"></aside>",
             },
@@ -162,7 +187,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: form on <form> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<form role=\\"form\\"></form>",
             },
@@ -185,7 +210,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: banner on <header> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<header role=\\"banner\\" class=\\"page-header\\"></header>",
             },
@@ -209,7 +234,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: button on <button> detected.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<button role=\\"button\\"></button>",
             },
@@ -233,7 +258,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: checkbox on <input> detected.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<input type=\\"checkbox\\" name=\\"agree\\" value=\\"checkbox1\\" role=\\"checkbox\\" />",
             },
@@ -257,7 +282,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: columnheader on <th> detected.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<th role=\\"columnheader\\">Some heading</th>",
             },
@@ -283,7 +308,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: listbox on <select> detected.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<select name=\\"color\\" id=\\"color\\" role=\\"listbox\\" multiple><option value=\\"default-color\\">black</option></select>",
             },
@@ -307,7 +332,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: main on <main> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<main role=\\"main\\"></main>",
             },
@@ -331,7 +356,7 @@ generateRuleTests({
               "isFixable": true,
               "line": 1,
               "message": "Use of redundant or invalid role: complementary on <aside> detected. If a landmark element is used, any role provided will either be redundant or incorrect.",
-              "rule": "no-redundant-landmark-role",
+              "rule": "no-redundant-role",
               "severity": 2,
               "source": "<aside role=\\"complementary\\"></aside>",
             },


### PR DESCRIPTION
CC: @judithhinlung 

Follow-up to https://github.com/ember-template-lint/ember-template-lint/pull/2487

Part of v5 release (https://github.com/ember-template-lint/ember-template-lint/issues/2319).