### PR TITLE
Use `npx` in stale todo command suggestion

### DIFF
--- a/docs/todos.md
+++ b/docs/todos.md
@@ -29,7 +29,7 @@ ember-template-lint . --include-todo
 If an error is fixed manually, `ember-template-lint` will let you know that there's a stale todo file. You'll see this error:
 
 ```bash
-error  Todo violation passes no-vague-rules rule. Please run `ember-template-lint /path/to/file.hbs --clean-todo` to remove this todo from the todo list.
+error  Todo violation passes no-vague-rules rule. Please run `npx ember-template-lint /path/to/file.hbs --clean-todo` to remove this todo from the todo list.
 ```
 
 You can fix this error/remove the stale todo file by running `--clean-todo`

--- a/lib/-private/todo-handler.js
+++ b/lib/-private/todo-handler.js
@@ -39,7 +39,7 @@ export default class TodoHandler {
         for (const todo of remove) {
           results.push({
             rule: 'invalid-todo-violation-rule',
-            message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`ember-template-lint ${todo.filePath} --clean-todo\` to remove this todo from the todo list.`,
+            message: `Todo violation passes \`${todo.ruleId}\` rule. Please run \`npx ember-template-lint ${todo.filePath} --clean-todo\` to remove this todo from the todo list.`,
             filePath: todo.filePath,
             moduleId: todo.moduleId,
             severity: 2,

--- a/test/acceptance/todo-cli-test.js
+++ b/test/acceptance/todo-cli-test.js
@@ -336,7 +336,7 @@ describe('todo usage', () => {
         expect(result.exitCode).toEqual(1);
         expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/require-button-type.hbs
-            -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`ember-template-lint app/templates/require-button-type.hbs --clean-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
+            -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`npx ember-template-lint app/templates/require-button-type.hbs --clean-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
 
           ✖ 1 problems (1 errors, 0 warnings)
             1 errors and 0 warnings potentially fixable with the \`--fix\` option."
@@ -386,7 +386,7 @@ describe('todo usage', () => {
         expect(result.exitCode).toEqual(1);
         expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/require-button-type.hbs
-            -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`ember-template-lint app/templates/require-button-type.hbs --clean-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
+            -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`npx ember-template-lint app/templates/require-button-type.hbs --clean-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
 
           ✖ 1 problems (1 errors, 0 warnings)
             1 errors and 0 warnings potentially fixable with the \`--fix\` option."
@@ -441,7 +441,7 @@ describe('todo usage', () => {
         expect(result.exitCode).toEqual(1);
         expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/require-button-type.hbs
-            -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`ember-template-lint app/templates/require-button-type.hbs --clean-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
+            -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`npx ember-template-lint app/templates/require-button-type.hbs --clean-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
 
           ✖ 1 problems (1 errors, 0 warnings)
             1 errors and 0 warnings potentially fixable with the \`--fix\` option."
@@ -491,7 +491,7 @@ describe('todo usage', () => {
         expect(result.exitCode).toEqual(1);
         expect(result.stdout).toMatchInlineSnapshot(`
           "app/templates/require-button-type.hbs
-            -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`ember-template-lint app/templates/require-button-type.hbs --clean-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
+            -:-  error  Todo violation passes \`require-button-type\` rule. Please run \`npx ember-template-lint app/templates/require-button-type.hbs --clean-todo\` to remove this todo from the todo list.  invalid-todo-violation-rule
 
           ✖ 1 problems (1 errors, 0 warnings)
             1 errors and 0 warnings potentially fixable with the \`--fix\` option."


### PR DESCRIPTION
We do the same for `npx @lint-todo/migrator`:
https://github.com/ember-template-lint/ember-template-lint/blob/master/bin/ember-template-lint.js#L127

We also mention in the README that it's intended to install `ember-template-lint` locally within the project:
https://github.com/ember-template-lint/ember-template-lint#usage

This probably means that most users don't have `ember-template-lint` installed globally and that copy-pasting and using the current suggested command will fail with: `command not found: ember-template-lint`.