### PR TITLE
no-redundant-role: Allow `role=list` on `<ul>` and `<ol>`

### DIFF
--- a/lib/rules/no-redundant-role.js
+++ b/lib/rules/no-redundant-role.js
@@ -34,6 +34,14 @@ const allowedElementRoles = [
     name: 'form',
     role: 'search',
   },
+  {
+    name: 'ol',
+    role: 'list',
+  },
+  {
+    name: 'ul',
+    role: 'list',
+  },
 ];
 
 export default class NoRedundantRole extends Rule {

--- a/test/unit/rules/no-redundant-role-test.js
+++ b/test/unit/rules/no-redundant-role-test.js
@@ -10,6 +10,8 @@ generateRuleTests({
     '<footer role={{this.foo}}></footer>',
     '<footer role="{{this.stuff}}{{this.foo}}"></footer>',
     '<nav role="navigation"></nav>',
+    '<ol role="list"></ol>',
+    '<ul role="list"></ul>',
     {
       config: { checkAllHTMLElements: false },
       template: '<body role="document"></body>',


### PR DESCRIPTION
Resolves #2713 