### PR TITLE
Fix autofixer bug with `firstObject` inside a `MustacheStatement` in `no-array-prototype-extensions`

### DIFF
--- a/lib/rules/no-array-prototype-extensions.js
+++ b/lib/rules/no-array-prototype-extensions.js
@@ -143,7 +143,7 @@ export default class NoArrayPrototypeExtensions extends Rule {
               path.parentNode.params[1].value = newValue;
               // for paths with a MustacheStatement parentNode replace the pathExpression with a get helper pathExpression
               // eg: `{{this.list.firstObject}}` => `{{get this.list "0"}}`
-            } else if (path.parentNode.type === 'MustacheStatement') {
+            } else if (path.parentNode.type === 'MustacheStatement' && path.parentKey === 'path') {
               path.parentNode[path.parentKey] = builders.path('get', node.loc);
               path.parentNode.params = getHelperParams(node);
             } else {

--- a/test/unit/rules/no-array-prototype-extensions-test.js
+++ b/test/unit/rules/no-array-prototype-extensions-test.js
@@ -112,6 +112,28 @@ generateRuleTests({
     },
     /** Fixable `firstObject` */
     {
+      template: `<div data-test={{eq this.list.firstObject.abc "def"}}>Hello</div>`,
+      fixedTemplate: '<div data-test={{eq (get this.list "0.abc") "def"}}>Hello</div>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 20,
+              "endColumn": 45,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Array prototype extension property firstObject usage is disallowed. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+              "rule": "no-array-prototype-extensions",
+              "severity": 2,
+              "source": "this.list.firstObject.abc",
+            },
+          ]
+        `);
+      },
+    },
+    {
       template: '{{foo bar=this.list.firstObject}}',
       fixedTemplate: '{{foo bar=(get this.list "0")}}',
       verifyResults(results) {


### PR DESCRIPTION
## Summary
`no-array-prototype-extensions` auto-fixer is generating an incorrect code when the path expression containing `firstObject` is inside `mustachestatement` as a param.

For example, the following template
```
<div data-test={{eq this.list.firstObject.abc "def"}}>Hello</div>
```

is modified to

```
<div data-test={{eq this.list "0.abc"}}>Hello</div>
```

instead of

```
<div data-test={{eq (get this.list "0.abc") "def"}}>Hello</div>
```

## Fix
The root cause of the issue was that there was a special handling of `firstObject` inside `MustachStatement`. Ideally, that piece of logic should run only when the mustache statement directly contains a path expression containing `firstObject`. In this PR, an additional condition has been added to check for the same.