### PR TITLE
Fix `--no-ignore-pattern`

### DIFF
--- a/lib/helpers/cli.js
+++ b/lib/helpers/cli.js
@@ -177,7 +177,10 @@ export function expandFileGlobs(workingDir, filePatterns, ignorePattern, glob = 
     let isLiteralPath = !isGlob(pattern) && isFile(path.resolve(workingDir, pattern));
 
     if (isLiteralPath) {
-      let isIgnored = micromatch.isMatch(pattern, ignorePattern);
+      // If `--no-ignore-pattern` is passed, the ignorePatter is `[false]`.
+      let isIgnored =
+        !(ignorePattern?.length === 1 && ignorePattern[0] === false) &&
+        micromatch.isMatch(pattern, ignorePattern);
 
       if (!isIgnored) {
         result.add(pattern);


### PR DESCRIPTION
add type check since `--no-ignore-patter` returns an array which `micromath.isMatch` can't handle