### PR TITLE
Allow passing only `@model` or `@models` for `<LinkTo>` in `no-unknown-arguments-for-builtin-components` rule

### DIFF
--- a/lib/rules/no-unknown-arguments-for-builtin-components.js
+++ b/lib/rules/no-unknown-arguments-for-builtin-components.js
@@ -97,7 +97,7 @@ const KnownArguments = {
       '@touchStart': 'touchstart',
     },
     conflicts: [['model', 'models']],
-    required: [['route', 'query']],
+    required: [['route', 'query', 'model', 'models']],
   },
   Input: {
     arguments: ['type', 'value', 'checked', 'insert-newline', 'enter', 'escape-press'],

--- a/test/unit/rules/no-unknown-arguments-for-builtin-components-test.js
+++ b/test/unit/rules/no-unknown-arguments-for-builtin-components-test.js
@@ -11,6 +11,8 @@ generateRuleTests({
     '<LinkTo @route="info" @model={{this.model}} />',
     '<LinkTo @route="info" />',
     '<LinkTo @query={{hash foo=bar}} />',
+    '<LinkTo @model={{this.model}} />',
+    '<LinkTo @models={{array comment.photo comment}} />',
   ],
 
   bad: [
@@ -94,27 +96,6 @@ generateRuleTests({
               "rule": "no-unknown-arguments-for-builtin-components",
               "severity": 2,
               "source": "@madel",
-            },
-          ]
-        `);
-      },
-    },
-
-    {
-      template: '<LinkTo @model={{this.model}} />',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 1,
-              "endColumn": 32,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "Arguments \\"@route\\" or \\"@query\\" is required for <LinkTo /> component.",
-              "rule": "no-unknown-arguments-for-builtin-components",
-              "severity": 2,
-              "source": "LinkTo",
             },
           ]
         `);


### PR DESCRIPTION
The no-unknown-arguments-for-builtin-components lint rule is triggered when a <LinkTo /> component only has the `@model` or `@models` argument, stating that it must have either `@route` or `@query` as well.

The <LinkTo /> component supports passing only the `@model` or `@models` argumment. In this case, it will simply reuse the current route / queryParams.

As such, we should update the linter rule to allow this case.

This closes https://github.com/ember-template-lint/ember-template-lint/issues/2700.