### PR TITLE
Add note about `title` property limitations to `require-valid-alt-text` rule doc

### DIFF
--- a/docs/rule/require-valid-alt-text.md
+++ b/docs/rule/require-valid-alt-text.md
@@ -49,6 +49,8 @@ This rule **allows** the following:
 
 Add alternative text to all embedded `<object>` elements using either inner text, setting the `title` prop, or using the `aria-label` or `aria-labelledby` props.
 
+Note, the `title` prop is generally less reliable than the alternatives. Some screen readers will not read this value aloud, leaving no description of the non-text content.
+
 This rule **forbids** the following:
 
 ```hbs


### PR DESCRIPTION
The `require-valid-alt-text` rule documentation suggests that alt text be added to all embedded `<object>` elements via inner text, `title` prop, or `aria-label`/`aria-labelledby`.

In general, the `title` prop may be a little bit less reliable, but it _is_ still valid according to the spec. As such, we might want to advise developers against using in case they're referencing this doc.

This closes https://github.com/ember-template-lint/ember-template-lint/issues/1888.