### PR TITLE
Add autofixer to `no-duplicate-attributes` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Each rule has emojis denoting:
 | [no-class-bindings](./docs/rule/no-class-bindings.md)                                                     | ✅  |     |     |     |
 | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md)                             | ✅  |     |     | 🔧  |
 | [no-debugger](./docs/rule/no-debugger.md)                                                                 | ✅  |     |     |     |
-| [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                                         | ✅  |     | ⌨️  |     |
+| [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                                         | ✅  |     | ⌨️  |  🔧  |
 | [no-duplicate-id](./docs/rule/no-duplicate-id.md)                                                         | ✅  |     | ⌨️  |     |
 | [no-duplicate-landmark-elements](./docs/rule/no-duplicate-landmark-elements.md)                           | ✅  |     | ⌨️  |     |
 | [no-dynamic-subexpression-invocations](./docs/rule/no-dynamic-subexpression-invocations.md)               |     |     |     |     |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Each rule has emojis denoting:
 | [no-class-bindings](./docs/rule/no-class-bindings.md)                                                     | ✅  |     |     |     |
 | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md)                             | ✅  |     |     | 🔧  |
 | [no-debugger](./docs/rule/no-debugger.md)                                                                 | ✅  |     |     |     |
-| [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                                         | ✅  |     | ⌨️  |  🔧  |
+| [no-duplicate-attributes](./docs/rule/no-duplicate-attributes.md)                                         | ✅  |     | ⌨️  | 🔧  |
 | [no-duplicate-id](./docs/rule/no-duplicate-id.md)                                                         | ✅  |     | ⌨️  |     |
 | [no-duplicate-landmark-elements](./docs/rule/no-duplicate-landmark-elements.md)                           | ✅  |     | ⌨️  |     |
 | [no-dynamic-subexpression-invocations](./docs/rule/no-dynamic-subexpression-invocations.md)               |     |     |     |     |

--- a/docs/rule/no-duplicate-attributes.md
+++ b/docs/rule/no-duplicate-attributes.md
@@ -2,6 +2,8 @@
 
 ✅ The `extends: 'recommended'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 This rule forbids multiple attributes passed to a Component, Helper, or an ElementNode with the same name. According to the [HTML attributes Spec](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2):
 
 > There must never be two or more attributes on the same start tag whose names are an ASCII case-insensitive match for each other.

--- a/lib/rules/no-duplicate-attributes.js
+++ b/lib/rules/no-duplicate-attributes.js
@@ -9,12 +9,21 @@ function logDuplicateAttributes(node, attributes, identifier, type) {
     for (currentIndex = index + 1; currentIndex < length; currentIndex++) {
       currentAttribute = attributes[currentIndex];
       if (attribute[identifier] === currentAttribute[identifier]) {
-        this.log({
-          message: `Duplicate attribute '${currentAttribute[identifier]}' found in the ${type}.`,
-          node: currentAttribute,
-          source: this.sourceForNode(node),
-        });
-        break;
+        if (this.mode === 'fix') {
+          if (type === 'Element') {
+            return node.attributes.splice(currentIndex, 1);
+          } else {
+            return node.hash.pairs.splice(currentIndex, 1);
+          }
+        } else {
+          this.log({
+            message: `Duplicate attribute '${currentAttribute[identifier]}' found in the ${type}.`,
+            node: currentAttribute,
+            isFixable: true,
+            source: this.sourceForNode(node),
+          });
+          break;
+        }
       }
     }
   }

--- a/test/unit/rules/no-duplicate-attributes-test.js
+++ b/test/unit/rules/no-duplicate-attributes-test.js
@@ -24,6 +24,7 @@ generateRuleTests({
     {
       // MustacheStatement
       template: '{{my-component firstName=firstName lastName=lastName firstName=firstName}}',
+      fixedTemplate: '{{my-component firstName=firstName lastName=lastName}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -33,6 +34,7 @@ generateRuleTests({
               "endColumn": 72,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Duplicate attribute 'firstName' found in the MustacheStatement.",
               "rule": "no-duplicate-attributes",
@@ -49,6 +51,10 @@ generateRuleTests({
         '{{#my-component firstName=firstName  lastName=lastName firstName=firstName as |fullName|}}' +
         ' {{fullName}}' +
         '{{/my-component}}',
+      fixedTemplate:
+        '{{#my-component firstName=firstName  lastName=lastName as |fullName|}}' +
+        ' {{fullName}}' +
+        '{{/my-component}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -58,6 +64,7 @@ generateRuleTests({
               "endColumn": 74,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Duplicate attribute 'firstName' found in the BlockStatement.",
               "rule": "no-duplicate-attributes",
@@ -71,6 +78,7 @@ generateRuleTests({
     {
       // ElementNode
       template: '<a class="btn" class="btn">{{btnLabel}}</a>',
+      fixedTemplate: '<a class="btn">{{btnLabel}}</a>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -80,6 +88,7 @@ generateRuleTests({
               "endColumn": 26,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Duplicate attribute 'class' found in the Element.",
               "rule": "no-duplicate-attributes",
@@ -94,6 +103,8 @@ generateRuleTests({
       // SubExpression
       template:
         '{{employee-profile employee=(hash firstName=firstName lastName=lastName age=age firstName=firstName)}}',
+      fixedTemplate:
+        '{{employee-profile employee=(hash firstName=firstName lastName=lastName age=age)}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -103,6 +114,7 @@ generateRuleTests({
               "endColumn": 99,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Duplicate attribute 'firstName' found in the SubExpression.",
               "rule": "no-duplicate-attributes",
@@ -117,7 +129,8 @@ generateRuleTests({
       // SubExpression within a SubExpression
       template:
         '{{employee-profile employee=(hash fullName=(hash firstName=firstName lastName=lastName firstName=firstName) age=age)}}',
-
+      fixedTemplate:
+        '{{employee-profile employee=(hash fullName=(hash firstName=firstName lastName=lastName) age=age)}}',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -126,6 +139,7 @@ generateRuleTests({
               "endColumn": 106,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Duplicate attribute 'firstName' found in the SubExpression.",
               "rule": "no-duplicate-attributes",


### PR DESCRIPTION
Part of #2571.

https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-duplicate-attributes.md