### PR TITLE
Allow nested `menuitem`s in `no-nested-interactive` rule

### DIFF
--- a/lib/rules/no-nested-interactive.js
+++ b/lib/rules/no-nested-interactive.js
@@ -14,6 +14,7 @@
    * boolean -- `true` for enabled / `false` for disabled
  */
 
+import ast from '../helpers/ast-node-info.js';
 import isInteractiveElement, { reason } from '../helpers/is-interactive-element.js';
 import parseConfig from '../helpers/parse-interactive-element-config.js';
 import Rule from './_base.js';
@@ -52,10 +53,14 @@ export default class NoNestedInteractive extends Rule {
             this._seenInteractiveChild = true;
           }
         } else if (this.hasParentNode()) {
-          this.log({
-            message: this.getLogMessage(node, this._parentInteractiveNode),
-            node,
-          });
+          if (this.hasMenuItemParentNode() && this.isMenuItemNode(node)) {
+            // nested menuitem nodes are valid to create a menu/sub-menu pattern
+          } else {
+            this.log({
+              message: this.getLogMessage(node, this._parentInteractiveNode),
+              node,
+            });
+          }
         } else if (this.isInteractiveFromTabindex(node)) {
           // do not consider a thing a "parent interactive node" for
           // tabindex alone
@@ -80,6 +85,10 @@ export default class NoNestedInteractive extends Rule {
 
   hasLabelParentNode() {
     return this._parentInteractiveNode && this._parentInteractiveNode.tag === 'label';
+  }
+
+  hasMenuItemParentNode() {
+    return this._parentInteractiveNode && this.isMenuItemNode(this._parentInteractiveNode);
   }
 
   hasParentNode() {
@@ -123,6 +132,12 @@ export default class NoNestedInteractive extends Rule {
     if (ignoreUsemapAttribute && actualReason.includes('usemap')) {
       return true;
     }
+  }
+
+  isMenuItemNode(node) {
+    let role = ast.findAttribute(node, 'role');
+
+    return role && role.value && role.value.chars === 'menuitem';
   }
 
   getLogMessage(node, parentNode) {

--- a/test/unit/rules/no-nested-interactive-test.js
+++ b/test/unit/rules/no-nested-interactive-test.js
@@ -15,6 +15,18 @@ generateRuleTests({
     '<div tabindex=-1><button>Click me!</button></div>',
     '<div tabindex="1"><button></button></div>',
     '<label><input></label>',
+    `
+    <ul role="menubar" aria-label="functions" id="appmenu">
+      <li role="menuitem" aria-haspopup="true">
+        File
+        <ul role="menu">
+          <li role="menuitem">New</li>
+          <li role="menuitem">Open</li>
+          <li role="menuitem">Print</li>
+        </ul>
+      </li>
+    </ul>
+    `,
     {
       config: {
         ignoredTags: ['button'],


### PR DESCRIPTION
Right now, the `no-nested-interactive` rule will flag nested elements with the `menuitem` role. This is a valid pattern used to create submenus, and as such should be allowed by the rule.

This closes https://github.com/ember-template-lint/ember-template-lint/issues/2628.