### PR TITLE
 Link to "skipping helpers" part of the codemod doc in `no-curly-component-invocation` docs

### DIFF
--- a/docs/rule/no-curly-component-invocation.md
+++ b/docs/rule/no-curly-component-invocation.md
@@ -97,3 +97,4 @@ look like they could be component invocations.
 - [RFC #311](https://github.com/emberjs/rfcs/pull/311) (Angle Bracket Syntax)
 - [RFC #457](https://github.com/emberjs/rfcs/pull/457) (Nested Components)
 - [RFC #459](https://github.com/emberjs/rfcs/pull/459) (Angle Bracket Syntax for built-in components)
+- [Skipping Helpers](https://github.com/ember-codemods/ember-angle-brackets-codemod#skipping-helpers) (Code snippet to obtain list of helpers in an ember app)


### PR DESCRIPTION
In order to ignore custom helpers in the `no-curly-component-invocation` linter rule, a developer manually must add these to the config `allow` list. The `ember-angle-brackets-codemod` README has a useful snippet that can be run in the console in order to generate a list of helpers in a given ember app.

Let's add a reference to that here in case folks want to use it to configure this lint rule too.

This closes https://github.com/ember-template-lint/ember-template-lint/issues/2286.