### PR TITLE
Add autofixer to `no-multiple-empty-lines` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Each rule has emojis denoting:
 | [no-link-to-tagname](./docs/rule/no-link-to-tagname.md)                                                   | ✅  |     |     |     |
 | [no-log](./docs/rule/no-log.md)                                                                           | ✅  |     |     |     |
 | [no-model-argument-in-route-templates](./docs/rule/no-model-argument-in-route-templates.md)               |     |     |     | 🔧  |
-| [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                                         |     | 💅  |     |     |
+| [no-multiple-empty-lines](./docs/rule/no-multiple-empty-lines.md)                                         |     | 💅  |     | 🔧  |
 | [no-mut-helper](./docs/rule/no-mut-helper.md)                                                             |     |     |     |     |
 | [no-negated-condition](./docs/rule/no-negated-condition.md)                                               | ✅  |     |     | 🔧  |
 | [no-nested-interactive](./docs/rule/no-nested-interactive.md)                                             | ✅  |     | ⌨️  |     |

--- a/docs/rule/no-multiple-empty-lines.md
+++ b/docs/rule/no-multiple-empty-lines.md
@@ -2,6 +2,8 @@
 
 💅 The `extends: 'stylistic'` property in a configuration file enables this rule.
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 Some developers prefer to have multiple blank lines removed, while others feel
 that it helps improve readability. Whitespace is useful for separating logical
 sections of code, but excess whitespace takes up more of the screen.

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -22,15 +22,15 @@ export default class NoMultipleEmptyLines extends Rule {
             for (let i = 0; i < max; i++) {
               fixChars += '\n';
             }
-            let x = node.body;
-            for (const element of x) {
+            let copyNode = node.body;
+            for (const element of copyNode) {
               if (element['type'] === 'TextNode') {
                 if (element.chars.length > max) {
                   element.chars = fixChars;
                 }
               }
             }
-            node.body = x;
+            node.body = copyNode;
             return node;
           } else {
             [

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -17,43 +17,62 @@ export default class NoMultipleEmptyLines extends Rule {
       Template: {
         exit(node) {
           let max = 'max' in this.config ? this.config.max : 1;
-
-          [
-            ...allLines
-
-              // Given a list of lines, first get a list of line numbers that are non-empty.
-              .reduce((nonEmptyLineNumbers, line, index) => {
-                if (line.trim()) {
-                  nonEmptyLineNumbers.push(index + 1);
+          if (this.mode === 'fix') {
+            let fixChars = '';
+            for (let i = 0; i < max; i++) {
+              fixChars += '\n';
+            }
+            let x = node.body;
+            for (const element of x) {
+              if (element['type'] === 'TextNode') {
+                if (element.chars.length > max) {
+                  element.chars = fixChars;
                 }
-                return nonEmptyLineNumbers;
-              }, []),
-
-            // Add a value at the end to allow trailing empty lines to be checked.
-            allLines.length + 1,
-          ]
-
-            // Given two line numbers of non-empty lines, report the lines between if the difference is too large.
-            .reduce((lastLineNumber, lineNumber) => {
-              if (lineNumber - lastLineNumber - 1 > max) {
-                let message = `More than ${max} blank ${max === 1 ? 'line' : 'lines'} not allowed.`;
-
-                let loc = {
-                  start: { line: lastLineNumber + max, column: 0 },
-                  end: { line: lineNumber, column: 0 },
-                };
-
-                this.log({
-                  message,
-                  node,
-                  line: loc.start.line,
-                  column: loc.start.column,
-                  source: this.sourceForLoc(loc),
-                });
               }
+            }
+            node.body = x;
+            return node;
+          } else {
+            [
+              ...allLines
 
-              return lineNumber;
-            }, 0);
+                // Given a list of lines, first get a list of line numbers that are non-empty.
+                .reduce((nonEmptyLineNumbers, line, index) => {
+                  if (line.trim()) {
+                    nonEmptyLineNumbers.push(index + 1);
+                  }
+                  return nonEmptyLineNumbers;
+                }, []),
+
+              // Add a value at the end to allow trailing empty lines to be checked.
+              allLines.length + 1,
+            ]
+
+              // Given two line numbers of non-empty lines, report the lines between if the difference is too large.
+              .reduce((lastLineNumber, lineNumber) => {
+                if (lineNumber - lastLineNumber - 1 > max) {
+                  let message = `More than ${max} blank ${
+                    max === 1 ? 'line' : 'lines'
+                  } not allowed.`;
+
+                  let loc = {
+                    start: { line: lastLineNumber + max, column: 0 },
+                    end: { line: lineNumber, column: 0 },
+                  };
+
+                  this.log({
+                    message,
+                    node,
+                    isFixable: true,
+                    line: loc.start.line,
+                    column: loc.start.column,
+                    source: this.sourceForLoc(loc),
+                  });
+                }
+
+                return lineNumber;
+              }, 0);
+          }
         },
       },
     };

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -18,7 +18,7 @@ export default class NoMultipleEmptyLines extends Rule {
         exit(node) {
           let max = 'max' in this.config ? this.config.max : 1;
           if (this.mode === 'fix') {
-            let fixChars = '';
+            let fixChars = '\n';
             for (let i = 0; i < max; i++) {
               fixChars += '\n';
             }

--- a/test/unit/rules/no-multiple-empty-lines-test.js
+++ b/test/unit/rules/no-multiple-empty-lines-test.js
@@ -26,6 +26,7 @@ generateRuleTests({
   bad: [
     {
       template: '<div>foo</div>\n\n\n<div>bar</div>',
+      fixedTemplate: '<div>foo</div>\n<div>bar</div>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -35,6 +36,7 @@ generateRuleTests({
               "endColumn": 14,
               "endLine": 4,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 2,
               "message": "More than 1 blank line not allowed.",
               "rule": "no-multiple-empty-lines",
@@ -49,6 +51,7 @@ generateRuleTests({
     },
     {
       template: '<div>foo</div>\n\n\n\n\n<div>bar</div>',
+      fixedTemplate: '<div>foo</div>\n<div>bar</div>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -58,6 +61,7 @@ generateRuleTests({
               "endColumn": 14,
               "endLine": 6,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 2,
               "message": "More than 1 blank line not allowed.",
               "rule": "no-multiple-empty-lines",
@@ -76,6 +80,7 @@ generateRuleTests({
       config: { max: 3 },
 
       template: '<div>foo</div>\n\n\n\n\n<div>bar</div>',
+      fixedTemplate: '<div>foo</div>\n\n\n<div>bar</div>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -85,6 +90,7 @@ generateRuleTests({
               "endColumn": 14,
               "endLine": 6,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 4,
               "message": "More than 3 blank lines not allowed.",
               "rule": "no-multiple-empty-lines",

--- a/test/unit/rules/no-multiple-empty-lines-test.js
+++ b/test/unit/rules/no-multiple-empty-lines-test.js
@@ -26,7 +26,7 @@ generateRuleTests({
   bad: [
     {
       template: '<div>foo</div>\n\n\n<div>bar</div>',
-      fixedTemplate: '<div>foo</div>\n<div>bar</div>',
+      fixedTemplate: '<div>foo</div>\n\n<div>bar</div>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -51,7 +51,7 @@ generateRuleTests({
     },
     {
       template: '<div>foo</div>\n\n\n\n\n<div>bar</div>',
-      fixedTemplate: '<div>foo</div>\n<div>bar</div>',
+      fixedTemplate: '<div>foo</div>\n\n<div>bar</div>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -80,7 +80,7 @@ generateRuleTests({
       config: { max: 3 },
 
       template: '<div>foo</div>\n\n\n\n\n<div>bar</div>',
-      fixedTemplate: '<div>foo</div>\n\n\n<div>bar</div>',
+      fixedTemplate: '<div>foo</div>\n\n\n\n<div>bar</div>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`


### PR DESCRIPTION
added --fix for no-multiple empty lines

[no-multiple-empty-lines](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-multiple-empty-lines.md)