### PR TITLE
Add autofixer to `no-trailing-spaces` rule

### DIFF
--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -9,17 +9,34 @@ export default class NoTrailingSpaces extends Rule {
 
         exit(node) {
           let source = this.sourceForNode(node);
-
-          for (const [i, line] of source.split('\n').entries()) {
-            let column = line.length - 1;
-            if (line[column] === ' ') {
-              this.log({
-                message: 'line cannot end with space',
-                node,
-                line: i + 1,
-                column,
-                source: line,
-              });
+          let fixer = source
+            .split('\n')
+            .map((element) => element.replace(/\s+$/g, ''))
+            .join('\n');
+          let copyNode = node;
+          if (this.mode === 'fix') {
+            for (const element of copyNode.body) {
+              if (element.type === 'BlockStatement') {
+                copyNode.loc.data.source.source = fixer;
+              } else {
+                element.chars = fixer;
+              }
+            }
+            node = copyNode;
+            return node;
+          } else {
+            for (const [i, line] of source.split('\n').entries()) {
+              let column = line.length - 1;
+              if (line[column] === ' ') {
+                this.log({
+                  message: 'line cannot end with space',
+                  node,
+                  line: i + 1,
+                  isFixable: true,
+                  column,
+                  source: line,
+                });
+              }
             }
           }
         },

--- a/test/unit/rules/no-trailing-spaces-test.js
+++ b/test/unit/rules/no-trailing-spaces-test.js
@@ -16,6 +16,7 @@ generateRuleTests({
   bad: [
     {
       template: 'test ',
+      fixedTemplate: 'test',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -25,6 +26,7 @@ generateRuleTests({
               "endColumn": 5,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "line cannot end with space",
               "rule": "no-trailing-spaces",
@@ -37,6 +39,7 @@ generateRuleTests({
     },
     {
       template: 'test \n',
+      fixedTemplate: 'test\n',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -46,6 +49,7 @@ generateRuleTests({
               "endColumn": 0,
               "endLine": 2,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "line cannot end with space",
               "rule": "no-trailing-spaces",
@@ -58,6 +62,7 @@ generateRuleTests({
     },
     {
       template: 'test\n' + ' \n',
+      fixedTemplate: 'test\n' + '\n',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -67,6 +72,7 @@ generateRuleTests({
               "endColumn": 0,
               "endLine": 3,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 2,
               "message": "line cannot end with space",
               "rule": "no-trailing-spaces",
@@ -81,6 +87,7 @@ generateRuleTests({
     // only generates one error instead of two
     {
       template: '{{#my-component}}\n' + '  test \n' + '{{/my-component}}',
+      fixedTemplate: '{{#my-component}}\n' + '  test\n' + '{{/my-component}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -90,6 +97,7 @@ generateRuleTests({
               "endColumn": 17,
               "endLine": 3,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 2,
               "message": "line cannot end with space",
               "rule": "no-trailing-spaces",


### PR DESCRIPTION
[no-trailing-spaces](https://github.com/ember-template-lint/ember-template-lint/blob/master/docs/rule/no-trailing-spaces.md)