### PR TITLE
Add options for different `html` / `hbs` quote styles in `quotes` rule

### DIFF
--- a/docs/rule/quotes.md
+++ b/docs/rule/quotes.md
@@ -11,8 +11,8 @@ Enforce the consistent use of either double or single quotes.
 Enforce either:
 
 ```hbs
-<div class='my-class'>test</div>
-{{my-helper 'hello there'}}
+<div class="my-class">test</div>
+{{my-helper "hello there"}}
 ```
 
 or:

--- a/docs/rule/quotes.md
+++ b/docs/rule/quotes.md
@@ -11,8 +11,8 @@ Enforce the consistent use of either double or single quotes.
 Enforce either:
 
 ```hbs
-<div class="my-class">test</div>
-{{my-helper "hello there"}}
+<div class='my-class'>test</div>
+{{my-helper 'hello there'}}
 ```
 
 or:
@@ -26,12 +26,29 @@ or:
 
 The following values are valid configuration:
 
-* string -- "double" requires the use of double quotes wherever possible, "single" requires the use of single quotes wherever possible
+- string -- "double" requires the use of double quotes wherever possible, "single" requires the use of single quotes wherever possible
+- object -- { curlies: "single"|"double"|false, html: "single"|"double"|false } - requires different quotes for Handlebars and HTML syntax
+
+For the object config, the properties `curlies` and `html` can be passed one of the following values: "single", "double", or `false`. If `false` is passed to a property, it will be as if this rule is turned off for that specific syntax.
+
+With the config `{ curlies: false, html: "double" }`, this would be **forbidden**:
+
+```hbs
+<div foo='bar'></div>
+```
+
+However, this would be **allowed**:
+
+```hbs
+{{component "foo"}}
+{{test x='y'}}
+<div foo="bar"></div>
+```
 
 ## Related Rules
 
-* [quotes](https://eslint.org/docs/rules/quotes) from eslint
+- [quotes](https://eslint.org/docs/rules/quotes) from eslint
 
 ## References
 
-* [Google style guide/quotes](https://google.github.io/styleguide/htmlcssguide.html#HTML_Quotation_Marks)
+- [Google style guide/quotes](https://google.github.io/styleguide/htmlcssguide.html#HTML_Quotation_Marks)

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -69,7 +69,10 @@ export default class Quotes extends Rule {
     } else if (goodChars.hbs === chars.double && goodChars.html === chars.double) {
       message = 'you must use double quotes in templates';
     } else {
-      message = 'you must use double quotes x and single quotes in y in templates';
+      const double = goodChars.hbs === chars.double ? 'Handlebars syntax' : 'HTML attributes';
+      const single = goodChars.hbs === chars.single ? 'Handlebars syntax' : 'HTML attributes';
+
+      message = `you must use double quotes for ${double} and single quotes for ${single} in templates`;
     }
 
     return {

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -14,6 +14,18 @@ export default class Quotes extends Rule {
       }
       case 'string': {
         if (['double', 'single'].includes(config)) {
+          return {
+            hbs: config,
+            html: config,
+          };
+        }
+        break;
+      }
+      case 'object': {
+        if (
+          ['double', 'single'].includes(config.hbs) &&
+          ['double', 'single'].includes(config.html)
+        ) {
           return config;
         }
         break;
@@ -28,6 +40,7 @@ export default class Quotes extends Rule {
       [
         '  * "double" - requires the use of double quotes wherever possible',
         '  * "single" - requires the use of single quotes wherever possible',
+        '  * { hbs: `single`|`double`, html: `single`|`double` } - requires different quotes for Handlebars and HTML syntax',
       ],
       config
     );
@@ -36,28 +49,33 @@ export default class Quotes extends Rule {
   }
 
   visitor() {
-    let badChar;
-    let goodChar;
+    const chars = {
+      single: "'",
+      double: '"',
+    };
+    const goodChars = {
+      hbs: chars[this.config.hbs],
+      html: chars[this.config.html],
+    };
+    const badChars = {
+      hbs: goodChars.hbs === chars.single ? chars.double : chars.single,
+      html: goodChars.html === chars.single ? chars.double : chars.single,
+    };
+
     let message;
-    switch (this.config) {
-      case 'double': {
-        badChar = "'";
-        goodChar = '"';
-        message = 'you must use double quotes in templates';
-        break;
-      }
-      case 'single': {
-        badChar = '"';
-        goodChar = "'";
-        message = 'you must use single quotes in templates';
-        break;
-      }
+
+    if (goodChars.hbs === chars.single && goodChars.html === chars.single) {
+      message = 'you must use single quotes in templates';
+    } else if (goodChars.hbs === chars.double && goodChars.html === chars.double) {
+      message = 'you must use double quotes in templates';
+    } else {
+      message = 'you must use double quotes x and single quotes in y in templates';
     }
 
     return {
       AttrNode(node) {
-        if (!node.isValueless && node.quoteType === badChar) {
-          if (attrValueHasChar(node.value, goodChar)) {
+        if (!node.isValueless && node.quoteType === badChars.html) {
+          if (attrValueHasChar(node.value, goodChars.html)) {
             // TODO: Autofix blocked on: https://github.com/ember-template-lint/ember-template-recast/issues/698
             return this.log({
               message,
@@ -65,7 +83,7 @@ export default class Quotes extends Rule {
             });
           }
           if (this.mode === 'fix') {
-            node.quoteType = goodChar;
+            node.quoteType = goodChars.html;
           } else {
             return this.log({
               message,
@@ -79,8 +97,8 @@ export default class Quotes extends Rule {
       StringLiteral(node, path) {
         let errorSource = this.sourceForNode(path.parentNode);
 
-        if (node.quoteType === badChar) {
-          if (node.value.includes(goodChar)) {
+        if (node.quoteType === badChars.hbs) {
+          if (node.value.includes(goodChars.hbs)) {
             // TODO: Autofix blocked on: https://github.com/ember-template-lint/ember-template-recast/issues/698
             return this.log({
               message,
@@ -89,7 +107,7 @@ export default class Quotes extends Rule {
             });
           }
           if (this.mode === 'fix') {
-            node.quoteType = goodChar;
+            node.quoteType = goodChars.hbs;
           } else {
             return this.log({
               message,

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -15,7 +15,7 @@ export default class Quotes extends Rule {
       case 'string': {
         if (['double', 'single'].includes(config)) {
           return {
-            hbs: config,
+            curlies: config,
             html: config,
           };
         }
@@ -23,9 +23,13 @@ export default class Quotes extends Rule {
       }
       case 'object': {
         if (
-          ['double', 'single'].includes(config.hbs) &&
-          ['double', 'single'].includes(config.html)
+          Object.keys(config).length === 2 &&
+          ['double', 'single', false].includes(config.curlies) &&
+          ['double', 'single', false].includes(config.html)
         ) {
+          if (!config.curlies && !config.html) {
+            return false;
+          }
           return config;
         }
         break;
@@ -40,7 +44,7 @@ export default class Quotes extends Rule {
       [
         '  * "double" - requires the use of double quotes wherever possible',
         '  * "single" - requires the use of single quotes wherever possible',
-        '  * { hbs: `single`|`double`, html: `single`|`double` } - requires different quotes for Handlebars and HTML syntax',
+        '  * { curlies: "single"|"double"|false, html: "single"|"double"|false } - requires different quotes for Handlebars and HTML syntax',
       ],
       config
     );
@@ -54,29 +58,42 @@ export default class Quotes extends Rule {
       double: '"',
     };
     const goodChars = {
-      hbs: chars[this.config.hbs],
+      curlies: chars[this.config.curlies],
       html: chars[this.config.html],
     };
-    const badChars = {
-      hbs: goodChars.hbs === chars.single ? chars.double : chars.single,
-      html: goodChars.html === chars.single ? chars.double : chars.single,
-    };
+    const badChars = {};
+    if (goodChars.curlies) {
+      badChars.curlies = goodChars.curlies === chars.single ? chars.double : chars.single;
+    }
+    if (goodChars.html) {
+      badChars.html = goodChars.html === chars.single ? chars.double : chars.single;
+    }
 
     let message;
 
-    if (goodChars.hbs === chars.single && goodChars.html === chars.single) {
+    if (goodChars.curlies === chars.single && goodChars.html === chars.single) {
       message = 'you must use single quotes in templates';
-    } else if (goodChars.hbs === chars.double && goodChars.html === chars.double) {
+    } else if (goodChars.curlies === chars.double && goodChars.html === chars.double) {
       message = 'you must use double quotes in templates';
+    } else if (!goodChars.curlies || !goodChars.html) {
+      const correctQuote =
+        goodChars.curlies === chars.single || goodChars.html === chars.single ? 'single' : 'double';
+      message = `you must use ${correctQuote} quotes in ${
+        goodChars.curlies ? 'Handlebars syntax' : 'HTML attributes'
+      }`;
     } else {
-      const double = goodChars.hbs === chars.double ? 'Handlebars syntax' : 'HTML attributes';
-      const single = goodChars.hbs === chars.single ? 'Handlebars syntax' : 'HTML attributes';
+      const double = goodChars.curlies === chars.double ? 'Handlebars syntax' : 'HTML attributes';
+      const single = goodChars.curlies === chars.single ? 'Handlebars syntax' : 'HTML attributes';
 
       message = `you must use double quotes for ${double} and single quotes for ${single} in templates`;
     }
 
     return {
       AttrNode(node) {
+        if (!goodChars.html) {
+          return;
+        }
+
         if (!node.isValueless && node.quoteType === badChars.html) {
           if (attrValueHasChar(node.value, goodChars.html)) {
             // TODO: Autofix blocked on: https://github.com/ember-template-lint/ember-template-recast/issues/698
@@ -98,10 +115,14 @@ export default class Quotes extends Rule {
       },
 
       StringLiteral(node, path) {
+        if (!goodChars.curlies) {
+          return;
+        }
+
         let errorSource = this.sourceForNode(path.parentNode);
 
-        if (node.quoteType === badChars.hbs) {
-          if (node.value.includes(goodChars.hbs)) {
+        if (node.quoteType === badChars.curlies) {
+          if (node.value.includes(goodChars.curlies)) {
             // TODO: Autofix blocked on: https://github.com/ember-template-lint/ember-template-recast/issues/698
             return this.log({
               message,
@@ -110,7 +131,7 @@ export default class Quotes extends Rule {
             });
           }
           if (this.mode === 'fix') {
-            node.quoteType = goodChars.hbs;
+            node.quoteType = goodChars.curlies;
           } else {
             return this.log({
               message,

--- a/test/unit/rules/quotes-test.js
+++ b/test/unit/rules/quotes-test.js
@@ -4,6 +4,7 @@ generateRuleTests({
   name: 'quotes',
 
   good: [
+    // string config
     {
       config: 'double',
       template: '{{component "test"}}',
@@ -28,12 +29,26 @@ generateRuleTests({
       config: 'single',
       template: "<input type='checkbox'>",
     },
+
+    // object config
     {
-      config: { hbs: 'single', html: 'double' },
+      config: { curlies: false, html: false },
+      template: `{{component "test"}} {{hello x='test'}} <input type='checkbox'> <input type="checkbox">`,
+    },
+    {
+      config: { curlies: false, html: 'single' },
+      template: `{{component "test"}} {{hello x='test'}} <input type='checkbox'>`,
+    },
+    {
+      config: { curlies: 'double', html: false },
+      template: `{{component "test"}} <input type='checkbox'> <input type="checkbox">`,
+    },
+    {
+      config: { curlies: 'single', html: 'double' },
       template: `<input type="checkbox"> {{hello 'test' x='test'}}`,
     },
     {
-      config: { hbs: 'double', html: 'single' },
+      config: { curlies: 'double', html: 'single' },
       template: `<input type='checkbox'> {{hello "test" x="test"}}`,
     },
   ],
@@ -277,7 +292,7 @@ generateRuleTests({
       },
     },
     {
-      config: { hbs: 'double', html: 'single' },
+      config: { curlies: 'double', html: 'single' },
       template: `<input type="checkbox"> {{hello 'test' x='test'}}`,
       fixedTemplate: `<input type='checkbox'> {{hello "test" x="test"}}`,
 
@@ -325,7 +340,7 @@ generateRuleTests({
       },
     },
     {
-      config: { hbs: 'single', html: 'double' },
+      config: { curlies: 'single', html: 'double' },
       template: `<input type='checkbox'> {{hello "test" x="test"}}`,
       fixedTemplate: `<input type="checkbox"> {{hello 'test' x='test'}}`,
 
@@ -394,21 +409,39 @@ generateRuleTests({
       },
     },
     {
-      config: { hbs: 'double' },
+      config: { curlies: 'double', html: 'sometimes' },
       template: 'test',
 
       result: {
         fatal: true,
-        message: 'You specified `{"hbs":"double"}`',
+        message: 'You specified `{"curlies":"double","html":"sometimes"}`',
       },
     },
     {
-      config: { hbs: 'double', html: 'sometimes' },
+      config: { curlies: 'double' },
       template: 'test',
 
       result: {
         fatal: true,
-        message: 'You specified `{"hbs":"double","html":"sometimes"}`',
+        message: 'You specified `{"curlies":"double"}`',
+      },
+    },
+    {
+      config: { html: 'sometimes' },
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `{"html":"sometimes"}`',
+      },
+    },
+    {
+      config: { curlies: 'double', html: 'single', other: 'foobar' },
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `{"curlies":"double","html":"single","other":"foobar"}`',
       },
     },
   ],

--- a/test/unit/rules/quotes-test.js
+++ b/test/unit/rules/quotes-test.js
@@ -291,7 +291,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "you must use double quotes x and single quotes in y in templates",
+              "message": "you must use double quotes for Handlebars syntax and single quotes for HTML attributes in templates",
               "rule": "quotes",
               "severity": 2,
               "source": "type=\\"checkbox\\"",
@@ -303,7 +303,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "you must use double quotes x and single quotes in y in templates",
+              "message": "you must use double quotes for Handlebars syntax and single quotes for HTML attributes in templates",
               "rule": "quotes",
               "severity": 2,
               "source": "{{hello 'test' x='test'}}",
@@ -315,7 +315,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "you must use double quotes x and single quotes in y in templates",
+              "message": "you must use double quotes for Handlebars syntax and single quotes for HTML attributes in templates",
               "rule": "quotes",
               "severity": 2,
               "source": "x='test'",
@@ -325,9 +325,9 @@ generateRuleTests({
       },
     },
     {
-      config: { hbs: 'double', html: 'single' },
-      template: `<input type="checkbox"> {{hello 'test' x='test'}}`,
-      fixedTemplate: `<input type='checkbox'> {{hello "test" x="test"}}`,
+      config: { hbs: 'single', html: 'double' },
+      template: `<input type='checkbox'> {{hello "test" x="test"}}`,
+      fixedTemplate: `<input type="checkbox"> {{hello 'test' x='test'}}`,
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -339,10 +339,10 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "you must use double quotes x and single quotes in y in templates",
+              "message": "you must use double quotes for HTML attributes and single quotes for Handlebars syntax in templates",
               "rule": "quotes",
               "severity": 2,
-              "source": "type=\\"checkbox\\"",
+              "source": "type='checkbox'",
             },
             {
               "column": 32,
@@ -351,10 +351,10 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "you must use double quotes x and single quotes in y in templates",
+              "message": "you must use double quotes for HTML attributes and single quotes for Handlebars syntax in templates",
               "rule": "quotes",
               "severity": 2,
-              "source": "{{hello 'test' x='test'}}",
+              "source": "{{hello \\"test\\" x=\\"test\\"}}",
             },
             {
               "column": 41,
@@ -363,10 +363,10 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "you must use double quotes x and single quotes in y in templates",
+              "message": "you must use double quotes for HTML attributes and single quotes for Handlebars syntax in templates",
               "rule": "quotes",
               "severity": 2,
-              "source": "x='test'",
+              "source": "x=\\"test\\"",
             },
           ]
         `);

--- a/test/unit/rules/quotes-test.js
+++ b/test/unit/rules/quotes-test.js
@@ -28,6 +28,14 @@ generateRuleTests({
       config: 'single',
       template: "<input type='checkbox'>",
     },
+    {
+      config: { hbs: 'single', html: 'double' },
+      template: `<input type="checkbox"> {{hello 'test' x='test'}}`,
+    },
+    {
+      config: { hbs: 'double', html: 'single' },
+      template: `<input type='checkbox'> {{hello "test" x="test"}}`,
+    },
   ],
 
   bad: [
@@ -268,6 +276,102 @@ generateRuleTests({
         `);
       },
     },
+    {
+      config: { hbs: 'double', html: 'single' },
+      template: `<input type="checkbox"> {{hello 'test' x='test'}}`,
+      fixedTemplate: `<input type='checkbox'> {{hello "test" x="test"}}`,
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 7,
+              "endColumn": 22,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "you must use double quotes x and single quotes in y in templates",
+              "rule": "quotes",
+              "severity": 2,
+              "source": "type=\\"checkbox\\"",
+            },
+            {
+              "column": 32,
+              "endColumn": 38,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "you must use double quotes x and single quotes in y in templates",
+              "rule": "quotes",
+              "severity": 2,
+              "source": "{{hello 'test' x='test'}}",
+            },
+            {
+              "column": 41,
+              "endColumn": 47,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "you must use double quotes x and single quotes in y in templates",
+              "rule": "quotes",
+              "severity": 2,
+              "source": "x='test'",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      config: { hbs: 'double', html: 'single' },
+      template: `<input type="checkbox"> {{hello 'test' x='test'}}`,
+      fixedTemplate: `<input type='checkbox'> {{hello "test" x="test"}}`,
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 7,
+              "endColumn": 22,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "you must use double quotes x and single quotes in y in templates",
+              "rule": "quotes",
+              "severity": 2,
+              "source": "type=\\"checkbox\\"",
+            },
+            {
+              "column": 32,
+              "endColumn": 38,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "you must use double quotes x and single quotes in y in templates",
+              "rule": "quotes",
+              "severity": 2,
+              "source": "{{hello 'test' x='test'}}",
+            },
+            {
+              "column": 41,
+              "endColumn": 47,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "you must use double quotes x and single quotes in y in templates",
+              "rule": "quotes",
+              "severity": 2,
+              "source": "x='test'",
+            },
+          ]
+        `);
+      },
+    },
   ],
 
   error: [
@@ -287,6 +391,24 @@ generateRuleTests({
       result: {
         fatal: true,
         message: 'You specified `true`',
+      },
+    },
+    {
+      config: { hbs: 'double' },
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `{"hbs":"double"}`',
+      },
+    },
+    {
+      config: { hbs: 'double', html: 'sometimes' },
+      template: 'test',
+
+      result: {
+        fatal: true,
+        message: 'You specified `{"hbs":"double","html":"sometimes"}`',
       },
     },
   ],


### PR DESCRIPTION
I think I did this right?

Fixes https://github.com/ember-template-lint/ember-template-lint/issues/617

Personally I think the default config should be as described in the issue above with double only used for HTML attributes. Also the config forces the need to specify both `hbs` and `html` but it could also just default to `double` for whichever one of those is missing. So for example you could just do `{ hbs: 'single' }` to get the same functionality, essentially still using `double` as a default. 

Some code/messages etc in here could probably use better words. Maybe moustache/curlies instead of handlebars for example. And HTML Attributes instead of just HTML. I'm too tired to deal with naming things.

I think it might need more tests too?



