### PR TITLE
Document how to write rule test cases for fatal errors

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -175,6 +175,7 @@ generateRuleTests({
 
   config: true,
 
+  // Passing test cases:
   good: [
     // Simple string test case:
     '{{#if condition}}<img>{{/if}}',
@@ -187,6 +188,7 @@ generateRuleTests({
     },
   ],
 
+  // Failing test cases:
   bad: [
     {
       // Jest snapshot test case (recommended):
@@ -224,7 +226,19 @@ generateRuleTests({
         line: 1,
         column: 0,
         isFixable: true,
-      }
+      },
+    },
+  ],
+
+  // Test cases that we expect to cause the rule to throw an exception (e.g. invalid config).
+  error: [
+    {
+      template: 'test',
+      config: { foo: true },
+      result: {
+        fatal: true,
+        message: 'Some exception message...',
+      },
     },
   ],
 });


### PR DESCRIPTION
This great feature was added here but was never documented: https://github.com/ember-template-lint/ember-template-lint/pull/288#discussion_r143617180 (for a long time we didn't have any documentation on how to write rule tests / plugins at all).