### PR TITLE
Add Node v19 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu, windows]
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [14.x, 16.x, 18.x, 19.x]
 
         # excluded because it is the `test` job above
         exclude:


### PR DESCRIPTION
This PR modifies CI to run tests with the latest Node version (19.x).