### PR TITLE
Throw the more-helpful, original exception when encountering an ESM plugin/config loading error 

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -100,8 +100,12 @@ export async function resolveProjectConfig(workingDir, options) {
 }
 
 /**
- * @todo remove this fallback once we drop support for Node 14
+ * Attempts to require a module using `require()` this is used as a fallback
+ * for when `import()` fails to load a module. This is needed to support loading
+ * CJS modules in legacy Node versions. If the module is ESM, then a ERR_REQUIRE_ESM
+ * error will be throw by `require`, in that case the original import error must be thrown.
  *
+ * @todo remove this fallback once we drop support for Node 14
  * @param {string} requirePath path of module to require
  * @param {Error} importError error thrown by import()
  * @throws {Error} error thrown by require() or importError if the module is ESM

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -110,7 +110,7 @@ function requireFallback(requirePath, importError) {
   try {
     return require(requirePath); // eslint-disable-line import/no-dynamic-require
   } catch (error) {
-    if (importError && error?.code === 'ERR_REQUIRE_ESM') {
+    if (importError && error.code === 'ERR_REQUIRE_ESM') {
       // if the module is ESM, throw the original import error
       throw importError;
     }

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -44,9 +44,9 @@ async function requirePlugin(workingDir, pluginName, fromConfigPath) {
 
     const { default: plugin } = await import(pluginURL);
     return plugin;
-  } catch {
+  } catch (error) {
     // Fallback to ensure we can load CJS plugins in Node versions before 16 (TODO: remove eventually).
-    return require(pluginPath); // eslint-disable-line import/no-dynamic-require
+    return requireFallback(pluginPath, error);
   }
 }
 
@@ -93,9 +93,29 @@ export async function resolveProjectConfig(workingDir, options) {
   try {
     const { default: config } = await import(configPath);
     return config;
-  } catch {
+  } catch (error) {
     // Fallback to ensure we can load CJS configs in Node versions before 16 (TODO: remove eventually).
-    return require(configPath); // eslint-disable-line import/no-dynamic-require
+    return requireFallback(configPath, error);
+  }
+}
+
+/**
+ * @todo remove this fallback once we drop support for Node 14
+ *
+ * @param {string} requirePath path of module to require
+ * @param {Error} importError error thrown by import()
+ * @throws {Error} error thrown by require() or importError if the module is ESM
+ */
+function requireFallback(requirePath, importError) {
+  try {
+    return require(requirePath); // eslint-disable-line import/no-dynamic-require
+  } catch (error) {
+    if (importError && error?.code === 'ERR_REQUIRE_ESM') {
+      // if the module is ESM, throw the original import error
+      throw importError;
+    }
+
+    throw error;
   }
 }
 

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -40,6 +40,21 @@ describe('public api', function () {
       );
     });
 
+    it('throws the correct error if the config file has an error on parsing - ESM', async function () {
+      await project.write({
+        '.template-lintrc.mjs': "import foo from '../foo/bar';\n export {};\n",
+      });
+
+      const linter = new Linter({
+        console: mockConsole,
+        configPath: path.join(project.baseDir, '.template-lintrc.mjs'),
+      });
+
+      await expect(async () => await linter.loadConfig()).rejects.toThrow(
+        /Cannot find module '..\/foo\/bar'/
+      );
+    });
+
     it('uses an empty set of rules if no .template-lintrc is present', async function () {
       let linter = new Linter({
         console: mockConsole,


### PR DESCRIPTION
This change fixes a bug that causes errors thrown during ESM plugin config loading to be swallowed. Currently if an error is thrown during ESM config loading it triggers a `require` of the same module which then throws `ERR_REQUIRE_ESM`, which is misleading and very hard to debug for plugin authors.