### PR TITLE
Ignore `{{(unique-id)}}` helper variation in `no-duplicate-id` rule

### DIFF
--- a/lib/rules/no-duplicate-id.js
+++ b/lib/rules/no-duplicate-id.js
@@ -2,7 +2,7 @@ import AstNodeInfo from '../helpers/ast-node-info.js';
 import { match } from '../helpers/node-matcher.js';
 import Rule from './_base.js';
 
-const IGNORE_IDS = new Set(['{{unique-id}}']); // Built-in helper
+const IGNORE_IDS = new Set(['{{unique-id}}', '{{(unique-id)}}']); // Built-in helper, with and without parens
 
 class ConditionalScope {
   constructor() {
@@ -126,6 +126,45 @@ export default class NoDuplicateId extends Rule {
         }
 
         const possibleBlockParamName = part.path && part.path.parts && part.path.parts[0];
+        let ancestorComponent = walkerPath.parent;
+        let foundComponentYieldBlock = false;
+
+        while (ancestorComponent) {
+          const blockParams = ancestorComponent.node.blockParams || [];
+
+          if (blockParams.includes(possibleBlockParamName)) {
+            foundComponentYieldBlock = true;
+            break;
+          } else {
+            // find the next one
+            ancestorComponent = ancestorComponent.parent;
+          }
+        }
+        // if we find the component yield block we want to create a unique id for it so it doesn't clash with
+        // other component blocks that uses the same naming
+        return foundComponentYieldBlock
+          ? sourceForNode +
+              ancestorComponent.node.tag +
+              ancestorComponent.node.loc.start.line +
+              ancestorComponent.node.loc.start.column
+          : sourceForNode;
+      }
+
+      let isMustacheWithSubExpression = {
+        type: 'MustacheStatement',
+        path: { type: 'SubExpression' },
+      };
+
+      if (match(part, isMustacheWithSubExpression)) {
+        const sourceForNode = scope.sourceForNode(part);
+
+        // If we cannot traverse up to find the possible yield block parent, return
+        if (!walkerPath) {
+          return sourceForNode;
+        }
+
+        const possibleBlockParamName =
+          part.path.path && part.path.path.parts && part.path.path.parts[0];
         let ancestorComponent = walkerPath.parent;
         let foundComponentYieldBlock = false;
 

--- a/test/unit/rules/no-duplicate-id-test.js
+++ b/test/unit/rules/no-duplicate-id-test.js
@@ -14,6 +14,10 @@ generateRuleTests({
     '<div id="{{unique-id}}"></div><div id="{{unique-id}}"></div>',
     "<div id='{{unique-id}}'></div><div id='{{unique-id}}'></div>",
 
+    // argument-less helpers have to be invoked with parens
+    '<div id="{{(unique-id)}}"></div><div id="{{(unique-id)}}"></div>',
+    '<div id={{(unique-id)}}></div><div id={{(unique-id)}}></div>',
+
     // Mustache Statements
     '<div id={{"id-00"}}></div>',
     '<div id={{this.divId00}}></div>',
@@ -724,6 +728,35 @@ generateRuleTests({
               "rule": "no-duplicate-id",
               "severity": 2,
               "source": "id=\\"nested\\"",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: `
+        {{#if this.foo}}
+          {{#if this.other}}
+            <div id={{(hello-world)}}></div>
+          {{/if}}
+        {{else}}
+          <div id={{(hello-world)}}></div>
+        {{/if}}
+        <div id={{(hello-world)}}></div>
+      `,
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 13,
+              "endColumn": 33,
+              "endLine": 9,
+              "filePath": "layout.hbs",
+              "line": 9,
+              "message": "ID attribute values must be unique",
+              "rule": "no-duplicate-id",
+              "severity": 2,
+              "source": "id={{(hello-world)}}",
             },
           ]
         `);


### PR DESCRIPTION
fixes https://github.com/ember-template-lint/ember-template-lint/issues/2777

TL DR:
This rule does not normalize id's I have tried to do it, but it seems a quite complex task.
