### PR TITLE
Add a failing `no-implicit-this` + gjs test

### DIFF
--- a/test/unit/rules/no-implicit-this-test.js
+++ b/test/unit/rules/no-implicit-this-test.js
@@ -65,6 +65,13 @@ let good = [
       filePath: 'layout.ts',
     },
   },
+  {
+    template: `let book = 'foo';
+      <template>{{book}}</template>`,
+    meta: {
+      filePath: 'layout.gjs',
+    },
+  },
 ];
 
 for (const statement of statements) {


### PR DESCRIPTION
This adds a simple test that shouldn't fail since `book` is part of the strict mode scope.