### PR TITLE
no-unnecessary-curly-parens: allow parens around helper

### DIFF
--- a/docs/rule/no-unnecessary-curly-parens.md
+++ b/docs/rule/no-unnecessary-curly-parens.md
@@ -2,21 +2,22 @@
 
 🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
 
-Parentheses are used to wrap helpers within mustache expressions. There is no need to wrap the entire mustache expression.
+Parentheses are used to wrap helpers within mustache expressions. The only situation where it is required to wrap the entire mustache expression is when invoking a helper without providing any arguments.
 
 ## Examples
 
 This rule **forbids** the following:
 
 ```hbs
-{{(foo)}}
 {{(concat "a" "b")}}
+{{(helper a="b")}}
 ```
 
 This rule **allows** the following:
 
 ```hbs
 {{foo}}
+{{(foo)}}
 {{concat "a" "b"}}
 {{concat (capitalize "foo") "-bar"}}
 ```

--- a/lib/rules/no-unnecessary-curly-parens.js
+++ b/lib/rules/no-unnecessary-curly-parens.js
@@ -7,7 +7,7 @@ export default class NoUnnecessaryCurlyParens extends Rule {
   visitor() {
     return {
       MustacheStatement(node, path) {
-        if (node.path.type === 'SubExpression') {
+        if (node.path.type === 'SubExpression' && (node.path.params.length || node.path.hash.pairs.length)) {
           if (this.mode === 'fix') {
             replaceNode(
               node,

--- a/lib/rules/no-unnecessary-curly-parens.js
+++ b/lib/rules/no-unnecessary-curly-parens.js
@@ -7,7 +7,10 @@ export default class NoUnnecessaryCurlyParens extends Rule {
   visitor() {
     return {
       MustacheStatement(node, path) {
-        if (node.path.type === 'SubExpression' && (node.path.params.length || node.path.hash.pairs.length)) {
+        if (
+          node.path.type === 'SubExpression' &&
+          (node.path.params.length || node.path.hash.pairs.length)
+        ) {
           if (this.mode === 'fix') {
             replaceNode(
               node,

--- a/test/unit/rules/no-unnecessary-curly-parens-test.js
+++ b/test/unit/rules/no-unnecessary-curly-parens-test.js
@@ -5,33 +5,16 @@ generateRuleTests({
 
   config: true,
 
-  good: ['{{foo}}', '{{concat "a" "b"}}', '{{concat (capitalize "foo") "-bar"}}'],
+  good: [
+    '{{foo}}',
+    '{{this.foo}}',
+    '{{(helper)}}',
+    '{{(this.helper)}}',
+    '{{concat "a" "b"}}',
+    '{{concat (capitalize "foo") "-bar"}}',
+  ],
 
   bad: [
-    {
-      template: '{{(foo)}}',
-      fixedTemplate: '{{foo}}',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 9,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "isFixable": true,
-              "line": 1,
-              "message": "Unnecessary parentheses enclosing statement",
-              "rule": "no-unnecessary-curly-parens",
-              "severity": 2,
-              "source": "{{(foo)}}",
-            },
-          ]
-        `);
-      },
-    },
-
     {
       template: '{{(concat "a" "b")}}',
       fixedTemplate: '{{concat "a" "b"}}',
@@ -57,15 +40,15 @@ generateRuleTests({
     },
 
     {
-      template: '{{((concat "a" "b"))}}',
-      fixedTemplate: '{{concat "a" "b"}}',
+      template: '{{(helper a="b")}}',
+      fixedTemplate: '{{helper a="b"}}',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
               "column": 0,
-              "endColumn": 22,
+              "endColumn": 18,
               "endLine": 1,
               "filePath": "layout.hbs",
               "isFixable": true,
@@ -73,7 +56,7 @@ generateRuleTests({
               "message": "Unnecessary parentheses enclosing statement",
               "rule": "no-unnecessary-curly-parens",
               "severity": 2,
-              "source": "{{((concat \\"a\\" \\"b\\"))}}",
+              "source": "{{(helper a=\\"b\\")}}",
             },
           ]
         `);


### PR DESCRIPTION
See https://github.com/ember-template-lint/ember-template-lint/pull/2792#discussion_r1100088097

There is a difference between `{{some-helper}}` and `{{(some-helper)}}`, where the former passes a reference to the helper, while the later invokes the helper and passes a value. If a helper is passed params, it is always invoked.

This PR updates the rule to only consider parens around the statement redundant if it is being passed params.