### PR TITLE
Add `additionalNonSemanticTags` option to `require-presentational-children` rule

### DIFF
--- a/docs/rule/require-presentational-children.md
+++ b/docs/rule/require-presentational-children.md
@@ -58,7 +58,7 @@ If violations are found, remediation should be planned to either add `role="pres
  The following values are valid configuration:
 
 * object -- An object with the following keys:
-  * `nonSemanticTags` -- An array of additional tags that should be considered presentation
+  * `additionalNonSemanticTags` -- An array of additional tags that should be considered presentation
 
 ## References
 

--- a/docs/rule/require-presentational-children.md
+++ b/docs/rule/require-presentational-children.md
@@ -53,6 +53,13 @@ This rule **allows** the following:
 
 If violations are found, remediation should be planned to either add `role="presentation"` to the descendants as a quickfix. A better fix is to not use semantic descendants.
 
+## Configuration
+
+ The following values are valid configuration:
+
+* object -- An object with the following keys:
+  * `nonSemanticTags` -- An array of additional tags that should be considered presentation
+
 ## References
 
 * [Roles That Automatically Hide Semantics by Making Their Descendants Presentational](https://w3c.github.io/aria-practices/#children_presentational)

--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -72,6 +72,10 @@ const SKIPPED_TAGS = new Set([
 ]);
 
 export default class RequirePresentationalChildren extends Rule {
+  parseConfig(config) {
+    return { additionalNonSemanticTags: config.additionalNonSemanticTags ?? [] };
+  }
+
   visitor() {
     return {
       ElementNode(node) {

--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -62,11 +62,13 @@ const NON_SEMANTIC_TAGS = new Set([
   'strike',
   'tt',
   'u',
+  'i',
+  'svg',
 ]);
 
 const SKIPPED_TAGS = new Set([
   // SVG tags can contain a lot of special child tags
-  // Instead of marking all possible SVG tags as `NON_SEMANTIG_TAG`,
+  // Instead of marking all possible SVG child tags as `NON_SEMANTIG_TAG`,
   // we skip checking this rule for presentational SVGs
   'svg',
 ]);
@@ -92,8 +94,11 @@ export default class RequirePresentationalChildren extends Rule {
         const children = getAllElementNodeDescendants(node);
 
         for (const child of children) {
+          // additional non semantic tags
+          const { nonSemanticTags } = this.config;
+          const nonSemantic = new Set([...NON_SEMANTIC_TAGS, ...nonSemanticTags])
           // If it's not a non semantic tag, it's semantic
-          if (!NON_SEMANTIC_TAGS.has(child.tag)) {
+          if (!nonSemantic.has(child.tag)) {
             this.log({
               node: child,
               message: createErrorMessage(node, roleAttrValue, child),

--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -96,7 +96,7 @@ export default class RequirePresentationalChildren extends Rule {
         for (const child of children) {
           // additional non semantic tags
           const { nonSemanticTags } = this.config;
-          const nonSemantic = new Set([...NON_SEMANTIC_TAGS, ...nonSemanticTags])
+          const nonSemantic = new Set([...NON_SEMANTIC_TAGS, ...nonSemanticTags]);
           // If it's not a non semantic tag, it's semantic
           if (!nonSemantic.has(child.tag)) {
             this.log({

--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -62,8 +62,6 @@ const NON_SEMANTIC_TAGS = new Set([
   'strike',
   'tt',
   'u',
-  'i',
-  'svg',
 ]);
 
 const SKIPPED_TAGS = new Set([

--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -73,7 +73,7 @@ const SKIPPED_TAGS = new Set([
 
 export default class RequirePresentationalChildren extends Rule {
   parseConfig(config) {
-    return { additionalNonSemanticTags: config.additionalNonSemanticTags ?? [] };
+    return { additionalNonSemanticTags: config?.additionalNonSemanticTags ?? [] };
   }
 
   visitor() {

--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -95,8 +95,8 @@ export default class RequirePresentationalChildren extends Rule {
 
         for (const child of children) {
           // additional non semantic tags
-          const { nonSemanticTags } = this.config;
-          const nonSemantic = new Set([...NON_SEMANTIC_TAGS, ...nonSemanticTags]);
+          const { additionalNonSemanticTags } = this.config;
+          const nonSemantic = new Set([...NON_SEMANTIC_TAGS, ...additionalNonSemanticTags]);
           // If it's not a non semantic tag, it's semantic
           if (!nonSemantic.has(child.tag)) {
             this.log({

--- a/test/unit/rules/require-presentational-children-test.js
+++ b/test/unit/rules/require-presentational-children-test.js
@@ -26,7 +26,7 @@ generateRuleTests({
       <circle cx="10" cy="10" r="10"></circle>
     </svg>`,
     {
-      config: { additionalNonSemanticTags: 'custom-element' },
+      config: { additionalNonSemanticTags: ['custom-element'] },
       template: `<button><div>item1</div><custom-element>item2</custom-element></button>`,
     },
   ],

--- a/test/unit/rules/require-presentational-children-test.js
+++ b/test/unit/rules/require-presentational-children-test.js
@@ -25,6 +25,10 @@ generateRuleTests({
       <title>Title here</title>
       <circle cx="10" cy="10" r="10"></circle>
     </svg>`,
+    {
+      config: { additionalNonSemanticTags: 'custom-element' },
+      template: `<button><div>item1</div><custom-element>item2</custom-element></button>`,
+    },
   ],
 
   bad: [


### PR DESCRIPTION
affects `require-presentational-children`
* ~Adds `<i>` and `<svg>` to the list of non-semantic tags - these will be allowed as children of elements like "button" without needing role="presentation" added~ https://github.com/ember-template-lint/ember-template-lint/pull/2821
* Adds config option `nonSemanticTags` to add additional tags that should also be considered non-semantic / presentation

---

This is a very common pattern in my codebase full of tables. I'd like to use the config to add `FaIcon` to the list, to avoid the need to add role="presentation" all the time.
```hbs
<th role="button" {{on "click" this.doSort}}>
  <div class="flex items-center justify-between">
    Some Column
    <FaIcon role="presentation" @icon="sort" />
  </div>
</th>
```

