### PR TITLE
Allow intermediate presentation role before context in `require-context-role` rule

### DIFF
--- a/docs/rule/require-context-role.md
+++ b/docs/rule/require-context-role.md
@@ -4,7 +4,7 @@
 
 ## `<* role><* role /></*>`
 
-The required context role defines the owning container where this role is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or owned by) an element with the required context role. For example, an element with `role="listitem"` is only meaningful when contained inside (or owned by) an element with `role="list"`.
+The required context role defines the owning container where this role is allowed. If a role has a required context, authors MUST ensure that an element with the role is contained inside (or owned by) an element with the required context role. For example, an element with `role="listitem"` is only meaningful when contained inside (or owned by) an element with `role="list"`. You may place intermediate elements with `role="presentation"` or `role="none"` to remove their semantic meaning.
 
 ## Roles to check
 
@@ -34,12 +34,34 @@ This rule **allows** the following:
 </div>
 ```
 
+```hbs
+<div role="menu">
+  <div role="presentation">
+    <a role="menuitem">Item One</a>
+  </div>
+  <div role="presentation">
+    <a role="menuitem">Item Two</a>
+  </div>
+</div>
+```
+
 This rule **forbids** the following:
 
 ```hbs
 <div>
   <div role="listitem">Item One</div>
   <div role="listitem">Item Two</div>
+</div>
+```
+
+```hbs
+<div role="menu">
+  <div role="button">
+    <a role="menuitem">Item One</a>
+  </div>
+  <div>
+    <a role="menuitem">Item Two</a>
+  </div>
 </div>
 ```
 

--- a/lib/rules/require-context-role.js
+++ b/lib/rules/require-context-role.js
@@ -76,12 +76,15 @@ export default class RequireContextRole extends Rule {
           parentPath = parentPath.parent;
           let parentNode = parentPath.node;
           if (parentNode && parentNode.type === 'ElementNode') {
-            parentElementIndex++;
             if (AstNodeInfo.hasAttribute(parentNode, 'aria-hidden')) {
               return;
             }
             const parentRole = AstNodeInfo.findAttribute(parentNode, 'role');
             const parentRoleValue = parentRole ? roleName(parentRole) : '';
+            if (parentRoleValue === 'presentation' || parentRoleValue === 'none') {
+              continue;
+            }
+            parentElementIndex++;
             if (!VALID_PARENTS_FOR_CHILD[roleValue].includes(parentRoleValue)) {
               this.log({
                 message: errorMessage(roleValue),

--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -62,11 +62,13 @@ const NON_SEMANTIC_TAGS = new Set([
   'strike',
   'tt',
   'u',
+  'i',
+  'svg',
 ]);
 
 const SKIPPED_TAGS = new Set([
   // SVG tags can contain a lot of special child tags
-  // Instead of marking all possible SVG tags as `NON_SEMANTIG_TAG`,
+  // Instead of marking all possible SVG child tags as `NON_SEMANTIG_TAG`,
   // we skip checking this rule for presentational SVGs
   'svg',
 ]);

--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -62,8 +62,6 @@ const NON_SEMANTIC_TAGS = new Set([
   'strike',
   'tt',
   'u',
-  'i',
-  'svg',
 ]);
 
 const SKIPPED_TAGS = new Set([

--- a/test/unit/rules/require-context-role-test.js
+++ b/test/unit/rules/require-context-role-test.js
@@ -21,6 +21,7 @@ generateRuleTests({
     '<div role="group"><div role="menuitemradio">Item One</div></div>',
     '<div role="menu"><div role="menuitemradio">Item One</div></div>',
     '<div role="menubar"><div role="menuitemradio">Item One</div></div>',
+    '<div role="menubar"><div role="presentation"><a role="menuitem">Item One</a></div></div>',
     '<div role="listbox"><div role="option">Item One</div></div>',
     '<div role="grid"><div role="row">Item One</div></div>',
     '<div role="rowgroup"><div role="row">Item One</div></div>',
@@ -279,20 +280,40 @@ generateRuleTests({
       },
     },
     {
-      template: '<div><div role="treeitem">Item One</div></div>',
+      template: '<div role="menu"><div><a role="menuitem">Item One</a></div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 10,
-              "endColumn": 25,
+              "column": 25,
+              "endColumn": 39,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "You have an element with the role of \\"treeitem\\" but it is missing the required (immediate) parent element of \\"[group, tree]\\". Reference: https://www.w3.org/TR/wai-aria-1.1/#treeitem.",
+              "message": You have an element with the role of \\"menuitem\\" but it is missing the required (immediate) parent element of \\"[group, menu, menubar]\\". Reference: https://www.w3.org/TR/wai-aria-1.1/#menuitem.",
               "rule": "require-context-role",
               "severity": 2,
               "source": "role=\\"treeitem\\"",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '<div role="menu"><div role="button"><a role="menuitem">Item One</a></div></div>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 39,
+              "endColumn": 53,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": You have an element with the role of \\"menuitem\\" but it is missing the required (immediate) parent element of \\"[group, menu, menubar]\\". Reference: https://www.w3.org/TR/wai-aria-1.1/#menuitem.",
+              "rule": "require-context-role",
+              "severity": 2,
+              "source": "role=\\"menuitem\\"",
             },
           ]
         `);

--- a/test/unit/rules/require-context-role-test.js
+++ b/test/unit/rules/require-context-role-test.js
@@ -286,14 +286,14 @@ generateRuleTests({
           [
             {
               "column": 25,
-              "endColumn": 39,
+              "endColumn": 40,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": You have an element with the role of \\"menuitem\\" but it is missing the required (immediate) parent element of \\"[group, menu, menubar]\\". Reference: https://www.w3.org/TR/wai-aria-1.1/#menuitem.",
+              "message": "You have an element with the role of \\"menuitem\\" but it is missing the required (immediate) parent element of \\"[group, menu, menubar]\\". Reference: https://www.w3.org/TR/wai-aria-1.1/#menuitem.",
               "rule": "require-context-role",
               "severity": 2,
-              "source": "role=\\"treeitem\\"",
+              "source": "role=\\"menuitem\\"",
             },
           ]
         `);
@@ -306,11 +306,11 @@ generateRuleTests({
           [
             {
               "column": 39,
-              "endColumn": 53,
+              "endColumn": 54,
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": You have an element with the role of \\"menuitem\\" but it is missing the required (immediate) parent element of \\"[group, menu, menubar]\\". Reference: https://www.w3.org/TR/wai-aria-1.1/#menuitem.",
+              "message": "You have an element with the role of \\"menuitem\\" but it is missing the required (immediate) parent element of \\"[group, menu, menubar]\\". Reference: https://www.w3.org/TR/wai-aria-1.1/#menuitem.",
               "rule": "require-context-role",
               "severity": 2,
               "source": "role=\\"menuitem\\"",

--- a/test/unit/rules/require-context-role-test.js
+++ b/test/unit/rules/require-context-role-test.js
@@ -280,6 +280,26 @@ generateRuleTests({
       },
     },
     {
+      template: '<div><div role="treeitem">Item One</div></div>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 10,
+              "endColumn": 25,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "You have an element with the role of \\"treeitem\\" but it is missing the required (immediate) parent element of \\"[group, tree]\\". Reference: https://www.w3.org/TR/wai-aria-1.1/#treeitem.",
+              "rule": "require-context-role",
+              "severity": 2,
+              "source": "role=\\"treeitem\\"",
+            },
+          ]
+        `);
+      },
+    },
+    {
       template: '<div role="menu"><div><a role="menuitem">Item One</a></div></div>',
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`


### PR DESCRIPTION
affects `require-context-role`
* no longer stops at the immediate parent when searching for context role, if that immediate parent has role "presentation" or "none".

Closes https://github.com/ember-template-lint/ember-template-lint/issues/2637

Various official docs (like MDN) all do this in their examples.
https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/menu_role#example_1_navigation_menu

The spec even has an example doing it. 
https://w3c.github.io/aria/#example-14
```html
<ul role="tree">
  <li role="presentation">
	<a role="treeitem" aria-expanded="true">An expanded tree node</a>
  </li>
  …
</ul>
```

My interpretation of the spec is that it can be many levels deep. But I'm happy to be corrected on that