### PR TITLE
Allow presentation role for `li` in `no-invalid-role` rule

### DIFF
--- a/lib/rules/no-invalid-role.js
+++ b/lib/rules/no-invalid-role.js
@@ -53,7 +53,6 @@ const ELEMENTS_DISALLOWING_PRESENTATION_OR_NONE_ROLE = new Set([
   'kbd',
   'label',
   'legend',
-  'li',
   'main',
   'map',
   'mark',

--- a/test/unit/rules/no-invalid-role-test.js
+++ b/test/unit/rules/no-invalid-role-test.js
@@ -17,6 +17,8 @@ generateRuleTests({
     '<span role="presentation"></span>',
     '<svg role="none"></svg>',
     '<svg role="presentation"></svg>',
+    '<li role="none"></li>',
+    '<li role="presentation"></li>',
     '<custom-component role="none"></custom-component>',
     '<AwesomeThing role="none"></AwesomeThing>',
     '<AwesomeThing role="presentation"></AwesomeThing>',
@@ -66,26 +68,6 @@ generateRuleTests({
               "rule": "no-invalid-role",
               "severity": 2,
               "source": "<ol role=\\"presentation\\"></ol>",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<li role="presentation"></li>',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 29,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "Use of presentation role on <li> detected. Semantic elements should not be used for presentation.",
-              "rule": "no-invalid-role",
-              "severity": 2,
-              "source": "<li role=\\"presentation\\"></li>",
             },
           ]
         `);


### PR DESCRIPTION
affects `no-invalid-role`
* removes `li` from the list of elements that are not allowed to have `role="presentation"`

It's pretty clear from docs and examples that `<li role="presentation">` is not only okay, but recommended in a lot of cases.

Closes https://github.com/ember-template-lint/ember-template-lint/issues/2817

Related PR https://github.com/ember-template-lint/ember-template-lint/pull/2819