### PR TITLE
Add `svg`/`i` non-semantic tags list in `require-presentational-children` rule

### DIFF
--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -62,6 +62,8 @@ const NON_SEMANTIC_TAGS = new Set([
   'strike',
   'tt',
   'u',
+  'i',
+  'svg',
 ]);
 
 const SKIPPED_TAGS = new Set([


### PR DESCRIPTION
affects `require-presentational-children`

These tags would almost certainly be used for presentation. I'm not tied to this though so feel free to correct me.

Shouldn't be a breaking change - it'll mean that users can remove `role="presentation"` from their `i` or `svg` tags that appear in roles that cannot support semantic children (eg buttons)