### PR TITLE
Remove `role` requirement for `img` tags in `require-valid-alt-text`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+
+## v5.7.2 (2023-03-28)
+
+#### :bug: Bug Fix
+* [#2853](https://github.com/ember-template-lint/ember-template-lint/pull/2853) Bump `ember-template-recast` to v6.1.4 ([@bertdeblock](https://github.com/bertdeblock))
+
+#### Committers: 1
+- Bert De Block ([@bertdeblock](https://github.com/bertdeblock))
+
+
 ## v5.7.1 (2023-03-16)
 
 #### :bug: Bug Fix

--- a/docs/rule/require-valid-alt-text.md
+++ b/docs/rule/require-valid-alt-text.md
@@ -12,7 +12,7 @@ This rule **forbids** the following:
 
 ### `<img>`
 
-An `<img>` must have the `alt` attribute. It must have either meaningful text, or be an empty string. If it is an empty string, the `<img>` element tag must also have `role="presentation"` or `role="none"`.
+An `<img>` must have the `alt` attribute. It must have either meaningful text, or be an empty string.
 
 The content of an `alt` attribute is used to calculate the machine-readable label of an element, whereas the text content is used to produce a label for the element. For this reason, adding a label to an icon can produce a confusing or duplicated label on a control that already has appropriate text content.
 
@@ -32,6 +32,7 @@ This rule **forbids** the following:
 <img src="baz" alt="Picture of baz fixing a bug." />
 <img src="b52.jpg" alt="52" />
 <img src="foo" alt="foo as a banana" role="presentation">
+<img src="foo" alt="" role="presentation"> // Adding a role breaks semantic
 ```
 
 This rule **allows** the following:
@@ -42,7 +43,7 @@ This rule **allows** the following:
 <img src="bar" aria-hidden="true" alt="Picture of me taking a photo of an image" /> // Will pass because it is hidden.
 <img src="baz" alt="Baz taking a {{photo}}" /> // This is valid since photo is a variable name.
 <img src="b52.jpg" alt="b52 bomber jet" />
-<img src="foo" alt="" role="presentation"> // This is valid because it has a role of presentation.
+<img src="foo" alt="">
 ```
 
 ### `<object>`

--- a/docs/rule/require-valid-alt-text.md
+++ b/docs/rule/require-valid-alt-text.md
@@ -16,7 +16,7 @@ An `<img>` must have the `alt` attribute. It must have either meaningful text, o
 
 The content of an `alt` attribute is used to calculate the machine-readable label of an element, whereas the text content is used to produce a label for the element. For this reason, adding a label to an icon can produce a confusing or duplicated label on a control that already has appropriate text content.
 
-If it's not a meaningful image, it should have an empty alt attribute value and have the role of presentation or none.
+If it's not a meaningful image, it should have an empty alt attribute value.
 
 `img` alt attribute does not contain the word image, picture, or photo. Screen readers already announce `img` elements as an image. There is no need to use words such as *image*, *photo*, *logo*, *spacer*, and/or *picture*.
 
@@ -31,8 +31,6 @@ This rule **forbids** the following:
 <img src="bar" alt="Image of me at a bar!" />
 <img src="baz" alt="Picture of baz fixing a bug." />
 <img src="b52.jpg" alt="52" />
-<img src="foo" alt="foo as a banana" role="presentation">
-<img src="foo" alt="" role="presentation"> // Adding a role breaks semantic
 ```
 
 This rule **allows** the following:

--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -55,14 +55,11 @@ export default class RequireValidAltText extends Rule {
             }
           }
           const hasRole = AstNodeInfo.hasAttribute(node, 'role');
-          let roleAttr, roleValue;
           if (hasRole) {
-            roleAttr = AstNodeInfo.findAttribute(node, 'role');
-            if (roleAttr.value.type === 'TextNode') {
-              roleValue = roleAttr.value.chars;
-            } else {
-              roleValue = roleAttr.value;
-            }
+            this.logNode({
+              message: 'The `role` attribute should not be given in `<img>` tags',
+              node,
+            });
           }
 
           let hasSrcAttr = AstNodeInfo.hasAttribute(node, 'src');
@@ -73,20 +70,6 @@ export default class RequireValidAltText extends Rule {
               srcValue = srcAttr.value.chars;
             } else {
               srcValue = srcAttr.value;
-            }
-          }
-
-          // if the role value is a mustache statement we can not validate it
-          if (hasAltAttribute && hasRole && !roleValue.type) {
-            if (
-              ['none', 'presentation'].includes(roleValue.trim().toLowerCase()) &&
-              altValue !== ''
-            ) {
-              this.logNode({
-                message:
-                  'The `alt` attribute should be empty if `<img>` has `role` of `none` or `presentation`',
-                node,
-              });
             }
           }
 
@@ -118,18 +101,6 @@ export default class RequireValidAltText extends Rule {
                 }
               } else {
                 normalizedAltValue = null;
-              }
-
-              if (normalizedAltValue === '') {
-                if (['presentation', 'none'].includes(roleValue)) {
-                  return;
-                }
-                this.logNode({
-                  message:
-                    'If the `alt` attribute is present and the value is an empty string, `role="presentation"` or `role="none"` must be present',
-                  node,
-                });
-                return;
               }
 
               if (normalizedAltValue !== null) {

--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -54,13 +54,6 @@ export default class RequireValidAltText extends Rule {
               altValue = altAttribute.value;
             }
           }
-          const hasRole = AstNodeInfo.hasAttribute(node, 'role');
-          if (hasRole) {
-            this.logNode({
-              message: 'The `role` attribute should not be given in `<img>` tags',
-              node,
-            });
-          }
 
           let hasSrcAttr = AstNodeInfo.hasAttribute(node, 'src');
           let srcAttr, srcValue;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-template-lint",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ember-template-lint",
-      "version": "5.7.0",
+      "version": "5.7.1",
       "license": "MIT",
       "dependencies": {
         "@lint-todo/utils": "^13.0.3",
@@ -15,7 +15,7 @@
         "ci-info": "^3.8.0",
         "date-fns": "^2.29.2",
         "ember-template-imports": "^3.4.1",
-        "ember-template-recast": "^6.1.3",
+        "ember-template-recast": "^6.1.4",
         "eslint-formatter-kakoune": "^1.0.0",
         "find-up": "^6.3.0",
         "fuse.js": "^6.5.3",
@@ -740,61 +740,61 @@
       "integrity": "sha512-JKF/a9I9jw6fGoz8kA7LEQslrwJ5jms5CXhu/aqkBWk+PmZ6pTl8mlb/eJ/5ujBGTiQzBhy5AIWF712iA+4/mw=="
     },
     "node_modules/@glimmer/global-context": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.83.1.tgz",
-      "integrity": "sha512-OwlgqpbOJU73EjZOZdftab0fKbtdJ4x/QQeJseL9cvaAUiK3+w52M5ONFxD1T/yPBp2Mf7NCYqA/uL8tRbzY2A==",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/global-context/-/global-context-0.84.3.tgz",
+      "integrity": "sha512-8Oy9Wg5IZxMEeAnVmzD2NkObf89BeHoFSzJgJROE/deutd3rxg83mvlOez4zBBGYwnTb+VGU2LYRpet92egJjA==",
       "dependencies": {
         "@glimmer/env": "^0.1.7"
       }
     },
     "node_modules/@glimmer/interfaces": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.83.1.tgz",
-      "integrity": "sha512-rjAztghzX97v8I4rk3+NguM3XGYcFjc/GbJ8qrEj19KF2lUDoDBW1sB7f0tov3BD5HlrGXei/vOh4+DHfjeB5w==",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/interfaces/-/interfaces-0.84.3.tgz",
+      "integrity": "sha512-dk32ykoNojt0mvEaIW6Vli5MGTbQo58uy3Epj7ahCgTHmWOKuw/0G83f2UmFprRwFx689YTXG38I/vbpltEjzg==",
       "dependencies": {
         "@simple-dom/interface": "^1.4.0"
       }
     },
     "node_modules/@glimmer/reference": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.83.1.tgz",
-      "integrity": "sha512-BThEwDlMkJB1WBPWDrww+VxgGyDbwxh5FFPvGhkovvCZnCb7fAMUCt9pi6CUZtviugkWOBFtE9P4eZZbOLkXeg==",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/reference/-/reference-0.84.3.tgz",
+      "integrity": "sha512-lV+p/aWPVC8vUjmlvYVU7WQJsLh319SdXuAWoX/SE3pq340BJlAJiEcAc6q52y9JNhT57gMwtjMX96W5Xcx/qw==",
       "dependencies": {
         "@glimmer/env": "^0.1.7",
-        "@glimmer/global-context": "0.83.1",
-        "@glimmer/interfaces": "0.83.1",
-        "@glimmer/util": "0.83.1",
-        "@glimmer/validator": "0.83.1"
+        "@glimmer/global-context": "0.84.3",
+        "@glimmer/interfaces": "0.84.3",
+        "@glimmer/util": "0.84.3",
+        "@glimmer/validator": "0.84.3"
       }
     },
     "node_modules/@glimmer/syntax": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.83.1.tgz",
-      "integrity": "sha512-n3vEd0GtjtgkOsd2gqkSimp8ecqq5KrHyana/s1XJZvVAPD5rMWT9WvAVWG8XAktns8BxjwLIUoj/vkOfA+eHg==",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/syntax/-/syntax-0.84.3.tgz",
+      "integrity": "sha512-ioVbTic6ZisLxqTgRBL2PCjYZTFIwobifCustrozRU2xGDiYvVIL0vt25h2c1ioDsX59UgVlDkIK4YTAQQSd2A==",
       "dependencies": {
-        "@glimmer/interfaces": "0.83.1",
-        "@glimmer/util": "0.83.1",
+        "@glimmer/interfaces": "0.84.3",
+        "@glimmer/util": "0.84.3",
         "@handlebars/parser": "~2.0.0",
         "simple-html-tokenizer": "^0.5.11"
       }
     },
     "node_modules/@glimmer/util": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.83.1.tgz",
-      "integrity": "sha512-amvjtl9dvrkxsoitXAly9W5NUaLIE3A2J2tWhBWIL1Z6DOFotfX7ytIosOIcPhJLZCtiXPHzMutQRv0G/MSMsA==",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/util/-/util-0.84.3.tgz",
+      "integrity": "sha512-qFkh6s16ZSRuu2rfz3T4Wp0fylFj3HBsONGXQcrAdZjdUaIS6v3pNj6mecJ71qRgcym9Hbaq/7/fefIwECUiKw==",
       "dependencies": {
         "@glimmer/env": "0.1.7",
-        "@glimmer/interfaces": "0.83.1",
+        "@glimmer/interfaces": "0.84.3",
         "@simple-dom/interface": "^1.4.0"
       }
     },
     "node_modules/@glimmer/validator": {
-      "version": "0.83.1",
-      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.83.1.tgz",
-      "integrity": "sha512-LaILSNnQgDHZpaUsfjVndbS1JfVn0xdTlJdFJblPbhoVklOBSReZVekens3EQ6xOr3BC612sRm1hBnEPixOY6A==",
+      "version": "0.84.3",
+      "resolved": "https://registry.npmjs.org/@glimmer/validator/-/validator-0.84.3.tgz",
+      "integrity": "sha512-RTBV4TokUB0vI31UC7ikpV7lOYpWUlyqaKV//pRC4pexYMlmqnVhkFrdiimB/R1XyNdUOQUmnIAcdic39NkbhQ==",
       "dependencies": {
         "@glimmer/env": "^0.1.7",
-        "@glimmer/global-context": "0.83.1"
+        "@glimmer/global-context": "0.84.3"
       }
     },
     "node_modules/@handlebars/parser": {
@@ -6024,13 +6024,13 @@
       }
     },
     "node_modules/ember-template-recast": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/ember-template-recast/-/ember-template-recast-6.1.3.tgz",
-      "integrity": "sha512-45lkfjrWlrMPlOd5rLFeQeePZwAvcS//x1x15kaiQTlqQdYWiYNXwbpWHqV+p9fXY6bEjl6EbyPhG/zBkgh8MA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/ember-template-recast/-/ember-template-recast-6.1.4.tgz",
+      "integrity": "sha512-fCh+rOK6z+/tsdkTbOE+e7f84P6ObnIRQrCCrnu21E4X05hPeradikIkRMhJdxn4NWrxitfZskQDd37TR/lsNQ==",
       "dependencies": {
-        "@glimmer/reference": "^0.83.1",
-        "@glimmer/syntax": "^0.83.1",
-        "@glimmer/validator": "^0.83.0",
+        "@glimmer/reference": "^0.84.3",
+        "@glimmer/syntax": "^0.84.3",
+        "@glimmer/validator": "^0.84.3",
         "async-promise-queue": "^1.0.5",
         "colors": "^1.4.0",
         "commander": "^8.3.0",
@@ -6038,7 +6038,7 @@
         "ora": "^5.4.0",
         "slash": "^3.0.0",
         "tmp": "^0.2.1",
-        "workerpool": "^6.1.5"
+        "workerpool": "^6.4.0"
       },
       "bin": {
         "ember-template-recast": "lib/bin.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "@scalvert/bin-tester": "^2.1.0",
         "common-tags": "^1.8.2",
         "eslint": "^8.36.0",
-        "eslint-config-prettier": "^8.7.0",
+        "eslint-config-prettier": "^8.8.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-filenames": "^1.3.2",
         "eslint-plugin-import": "^2.27.5",
@@ -6427,9 +6427,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.7.0.tgz",
-      "integrity": "sha512-HHVXLSlVUhMSmyW4ZzEuvjpwqamgmlfkutD53cYXLikh4pt/modINRcCIApJ84czDxM4GZInwUrromsDdTImTA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.8.0.tgz",
+      "integrity": "sha512-wLbQiFre3tdGgpDv67NQKnJuTlcUVYHas3k+DZCc2U2BadthoEY4B7hLPvAxaqdyOGCzuLfii2fqGph10va7oA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-template-lint",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ember-template-lint",
-      "version": "5.7.1",
+      "version": "5.7.2",
       "license": "MIT",
       "dependencies": {
         "@lint-todo/utils": "^13.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "npm-package-json-lint": "^6.4.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^2.8.4",
-        "release-it": "^15.8.0",
+        "release-it": "^15.9.3",
         "sort-package-json": "^2.4.1",
         "yeoman-environment": "^3.15.1",
         "yeoman-generator": "^5.8.0",
@@ -4119,6 +4119,15 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/bin-links": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/bin-links/-/bin-links-3.0.3.tgz",
@@ -4229,6 +4238,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bplist-parser": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+      "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+      "dev": true,
+      "dependencies": {
+        "big-integer": "^1.6.44"
+      },
+      "engines": {
+        "node": ">= 5.10.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -4647,6 +4668,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/bundle-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+      "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+      "dev": true,
+      "dependencies": {
+        "run-applescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -5484,9 +5520,9 @@
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.0.tgz",
-      "integrity": "sha512-0tLZ9URlPGU7JsKq0DQOQ3FoRsYX8xDZ7xMiATQfaiGMz7EHowNkbU9u1coAOmnh9p/1ySpm0RB3JNWRXM5GCg==",
+      "version": "8.1.3",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
+      "integrity": "sha512-/UkO2JKI18b5jVMJUp0lvKFMpa/Gye+ZgZjKD+DGEN9y7NRcf/nK1A0sp67ONmKtnDCNMS44E6jrk0Yc3bDuUw==",
       "dev": true,
       "dependencies": {
         "import-fresh": "^3.2.1",
@@ -5514,6 +5550,45 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/cross-spawn-async": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn-async/-/cross-spawn-async-2.2.5.tgz",
+      "integrity": "sha512-snteb3aVrxYYOX9e8BabYFK9WhCDhTlw1YQktfTthBogxri4/2r9U2nQc0ffY73ZAxezDc+U8gvHAeU1wy1ubQ==",
+      "deprecated": "cross-spawn no longer requires a build toolchain, use it instead",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^4.0.0",
+        "which": "^1.2.8"
+      }
+    },
+    "node_modules/cross-spawn-async/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/cross-spawn-async/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/cross-spawn-async/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "dev": true
     },
     "node_modules/crypto-random-string": {
       "version": "4.0.0",
@@ -5737,6 +5812,129 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/default-browser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-3.1.0.tgz",
+      "integrity": "sha512-SOHecvSoairSAWxEHP/0qcsld/KtI3DargfEuELQDyHIYmS2EMgdGhHOTC1GxaYr+NLUV6kDroeiSBfnNHnn8w==",
+      "dev": true,
+      "dependencies": {
+        "bundle-name": "^3.0.0",
+        "default-browser-id": "^3.0.0",
+        "execa": "^5.0.0",
+        "xdg-default-browser": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+      "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+      "dev": true,
+      "dependencies": {
+        "bplist-parser": "^0.2.0",
+        "untildify": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/default-browser/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/default-browser/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/default-browser/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/default-browser/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/defaults": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
@@ -5766,12 +5964,15 @@
       }
     },
     "node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
       "dev": true,
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
@@ -8712,29 +8913,29 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.1.4.tgz",
-      "integrity": "sha512-9hiJxE5gkK/cM2d1mTEnuurGTAoHebbkX0BYl3h7iEg7FYfuNIom+nDfBCSWtvSnoSrWCeBxqqBZu26xdlJlXA==",
+      "version": "9.1.5",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-9.1.5.tgz",
+      "integrity": "sha512-3ygAIh8gcZavV9bj6MTdYddG2zPSYswP808fKS46NOwlF0zZljVpnLCHODDqItWJDbDpLb3aouAxGaJbkxoppA==",
       "dev": true,
       "dependencies": {
         "ansi-escapes": "^6.0.0",
-        "chalk": "^5.1.2",
+        "chalk": "^5.2.0",
         "cli-cursor": "^4.0.0",
         "cli-width": "^4.0.0",
         "external-editor": "^3.0.3",
         "figures": "^5.0.0",
         "lodash": "^4.17.21",
-        "mute-stream": "0.0.8",
+        "mute-stream": "1.0.0",
         "ora": "^6.1.2",
         "run-async": "^2.4.0",
-        "rxjs": "^7.5.7",
+        "rxjs": "^7.8.0",
         "string-width": "^5.1.2",
         "strip-ansi": "^7.0.1",
         "through": "^2.3.6",
-        "wrap-ansi": "^8.0.1"
+        "wrap-ansi": "^8.1.0"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.18.0"
       }
     },
     "node_modules/inquirer/node_modules/ansi-escapes": {
@@ -8762,41 +8963,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/inquirer/node_modules/bl": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/inquirer/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/inquirer/node_modules/cli-cursor": {
@@ -8863,6 +9029,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/inquirer/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/inquirer/node_modules/onetime": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
@@ -8879,18 +9054,18 @@
       }
     },
     "node_modules/inquirer/node_modules/ora": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
-      "integrity": "sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.0.tgz",
+      "integrity": "sha512-1/D8uRFY0ay2kgBpmAwmSA404w4OoPVhHMqRqtjvrcK/dnzcEZxMJ+V4DUbyICu8IIVRclHcOf5wlD1tMY4GUQ==",
       "dev": true,
       "dependencies": {
-        "bl": "^5.0.0",
         "chalk": "^5.0.0",
         "cli-cursor": "^4.0.0",
         "cli-spinners": "^2.6.1",
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^1.1.0",
         "log-symbols": "^5.1.0",
+        "stdin-discarder": "^0.1.0",
         "strip-ansi": "^7.0.1",
         "wcwidth": "^1.0.1"
       },
@@ -8933,9 +9108,9 @@
       }
     },
     "node_modules/inquirer/node_modules/type-fest": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.6.1.tgz",
-      "integrity": "sha512-htXWckxlT6U4+ilVgweNliPqlsVSSucbxVexRYllyMVJDtf5rTjv6kF/s+qAd4QSL1BZcnJPEJavYBPQiWuZDA==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-3.7.1.tgz",
+      "integrity": "sha512-8LZNdvuztgxCF4eYpEmPYUPS0lbbByM2qHcp2oMxHZhWLIQB9QE36EeQ1PKwsUIDZXEP8HCBEmkBbT1//kLU4Q==",
       "dev": true,
       "engines": {
         "node": ">=14.16"
@@ -9105,15 +9280,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
       "dev": true,
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9153,6 +9328,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-installed-globally": {
@@ -9454,6 +9647,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-wsl/node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-yarn-global": {
@@ -14332,17 +14540,18 @@
       }
     },
     "node_modules/open": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
-      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.0.0.tgz",
+      "integrity": "sha512-yerrN5WPzgwuE3T6rxAkT1UuMLDzs4Szpug7hy9s4gru3iOTnaU0yKc1AYOVYrBzvykce5gUdr9RPNB4R+Zc/A==",
       "dev": true,
       "dependencies": {
-        "define-lazy-prop": "^2.0.0",
-        "is-docker": "^2.1.1",
+        "default-browser": "^3.1.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
         "is-wsl": "^2.2.0"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -15361,6 +15570,12 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true
     },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true
+    },
     "node_modules/punycode": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
@@ -15846,28 +16061,28 @@
       }
     },
     "node_modules/release-it": {
-      "version": "15.9.0",
-      "resolved": "https://registry.npmjs.org/release-it/-/release-it-15.9.0.tgz",
-      "integrity": "sha512-uYlbEMvOHeMNLK7AOrckjxNrUB7fU2euiNQ199eGcqCaoOUxD+QqQ6MMBuYaLB0cqvjCgvH5XoaySZW5HFMPLg==",
+      "version": "15.9.3",
+      "resolved": "https://registry.npmjs.org/release-it/-/release-it-15.9.3.tgz",
+      "integrity": "sha512-yFZTGJ9lH075zEAiVB4w58GgQ+bFR4by+eNClN3sdLtTLwbEm9VXrISt+8vO1fHDH83557Fns5ub1FuhAY/a3A==",
       "dev": true,
       "dependencies": {
         "@iarna/toml": "2.2.5",
         "@octokit/rest": "19.0.7",
         "async-retry": "1.3.3",
         "chalk": "5.2.0",
-        "cosmiconfig": "8.1.0",
+        "cosmiconfig": "8.1.3",
         "execa": "7.1.1",
         "git-url-parse": "13.1.0",
         "globby": "13.1.3",
         "got": "12.6.0",
-        "inquirer": "9.1.4",
+        "inquirer": "9.1.5",
         "is-ci": "3.0.1",
         "lodash": "4.17.21",
         "mime-types": "2.1.35",
         "new-github-release-url": "2.0.0",
         "node-fetch": "3.3.1",
-        "open": "8.4.2",
-        "ora": "6.1.2",
+        "open": "9.0.0",
+        "ora": "6.3.0",
         "os-name": "5.1.0",
         "promise.allsettled": "1.0.6",
         "proxy-agent": "5.0.0",
@@ -15895,41 +16110,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/release-it/node_modules/bl": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
-      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
-      "dev": true,
-      "dependencies": {
-        "buffer": "^6.0.3",
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "node_modules/release-it/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/release-it/node_modules/cli-cursor": {
@@ -16024,18 +16204,18 @@
       }
     },
     "node_modules/release-it/node_modules/ora": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-6.1.2.tgz",
-      "integrity": "sha512-EJQ3NiP5Xo94wJXIzAyOtSb0QEIAUu7m8t6UZ9krbz0vAJqr92JpcK/lEXg91q6B9pEGqrykkd2EQplnifDSBw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-6.3.0.tgz",
+      "integrity": "sha512-1/D8uRFY0ay2kgBpmAwmSA404w4OoPVhHMqRqtjvrcK/dnzcEZxMJ+V4DUbyICu8IIVRclHcOf5wlD1tMY4GUQ==",
       "dev": true,
       "dependencies": {
-        "bl": "^5.0.0",
         "chalk": "^5.0.0",
         "cli-cursor": "^4.0.0",
         "cli-spinners": "^2.6.1",
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^1.1.0",
         "log-symbols": "^5.1.0",
+        "stdin-discarder": "^0.1.0",
         "strip-ansi": "^7.0.1",
         "wcwidth": "^1.0.1"
       },
@@ -16305,6 +16485,110 @@
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "engines": {
         "node": "6.* || >= 7.*"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+      "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/run-applescript/node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
+    "node_modules/run-applescript/node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/run-applescript/node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/run-applescript/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript/node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/run-async": {
@@ -16879,6 +17163,56 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stdin-discarder": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/stdin-discarder/-/stdin-discarder-0.1.0.tgz",
+      "integrity": "sha512-xhV7w8S+bUwlPTb4bAOUQhv8/cSS5offJuX8GQGq32ONF0ZtDWKfkdomM3HMRA+LhX6um/FZ0COqlwsjD53LeQ==",
+      "dev": true,
+      "dependencies": {
+        "bl": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stdin-discarder/node_modules/bl": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-5.1.0.tgz",
+      "integrity": "sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==",
+      "dev": true,
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/stdin-discarder/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
@@ -17085,6 +17419,15 @@
       "dependencies": {
         "is-utf8": "^0.2.0"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17340,6 +17683,15 @@
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
+    },
+    "node_modules/titleize": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/titleize/-/titleize-1.0.1.tgz",
+      "integrity": "sha512-rUwGDruKq1gX+FFHbTl5qjI7teVO7eOe+C8IcQ7QT+1BK3eEUXJqbZcBOeaRP4FwSC/C1A5jDoIVta0nIQ9yew==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -18413,6 +18765,56 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/xdg-default-browser": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/xdg-default-browser/-/xdg-default-browser-2.1.0.tgz",
+      "integrity": "sha512-HY4G725+IDQr16N8XOjAms5qJGArdJaWIuC7Q7A8UXIwj2mifqnPXephazyL7sIkQPvmEoPX3E0v2yFv6hQUNg==",
+      "dev": true,
+      "dependencies": {
+        "execa": "^0.2.2",
+        "titleize": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/xdg-default-browser/node_modules/execa": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.2.2.tgz",
+      "integrity": "sha512-zmBGzLd3nhA/NB9P7VLoceAO6vyYPftvl809Vjwe5U2fYI9tYWbeKqP3wZlAw9WS+znnkogf/bhSU+Gcn2NbkQ==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn-async": "^2.1.1",
+        "npm-run-path": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "path-key": "^1.0.0",
+        "strip-eof": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/xdg-default-browser/node_modules/npm-run-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
+      "integrity": "sha512-PrGAi1SLlqNvKN5uGBjIgnrTb8fl0Jz0a3JJmeMcGnIBh7UE9Gc4zsAMlwDajOMg2b1OgP6UPvoLUboTmMZPFA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xdg-default-browser/node_modules/path-key": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-1.0.0.tgz",
+      "integrity": "sha512-T3hWy7tyXlk3QvPFnT+o2tmXRzU4GkitkUWLp/WZ0S/FXd7XMx176tRurgTvHTNMJOQzTcesHNpBqetH86mQ9g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/xregexp": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "markdownlint-cli": "^0.33.0",
         "npm-package-json-lint": "^6.4.0",
         "npm-run-all": "^4.1.5",
-        "prettier": "^2.8.4",
+        "prettier": "^2.8.7",
         "release-it": "^15.9.3",
         "sort-package-json": "^2.4.1",
         "yeoman-environment": "^3.15.1",
@@ -15352,9 +15352,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.4",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
-      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
+      "version": "2.8.7",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
+      "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-template-lint",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "description": "Linter for Ember or Handlebars templates.",
   "keywords": [
     "ember",

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "markdownlint-cli": "^0.33.0",
     "npm-package-json-lint": "^6.4.0",
     "npm-run-all": "^4.1.5",
-    "prettier": "^2.8.4",
+    "prettier": "^2.8.7",
     "release-it": "^15.9.3",
     "sort-package-json": "^2.4.1",
     "yeoman-environment": "^3.15.1",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@scalvert/bin-tester": "^2.1.0",
     "common-tags": "^1.8.2",
     "eslint": "^8.36.0",
-    "eslint-config-prettier": "^8.7.0",
+    "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-filenames": "^1.3.2",
     "eslint-plugin-import": "^2.27.5",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "npm-package-json-lint": "^6.4.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.4",
-    "release-it": "^15.8.0",
+    "release-it": "^15.9.3",
     "sort-package-json": "^2.4.1",
     "yeoman-environment": "^3.15.1",
     "yeoman-generator": "^5.8.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ci-info": "^3.8.0",
     "date-fns": "^2.29.2",
     "ember-template-imports": "^3.4.1",
-    "ember-template-recast": "^6.1.3",
+    "ember-template-recast": "^6.1.4",
     "eslint-formatter-kakoune": "^1.0.0",
     "find-up": "^6.3.0",
     "fuse.js": "^6.5.3",

--- a/test/unit/rules/attribute-order-test.js
+++ b/test/unit/rules/attribute-order-test.js
@@ -850,6 +850,28 @@ generateRuleTests({
         `);
       },
     },
+    {
+      template: '<Link @b="b" @a="a">Foo</Link>',
+      fixedTemplate: '<Link @a="a" @b="b">Foo</Link>',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 13,
+              "endColumn": 19,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Argument @a=\\"a\\" is not alphabetized",
+              "rule": "attribute-order",
+              "severity": 2,
+              "source": "@a=\\"a\\"",
+            },
+          ]
+        `);
+      },
+    },
   ],
 
   error: [

--- a/test/unit/rules/require-valid-alt-text-test.js
+++ b/test/unit/rules/require-valid-alt-text-test.js
@@ -12,12 +12,17 @@ generateRuleTests({
     '<img aria-hidden="true">',
     '<img hidden>',
     '<img alt="" src="zoey.jpg">',
+    '<img alt="" role="none" src="zoey.jpg">',
+    '<img alt="" role="presentation" src="zoey.jpg">',
     '<img alt="a stylized graphic of a female hamster" src="zoey.jpg">',
+    '<img alt="a stylized graphic of a female hamster" role="presentation" src="zoey.jpg">',
 
     '<img alt="some-alt-name">',
     '<img alt="name {{picture}}">',
     '<img alt="{{picture}}">',
     '<img alt="">',
+    '<img alt="" role="none">',
+    '<img alt="" role="presentation">',
 
     // Valid words containing redundant words.
     '<img alt="logout">',
@@ -48,7 +53,7 @@ generateRuleTests({
     '<area aria-hidden="true">',
     '<area aria-labelledby="some-alt">',
     '<area aria-label="some-alt">',
-    '<img alt={{this.altText}}>',
+    '<img role={{unless this.altText "presentation"}} alt={{this.altText}}>',
   ],
 
   bad: [
@@ -316,46 +321,6 @@ generateRuleTests({
               "rule": "require-valid-alt-text",
               "severity": 2,
               "source": "<img alt=\\"52\\" src=\\"b52.jpg\\">",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<img alt="not-null-alt" src="zoey.jpg" role="none">',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 51,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "The \`role\` attribute should not be given in \`<img>\` tags",
-              "rule": "require-valid-alt-text",
-              "severity": 2,
-              "source": "<img alt=\\"not-null-alt\\" src=\\"zoey.jpg\\" role=\\"none\\">",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<img alt="not-null-alt" src="zoey.jpg" role="presentation">',
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 59,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "The \`role\` attribute should not be given in \`<img>\` tags",
-              "rule": "require-valid-alt-text",
-              "severity": 2,
-              "source": "<img alt=\\"not-null-alt\\" src=\\"zoey.jpg\\" role=\\"presentation\\">",
             },
           ]
         `);

--- a/test/unit/rules/require-valid-alt-text-test.js
+++ b/test/unit/rules/require-valid-alt-text-test.js
@@ -11,15 +11,13 @@ generateRuleTests({
     '<img alt="blah {{derp}}">',
     '<img aria-hidden="true">',
     '<img hidden>',
-    '<img alt="" role="none" src="zoey.jpg">',
-    '<img alt="" role="presentation" src="zoey.jpg">',
+    '<img alt="" src="zoey.jpg">',
     '<img alt="a stylized graphic of a female hamster" src="zoey.jpg">',
 
     '<img alt="some-alt-name">',
     '<img alt="name {{picture}}">',
     '<img alt="{{picture}}">',
-    '<img alt="" role="none">',
-    '<img alt="" role="presentation">',
+    '<img alt="">',
 
     // Valid words containing redundant words.
     '<img alt="logout">',
@@ -50,7 +48,7 @@ generateRuleTests({
     '<area aria-hidden="true">',
     '<area aria-labelledby="some-alt">',
     '<area aria-label="some-alt">',
-    '<img role={{unless this.altText "presentation"}} alt={{this.altText}}>',
+    '<img alt={{this.altText}}>',
   ],
 
   bad: [
@@ -91,48 +89,6 @@ generateRuleTests({
               "rule": "require-valid-alt-text",
               "severity": 2,
               "source": "<img src=\\"zoey.jpg\\">",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<img alt="" src="zoey.jpg">',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 27,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "If the \`alt\` attribute is present and the value is an empty string, \`role=\\"presentation\\"\` or \`role=\\"none\\"\` must be present",
-              "rule": "require-valid-alt-text",
-              "severity": 2,
-              "source": "<img alt=\\"\\" src=\\"zoey.jpg\\">",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<img alt src="zoey.jpg">',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 24,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "If the \`alt\` attribute is present and the value is an empty string, \`role=\\"presentation\\"\` or \`role=\\"none\\"\` must be present",
-              "rule": "require-valid-alt-text",
-              "severity": 2,
-              "source": "<img alt src=\\"zoey.jpg\\">",
             },
           ]
         `);
@@ -376,7 +332,7 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "The \`alt\` attribute should be empty if \`<img>\` has \`role\` of \`none\` or \`presentation\`",
+              "message": "The \`role\` attribute should not be given in \`<img>\` tags",
               "rule": "require-valid-alt-text",
               "severity": 2,
               "source": "<img alt=\\"not-null-alt\\" src=\\"zoey.jpg\\" role=\\"none\\">",
@@ -396,7 +352,7 @@ generateRuleTests({
               "endLine": 1,
               "filePath": "layout.hbs",
               "line": 1,
-              "message": "The \`alt\` attribute should be empty if \`<img>\` has \`role\` of \`none\` or \`presentation\`",
+              "message": "The \`role\` attribute should not be given in \`<img>\` tags",
               "rule": "require-valid-alt-text",
               "severity": 2,
               "source": "<img alt=\\"not-null-alt\\" src=\\"zoey.jpg\\" role=\\"presentation\\">",


### PR DESCRIPTION
Affects `require-valid-alt-text`.

`role` should never be needed when using an `img` tag according to the [W3C Nu Validator](https://validator.w3.org/nu/#textarea).

Closes #2190 
Closes #2579.