### PR TITLE
Skip `block-indentation` rule in embedded templates

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -242,6 +242,7 @@ export default class Linter {
           filePath: options.filePath,
           rawSource: templateInfo.template,
           fileConfig,
+          isStrictMode: templateInfo.isStrictMode,
         });
 
         let visitor = await rule.getVisitor();

--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -108,6 +108,10 @@ function removeWhitespaceEnd(str) {
 
 export default class BlockIndentation extends Rule {
   parseConfig(config) {
+    if (!this.isStrictMode) {
+      return false;
+    }
+
     let configType = typeof config;
 
     let defaultConfig = {

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -232,6 +232,22 @@ generateRuleTests({
     {
       template: '<title></title>\n<path/><path/>',
     },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`',
+        '    <div class="parent">',
+        '      <div class="child"></div>',
+        '    </div>',
+        '  `);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+    },
   ],
 
   bad: [


### PR DESCRIPTION
The issue with the `block-indentation` rule in embedded templates as reported in https://github.com/ember-template-lint/ember-template-lint/issues/2826 is pretty annoying in existing tests. Turning off the rule entirely is not ideal, as it's really valuable to keep linting this. So, this PR ~adds an option to skip embedded templates entirely, basically keeping the functionality of the v4 version until a proper solution can be found.~ disables the rule in embedded templates for now. I have attempted to fix it fully in https://github.com/ember-template-lint/ember-template-lint/pull/2838, but I can imagine that might need some iterating before it can land. 

I'm not sure if this will be considered a proper way of fixing it, but this is close to being a blocker for me to upgrade to v5, and it's a small change with a great effect :pray: .