### PR TITLE
Fix embedded templates handling in `block-indentation` rule 

### DIFF
--- a/lib/extract-templates.js
+++ b/lib/extract-templates.js
@@ -2,7 +2,7 @@ import { parseTemplates } from 'ember-template-imports/lib/parse-templates.js';
 import * as util from 'ember-template-imports/src/util.js';
 
 export const SUPPORTED_EXTENSIONS = ['.js', '.ts', '.gjs', '.gts'];
-const LOCATION_START = Object.freeze({ line: 0, column: 0, start: 0, end: 0 });
+const LOCATION_START = Object.freeze({ line: 0, column: 0, start: 0, end: 0, columnOffset: 0 });
 /**
  * Processes results and corrects for template location offsets.
  *
@@ -86,12 +86,18 @@ export function extractTemplates(moduleSource, relativePath) {
  *
  * @returns {TemplateInfo}
  */
-function makeTemplateInfo({ line, column, start, end }, template, templateInfo, isEmbedded) {
+function makeTemplateInfo(
+  { line, column, start, end, columnOffset },
+  template,
+  templateInfo,
+  isEmbedded
+) {
   return {
     line,
     start,
     end,
     column,
+    columnOffset,
     template,
     isEmbedded,
     isStrictMode: !isEmbedded || isStrictMode(templateInfo),
@@ -118,11 +124,13 @@ export function isSupportedScriptFileExtension(filePath = '') {
 
 export function coordinatesOf(text, offset, start, end) {
   const contentBeforeTemplateStart = text.slice(0, offset).split('\n');
+  const lineBeforeTemplateStart = contentBeforeTemplateStart[contentBeforeTemplateStart.length - 1];
   return {
     line: contentBeforeTemplateStart.length,
-    column: contentBeforeTemplateStart[contentBeforeTemplateStart.length - 1].length,
+    column: lineBeforeTemplateStart.length,
     start,
     end,
+    columnOffset: lineBeforeTemplateStart.length - lineBeforeTemplateStart.trimStart().length,
   };
 }
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -240,6 +240,7 @@ export default class Linter {
         let rule = this._buildRule(ruleName, {
           shouldFix: true,
           filePath: options.filePath,
+          columnOffset: templateInfo.columnOffset,
           rawSource: templateInfo.template,
           fileConfig,
         });
@@ -367,6 +368,7 @@ export default class Linter {
         fileConfig,
         filePath: options.filePath,
         configResolver: options.configResolver,
+        columnOffset: templateInfo.columnOffset,
         rawSource: templateInfo.template,
         isStrictMode: templateInfo.isStrictMode,
       });

--- a/lib/rules/_base.js
+++ b/lib/rules/_base.js
@@ -66,6 +66,8 @@ export default class {
     this[MODULE_NAME] = options.moduleName;
     this._rawSource = options.rawSource;
 
+    this.columnOffset = options.columnOffset;
+
     // split into a source array (allow windows and posix line endings)
     this.source = options.rawSource.match(reLines);
   }

--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -102,8 +102,12 @@ function get(node, path) {
   return value;
 }
 
-function removeWhitespaceEnd(str) {
-  return str.replace(/ +$/, '');
+function addWhitespaceEnd(str, count) {
+  return `${str}${' '.repeat(count)}`;
+}
+
+function removeWhitespaceEnd(str, count) {
+  return str.replace(new RegExp(` {${count}}$`), '');
 }
 
 export default class BlockIndentation extends Rule {
@@ -306,13 +310,20 @@ export default class BlockIndentation extends Rule {
     const hasLeadingContent =
       !isDirectChildOfTemplate || this.hasLeadingContent(node, this.template.body);
     const startColumn = node.loc.start.column;
+    const expectedStartColumn =
+      this.columnOffset === 0 || node.loc.start.line === 1
+        ? 0
+        : this.columnOffset + this.config.indentation;
 
     // If it's not a direct child of the template the block start is already fixed by the validateBlockChildren function
-    if (isDirectChildOfTemplate && startColumn !== 0 && !hasLeadingContent) {
+    if (isDirectChildOfTemplate && startColumn !== expectedStartColumn && !hasLeadingContent) {
       if (this.mode === 'fix') {
         const previousNode = this.template.body[indexOfNodeInTemplate - 1];
         if (previousNode.type === 'TextNode') {
-          previousNode.chars = removeWhitespaceEnd(previousNode.chars);
+          previousNode.chars =
+            startColumn > expectedStartColumn
+              ? removeWhitespaceEnd(previousNode.chars, startColumn - expectedStartColumn)
+              : addWhitespaceEnd(previousNode.chars, expectedStartColumn - startColumn);
         }
       } else {
         let isElementNode = node && node.type === 'ElementNode';
@@ -322,7 +333,7 @@ export default class BlockIndentation extends Rule {
 
         let warning =
           `Incorrect indentation for \`${display}\` beginning at ${startLocation}. ` +
-          `Expected \`${display}\` to be at an indentation of 0, but was found at ${startColumn}.`;
+          `Expected \`${display}\` to be at an indentation of ${expectedStartColumn}, but was found at ${startColumn}.`;
 
         this.log({
           message: warning,
@@ -347,8 +358,12 @@ export default class BlockIndentation extends Rule {
 
     let controlCharCount = this.endingControlCharCount(node);
     let correctedEndColumn = endColumn - displayName.length - controlCharCount;
+    let expectedEndColumn =
+      this.columnOffset === 0 || node.loc.end.line !== this.template.loc.end.line
+        ? startColumn
+        : this.columnOffset;
 
-    if (correctedEndColumn !== startColumn) {
+    if (correctedEndColumn !== expectedEndColumn) {
       if (this.mode === 'fix') {
         // If we are in a child (path set) we want to edit directly the source and not the source of the node
         const elementSource = path
@@ -362,7 +377,7 @@ export default class BlockIndentation extends Rule {
           lines,
           node.loc.end.line - (path ? 1 : node.loc.start.line),
           correctedEndColumn,
-          startColumn,
+          expectedEndColumn,
           path
         );
         return fixedNode;
@@ -372,7 +387,7 @@ export default class BlockIndentation extends Rule {
 
         let warning =
           `Incorrect indentation for \`${displayName}\` beginning at ${startLocation}` +
-          `. Expected \`${display}\` ending at ${endLocation} to be at an indentation of ${startColumn} but ` +
+          `. Expected \`${display}\` ending at ${endLocation} to be at an indentation of ${expectedEndColumn} but ` +
           `was found at ${correctedEndColumn}.`;
 
         this.log({
@@ -405,7 +420,9 @@ export default class BlockIndentation extends Rule {
     }
 
     let startColumn = node.loc.start.column;
-    let expectedStartColumn = startColumn + this.config.indentation;
+    let correctedStartColumn =
+      this.columnOffset > 0 && node.loc.start.line === 1 ? this.columnOffset : startColumn;
+    let expectedStartColumn = correctedStartColumn + this.config.indentation;
     let fixedNode = node;
 
     let i = 0;
@@ -477,7 +494,7 @@ export default class BlockIndentation extends Rule {
 
           fixedNode = this.fixLine(
             lines,
-            childStartLine - 1,
+            childStartLine - (path ? 1 : fixedNode.loc.start.line),
             childStartColumn,
             expectedStartColumn,
             path
@@ -520,9 +537,11 @@ export default class BlockIndentation extends Rule {
 
     let inverse = node.inverse;
     let startColumn = node.loc.start.column;
+    let expectedStartColumn =
+      this.columnOffset > 0 && node.loc.start.line === 1 ? this.columnOffset : startColumn;
     let elseStartColumn = node.program.loc.end.column;
 
-    if (elseStartColumn !== startColumn) {
+    if (elseStartColumn !== expectedStartColumn) {
       if (this.mode === 'fix') {
         // If we are in a child (path set) we want to edit directly the source and not the source of the node
         const sourceToFix = path
@@ -533,7 +552,13 @@ export default class BlockIndentation extends Rule {
             });
         const lines = sourceToFix.split('\n');
         const elseLine = node.program.loc.end.line;
-        const fixedNode = this.fixLine(lines, elseLine - 1, elseStartColumn, startColumn, path);
+        const fixedNode = this.fixLine(
+          lines,
+          elseLine - 1,
+          elseStartColumn,
+          expectedStartColumn,
+          path
+        );
         return fixedNode;
       } else {
         let displayName = node.path.original;
@@ -542,7 +567,7 @@ export default class BlockIndentation extends Rule {
 
         let warning =
           `Incorrect indentation for inverse block of \`{{#${displayName}}}\` beginning at ${startLocation}` +
-          `. Expected \`{{else}}\` starting at ${elseLocation} to be at an indentation of ${startColumn} but ` +
+          `. Expected \`{{else}}\` starting at ${elseLocation} to be at an indentation of ${expectedStartColumn} but ` +
           `was found at ${elseStartColumn}.`;
 
         this.log({

--- a/test/unit/extract-templates-test.js
+++ b/test/unit/extract-templates-test.js
@@ -25,6 +25,7 @@ describe('extractTemplates', function () {
         [
           {
             "column": 0,
+            "columnOffset": 0,
             "end": 0,
             "isEmbedded": undefined,
             "isStrictMode": true,
@@ -41,6 +42,7 @@ describe('extractTemplates', function () {
         [
           {
             "column": 60,
+            "columnOffset": 6,
             "end": 238,
             "isEmbedded": true,
             "isStrictMode": false,
@@ -71,6 +73,7 @@ describe('extractTemplates', function () {
         [
           {
             "column": 60,
+            "columnOffset": 6,
             "end": 242,
             "isEmbedded": true,
             "isStrictMode": true,
@@ -109,6 +112,7 @@ describe('extractTemplates', function () {
         [
           {
             "column": 63,
+            "columnOffset": 6,
             "end": 255,
             "isEmbedded": true,
             "isStrictMode": true,
@@ -139,6 +143,7 @@ describe('extractTemplates', function () {
         [
           {
             "column": 39,
+            "columnOffset": 0,
             "end": 58,
             "isEmbedded": true,
             "isStrictMode": true,
@@ -174,6 +179,7 @@ describe('extractTemplates', function () {
         [
           {
             "column": 0,
+            "columnOffset": 0,
             "end": 0,
             "isEmbedded": undefined,
             "isStrictMode": true,
@@ -190,6 +196,7 @@ describe('extractTemplates', function () {
         [
           {
             "column": 39,
+            "columnOffset": 0,
             "end": 58,
             "isEmbedded": true,
             "isStrictMode": true,
@@ -237,6 +244,7 @@ describe('calculate template coordinates', function () {
     expect(coordinatesOf(typescript, 228)).toEqual({
       line: 8,
       column: 12,
+      columnOffset: 2,
     });
   });
 });

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -232,6 +232,108 @@ generateRuleTests({
     {
       template: '<title></title>\n<path/><path/>',
     },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`',
+        '    <div class="parent">',
+        '      <div class="child"></div>',
+        '    </div>',
+        '  `);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+    },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`<div class="parent">',
+        '    <div class="child"></div>',
+        '  </div>`);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+    },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`',
+        '    {{#if foo}}',
+        '      {{foo}}',
+        '    {{else}}',
+        '      {{bar}}',
+        '    {{/if}}',
+        '  `);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+    },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`{{#if foo}}',
+        '    {{foo}}',
+        '  {{else}}',
+        '    {{bar}}',
+        '  {{/if}}`);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+    },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`',
+        '    {{#if foo}}',
+        '      {{foo}}',
+        '    {{else if bar}}',
+        '      {{bar}}',
+        '    {{else}}',
+        '      {{baz}}',
+        '    {{/if}}',
+        '  `);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+    },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`{{#if foo}}',
+        '    {{foo}}',
+        '  {{else if bar}}',
+        '    {{bar}}',
+        '  {{else}}',
+        '    {{baz}}',
+        '  {{/if}}`);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+    },
   ],
 
   bad: [
@@ -1322,6 +1424,256 @@ generateRuleTests({
                 </div>
               </div>
             </div>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`',
+        '  <div class="parent">',
+        '    <div class="child"></div>',
+        '  </div>',
+        '  `);',
+        ');',
+      ].join('\n'),
+      fixedTemplate: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`',
+        '    <div class="parent">',
+        '      <div class="child"></div>',
+        '    </div>',
+        '  `);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 2,
+              "endColumn": 8,
+              "endLine": 7,
+              "filePath": "layout.js",
+              "isFixable": true,
+              "line": 5,
+              "message": "Incorrect indentation for \`<div>\` beginning at L2:C2. Expected \`<div>\` to be at an indentation of 4, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class=\\"parent\\">
+              <div class=\\"child\\"></div>
+            </div>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`  <div class="parent">',
+        '<div class="child"></div>',
+        '</div>`);',
+        ');',
+      ].join('\n'),
+      fixedTemplate: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`<div class="parent">',
+        '    <div class="child"></div>',
+        '  </div>`);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 21,
+              "endColumn": 25,
+              "endLine": 6,
+              "filePath": "layout.js",
+              "isFixable": true,
+              "line": 4,
+              "message": "Incorrect indentation for \`<div>\` beginning at L1:C2. Expected \`<div>\` to be at an indentation of 0, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class=\\"parent\\">
+          <div class=\\"child\\"></div>
+          </div>",
+            },
+            {
+              "column": 6,
+              "endColumn": 6,
+              "endLine": 6,
+              "filePath": "layout.js",
+              "isFixable": true,
+              "line": 6,
+              "message": "Incorrect indentation for \`div\` beginning at L1:C2. Expected \`</div>\` ending at L3:C6 to be at an indentation of 2 but was found at 0.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class=\\"parent\\">
+          <div class=\\"child\\"></div>
+          </div>",
+            },
+            {
+              "column": 0,
+              "endColumn": 6,
+              "endLine": 6,
+              "filePath": "layout.js",
+              "isFixable": true,
+              "line": 5,
+              "message": "Incorrect indentation for \`<div>\` beginning at L2:C0. Expected \`<div>\` to be at an indentation of 4 but was found at 0.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class=\\"parent\\">
+          <div class=\\"child\\"></div>
+          </div>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`',
+        '   {{#if foo}}',
+        '    {{foo}}',
+        '    {{else if bar}}',
+        '      {{bar}}',
+        '  {{else}}',
+        '      {{baz}}',
+        '    {{/if}}',
+        '  `);',
+        ');',
+      ].join('\n'),
+      fixedTemplate: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`',
+        '    {{#if foo}}',
+        '      {{foo}}',
+        '    {{else if bar}}',
+        '      {{bar}}',
+        '    {{else}}',
+        '      {{baz}}',
+        '    {{/if}}',
+        '  `);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 3,
+              "endColumn": 11,
+              "endLine": 11,
+              "filePath": "layout.js",
+              "isFixable": true,
+              "line": 5,
+              "message": "Incorrect indentation for \`{{#if}}\` beginning at L2:C3. Expected \`{{#if}}\` to be at an indentation of 4, but was found at 3.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+              {{foo}}
+              {{else if bar}}
+                {{bar}}
+            {{else}}
+                {{baz}}
+              {{/if}}",
+            },
+            {
+              "column": 4,
+              "endColumn": 11,
+              "endLine": 11,
+              "filePath": "layout.js",
+              "isFixable": true,
+              "line": 7,
+              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L2:C3. Expected \`{{else}}\` starting at L4:C4 to be at an indentation of 3 but was found at 4.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+              {{foo}}
+              {{else if bar}}
+                {{bar}}
+            {{else}}
+                {{baz}}
+              {{/if}}",
+            },
+            {
+              "column": 11,
+              "endColumn": 11,
+              "endLine": 11,
+              "filePath": "layout.js",
+              "isFixable": true,
+              "line": 11,
+              "message": "Incorrect indentation for \`if\` beginning at L2:C3. Expected \`{{/if}}\` ending at L8:C11 to be at an indentation of 3 but was found at 4.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+              {{foo}}
+              {{else if bar}}
+                {{bar}}
+            {{else}}
+                {{baz}}
+              {{/if}}",
+            },
+            {
+              "column": 4,
+              "endColumn": 11,
+              "endLine": 11,
+              "filePath": "layout.js",
+              "isFixable": true,
+              "line": 6,
+              "message": "Incorrect indentation for \`{{foo}}\` beginning at L3:C4. Expected \`{{foo}}\` to be at an indentation of 5 but was found at 4.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+              {{foo}}
+              {{else if bar}}
+                {{bar}}
+            {{else}}
+                {{baz}}
+              {{/if}}",
+            },
+            {
+              "column": 2,
+              "endColumn": 4,
+              "endLine": 11,
+              "filePath": "layout.js",
+              "isFixable": true,
+              "line": 9,
+              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L4:C4. Expected \`{{else}}\` starting at L6:C2 to be at an indentation of 4 but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{else if bar}}
+                {{bar}}
+            {{else}}
+                {{baz}}
+              ",
             },
           ]
         `);


### PR DESCRIPTION
This partially fixes the issue described in https://github.com/ember-template-lint/ember-template-lint/issues/2826. The example in that issue is a combination of `block-indentation` and `attribute-indentation` I think, and this PR only fixes the `block-indentation`, which I guess is more important to fix than attribute indentation. I've added some examples to the tests that work now (including autofix), but I'm happy to get feedback on other scenarios that need to be tested as well. An example of what this PR fixes:

```js
import { hbs } from 'ember-cli-htmlbars';

test('it renders', async (assert) => {
  await render(hbs`
    <div class="parent">
      <div class="child"></div>
    </div>
  `);
);
```

Before this PR, the linter would only be happy if it were formatted like:
```js
import { hbs } from 'ember-cli-htmlbars';

test('it renders', async (assert) => {
  await render(hbs`
<div class="parent">
  <div class="child"></div>
</div>
  `);
);
``` 
which is not very pretty and intuitive. 