### PR TITLE
Avoid crash with dynamic `aria-label` in `no-invalid-link-text` rule

### DIFF
--- a/lib/rules/no-invalid-link-text.js
+++ b/lib/rules/no-invalid-link-text.js
@@ -35,6 +35,10 @@ function hasValidAriaLabel(node) {
   const ariaLabelAttr = AstNodeInfo.findAttribute(node, 'aria-label');
 
   if (ariaLabelAttr) {
+    if (ariaLabelAttr.value?.type === 'MustacheStatement') {
+      // We can't evaluate MustacheStatements so we assume this is valid
+      return true;
+    }
     let ariaLabel = getTrimmedText(ariaLabelAttr.value.chars);
     return !DISALLOWED_LINK_TEXT.has(ariaLabel);
   }

--- a/test/unit/rules/no-invalid-link-text-test.js
+++ b/test/unit/rules/no-invalid-link-text-test.js
@@ -14,6 +14,8 @@ generateRuleTests({
     '<a href="https://myurl.com" aria-label="click here to read about our company"></a>',
     '<a href="https://myurl.com" aria-hidden="true"></a>',
     '<a href="https://myurl.com" hidden></a>',
+    '<LinkTo aria-label={{t "some-translation"}}>A link with translation</LinkTo>',
+    '<a href="#" aria-label={{this.anAriaLabel}}>A link with a variable as aria-label</a>',
     {
       config: { allowEmptyLinks: true },
       template: '<a href="https://myurl.com"></a>',


### PR DESCRIPTION
Since MustacheStatements can return a valid aria string but don't respond to the regular string checks, we need to exit the rule early.

Fixes https://github.com/ember-template-lint/ember-template-lint/issues/2798