### PR TITLE
Disable `no-curly-component-invocation` and `no-implicit-this` rules for `gjs` / `gts` files (#2844)Co-authored-by: Bryan Mishkin <698306+bmish@users.noreply.github.com>

### DIFF
--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -91,4 +91,13 @@ export default {
     'style-concatenation': 'error',
     'table-groups': 'error',
   },
+  overrides: [
+    {
+      files: ['**/*.gjs', '**/*.gts'],
+      rules: {
+        'no-curly-component-invocation': 'off',
+        'no-implicit-this': 'off',
+      },
+    },
+  ],
 };

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -95,17 +95,17 @@ export default {
     {
       files: ['**/*.gjs', '**/*.gts'],
       rules: {
-        // in gjs/gts, curly-component-invocation, and no-implicit-this were incorrectly triggered, 
+        // in gjs/gts, curly-component-invocation, and no-implicit-this were incorrectly triggered,
         // because {{foo}}, which is ambiguous in loose-mode templates could have "foo" defined in JS scope.
         // For example:
-        // 
+        //
         //  const foo = "hello there";
         //  <template>{{foo}}</template>
-        // 
+        //
         // template-lint *only* looks at what is between the <template> tags, and doesn't know about the surrounding context.
         // so these two rules are regularly false-negatives.
         // additionally, because eslint-plugin-ember looks at the intermediate/transformed code of <template>,
-        // eslint is responsible for reporting when "foo" would be undefined (which is the only thing it can be (other than defined) 
+        // eslint is responsible for reporting when "foo" would be undefined (which is the only thing it can be (other than defined)
         // in strict mode -- there is no implicit this ever)
         'no-curly-component-invocation': 'off',
         'no-implicit-this': 'off',

--- a/lib/config/recommended.js
+++ b/lib/config/recommended.js
@@ -95,6 +95,18 @@ export default {
     {
       files: ['**/*.gjs', '**/*.gts'],
       rules: {
+        // in gjs/gts, curly-component-invocation, and no-implicit-this were incorrectly triggered, 
+        // because {{foo}}, which is ambiguous in loose-mode templates could have "foo" defined in JS scope.
+        // For example:
+        // 
+        //  const foo = "hello there";
+        //  <template>{{foo}}</template>
+        // 
+        // template-lint *only* looks at what is between the <template> tags, and doesn't know about the surrounding context.
+        // so these two rules are regularly false-negatives.
+        // additionally, because eslint-plugin-ember looks at the intermediate/transformed code of <template>,
+        // eslint is responsible for reporting when "foo" would be undefined (which is the only thing it can be (other than defined) 
+        // in strict mode -- there is no implicit this ever)
         'no-curly-component-invocation': 'off',
         'no-implicit-this': 'off',
       },


### PR DESCRIPTION
Fixes #2830

Normally this would be a breaking change under any other circumstances, but gjs/gts folks need to disable these rules anyway, so this is more a bugfix.