### PR TITLE
Disable embedded templates handling for `eol-last` rule (#2846

### DIFF
--- a/docs/rule/eol-last.md
+++ b/docs/rule/eol-last.md
@@ -4,7 +4,7 @@
 
 🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
 
-Require or disallow newline at the end of files.
+Require or disallow newline at the end of template files. This rule doesn't apply to embedded templates (e.g. a rendered template in a -test.js file).
 
 ## Examples
 
@@ -25,9 +25,9 @@ or this (with newline at end):
 
 The following values are valid configuration:
 
-- "always" - enforces that files end with a newline
+- "always" - enforces that template files end with a newline
 - "editorconfig" - requires or disallows final newlines based your projects `.editorconfig` settings (via `insert_final_newline`)
-- "never" - enforces that files do not end with a newline'
+- "never" - enforces that template files do not end with a newline'
 
 ## Related Rules
 

--- a/lib/linter.js
+++ b/lib/linter.js
@@ -242,6 +242,7 @@ export default class Linter {
           filePath: options.filePath,
           columnOffset: templateInfo.columnOffset,
           rawSource: templateInfo.template,
+          isStrictMode: templateInfo.isStrictMode,
           fileConfig,
         });
 

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -5,6 +5,12 @@ import Rule from './_base.js';
 
 export default class EolLast extends Rule {
   parseConfig(config) {
+    // In strict mode (= template is embedded in e.g. a JS file) we want to disable this rule,
+    // because it is not meant for templates specifically, but for template files.
+    if (!this.isStrictMode) {
+      return false;
+    }
+
     let configType = typeof config;
 
     switch (configType) {

--- a/test/unit/rules/eol-last-test.js
+++ b/test/unit/rules/eol-last-test.js
@@ -43,6 +43,21 @@ generateRuleTests({
       config: 'always',
       template: '{{#my-component}}{{/my-component}}\n',
     },
+    // test that the config is ignored when the template is embedded, because this rule
+    // is meant for newlines at the end of files, not for templates themselves.
+    {
+      config: 'always',
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`<img>`);',
+        ');',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+    },
   ],
 
   bad: [


### PR DESCRIPTION
In our test suite this is the last remaining (enabled) rule that provides incorrect results in embedded templates. Enforcing a newline at the end of an embedded template doesn't make much sense to me, so disabling the rule seems the easiest solution. You could argue to set the config to `"never"` instead of disabling completely, but that requires more changes and in the end it's not what this rule is meant for (which is having a newline or not at the end of a **file**, rather than at the end of a **template**).