### PR TITLE
Fix override for gjs files in `recommended` config

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -310,7 +310,7 @@ function processExtends(config) {
     }
 
     config.rules = Object.assign({}, extendedRules, config.rules);
-    config.overrides = [...extendedOverrides, ...config.overrides];
+    config.overrides = [...extendedOverrides, ...(config.overrides || [])];
   }
 }
 

--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -277,6 +277,7 @@ async function processLoadedConfigurations(workingDir, config, options) {
 function processExtends(config) {
   let extendedList = normalizeExtends(config);
   let extendedRules = {};
+  let extendedOverrides = [];
 
   if (extendedList) {
     for (const extendName of extendedList) {
@@ -290,6 +291,10 @@ function processExtends(config) {
           processExtends(configuration);
 
           delete configuration.loadedConfigurations;
+
+          if (configuration.overrides) {
+            extendedOverrides = [...extendedOverrides, ...configuration.overrides];
+          }
 
           if (configuration.rules) {
             extendedRules = Object.assign({}, extendedRules, configuration.rules);
@@ -305,6 +310,7 @@ function processExtends(config) {
     }
 
     config.rules = Object.assign({}, extendedRules, config.rules);
+    config.overrides = [...extendedOverrides, ...config.overrides];
   }
 }
 

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -174,6 +174,7 @@ describe('get-config', function () {
     });
 
     expect(actual.rules['no-debugger']).toEqual({ config: true, severity: 2 });
+    expect(actual.overrides[0]?.files).toEqual(['**/*.gjs', '**/*.gts']);
   });
 
   it('can extend and override a default configuration', async function () {


### PR DESCRIPTION
Resolves https://github.com/ember-template-lint/ember-template-lint/issues/2785
The perceived effect of this bug is that gjs and gts files do not have these rules disabled: https://github.com/ember-template-lint/ember-template-lint/blob/master/lib/config/recommended.js#L94

The `recommended` config has `overrides`, but that `overrides` was not making it in to user-configs.

Using the default config,
```js
'use strict';

module.exports = {
  plugins: [],
  extends: 'recommended'
};
```


**Before**
```
❯ pnpm ember-template-lint --print-config app/components/limber/layout/controls/index.gts
...
  "overrides": [],
```

**After**
```
❯ pnpm ember-template-lint --print-config app/components/limber/layout/controls/index.gts
...
  "overrides": [
    {
      "files": [
        "**/*.gjs",
        "**/*.gts"
      ],
      "rules": {
        "no-curly-component-invocation": {
          "config": false,
          "severity": 0
        },
        "no-implicit-this": {
          "config": false,
          "severity": 0
        }
      }
    }
  ],

```