### PR TITLE
Add autofixer to `no-unnecessary-curly-strings` rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Each rule has emojis denoting:
 | [no-unnecessary-component-helper](./docs/rule/no-unnecessary-component-helper.md)                         | ✅  |     |     | 🔧  |
 | [no-unnecessary-concat](./docs/rule/no-unnecessary-concat.md)                                             |     | 💅  |     | 🔧  |
 | [no-unnecessary-curly-parens](./docs/rule/no-unnecessary-curly-parens.md)                                 |     |     |     | 🔧  |
-| [no-unnecessary-curly-strings](./docs/rule/no-unnecessary-curly-strings.md)                               |     |     |     |     |
+| [no-unnecessary-curly-strings](./docs/rule/no-unnecessary-curly-strings.md)                               |     |     |     | 🔧  |
 | [no-unsupported-role-attributes](./docs/rule/no-unsupported-role-attributes.md)                           | ✅  |     | ⌨️  | 🔧  |
 | [no-unused-block-params](./docs/rule/no-unused-block-params.md)                                           | ✅  |     |     |     |
 | [no-valueless-arguments](./docs/rule/no-valueless-arguments.md)                                           | ✅  |     |     |     |

--- a/docs/rule/no-unnecessary-curly-strings.md
+++ b/docs/rule/no-unnecessary-curly-strings.md
@@ -1,5 +1,7 @@
 # no-unnecessary-curly-strings
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 Strings need not be wrapped in the curly braces (mustache expressions).
 
 ## Examples

--- a/lib/rules/no-unnecessary-curly-strings.js
+++ b/lib/rules/no-unnecessary-curly-strings.js
@@ -1,14 +1,25 @@
 import Rule from './_base.js';
+import { builders as b } from 'ember-template-recast';
+import replaceNode from '../helpers/replace-node.js';
 
 export default class NoUnnecessaryCurlyStrings extends Rule {
   visitor() {
     return {
-      MustacheStatement(node) {
+      MustacheStatement(node, { parentNode, parentKey }) {
         if (node.path.type === 'StringLiteral') {
-          this.log({
-            node,
-            message: 'Unnecessary curly braces around string',
-          });
+          if (this.mode === 'fix') {
+            if (parentNode.type === 'AttrNode') {
+              parentNode.quoteType = node.path.quoteType;
+            }
+            const newNode = b.text(node.path.original);
+            replaceNode(node, parentNode, parentKey, newNode);
+          } else {
+            this.log({
+              node,
+              message: 'Unnecessary curly braces around string',
+              isFixable: true,
+            });
+          }
         }
       },
     };

--- a/test/unit/rules/no-unnecessary-curly-strings-test.js
+++ b/test/unit/rules/no-unnecessary-curly-strings-test.js
@@ -25,7 +25,8 @@ generateRuleTests({
 
   bad: [
     {
-      template: '<FooBar class={{"btn"}} />',
+      template: '<FooBar class={{"btn"}} @fooArg={{\'barbaz\'}} />',
+      fixedTemplate: '<FooBar class="btn" @fooArg=\'barbaz\' />',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -35,11 +36,24 @@ generateRuleTests({
               "endColumn": 23,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Unnecessary curly braces around string",
               "rule": "no-unnecessary-curly-strings",
               "severity": 2,
               "source": "{{\\"btn\\"}}",
+            },
+            {
+              "column": 32,
+              "endColumn": 44,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Unnecessary curly braces around string",
+              "rule": "no-unnecessary-curly-strings",
+              "severity": 2,
+              "source": "{{'barbaz'}}",
             },
           ]
         `);
@@ -47,6 +61,7 @@ generateRuleTests({
     },
     {
       template: '<FooBar class="btn">{{"Foo"}}</FooBar>',
+      fixedTemplate: '<FooBar class="btn">Foo</FooBar>',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
@@ -56,6 +71,7 @@ generateRuleTests({
               "endColumn": 29,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": true,
               "line": 1,
               "message": "Unnecessary curly braces around string",
               "rule": "no-unnecessary-curly-strings",


### PR DESCRIPTION
Adds an autofixer for https://github.com/ember-template-lint/ember-template-lint/pull/2794

Related to this issue: https://github.com/ember-template-lint/ember-template-lint/issues/2571