### PR TITLE
Fix location reporting in `block-indentation` rule

### DIFF
--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -393,8 +393,8 @@ export default class BlockIndentation extends Rule {
         this.log({
           message: warning,
           node,
-          line: node.loc.end.line,
-          column: node.loc.end.column,
+          line: node.loc.start.line,
+          column: node.loc.start.column,
           isFixable: true,
         });
       }

--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -393,8 +393,6 @@ export default class BlockIndentation extends Rule {
         this.log({
           message: warning,
           node,
-          line: node.loc.start.line,
-          column: node.loc.start.column,
           isFixable: true,
         });
       }

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -359,12 +359,12 @@ generateRuleTests({
                   {{/each}}",
             },
             {
-              "column": 17,
+              "column": 2,
               "endColumn": 17,
               "endLine": 3,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 3,
+              "line": 2,
               "message": "Incorrect indentation for \`each\` beginning at L2:C2. Expected \`{{/each}}\` ending at L3:C17 to be at an indentation of 2 but was found at 8.",
               "rule": "block-indentation",
               "severity": 2,
@@ -383,12 +383,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 8,
+              "column": 0,
               "endColumn": 8,
               "endLine": 2,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 2,
+              "line": 1,
               "message": "Incorrect indentation for \`div\` beginning at L1:C0. Expected \`</div>\` ending at L2:C8 to be at an indentation of 0 but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
@@ -407,12 +407,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 30,
+              "column": 0,
               "endColumn": 30,
               "endLine": 2,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 2,
+              "line": 1,
               "message": "Incorrect indentation for \`div\` beginning at L1:C0. Expected \`</div>\` ending at L2:C30 to be at an indentation of 0 but was found at 24.",
               "rule": "block-indentation",
               "severity": 2,
@@ -493,12 +493,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 11,
+              "column": 2,
               "endColumn": 11,
               "endLine": 5,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 5,
+              "line": 3,
               "message": "Incorrect indentation for \`if\` beginning at L3:C2. Expected \`{{/if}}\` ending at L5:C11 to be at an indentation of 2 but was found at 4.",
               "rule": "block-indentation",
               "severity": 2,
@@ -604,12 +604,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 17,
+              "column": 18,
               "endColumn": 17,
               "endLine": 3,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 3,
+              "line": 2,
               "message": "Incorrect indentation for \`some-thing\` beginning at L2:C18. Expected \`{{/some-thing}}\` ending at L3:C17 to be at an indentation of 18 but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
@@ -631,12 +631,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 6,
+              "column": 10,
               "endColumn": 6,
               "endLine": 4,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 4,
+              "line": 2,
               "message": "Incorrect indentation for \`p\` beginning at L2:C10. Expected \`</p>\` ending at L4:C6 to be at an indentation of 10 but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
@@ -722,12 +722,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 9,
+              "column": 0,
               "endColumn": 9,
               "endLine": 6,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 6,
+              "line": 1,
               "message": "Incorrect indentation for \`if\` beginning at L1:C0. Expected \`{{/if}}\` ending at L6:C9 to be at an indentation of 0 but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
@@ -1000,12 +1000,12 @@ generateRuleTests({
           {{/if}}",
             },
             {
-              "column": 7,
+              "column": 1,
               "endColumn": 7,
               "endLine": 2,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 2,
+              "line": 1,
               "message": "Incorrect indentation for \`if\` beginning at L1:C1. Expected \`{{/if}}\` ending at L2:C7 to be at an indentation of 1 but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
@@ -1518,12 +1518,12 @@ generateRuleTests({
           </div>",
             },
             {
-              "column": 6,
-              "endColumn": 6,
+              "column": 21,
+              "endColumn": 25,
               "endLine": 6,
               "filePath": "layout.js",
               "isFixable": true,
-              "line": 6,
+              "line": 4,
               "message": "Incorrect indentation for \`div\` beginning at L1:C2. Expected \`</div>\` ending at L3:C6 to be at an indentation of 2 but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
@@ -1624,12 +1624,12 @@ generateRuleTests({
               {{/if}}",
             },
             {
-              "column": 11,
+              "column": 3,
               "endColumn": 11,
               "endLine": 11,
               "filePath": "layout.js",
               "isFixable": true,
-              "line": 11,
+              "line": 5,
               "message": "Incorrect indentation for \`if\` beginning at L2:C3. Expected \`{{/if}}\` ending at L8:C11 to be at an indentation of 3 but was found at 4.",
               "rule": "block-indentation",
               "severity": 2,


### PR DESCRIPTION
### Background
This PR fixes [#2906](https://github.com/ember-template-lint/ember-template-lint/issues/2906
), a bug in the `block-indentation` rule in which the same value is reported for start and end line locations.

```hbs
  {{#each cats as |dog|}}
       {{/each}}

**Before**:
             {
              "column": 8,
               "endColumn": 8,
               "endLine": 2,
               "filePath": "layout.hbs",
               "isFixable": true,
              "line": 2,
...

**After**:
                "column": 0,
               "endColumn": 8,
               "endLine": 2,
               "filePath": "layout.hbs",
               "isFixable": true,
                "line": 1,
...

### Testing
Test Suites: 148 passed, 148 total
Tests:       5 skipped, 8517 passed, 8522 total
Snapshots:   1106 passed, 1106 total
Time:        139.666 s
Ran all test suites.
✨  Done in 174.15s.
