### PR TITLE
Fix `aria-query` related crash in `no-unsupported-role-attributes` rule

### DIFF
--- a/lib/rules/no-unsupported-role-attributes.js
+++ b/lib/rules/no-unsupported-role-attributes.js
@@ -23,7 +23,8 @@ function getImplicitRole(element, typeAttribute) {
       }
     }
   }
-  let implicitRoles = elementRoles.get(elementRoles.keys().find((key) => key.name === element));
+  const key = elementRoles.keys().find((key) => key.name === element);
+  const implicitRoles = key && elementRoles.get(key);
   return implicitRoles && implicitRoles[0];
 }
 


### PR DESCRIPTION
Fixes failing tests with the latest version of aria-query.

Fixes #2912.