### PR TITLE
Update incorrect tests

### DIFF
--- a/lib/rules/no-unsupported-role-attributes.js
+++ b/lib/rules/no-unsupported-role-attributes.js
@@ -23,7 +23,8 @@ function getImplicitRole(element, typeAttribute) {
       }
     }
   }
-  let implicitRoles = elementRoles.get(elementRoles.keys().find((key) => key.name === element));
+  const key = elementRoles.keys().find((key) => key.name === element);
+  const implicitRoles = key && elementRoles.get(key);
   return implicitRoles && implicitRoles[0];
 }
 

--- a/test/unit/rules/no-unsupported-role-attributes-test.js
+++ b/test/unit/rules/no-unsupported-role-attributes-test.js
@@ -15,7 +15,7 @@ generateRuleTests({
     '<dialog />',
     '<a href="#" aria-describedby=""></a>',
     '<menu type="toolbar" aria-hidden="true" />',
-    '<menuitem type="command" aria-labelledby={{this.label}} />',
+    '<a role="menuitem" aria-labelledby={{this.label}} />',
     '<input type="image" aria-atomic />',
     '<input type="submit" aria-disabled="true" />',
     '<select aria-expanded="false" aria-controls="ctrlID" />',
@@ -167,38 +167,38 @@ generateRuleTests({
       },
     },
     {
-      template: '<menuitem type="command" aria-checked={{this.checked}} />',
-      fixedTemplate: '<menuitem type="command" />',
+      template: '<a role="menuitem" aria-checked={{this.checked}} />',
+      fixedTemplate: '<a role="menuitem" />',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
               "column": 0,
-              "endColumn": 57,
+              "endColumn": 51,
               "endLine": 1,
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "The attribute aria-checked is not supported by the element menuitem with the implicit role of command",
+              "message": "The attribute aria-checked is not supported by the role menuitem",
               "rule": "no-unsupported-role-attributes",
               "severity": 2,
-              "source": "<menuitem type=\\"command\\" aria-checked={{this.checked}} />",
+              "source": "<a role=\\"menuitem\\" aria-checked={{this.checked}} />",
             },
           ]
         `);
       },
     },
     {
-      template: '<input type="checkbox" aria-invalid="grammar" />',
-      fixedTemplate: '<input type="checkbox" />',
+      template: '<input type="button" aria-invalid="grammar" />',
+      fixedTemplate: '<input type="button" />',
 
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
             {
               "column": 0,
-              "endColumn": 48,
+              "endColumn": 46,
               "endLine": 1,
               "filePath": "layout.hbs",
               "isFixable": true,
@@ -206,7 +206,7 @@ generateRuleTests({
               "message": "The attribute aria-invalid is not supported by the element input with the implicit role of button",
               "rule": "no-unsupported-role-attributes",
               "severity": 2,
-              "source": "<input type=\\"checkbox\\" aria-invalid=\\"grammar\\" />",
+              "source": "<input type=\\"button\\" aria-invalid=\\"grammar\\" />",
             },
           ]
         `);


### PR DESCRIPTION
This builds off https://github.com/ember-template-lint/ember-template-lint/pull/2914.

I'm pretty sure these tests were incorrect and it was just hidden by the other bug.

The checkbox role *does* support aria-invalid. So I changed that one to button role, which does not.

Also, the menuitem element (not to be confused with the menuitem role) does not appear at all in the set of elementRoles from aria-query. So I changed that test to use `<a role="menuitem">` instead. The menuitem element is [deprecated and non-standard](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/menuitem).

Also note that the "command" role is abstract and not supposed to be used by authors, which is why I replaced it with the "menuitem" role, which is one of the concrete children of "command".