### PR TITLE
Fix crash in `no-unsupported-role-attributes` rule

### DIFF
--- a/lib/rules/no-unsupported-role-attributes.js
+++ b/lib/rules/no-unsupported-role-attributes.js
@@ -13,7 +13,7 @@ function createUnsupportedAttributeErrorMessage(attr, role, element) {
 function getImplicitRole(element, typeAttribute) {
   if (element === 'input') {
     for (let key of elementRoles.keys()) {
-      if (key.name === element) {
+      if (key.name === element && key.attributes) {
         let attributes = key.attributes;
         for (let attribute of attributes) {
           if (attribute.name === 'type' && attribute.value === typeAttribute) {

--- a/test/unit/rules/no-unsupported-role-attributes-test.js
+++ b/test/unit/rules/no-unsupported-role-attributes-test.js
@@ -24,6 +24,7 @@ generateRuleTests({
     '{{other-component role=this.role aria-bogus="true"}}',
     '<ItemCheckbox @model={{@model}} @checkable={{@checkable}} />',
     '<some-custom-element />',
+    '<input type="password">',
   ],
 
   bad: [


### PR DESCRIPTION
Resolves #2916.

Handle the case where aria-query's role mapping data does not have an attributes property defined.

Note: as I mentioned in #2916 I'm a little confused by the current behavior where an `<input>` with a `type` that doesn't match anything sort of defaults to being treated like a `<button>`. If that's correct (or correct enough) then this should work, but if that's also a bug then we'll want a different solution here.