### PR TITLE
Create failing no-obscure-array-access-test

### DIFF
--- a/test/unit/rules/no-obscure-array-access-test.js
+++ b/test/unit/rules/no-obscure-array-access-test.js
@@ -154,5 +154,27 @@ generateRuleTests({
         `);
       },
     },
+    {
+      template: '<Foo @onClick={{fn this.func @foo.0.bar}} />',
+      fixedTemplate: '<Foo @onClick={{fn this.func (get @foo "0.bar")}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 12,
+              "endColumn": 38,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Obscure expressions are prohibited. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+              "rule": "no-obscure-array-access",
+              "severity": 2,
+              "source": "@foo.0.bar",
+            },
+          ]
+        `);
+      },
+    },
   ],
 });


### PR DESCRIPTION
This shows that the rule no-obscure-array-access-test fix is incorrect.
This code:
```hbs
<Button @onClick={{fn this.myFunc @row.0.sha256}}>
  Button
</Button>
```
Is expected to be fixed to:
```hbs
<Button @onClick={{fn this.myFunc (get @row "0.sha256")}}>
  Button
</Button>
```
But instead is fixed to:
```hbs
<Button @onClick={{fn @row "0.sha256"}}>
  Button
</Button>
```

Which is incorrect. The function `this.myFunc` is now gone.