### PR TITLE
Fixes location reporting in `simple-unless` rule

### DIFF
--- a/lib/rules/simple-unless.js
+++ b/lib/rules/simple-unless.js
@@ -105,29 +105,26 @@ export default class SimpleUnless extends Rule {
       return;
     }
     let node = block.program;
-    let loc = node.loc.end;
     let actual = '{{else}}';
 
-    this._logMessage(node, messages.followingElseBlock, loc.line, loc.column, actual, true);
+    this._logMessage(node, messages.followingElseBlock, actual, true);
   }
 
   _followingElseIfBlock(block) {
     let inverse = block.inverse;
     let node = block.program;
-    let loc = node.loc.end;
     let parameter = inverse.body[0].params[0].original;
     let actual = `{{else if ${parameter}}}`;
 
-    this._logMessage(node, messages.followingElseBlock, loc.line, loc.column, actual);
+    this._logMessage(node, messages.followingElseBlock, actual);
   }
 
   _asElseUnlessBlock(block) {
     let inverse = block.inverse;
     let node = inverse.body[0];
-    let loc = node.loc.start;
     let actual = '{{else unless ...';
 
-    this._logMessage(node, messages.asElseUnlessBlock, loc.line, loc.column, actual);
+    this._logMessage(node, messages.asElseUnlessBlock, actual);
   }
 
   _withHelper(node, fixMode) {
@@ -145,33 +142,30 @@ export default class SimpleUnless extends Rule {
       for (const param of params) {
         if (param.type === 'SubExpression') {
           if (++helperCount > maxHelpers && maxHelpers > -1) {
-            let loc = param.loc.start;
             let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
             let message = `${messages.withHelper} MaxHelpers: ${maxHelpers}`;
 
-            this._logMessage(param, message, loc.line, loc.column, actual, true);
+            this._logMessage(param, message, actual, true);
             shouldFix = true;
           }
 
           if (allowlist.length > 0 && !allowlist.includes(param.path.original)) {
-            let loc = param.loc.start;
             let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
             let message = `${messages.withHelper} Allowed helper${
               allowlist.length > 1 ? 's' : ''
             }: ${allowlist.toString()}`;
 
-            this._logMessage(param, message, loc.line, loc.column, actual, true);
+            this._logMessage(param, message, actual, true);
             shouldFix = true;
           }
 
           if (denylist.length > 0 && denylist.includes(param.path.original)) {
-            let loc = param.loc.start;
             let actual = `{{unless ${helperCount > 1 ? '(... ' : ''}(${param.path.original} ...`;
             let message = `${messages.withHelper} Restricted helper${
               denylist.length > 1 ? 's' : ''
             }: ${denylist.toString()}`;
 
-            this._logMessage(param, message, loc.line, loc.column, actual, true);
+            this._logMessage(param, message, actual, true);
             shouldFix = true;
           }
 
@@ -209,12 +203,10 @@ export default class SimpleUnless extends Rule {
     );
   }
 
-  _logMessage(node, message, line, column, source, isFixable = false) {
+  _logMessage(node, message, source, isFixable = false) {
     return this.log({
       message,
       node,
-      line,
-      column,
       source,
       isFixable,
     });

--- a/test/unit/rules/simple-unless-test.js
+++ b/test/unit/rules/simple-unless-test.js
@@ -158,12 +158,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
+              "column": 23,
               "endColumn": 0,
               "endLine": 3,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 3,
+              "line": 1,
               "message": "Using an {{else}} block with {{unless}} should be avoided.",
               "rule": "simple-unless",
               "severity": 2,
@@ -181,12 +181,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
+              "column": 23,
               "endColumn": 0,
               "endLine": 3,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 3,
+              "line": 1,
               "message": "Using an {{else}} block with {{unless}} should be avoided.",
               "rule": "simple-unless",
               "severity": 2,
@@ -216,12 +216,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
+              "column": 23,
               "endColumn": 0,
               "endLine": 2,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 2,
+              "line": 1,
               "message": "Using an {{else}} block with {{unless}} should be avoided.",
               "rule": "simple-unless",
               "severity": 2,
@@ -244,12 +244,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
+              "column": 23,
               "endColumn": 0,
               "endLine": 3,
               "filePath": "layout.hbs",
               "isFixable": false,
-              "line": 3,
+              "line": 1,
               "message": "Using an {{else}} block with {{unless}} should be avoided.",
               "rule": "simple-unless",
               "severity": 2,
@@ -274,12 +274,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
+              "column": 23,
               "endColumn": 0,
               "endLine": 3,
               "filePath": "layout.hbs",
               "isFixable": false,
-              "line": 3,
+              "line": 1,
               "message": "Using an {{else}} block with {{unless}} should be avoided.",
               "rule": "simple-unless",
               "severity": 2,
@@ -304,12 +304,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
+              "column": 23,
               "endColumn": 0,
               "endLine": 3,
               "filePath": "layout.hbs",
               "isFixable": false,
-              "line": 3,
+              "line": 1,
               "message": "Using an {{else}} block with {{unless}} should be avoided.",
               "rule": "simple-unless",
               "severity": 2,
@@ -494,12 +494,12 @@ generateRuleTests({
         expect(results).toMatchInlineSnapshot(`
           [
             {
-              "column": 0,
+              "column": 20,
               "endColumn": 0,
               "endLine": 3,
               "filePath": "layout.hbs",
               "isFixable": true,
-              "line": 3,
+              "line": 1,
               "message": "Using an {{else}} block with {{unless}} should be avoided.",
               "rule": "simple-unless",
               "severity": 2,


### PR DESCRIPTION
### Background
This PR fixes [#2906](https://github.com/ember-template-lint/ember-template-lint/issues/2939
), a bug in the `simple-unless` rule in which the same value is reported for start and end line locations.

```hbs
  {{#unless this.foo}}
    'Bingo!'
  {{else}}
    'Bogus!'
  {{/unless}}

**Before**:
  {
    "column": 0,
    "endColumn": 0,
    "endLine": 3,
    "filePath": "layout.hbs",
    "isFixable": true,
    "line": 3,
    "message": "Using an {{else}} block with {{unless}} should be avoided.",
    "rule": "simple-unless",
    "severity": 2,
    "source": "{{else}}",
  }

**After**:
  {
    "column": 20,
    "endColumn": 0,
    "endLine": 3,
    "filePath": "layout.hbs",
    "isFixable": true,
    "line": 1,
    "message": "Using an {{else}} block with {{unless}} should be avoided.",
    "rule": "simple-unless",
    "severity": 2,
    "source": "{{else}}",
  }


### Testing
Test Suites: 149 passed, 149 total
Tests:       5 skipped, 8540 passed, 8545 total
Snapshots:   1109 passed, 1109 total
Time:        130.081 s
Ran all test suites.
✨  Done in 140.24s.
