### PR TITLE
Don't require redundant role for `<img alt="" />` in `require-valid-alt-text` rule

### DIFF
--- a/docs/rule/require-valid-alt-text.md
+++ b/docs/rule/require-valid-alt-text.md
@@ -12,7 +12,7 @@ This rule **forbids** the following:
 
 ### `<img>`
 
-An `<img>` must have the `alt` attribute. It must have either meaningful text, or be an empty string. If it is an empty string, the `<img>` element tag must also have `role="presentation"` or `role="none"`.
+An `<img>` must have the `alt` attribute. It must have either meaningful text, or be an empty string.
 
 The content of an `alt` attribute is used to calculate the machine-readable label of an element, whereas the text content is used to produce a label for the element. For this reason, adding a label to an icon can produce a confusing or duplicated label on a control that already has appropriate text content.
 

--- a/lib/rules/require-valid-alt-text.js
+++ b/lib/rules/require-valid-alt-text.js
@@ -120,18 +120,6 @@ export default class RequireValidAltText extends Rule {
                 normalizedAltValue = null;
               }
 
-              if (normalizedAltValue === '') {
-                if (['presentation', 'none'].includes(roleValue)) {
-                  return;
-                }
-                this.logNode({
-                  message:
-                    'If the `alt` attribute is present and the value is an empty string, `role="presentation"` or `role="none"` must be present',
-                  node,
-                });
-                return;
-              }
-
               if (normalizedAltValue !== null) {
                 if (/^\d+$/g.test(normalizedAltValue)) {
                   this.logNode({

--- a/test/unit/rules/require-valid-alt-text-test.js
+++ b/test/unit/rules/require-valid-alt-text-test.js
@@ -18,8 +18,15 @@ generateRuleTests({
     '<img alt="some-alt-name">',
     '<img alt="name {{picture}}">',
     '<img alt="{{picture}}">',
+    '<img alt="">',
+    '<img alt="" src="zoey.jpg">',
     '<img alt="" role="none">',
     '<img alt="" role="presentation">',
+
+    '<img alt>',
+    '<img alt role="none">',
+    '<img alt role="presentation">',
+    '<img alt src="zoey.jpg">',
 
     // Valid words containing redundant words.
     '<img alt="logout">',
@@ -91,48 +98,6 @@ generateRuleTests({
               "rule": "require-valid-alt-text",
               "severity": 2,
               "source": "<img src=\\"zoey.jpg\\">",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<img alt="" src="zoey.jpg">',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 27,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "If the \`alt\` attribute is present and the value is an empty string, \`role=\\"presentation\\"\` or \`role=\\"none\\"\` must be present",
-              "rule": "require-valid-alt-text",
-              "severity": 2,
-              "source": "<img alt=\\"\\" src=\\"zoey.jpg\\">",
-            },
-          ]
-        `);
-      },
-    },
-    {
-      template: '<img alt src="zoey.jpg">',
-
-      verifyResults(results) {
-        expect(results).toMatchInlineSnapshot(`
-          [
-            {
-              "column": 0,
-              "endColumn": 24,
-              "endLine": 1,
-              "filePath": "layout.hbs",
-              "line": 1,
-              "message": "If the \`alt\` attribute is present and the value is an empty string, \`role=\\"presentation\\"\` or \`role=\\"none\\"\` must be present",
-              "rule": "require-valid-alt-text",
-              "severity": 2,
-              "source": "<img alt src=\\"zoey.jpg\\">",
             },
           ]
         `);


### PR DESCRIPTION
Closes https://github.com/ember-template-lint/ember-template-lint/issues/2951, 
Closes https://github.com/ember-template-lint/ember-template-lint/issues/2190, 
Closes https://github.com/ember-template-lint/ember-template-lint/issues/2579, 
Closes https://github.com/ember-template-lint/ember-template-lint/pull/2828


This updates the `require-valid-alt-text` rule so that it does not *require* setting `role="presentation"` or `role="none"` for an `<img alt="" />`.

Context

After bumping `aria-query` in https://github.com/ember-template-lint/ember-template-lint/pull/2927, `ember-template-lint` began reporting an error for the following:

```html
<img alt="" role="presentation" />
```

The error is from the `no-redundant-role`. I believe it is correct to report an error in this case because `<img alt="" />` already [implicitly has a `role` of `presentation`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#technical_summary).

However, this new behavior was in direct conflict with part of the `require-valid-alt-text` rule that required setting `role="presentation"` or `role="none"` whenever an image has `alt=""`. It is valid to set one of these roles but it should not be required. Removing this requirement allows these two rules (`no-redundant-role` and `require-valid-alt-text`) to continue to be used together.