### PR TITLE
chore: lint todo utils to 13.1.1, fixes compact todo issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.11.1",
       "license": "MIT",
       "dependencies": {
-        "@lint-todo/utils": "^13.0.3",
+        "@lint-todo/utils": "^13.1.1",
         "aria-query": "^5.3.0",
         "chalk": "^5.3.0",
         "ci-info": "^3.8.0",
@@ -1631,16 +1631,16 @@
       }
     },
     "node_modules/@lint-todo/utils": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@lint-todo/utils/-/utils-13.1.0.tgz",
-      "integrity": "sha512-uzcZPIPH7hcs+hKMiHfp58MosJpI9sTTgl1pGYau4zq34q1ppswJ6nLeohv/cDhqEBrHjtvldt8zDnVJXRvBlA==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/@lint-todo/utils/-/utils-13.1.1.tgz",
+      "integrity": "sha512-F5z53uvRIF4dYfFfJP3a2Cqg+4P1dgJchJsFnsZE0eZp0LK8X7g2J0CsJHRgns+skpXOlM7n5vFGwkWCWj8qJg==",
       "dependencies": {
-        "@types/eslint": "^7.2.13",
+        "@types/eslint": "^8.4.9",
         "find-up": "^5.0.0",
         "fs-extra": "^9.1.0",
         "proper-lockfile": "^4.1.2",
         "slash": "^3.0.0",
-        "tslib": "^2.4.0",
+        "tslib": "^2.4.1",
         "upath": "^2.0.1"
       },
       "engines": {
@@ -2958,18 +2958,18 @@
       "dev": true
     },
     "node_modules/@types/eslint": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.29.0.tgz",
-      "integrity": "sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==",
+      "version": "8.44.2",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.2.tgz",
+      "integrity": "sha512-sdPRb9K6iL5XZOmBubg8yiFp5yS/JdUDQsq5e6h95km91MCYMuvp7mh1fjPEYUhvHepKpZOjnEaMBR4PxjWDzg==",
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
-      "integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
+      "integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA=="
     },
     "node_modules/@types/expect": {
       "version": "1.20.4",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     ]
   },
   "dependencies": {
-    "@lint-todo/utils": "^13.0.3",
+    "@lint-todo/utils": "^13.1.1",
     "aria-query": "^5.3.0",
     "chalk": "^5.3.0",
     "ci-info": "^3.8.0",


### PR DESCRIPTION
I recently contributed to `@lint-todo/utils` package and would love to see that fix given to everyone.

This fix ensures `--compact-todo` ends the file with a newline (previously it was always stripping the final newline in the file). This avoids other knock on issues like;
* doubled operation lines after an update-todo or other "append" task, which then cause;
  * lint errors to reappear
  * more merge conflicts
  * errornous lines in the file that are never cleaned up

Above all I think it would be worthwhile just to ensure that reported issues in ETL are as reported and not subtly caused by the above.
https://github.com/ember-template-lint/ember-template-lint/issues/2482