### PR TITLE
Support auto lookup of `.mjs` and `.cjs` config files

### DIFF
--- a/lib/get-config.js
+++ b/lib/get-config.js
@@ -24,7 +24,7 @@ const KNOWN_ROOT_PROPERTIES = new Set([
 const SUPPORTED_OVERRIDE_KEYS = new Set(['files', 'rules']);
 const SUPPORTED_FORMAT_PROPS = new Set(['name', 'outputFile']);
 
-const CONFIG_FILE_NAME = '.template-lintrc.js';
+const CONFIG_FILE_NAMES = ['.template-lintrc.js', '.template-lintrc.mjs', '.template-lintrc.cjs'];
 const ALLOWED_ERROR_CODES = new Set([
   // resolve package error codes
   'MODULE_NOT_FOUND',
@@ -77,7 +77,7 @@ export async function resolveProjectConfig(workingDir, options) {
     return {};
   } else {
     // look for our config file relative to the specified working directory
-    configPath = findUpSync(CONFIG_FILE_NAME, {
+    configPath = findUpSync(CONFIG_FILE_NAMES, {
       cwd: workingDir,
     });
 

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -970,4 +970,36 @@ describe('getRuleFromString', function () {
       );
     }
   });
+
+  it('supports a `.template-lintrc.mjs` config file', async function () {
+    let project = await Project.defaultSetup();
+
+    project.write({
+      '.template-lintrc.mjs': `export default { extends: 'recommended' };`,
+    });
+
+    try {
+      const config = await resolveProjectConfig(project.baseDir, {});
+
+      expect(config).toEqual({ extends: 'recommended' });
+    } finally {
+      project.dispose();
+    }
+  });
+
+  it('supports a `.template-lintrc.cjs` config file', async function () {
+    let project = await Project.defaultSetup();
+
+    project.write({
+      '.template-lintrc.cjs': `module.exports = { extends: 'recommended' };`,
+    });
+
+    try {
+      const config = await resolveProjectConfig(project.baseDir, {});
+
+      expect(config).toEqual({ extends: 'recommended' });
+    } finally {
+      project.dispose();
+    }
+  });
 });


### PR DESCRIPTION
`ember-template-lint` is written in ESM, which means plugins must be written in ESM as well.
If you want to `import` a plugin in your `ember-template-lint` config file, your project must be in ESM or your `ember-template-lint` config file must be an `.mjs` file, but it seems `ember-template-lint` doesn't auto lookup `.template-lintrc.mjs` config files. You can do `--config-path=.template-lintrc.mjs`, but that's a little verbose if you have multiple `ember-template-lint` invocations.