### PR TITLE
Add rule `no-builtin-form-components`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Each rule has emojis denoting:
 | [no-autofocus-attribute](./docs/rule/no-autofocus-attribute.md)                                           | ✅  |     | ⌨️  |     |
 | [no-bare-strings](./docs/rule/no-bare-strings.md)                                                         |     |     |     |     |
 | [no-block-params-for-html-elements](./docs/rule/no-block-params-for-html-elements.md)                     | ✅  |     |     |     |
+| [no-builtin-form-components](./docs/rule/no-builtin-form-components.md)                                   |     |     |     |     |
 | [no-capital-arguments](./docs/rule/no-capital-arguments.md)                                               | ✅  |     |     |     |
 | [no-class-bindings](./docs/rule/no-class-bindings.md)                                                     | ✅  |     |     |     |
 | [no-curly-component-invocation](./docs/rule/no-curly-component-invocation.md)                             | ✅  |     |     | 🔧  |

--- a/docs/rule/no-builtin-form-components.md
+++ b/docs/rule/no-builtin-form-components.md
@@ -1,6 +1,6 @@
 # no-builtin-form-components
 
-Ember's built-in form components use two-way data binding, where the property as `@value` or `@checked` is mutated by user interaction. This goes against the Data Down Actions Up principle, goes against Glimmer Components’ intention to have immutable arguments, and is [discouraged by the Ember Core team](https://www.pzuraq.com/on-mut-and-2-way-binding/).
+Ember's built-in form components use two-way data binding, where the property passed as `@value` or `@checked` is mutated by user interaction. This goes against the Data Down Actions Up principle, goes against Glimmer Components’ intention to have immutable arguments, and is [discouraged by the Ember Core team](https://www.pzuraq.com/on-mut-and-2-way-binding/).
 
 ## Examples
 
@@ -17,6 +17,8 @@ This rule **forbids** the following:
 ## Migration
 
 The migration path typically involves replacing the built-in form component with a native HTML element and binding an event listener to handle user input.
+
+In the following example the initial value of a field is controlled by a local tracked property, which is updated by an event listener.
 
 ```js
 import Component from '@glimmer/component';
@@ -51,6 +53,8 @@ You may consider composing the [set helper](https://github.com/pzuraq/ember-set-
 />
 ```
 
+Depending on your requirements, consider using form management patterns like the "light" [Form component from ember-primitives](https://ember-primitives.pages.dev/7-forms/1-intro) or the "controlled" [ember-headless-form](https://ember-headless-form.pages.dev/).
+
 ## Related Rules
 
 * [no-mut-helper](no-mut-helper.md)
@@ -63,3 +67,5 @@ You may consider composing the [set helper](https://github.com/pzuraq/ember-set-
 * [Native HTML `input`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
 * [Native HTML `textarea`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)
 * [The `on` modifier](https://guides.emberjs.com/release/components/component-state-and-actions/#toc_html-modifiers-and-actions)
+* [Form component – ember-primitives](https://ember-primitives.pages.dev/7-forms/1-intro)
+* [ember-headless-form](https://ember-headless-form.pages.dev/)

--- a/docs/rule/no-builtin-form-components.md
+++ b/docs/rule/no-builtin-form-components.md
@@ -1,0 +1,65 @@
+# no-builtin-form-components
+
+Ember's built-in form components use two-way data binding, where the property as `@value` or `@checked` is mutated by user interaction. This goes against the Data Down Actions Up principle, goes against Glimmer Components’ intention to have immutable arguments, and is [discouraged by the Ember Core team](https://www.pzuraq.com/on-mut-and-2-way-binding/).
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+<Input />
+```
+
+```hbs
+<Textarea></Textarea>
+```
+
+## Migration
+
+The migration path typically involves replacing the built-in form component with a native HTML element and binding an event listener to handle user input.
+
+```js
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class MyComponent extends Component {
+  @tracked name;
+
+  @action
+  updateName(event) {
+    this.name = event.target.value;
+  }
+}
+```
+
+```hbs
+<input
+  type="text"
+  value={{this.name}}
+  {{on "input" this.updateName}}
+/>
+```
+
+You may consider composing the [set helper](https://github.com/pzuraq/ember-set-helper) with the [pick helper](https://github.com/DockYard/ember-composable-helpers#pick) to avoid creating an action within a component class.
+
+```hbs
+<input
+  type="text"
+  value={{this.name}}
+  {{on "input" (pick "target.value" (set this "name"))}}
+/>
+```
+
+## Related Rules
+
+* [no-mut-helper](no-mut-helper.md)
+
+## References
+
+* [Built-in components guides](https://guides.emberjs.com/release/components/built-in-components/)
+* [Built-in `Input` component API](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input)
+* [Built-in `Textarea` component API](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
+* [Native HTML `input`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
+* [Native HTML `textarea`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)
+* [The `on` modifier](https://guides.emberjs.com/release/components/component-state-and-actions/#toc_html-modifiers-and-actions)

--- a/docs/rule/no-builtin-form-components.md
+++ b/docs/rule/no-builtin-form-components.md
@@ -16,7 +16,35 @@ This rule **forbids** the following:
 
 ## Migration
 
-The migration path typically involves replacing the built-in form component with a native HTML element and binding an event listener to handle user input.
+Many forms may be simplified by switching to a light one-way data approach.
+
+For example – vanilla JavaScript has everything we need to handle form data, de-sync it from our source data and collect all user input in a single object.
+
+```js
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { action } from '@ember/object';
+
+export default class MyComponent extends Component {
+  @tracked userInput = {};
+
+  @action
+  handleInput(event) {
+    const formData = new FormData(event.currentTarget);
+    this.userInput = Object.fromEntries(formData.entries());
+  }
+}
+```
+
+```hbs
+<form {{on "input" this.handleInput}}>
+  <label> Name
+    <input name="name">
+  </label>
+</form>
+```
+
+Another option would is to "control" the field's value by replacing the built-in form component with a native HTML element and binding an event listener to handle user input.
 
 In the following example the initial value of a field is controlled by a local tracked property, which is updated by an event listener.
 
@@ -53,19 +81,17 @@ You may consider composing the [set helper](https://github.com/pzuraq/ember-set-
 />
 ```
 
-Depending on your requirements, consider using form management patterns like the "light" [Form component from ember-primitives](https://ember-primitives.pages.dev/7-forms/1-intro) or the "controlled" [ember-headless-form](https://ember-headless-form.pages.dev/).
-
 ## Related Rules
 
 * [no-mut-helper](no-mut-helper.md)
 
 ## References
 
+* [Native HTML `input`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
+* [Native HTML `textarea`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)
+* [Native HTML `FormData`](https://developer.mozilla.org/en-US/docs/Web/API/FormData)
+* [The `on` modifier](https://guides.emberjs.com/release/components/component-state-and-actions/#toc_html-modifiers-and-actions)
+* [ember-headless-form](https://ember-headless-form.pages.dev/)
 * [Built-in components guides](https://guides.emberjs.com/release/components/built-in-components/)
 * [Built-in `Input` component API](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Input?anchor=Input)
 * [Built-in `Textarea` component API](https://api.emberjs.com/ember/release/classes/Ember.Templates.components/methods/Textarea?anchor=Textarea)
-* [Native HTML `input`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
-* [Native HTML `textarea`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea)
-* [The `on` modifier](https://guides.emberjs.com/release/components/component-state-and-actions/#toc_html-modifiers-and-actions)
-* [Form component – ember-primitives](https://ember-primitives.pages.dev/7-forms/1-intro)
-* [ember-headless-form](https://ember-headless-form.pages.dev/)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -27,6 +27,7 @@ import noattrsincomponents from './no-attrs-in-components.js';
 import noautofocusattribute from './no-autofocus-attribute.js';
 import nobarestrings from './no-bare-strings.js';
 import noblockparamsforhtmlelements from './no-block-params-for-html-elements.js';
+import nobuiltinformcomponents from './no-builtin-form-components.js';
 import nocapitalarguments from './no-capital-arguments.js';
 import noclassbindings from './no-class-bindings.js';
 import nocurlycomponentinvocation from './no-curly-component-invocation.js';
@@ -148,6 +149,7 @@ export default {
   'no-autofocus-attribute': noautofocusattribute,
   'no-bare-strings': nobarestrings,
   'no-block-params-for-html-elements': noblockparamsforhtmlelements,
+  'no-builtin-form-components': nobuiltinformcomponents,
   'no-capital-arguments': nocapitalarguments,
   'no-class-bindings': noclassbindings,
   'no-curly-component-invocation': nocurlycomponentinvocation,

--- a/lib/rules/no-builtin-form-components.js
+++ b/lib/rules/no-builtin-form-components.js
@@ -1,0 +1,25 @@
+import Rule from './_base.js';
+
+const WHY = 'Built-in form components use two-way binding to mutate values.';
+const ACTION = 'Instead, refactor to use a native HTML element.';
+export const MESSAGES = {
+  Input: `Do not use the \`Input\` component. ${WHY} ${ACTION}`,
+  Textarea: `Do not use the \`Textarea\` component. ${WHY} ${ACTION}`,
+};
+
+const COMPONENTS = new Set(['Input', 'Textarea']);
+
+export default class NoBuiltinFormComponents extends Rule {
+  visitor() {
+    return {
+      ElementNode(node) {
+        if (COMPONENTS.has(node.tag)) {
+          this.log({
+            message: MESSAGES[node.tag],
+            node,
+          });
+        }
+      },
+    };
+  }
+}

--- a/test/unit/rules/no-builtin-form-components-test.js
+++ b/test/unit/rules/no-builtin-form-components-test.js
@@ -1,0 +1,61 @@
+import generateRuleTests from '../../helpers/rule-test-harness.js';
+
+generateRuleTests({
+  name: 'no-builtin-form-components',
+
+  config: true,
+
+  good: [
+    '<input type="text" />',
+    '<input type="checkbox" />',
+    '<input type="radio" />',
+    '<textarea></textarea>',
+  ],
+
+  bad: [
+    {
+      template: '<Input />',
+      verifyResults(results) {
+        expect({ results }).toMatchInlineSnapshot(`
+          {
+            "results": [
+              {
+                "column": 0,
+                "endColumn": 9,
+                "endLine": 1,
+                "filePath": "layout.hbs",
+                "line": 1,
+                "message": "Do not use the \`Input\` component. Built-in form components use two-way binding to mutate values. Instead, refactor to use a native HTML element.",
+                "rule": "no-builtin-form-components",
+                "severity": 2,
+                "source": "<Input />",
+              },
+            ],
+          }
+        `);
+      },
+    },
+    {
+      template: '<Textarea></Textarea>',
+      verifyResults(results) {
+        expect({ results }).toMatchInlineSnapshot(`
+          {
+            "results": [
+              {
+                "column": 0,
+                "endColumn": 21,
+                "endLine": 1,
+                "filePath": "layout.hbs",
+                "line": 1,
+                "message": "Do not use the \`Textarea\` component. Built-in form components use two-way binding to mutate values. Instead, refactor to use a native HTML element.",
+                "rule": "no-builtin-form-components",
+                "severity": 2,
+                "source": "<Textarea></Textarea>",
+              },
+            ],
+          }
+        `);
+      },
+    },
+  ],
+});


### PR DESCRIPTION
Was surprised to find that no such rule exists.

Combined with `no-mut-helper` this can help prevent two-way binding being present in a codebase.

[Rule docs rendered](https://github.com/ember-template-lint/ember-template-lint/blob/0f684349a4bc11ac41a15913dbac164be62febbf/docs/rule/no-builtin-form-components.md)