### PR TITLE
Start running test that was disabled in Node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,7 @@ jobs:
       - name: install dependencies
         run: npm ci
 
-      # Temporarily exclude `test/unit/get-config-test.js` in Node versions before 16 (TODO: remove eventually).
-      # Tests triggering `resolveProjectConfig` and thus `await import()` for config/plugin loading cause this error:
-      #   ReferenceError: You are trying to `import` a file after the Jest environment has been torn down.
-      # Possibly related: https://github.com/facebook/jest/issues/11438
-      - run: npm run test:jest -- --testPathIgnorePatterns=test/unit/get-config-test.js --testPathIgnorePatterns=test/acceptance/public-api-test.js
+      - run: npm run test:jest
 
   floating-dependencies:
     name: Floating Dependencies

--- a/test/unit/get-config-test.js
+++ b/test/unit/get-config-test.js
@@ -1,5 +1,3 @@
-// TODO: This test file is temporarily disabled in Node versions before 16 (see ci.yml).
-
 import { stripIndent } from 'common-tags';
 import { join } from 'node:path';
 


### PR DESCRIPTION
Was disabled due to old Node / jest issue.

Follow-up to:
* #3023