### PR TITLE
Remove bad advice about ember-composable-helpers

### DIFF
--- a/docs/rule/no-builtin-form-components.md
+++ b/docs/rule/no-builtin-form-components.md
@@ -73,16 +73,6 @@ export default class MyComponent extends Component {
 />
 ```
 
-You may consider composing the [set helper](https://github.com/pzuraq/ember-set-helper) with the [pick helper](https://github.com/DockYard/ember-composable-helpers#pick) to avoid creating an action within a component class.
-
-```hbs
-<input
-  type="text"
-  value={{this.name}}
-  {{on "input" (pick "target.value" (set this "name"))}}
-/>
-```
-
 ## Related Rules
 
 * [no-mut-helper](no-mut-helper.md)


### PR DESCRIPTION
ember-composable-helpers is unmaintained. I don't think the docs should be pointing people at it.

(Even ember-set-helper is a slightly quirky suggestion. A default lint rule should probably be sticking to default ember features.)