### PR TITLE
Fix `--no-error-on-unmatched-pattern` for multiple patterns

### DIFF
--- a/bin/ember-template-lint.js
+++ b/bin/ember-template-lint.js
@@ -172,15 +172,16 @@ async function run() {
 
   let filePaths;
   try {
-    filePaths = getFilesToLint(options.workingDirectory, positional, options.ignorePattern);
+    filePaths = getFilesToLint(
+      options.workingDirectory,
+      positional,
+      options.ignorePattern,
+      options.errorOnUnmatchedPattern !== false
+    );
   } catch (error) {
-    if (error.name === 'NoMatchingFilesError' && options.errorOnUnmatchedPattern === false) {
-      return;
-    } else {
-      console.error(error.message);
-      process.exitCode = 1;
-      return;
-    }
+    console.error(error.message);
+    process.exitCode = 1;
+    return;
   }
 
   if (options.printConfig) {

--- a/lib/helpers/cli.js
+++ b/lib/helpers/cli.js
@@ -170,7 +170,13 @@ export function parseArgv(_argv) {
   }
 }
 
-export function expandFileGlobs(workingDir, filePatterns, ignorePattern, glob = executeGlobby) {
+export function expandFileGlobs(
+  workingDir,
+  filePatterns,
+  ignorePattern,
+  glob = executeGlobby,
+  errorOnUnmatchedPattern = true
+) {
   let result = new Set();
 
   for (const pattern of filePatterns) {
@@ -190,7 +196,7 @@ export function expandFileGlobs(workingDir, filePatterns, ignorePattern, glob = 
     }
 
     const globResults = glob(workingDir, pattern, ignorePattern);
-    if (!globResults || globResults.length === 0) {
+    if (errorOnUnmatchedPattern && (!globResults || globResults.length === 0)) {
       throw new NoMatchingFilesError(`No files matching the pattern were found: "${pattern}"`);
     }
 
@@ -202,13 +208,24 @@ export function expandFileGlobs(workingDir, filePatterns, ignorePattern, glob = 
   return result;
 }
 
-export function getFilesToLint(workingDir, filePatterns, ignorePattern = []) {
+export function getFilesToLint(
+  workingDir,
+  filePatterns,
+  ignorePattern = [],
+  errorOnUnmatchedPattern = true
+) {
   let files;
 
   if (filePatterns.length === 0 || filePatterns.includes('-') || filePatterns.includes(STDIN)) {
     files = new Set([STDIN]);
   } else {
-    files = expandFileGlobs(workingDir, filePatterns, ignorePattern);
+    files = expandFileGlobs(
+      workingDir,
+      filePatterns,
+      ignorePattern,
+      executeGlobby,
+      errorOnUnmatchedPattern
+    );
   }
 
   return files;

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -239,6 +239,36 @@ describe('ember-template-lint executable', function () {
       });
     });
 
+    describe('given --no-error-on-unmatched-pattern flag and a path to multiple files', function () {
+      it('should exit without an error', async function () {
+        await project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        await project.write({
+          app: {
+            templates: {
+              'application.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+              components: {
+                'foo.hbs': '{{fooData}}',
+              },
+            },
+          },
+        });
+
+        let result = await runBin(
+          '--no-error-on-unmatched-pattern',
+          'app/templates/application.hbs',
+          'app/templates/application-1.hbs'
+        );
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toBeTruthy();
+        expect(result.stderr).toBeFalsy();
+      });
+    });
+
     describe('given path to single file with errors', function () {
       it('should print errors', async function () {
         await project.setConfig({


### PR DESCRIPTION
Previously, when the cli was passed multiple patterns and `--no-error-on-unmatched-pattern` was set, any failing pattern would cause the entire CLI call to be aborted. This commit updates things so that the logic is applied on a per-pattern basis, so that any matching patterns are still checked.

This brings ember-template-lint into line with ESLint's `--no-error-on-unmatched-pattern` flag.

Resolves #2758