### PR TITLE
Add new require-strict-mode rule 

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Each rule has emojis denoting:
 | [require-media-caption](./docs/rule/require-media-caption.md)                                             | ✅  |     | ⌨️  |     |
 | [require-presentational-children](./docs/rule/require-presentational-children.md)                         | ✅  |     | ⌨️  |     |
 | [require-splattributes](./docs/rule/require-splattributes.md)                                             |     |     |     |     |
+| [require-strict-mode](./docs/rule/require-strict-mode.md)                                                 |     |     |     |     |
 | [require-valid-alt-text](./docs/rule/require-valid-alt-text.md)                                           | ✅  |     | ⌨️  |     |
 | [require-valid-named-block-naming-format](./docs/rule/require-valid-named-block-naming-format.md)         | ✅  |     |     | 🔧  |
 | [self-closing-void-elements](./docs/rule/self-closing-void-elements.md)                                   |     | 💅  |     | 🔧  |

--- a/docs/rule/require-strict-mode.md
+++ b/docs/rule/require-strict-mode.md
@@ -1,0 +1,49 @@
+# require-strict-mode
+
+Ember's Polaris edition component authoring format is template tag, which makes templates follow "strict mode" semantics.
+
+This rule requires all templates to use strict mode (template tag). Effectively this means you may only have template content in `.gjs`/`.gts` files, not in `.hbs` or `.js`/`.ts`.
+
+## Examples
+
+This rule **forbids** the following:
+
+```hbs
+// button.hbs
+<button>{{yield}}</button>
+```
+
+```js
+// button-test.js
+import { hbs } from 'ember-cli-htmlbars';
+
+test('it renders', async (assert) => {
+  await render(hbs`<Button>Ok</Button>`);
+  // ...
+});
+```
+
+This rule **allows** the following:
+
+```gjs
+// button.gjs
+<template>
+  <button>{{yield}}</button>
+</template>  
+```
+
+```gjs
+// button-test.gjs
+import { hbs } from 'ember-cli-htmlbars';
+import { Button } from 'ember-awesome-button';
+
+test('it renders', async (assert) => {
+  await render(<template><Button>Ok</Button></template>);
+  // ..
+});
+```
+
+## References
+
+- [Template Tag Guide](https://guides.emberjs.com/release/components/template-tag-format/)
+- [Strict Mode RFC](https://rfcs.emberjs.com/id/0496-handlebars-strict-mode/)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -111,6 +111,7 @@ import requiremandatoryroleattributes from './require-mandatory-role-attributes.
 import requiremediacaption from './require-media-caption.js';
 import requirepresentationalchildren from './require-presentational-children.js';
 import requiresplattributes from './require-splattributes.js';
+import requirestrictmode from './require-strict-mode.js';
 import requirevalidalttext from './require-valid-alt-text.js';
 import requirevalidnamedblocknamingformat from './require-valid-named-block-naming-format.js';
 import selfclosingvoidelements from './self-closing-void-elements.js';
@@ -233,6 +234,7 @@ export default {
   'require-media-caption': requiremediacaption,
   'require-presentational-children': requirepresentationalchildren,
   'require-splattributes': requiresplattributes,
+  'require-strict-mode': requirestrictmode,
   'require-valid-alt-text': requirevalidalttext,
   'require-valid-named-block-naming-format': requirevalidnamedblocknamingformat,
   'self-closing-void-elements': selfclosingvoidelements,

--- a/lib/rules/require-strict-mode.js
+++ b/lib/rules/require-strict-mode.js
@@ -1,0 +1,21 @@
+import Rule from './_base.js';
+
+export const ERROR_MESSAGE =
+  'Templates are required to be in strict mode. Consider refactoring to template tag format.';
+
+export default class RequireStrictMode extends Rule {
+  visitor() {
+    return {
+      Template: {
+        exit(node) {
+          if (!this.isStrictMode) {
+            this.log({
+              message: ERROR_MESSAGE,
+              node,
+            });
+          }
+        },
+      },
+    };
+  }
+}

--- a/test/unit/rules/require-strict-mode-test.js
+++ b/test/unit/rules/require-strict-mode-test.js
@@ -1,0 +1,85 @@
+import generateRuleTests from '../../helpers/rule-test-harness.js';
+
+generateRuleTests({
+  name: 'require-strict-mode',
+
+  config: true,
+
+  good: [
+    {
+      template: `<template>hello</template>`,
+      meta: {
+        filePath: 'hello.gjs',
+      },
+    },
+    {
+      template: `import Component from '@glimmer/component';
+
+  export default HelloComponent extends Component {
+    <template>hello</template>
+  }`,
+      meta: {
+        filePath: 'hello.gjs',
+      },
+    },
+  ],
+
+  bad: [
+    {
+      template: `<div>
+  hello
+</div>`,
+      meta: {
+        filePath: 'hello.hbs',
+      },
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 6,
+              "endLine": 3,
+              "filePath": "hello.hbs",
+              "line": 1,
+              "message": "Templates are required to be in strict mode. Consider refactoring to template tag format.",
+              "rule": "require-strict-mode",
+              "severity": 2,
+              "source": "<div>
+            hello
+          </div>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
+        "test('it renders', async (assert) => {",
+        '  await render(hbs`hello`);',
+        '});',
+      ].join('\n'),
+      meta: {
+        filePath: 'hello-test.js',
+      },
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 19,
+              "endColumn": 24,
+              "endLine": 4,
+              "filePath": "hello-test.js",
+              "line": 4,
+              "message": "Templates are required to be in strict mode. Consider refactoring to template tag format.",
+              "rule": "require-strict-mode",
+              "severity": 2,
+              "source": "hello",
+            },
+          ]
+        `);
+      },
+    },
+  ],
+});


### PR DESCRIPTION
This allows teams that have fully adopted template tag to prevent accidentally falling back to hbs.

Branched off #3101, that needs to get merged first! (only the last commit here is relevant to this PR)