### PR TITLE
Fix new rule example in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ If you are opening an issue to request a new feature, please provide:
 
 ```bash
 # create a new rule
-- npm run new:rule rule-name
+- npm run new:rule
 
 # test rule
 - npm run test:jest rule-name


### PR DESCRIPTION
The example did't work, was causing an error:

```
Error: You don't seem to have a generator with the name “ember-template-lint:new-rule,rule-name” installed.
```

There is an interactive prompt for the rule name, so probably shouldn't get passed in the command. Without that the generator works as expected.