### PR TITLE
Fix the no-yield-only rule

### DIFF
--- a/lib/rules/no-yield-only.js
+++ b/lib/rules/no-yield-only.js
@@ -2,18 +2,38 @@ import Rule from './_base.js';
 
 const ERROR_MESSAGE = '{{yield}}-only templates are not allowed';
 
+function isEmptyNode(node) {
+  return (
+    node.type === 'MustacheCommentStatement' ||
+    node.type === 'CommentStatement' ||
+    (node.type === 'TextNode' && !node.chars.trim())
+  );
+}
+
+function isYieldOnly(node) {
+  return (
+    node.type === 'MustacheStatement' && node.path.original === 'yield' && node.params.length === 0
+  );
+}
+
 export default class NoYieldOnly extends Rule {
   visitor() {
-    if (this._rawSource.trim() !== '{{yield}}') {
-      return;
-    }
-
+    let isOnlyYield = false;
     return {
+      Template(node) {
+        const nonEmptyNodes = node.body.filter((n) => !isEmptyNode(n));
+        if (nonEmptyNodes.length === 1 && isYieldOnly(nonEmptyNodes[0])) {
+          // Don't actually trigger here so that we can get potential lint disable declarations
+          isOnlyYield = true;
+        }
+      },
       MustacheStatement(node) {
-        this.log({
-          message: ERROR_MESSAGE,
-          node,
-        });
+        if (isOnlyYield) {
+          this.log({
+            message: ERROR_MESSAGE,
+            node,
+          });
+        }
       },
     };
   }

--- a/test/unit/rules/no-yield-only-test.js
+++ b/test/unit/rules/no-yield-only-test.js
@@ -11,6 +11,7 @@ generateRuleTests({
     '{{#yield}}{{/yield}}',
     '<Yield/>',
     '<yield/>',
+    '{{! template-lint-disable no-yield-only }}{{yield}}',
   ],
 
   bad: [
@@ -65,6 +66,27 @@ generateRuleTests({
             {
               "column": 2,
               "endColumn": 11,
+              "endLine": 2,
+              "filePath": "layout.hbs",
+              "line": 2,
+              "message": "{{yield}}-only templates are not allowed",
+              "rule": "no-yield-only",
+              "severity": 2,
+              "source": "{{yield}}",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: '\n{{! some comment }}  {{yield}}\n     ',
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 21,
+              "endColumn": 30,
               "endLine": 2,
               "filePath": "layout.hbs",
               "line": 2,


### PR DESCRIPTION
The `no-yield-only` rule would only match a template that was just the string `{{yield}}`. If you added a comment, for example, it would start passing. This is especially problematic with the new report-unused-disables functionality.