### PR TITLE
Fix block-indentation not working correctly for GJS files

### DIFF
--- a/lib/linter.js
+++ b/lib/linter.js
@@ -294,6 +294,7 @@ export default class Linter {
             {
               line: coordinates.line,
               column: coordinates.column,
+              columnOffset: coordinates.columnOffset,
               template,
               isEmbedded: true,
               isStrictMode: true,

--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -310,8 +310,11 @@ export default class BlockIndentation extends Rule {
     const hasLeadingContent =
       !isDirectChildOfTemplate || this.hasLeadingContent(node, this.template.body);
     const startColumn = node.loc.start.column;
+
+    // Embedded templates should be indented 1 level past the starting offset (unless the first line)
+    const isStandalone = !this.isEmbedded || !this.isStrictMode;
     const expectedStartColumn =
-      this.columnOffset === 0 || node.loc.start.line === 1
+      (this.columnOffset === 0 && isStandalone) || node.loc.start.line === 1
         ? 0
         : this.columnOffset + this.config.indentation;
 
@@ -387,7 +390,7 @@ export default class BlockIndentation extends Rule {
 
         let warning =
           `Incorrect indentation for \`${displayName}\` beginning at ${startLocation}` +
-          `. Expected \`${display}\` ending at ${endLocation} to be at an indentation of ${expectedEndColumn} but ` +
+          `. Expected \`${display}\` ending at ${endLocation} to be at an indentation of ${expectedEndColumn}, but ` +
           `was found at ${correctedEndColumn}.`;
 
         this.log({
@@ -505,7 +508,7 @@ export default class BlockIndentation extends Rule {
           let startLocation = `L${childStartLine}:C${childStartColumn}`;
           let warning =
             `Incorrect indentation for \`${display}\` beginning at ${startLocation}` +
-            `. Expected \`${display}\` to be at an indentation of ${expectedStartColumn} but ` +
+            `. Expected \`${display}\` to be at an indentation of ${expectedStartColumn}, but ` +
             `was found at ${childStartColumn}.`;
 
           this.log({
@@ -552,7 +555,7 @@ export default class BlockIndentation extends Rule {
         const elseLine = node.program.loc.end.line;
         const fixedNode = this.fixLine(
           lines,
-          elseLine - 1,
+          elseLine - (path ? 1 : node.loc.start.line),
           elseStartColumn,
           expectedStartColumn,
           path
@@ -565,7 +568,7 @@ export default class BlockIndentation extends Rule {
 
         let warning =
           `Incorrect indentation for inverse block of \`{{#${displayName}}}\` beginning at ${startLocation}` +
-          `. Expected \`{{else}}\` starting at ${elseLocation} to be at an indentation of ${expectedStartColumn} but ` +
+          `. Expected \`{{else}}\` starting at ${elseLocation} to be at an indentation of ${expectedStartColumn}, but ` +
           `was found at ${elseStartColumn}.`;
 
         this.log({

--- a/test/acceptance/public-api-test.js
+++ b/test/acceptance/public-api-test.js
@@ -630,7 +630,7 @@ describe('public api', function () {
 
       let expected = {
         message:
-          'Incorrect indentation for `<p>` beginning at L2:C0. Expected `<p>` to be at an indentation of 2 but was found at 0.',
+          'Incorrect indentation for `<p>` beginning at L2:C0. Expected `<p>` to be at an indentation of 2, but was found at 0.',
         filePath: 'some/path/here.hbs',
         isFixable: true,
         line: 2,

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -334,6 +334,110 @@ generateRuleTests({
         filePath: 'layout.js',
       },
     },
+    {
+      template: [
+        '<template>',
+        '  <div class="parent">',
+        '    <div class="child"></div>',
+        '  </div>',
+        '</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+    },
+    {
+      template: [
+        '<template><div class="parent">',
+        '  <div class="child"></div>',
+        '</div></template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+    },
+    {
+      template: [
+        'const MyComponent = <template>',
+        '  <div class="parent">',
+        '    <div class="child"></div>',
+        '  </div>',
+        '</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+    },
+    {
+      template: [
+        'function fetchComponent() {',
+        '  return <template>',
+        '    <div class="parent">',
+        '      <div class="child"></div>',
+        '    </div>',
+        '  </template>',
+        '}',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+    },
+    {
+      template: [
+        'const MyComponent = <template>',
+        '  {{#if foo}}',
+        '    {{foo}}',
+        '  {{else}}',
+        '    {{bar}}',
+        '  {{/if}}',
+        '</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+    },
+    {
+      template: [
+        '<template>{{#if foo}}',
+        '  {{foo}}',
+        '{{else}}',
+        '  {{bar}}',
+        '{{/if}}</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+    },
+    {
+      template: [
+        'const MyComponent = <template>',
+        '  {{#if foo}}',
+        '    {{foo}}',
+        '  {{else if bar}}',
+        '    {{bar}}',
+        '  {{else}}',
+        '    {{baz}}',
+        '  {{/if}}',
+        '</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+    },
+    {
+      template: [
+        '<template>{{#if foo}}',
+        '  {{foo}}',
+        '{{else if bar}}',
+        '  {{bar}}',
+        '{{else}}',
+        '  {{baz}}',
+        '{{/if}}</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+    },
   ],
 
   bad: [
@@ -365,7 +469,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`each\` beginning at L2:C2. Expected \`{{/each}}\` ending at L3:C17 to be at an indentation of 2 but was found at 8.",
+              "message": "Incorrect indentation for \`each\` beginning at L2:C2. Expected \`{{/each}}\` ending at L3:C17 to be at an indentation of 2, but was found at 8.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#each cats as |dog|}}
@@ -389,7 +493,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "Incorrect indentation for \`div\` beginning at L1:C0. Expected \`</div>\` ending at L2:C8 to be at an indentation of 0 but was found at 2.",
+              "message": "Incorrect indentation for \`div\` beginning at L1:C0. Expected \`</div>\` ending at L2:C8 to be at an indentation of 0, but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -413,7 +517,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "Incorrect indentation for \`div\` beginning at L1:C0. Expected \`</div>\` ending at L2:C30 to be at an indentation of 0 but was found at 24.",
+              "message": "Incorrect indentation for \`div\` beginning at L1:C0. Expected \`</div>\` ending at L2:C30 to be at an indentation of 0, but was found at 24.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -437,7 +541,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`<p>\` beginning at L2:C0. Expected \`<p>\` to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`<p>\` beginning at L2:C0. Expected \`<p>\` to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -462,7 +566,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`<p>\` beginning at L2:C0. Expected \`<p>\` to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`<p>\` beginning at L2:C0. Expected \`<p>\` to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if}}
@@ -499,7 +603,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 3,
-              "message": "Incorrect indentation for \`if\` beginning at L3:C2. Expected \`{{/if}}\` ending at L5:C11 to be at an indentation of 2 but was found at 4.",
+              "message": "Incorrect indentation for \`if\` beginning at L3:C2. Expected \`{{/if}}\` ending at L5:C11 to be at an indentation of 2, but was found at 4.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if something}}
@@ -526,7 +630,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`<p>\` beginning at L2:C2. Expected \`<p>\` to be at an indentation of 4 but was found at 2.",
+              "message": "Incorrect indentation for \`<p>\` beginning at L2:C2. Expected \`<p>\` to be at an indentation of 4, but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -551,7 +655,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 3,
-              "message": "Incorrect indentation for \`{{bar}}\` beginning at L3:C0. Expected \`{{bar}}\` to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`{{bar}}\` beginning at L3:C0. Expected \`{{bar}}\` to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -577,7 +681,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 3,
-              "message": "Incorrect indentation for \`{{bar}}\` beginning at L3:C0. Expected \`{{bar}}\` to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`{{bar}}\` beginning at L3:C0. Expected \`{{bar}}\` to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -610,7 +714,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`some-thing\` beginning at L2:C18. Expected \`{{/some-thing}}\` ending at L3:C17 to be at an indentation of 18 but was found at 2.",
+              "message": "Incorrect indentation for \`some-thing\` beginning at L2:C18. Expected \`{{/some-thing}}\` ending at L3:C17 to be at an indentation of 18, but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#some-thing}}
@@ -637,7 +741,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`p\` beginning at L2:C10. Expected \`</p>\` ending at L4:C6 to be at an indentation of 10 but was found at 2.",
+              "message": "Incorrect indentation for \`p\` beginning at L2:C10. Expected \`</p>\` ending at L4:C6 to be at an indentation of 10, but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<p>
@@ -663,7 +767,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`<!-- foo bar baz -->\` beginning at L2:C0. Expected \`<!-- foo bar baz -->\` to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`<!-- foo bar baz -->\` beginning at L2:C0. Expected \`<!-- foo bar baz -->\` to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -688,7 +792,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L1:C0. Expected \`{{else}}\` starting at L2:C2 to be at an indentation of 0 but was found at 2.",
+              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L1:C0. Expected \`{{else}}\` starting at L2:C2 to be at an indentation of 0, but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if foo}}
@@ -728,7 +832,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "Incorrect indentation for \`if\` beginning at L1:C0. Expected \`{{/if}}\` ending at L6:C9 to be at an indentation of 0 but was found at 2.",
+              "message": "Incorrect indentation for \`if\` beginning at L1:C0. Expected \`{{/if}}\` ending at L6:C9 to be at an indentation of 0, but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if foo}}
@@ -757,7 +861,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for inverse block of \`{{#each}}\` beginning at L1:C0. Expected \`{{else}}\` starting at L2:C2 to be at an indentation of 0 but was found at 2.",
+              "message": "Incorrect indentation for inverse block of \`{{#each}}\` beginning at L1:C0. Expected \`{{else}}\` starting at L2:C2 to be at an indentation of 0, but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#each foo as |bar|}}
@@ -795,7 +899,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 4,
-              "message": "Incorrect indentation for \`{{! comment with incorrect indentation }}\` beginning at L4:C4. Expected \`{{! comment with incorrect indentation }}\` to be at an indentation of 2 but was found at 4.",
+              "message": "Incorrect indentation for \`{{! comment with incorrect indentation }}\` beginning at L4:C4. Expected \`{{! comment with incorrect indentation }}\` to be at an indentation of 2, but was found at 4.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -841,7 +945,7 @@ generateRuleTests({
               "line": 1,
               "message": "Incorrect indentation for \`Good morning
           \` beginning at L1:C19. Expected \`Good morning
-          \` to be at an indentation of 2 but was found at 19.",
+          \` to be at an indentation of 2, but was found at 19.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if isMorning}}  Good morning
@@ -884,7 +988,7 @@ generateRuleTests({
               "line": 4,
               "message": "Incorrect indentation for \`Good afternoon
           \` beginning at L4:C4. Expected \`Good afternoon
-          \` to be at an indentation of 2 but was found at 4.",
+          \` to be at an indentation of 2, but was found at 4.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{else if isAfternoon~}}
@@ -909,7 +1013,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`{{! What a comment }}\` beginning at L2:C0. Expected \`{{! What a comment }}\` to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`{{! What a comment }}\` beginning at L2:C0. Expected \`{{! What a comment }}\` to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -935,7 +1039,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "Incorrect indentation for \`{{! bad comment }}\` beginning at L1:C6. Expected \`{{! bad comment }}\` to be at an indentation of 2 but was found at 6.",
+              "message": "Incorrect indentation for \`{{! bad comment }}\` beginning at L1:C6. Expected \`{{! bad comment }}\` to be at an indentation of 2, but was found at 6.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div> {{! bad comment }}
@@ -966,7 +1070,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 3,
-              "message": "Incorrect indentation for \`<span>\` beginning at L3:C0. Expected \`<span>\` to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`<span>\` beginning at L3:C0. Expected \`<span>\` to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if media.isMobile}}
@@ -1006,7 +1110,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "Incorrect indentation for \`if\` beginning at L1:C1. Expected \`{{/if}}\` ending at L2:C7 to be at an indentation of 1 but was found at 0.",
+              "message": "Incorrect indentation for \`if\` beginning at L1:C1. Expected \`{{/if}}\` ending at L2:C7 to be at an indentation of 1, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if foo}}
@@ -1030,7 +1134,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L1:C0. Expected \`{{else}}\` starting at L1:C14 to be at an indentation of 0 but was found at 14.",
+              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L1:C0. Expected \`{{else}}\` starting at L1:C14 to be at an indentation of 0, but was found at 14.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if foo}}foo{{else}}
@@ -1044,7 +1148,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 1,
-              "message": "Incorrect indentation for \`foo\` beginning at L1:C11. Expected \`foo\` to be at an indentation of 2 but was found at 11.",
+              "message": "Incorrect indentation for \`foo\` beginning at L1:C11. Expected \`foo\` to be at an indentation of 2, but was found at 11.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if foo}}foo{{else}}
@@ -1071,7 +1175,7 @@ generateRuleTests({
               "line": 4,
               "message": "Incorrect indentation for \`bar
           \` beginning at L4:C4. Expected \`bar
-          \` to be at an indentation of 2 but was found at 4.",
+          \` to be at an indentation of 2, but was found at 4.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if foo}}
@@ -1114,7 +1218,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 4,
-              "message": "Incorrect indentation for \`{{#if}}\` beginning at L4:C4. Expected \`{{#if}}\` to be at an indentation of 2 but was found at 4.",
+              "message": "Incorrect indentation for \`{{#if}}\` beginning at L4:C4. Expected \`{{#if}}\` to be at an indentation of 2, but was found at 4.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if foo}}
@@ -1201,7 +1305,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`{{#foobar.baz}}\` beginning at L2:C3. Expected \`{{#foobar.baz}}\` to be at an indentation of 2 but was found at 3.",
+              "message": "Incorrect indentation for \`{{#foobar.baz}}\` beginning at L2:C3. Expected \`{{#foobar.baz}}\` to be at an indentation of 2, but was found at 3.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#foo bar as |foobar|}}
@@ -1216,7 +1320,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 3,
-              "message": "Incorrect indentation for \`{{foobar.baz}}\` beginning at L3:C3. Expected \`{{foobar.baz}}\` to be at an indentation of 2 but was found at 3.",
+              "message": "Incorrect indentation for \`{{foobar.baz}}\` beginning at L3:C3. Expected \`{{foobar.baz}}\` to be at an indentation of 2, but was found at 3.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#foo bar as |foobar|}}
@@ -1241,7 +1345,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`<!-- Comment -->\` beginning at L2:C0. Expected \`<!-- Comment -->\` to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`<!-- Comment -->\` beginning at L2:C0. Expected \`<!-- Comment -->\` to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -1265,7 +1369,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`{{! Comment }}\` beginning at L2:C0. Expected \`{{! Comment }}\` to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`{{! Comment }}\` beginning at L2:C0. Expected \`{{! Comment }}\` to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -1292,7 +1396,7 @@ generateRuleTests({
               "filePath": "layout.hbs",
               "isFixable": true,
               "line": 2,
-              "message": "Incorrect indentation for \`test\` beginning at L2:C0. Expected \`test\` to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`test\` beginning at L2:C0. Expected \`test\` to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div>
@@ -1524,7 +1628,7 @@ generateRuleTests({
               "filePath": "layout.js",
               "isFixable": true,
               "line": 4,
-              "message": "Incorrect indentation for \`div\` beginning at L1:C2. Expected \`</div>\` ending at L3:C6 to be at an indentation of 2 but was found at 0.",
+              "message": "Incorrect indentation for \`div\` beginning at L1:C2. Expected \`</div>\` ending at L3:C6 to be at an indentation of 2, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div class="parent">
@@ -1538,7 +1642,7 @@ generateRuleTests({
               "filePath": "layout.js",
               "isFixable": true,
               "line": 5,
-              "message": "Incorrect indentation for \`<div>\` beginning at L2:C0. Expected \`<div>\` to be at an indentation of 4 but was found at 0.",
+              "message": "Incorrect indentation for \`<div>\` beginning at L2:C0. Expected \`<div>\` to be at an indentation of 4, but was found at 0.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "<div class="parent">
@@ -1612,7 +1716,7 @@ generateRuleTests({
               "filePath": "layout.js",
               "isFixable": true,
               "line": 7,
-              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L2:C3. Expected \`{{else}}\` starting at L4:C4 to be at an indentation of 3 but was found at 4.",
+              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L2:C3. Expected \`{{else}}\` starting at L4:C4 to be at an indentation of 3, but was found at 4.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if foo}}
@@ -1630,7 +1734,7 @@ generateRuleTests({
               "filePath": "layout.js",
               "isFixable": true,
               "line": 5,
-              "message": "Incorrect indentation for \`if\` beginning at L2:C3. Expected \`{{/if}}\` ending at L8:C11 to be at an indentation of 3 but was found at 4.",
+              "message": "Incorrect indentation for \`if\` beginning at L2:C3. Expected \`{{/if}}\` ending at L8:C11 to be at an indentation of 3, but was found at 4.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if foo}}
@@ -1648,7 +1752,7 @@ generateRuleTests({
               "filePath": "layout.js",
               "isFixable": true,
               "line": 6,
-              "message": "Incorrect indentation for \`{{foo}}\` beginning at L3:C4. Expected \`{{foo}}\` to be at an indentation of 5 but was found at 4.",
+              "message": "Incorrect indentation for \`{{foo}}\` beginning at L3:C4. Expected \`{{foo}}\` to be at an indentation of 5, but was found at 4.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{#if foo}}
@@ -1666,7 +1770,460 @@ generateRuleTests({
               "filePath": "layout.js",
               "isFixable": true,
               "line": 9,
-              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L4:C4. Expected \`{{else}}\` starting at L6:C2 to be at an indentation of 4 but was found at 2.",
+              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L4:C4. Expected \`{{else}}\` starting at L6:C2 to be at an indentation of 4, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{else if bar}}
+                {{bar}}
+            {{else}}
+                {{baz}}
+              ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: [
+        '<template>',
+        '<div class="parent">',
+        '  <div class="child"></div>',
+        '</div>',
+        '</template>',
+      ].join('\n'),
+      fixedTemplate: [
+        '<template>',
+        '  <div class="parent">',
+        '    <div class="child"></div>',
+        '  </div>',
+        '</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 6,
+              "endLine": 4,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 2,
+              "message": "Incorrect indentation for \`<div>\` beginning at L2:C0. Expected \`<div>\` to be at an indentation of 2, but was found at 0.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class="parent">
+            <div class="child"></div>
+          </div>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: [
+        '<template><div class="parent">',
+        '<div class="child"></div>',
+        '</div></template>',
+      ].join('\n'),
+      fixedTemplate: [
+        '<template><div class="parent">',
+        '  <div class="child"></div>',
+        '</div></template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 6,
+              "endLine": 3,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 2,
+              "message": "Incorrect indentation for \`<div>\` beginning at L2:C0. Expected \`<div>\` to be at an indentation of 2, but was found at 0.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class="parent">
+          <div class="child"></div>
+          </div>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      // Root start & end block in embedded template can be fixed
+      template: [
+        'const MyComponent = <template>',
+        '<div class="parent">',
+        '  <div class="child"></div>',
+        ' </div>',
+        '</template>',
+      ].join('\n'),
+      fixedTemplate: [
+        'const MyComponent = <template>',
+        '  <div class="parent">',
+        '    <div class="child"></div>',
+        '  </div>',
+        '</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 7,
+              "endLine": 4,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 2,
+              "message": "Incorrect indentation for \`<div>\` beginning at L2:C0. Expected \`<div>\` to be at an indentation of 2, but was found at 0.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class="parent">
+            <div class="child"></div>
+           </div>",
+            },
+            {
+              "column": 0,
+              "endColumn": 7,
+              "endLine": 4,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 2,
+              "message": "Incorrect indentation for \`div\` beginning at L2:C0. Expected \`</div>\` ending at L4:C7 to be at an indentation of 0, but was found at 1.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class="parent">
+            <div class="child"></div>
+           </div>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      // Root start block in embedded template with columnOffset can be fixed
+      template: [
+        'function fetchComponent() {',
+        '  return <template>',
+        '  <div class="parent">',
+        '      <div class="child"></div>',
+        '    </div>',
+        '  </template>',
+        '}',
+      ].join('\n'),
+      fixedTemplate: [
+        'function fetchComponent() {',
+        '  return <template>',
+        '    <div class="parent">',
+        '      <div class="child"></div>',
+        '    </div>',
+        '  </template>',
+        '}',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 2,
+              "endColumn": 10,
+              "endLine": 5,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 3,
+              "message": "Incorrect indentation for \`<div>\` beginning at L2:C2. Expected \`<div>\` to be at an indentation of 4, but was found at 2.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class="parent">
+                <div class="child"></div>
+              </div>",
+            },
+            {
+              "column": 2,
+              "endColumn": 10,
+              "endLine": 5,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 3,
+              "message": "Incorrect indentation for \`div\` beginning at L2:C2. Expected \`</div>\` ending at L4:C10 to be at an indentation of 2, but was found at 4.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class="parent">
+                <div class="child"></div>
+              </div>",
+            },
+            {
+              "column": 6,
+              "endColumn": 10,
+              "endLine": 5,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 4,
+              "message": "Incorrect indentation for \`<div>\` beginning at L3:C6. Expected \`<div>\` to be at an indentation of 4, but was found at 6.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "<div class="parent">
+                <div class="child"></div>
+              </div>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      // Root else block in embedded template can be fixed
+      template: [
+        '<template>',
+        '  {{#if foo}}',
+        '    {{foo}}',
+        '    {{else if bar}}',
+        '    {{bar}}',
+        '  {{/if}}',
+        '</template>',
+      ].join('\n'),
+      fixedTemplate: [
+        '<template>',
+        '  {{#if foo}}',
+        '    {{foo}}',
+        '  {{else if bar}}',
+        '    {{bar}}',
+        '  {{/if}}',
+        '</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 4,
+              "endColumn": 9,
+              "endLine": 6,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 4,
+              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L2:C2. Expected \`{{else}}\` starting at L4:C4 to be at an indentation of 2, but was found at 4.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+              {{foo}}
+              {{else if bar}}
+              {{bar}}
+            {{/if}}",
+            },
+            {
+              "column": 4,
+              "endColumn": 2,
+              "endLine": 6,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 5,
+              "message": "Incorrect indentation for \`{{bar}}\` beginning at L5:C4. Expected \`{{bar}}\` to be at an indentation of 6, but was found at 4.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{else if bar}}
+              {{bar}}
+            ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      // Nested else block in embedded template can be fixed
+      template: [
+        '<template>',
+        '  {{#if a}}',
+        '    {{#if foo}}',
+        '      {{foo}}',
+        '      {{else if bar}}',
+        '      {{bar}}',
+        '    {{/if}}',
+        '  {{/if}}',
+        '</template>',
+      ].join('\n'),
+      fixedTemplate: [
+        '<template>',
+        '  {{#if a}}',
+        '    {{#if foo}}',
+        '      {{foo}}',
+        '    {{else if bar}}',
+        '      {{bar}}',
+        '    {{/if}}',
+        '  {{/if}}',
+        '</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 6,
+              "endColumn": 11,
+              "endLine": 7,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 5,
+              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L3:C4. Expected \`{{else}}\` starting at L5:C6 to be at an indentation of 4, but was found at 6.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+                {{foo}}
+                {{else if bar}}
+                {{bar}}
+              {{/if}}",
+            },
+            {
+              "column": 6,
+              "endColumn": 4,
+              "endLine": 7,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 6,
+              "message": "Incorrect indentation for \`{{bar}}\` beginning at L6:C6. Expected \`{{bar}}\` to be at an indentation of 8, but was found at 6.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{else if bar}}
+                {{bar}}
+              ",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      // Messed up indentation with if/else in embedded template can be fixed
+      template: [
+        '<template>',
+        '   {{#if foo}}',
+        '    {{foo}}',
+        '    {{else if bar}}',
+        '      {{bar}}',
+        '  {{else}}',
+        '      {{baz}}',
+        '    {{/if}}',
+        '</template>',
+      ].join('\n'),
+      fixedTemplate: [
+        '<template>',
+        '  {{#if foo}}',
+        '    {{foo}}',
+        '  {{else if bar}}',
+        '    {{bar}}',
+        '  {{else}}',
+        '    {{baz}}',
+        '  {{/if}}',
+        '</template>',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.gjs',
+      },
+
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 3,
+              "endColumn": 11,
+              "endLine": 8,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 2,
+              "message": "Incorrect indentation for \`{{#if}}\` beginning at L2:C3. Expected \`{{#if}}\` to be at an indentation of 2, but was found at 3.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+              {{foo}}
+              {{else if bar}}
+                {{bar}}
+            {{else}}
+                {{baz}}
+              {{/if}}",
+            },
+            {
+              "column": 4,
+              "endColumn": 11,
+              "endLine": 8,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 4,
+              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L2:C3. Expected \`{{else}}\` starting at L4:C4 to be at an indentation of 3, but was found at 4.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+              {{foo}}
+              {{else if bar}}
+                {{bar}}
+            {{else}}
+                {{baz}}
+              {{/if}}",
+            },
+            {
+              "column": 3,
+              "endColumn": 11,
+              "endLine": 8,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 2,
+              "message": "Incorrect indentation for \`if\` beginning at L2:C3. Expected \`{{/if}}\` ending at L8:C11 to be at an indentation of 3, but was found at 4.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+              {{foo}}
+              {{else if bar}}
+                {{bar}}
+            {{else}}
+                {{baz}}
+              {{/if}}",
+            },
+            {
+              "column": 4,
+              "endColumn": 11,
+              "endLine": 8,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 3,
+              "message": "Incorrect indentation for \`{{foo}}\` beginning at L3:C4. Expected \`{{foo}}\` to be at an indentation of 5, but was found at 4.",
+              "rule": "block-indentation",
+              "severity": 2,
+              "source": "{{#if foo}}
+              {{foo}}
+              {{else if bar}}
+                {{bar}}
+            {{else}}
+                {{baz}}
+              {{/if}}",
+            },
+            {
+              "column": 2,
+              "endColumn": 4,
+              "endLine": 8,
+              "filePath": "layout.gjs",
+              "isFixable": true,
+              "line": 6,
+              "message": "Incorrect indentation for inverse block of \`{{#if}}\` beginning at L4:C4. Expected \`{{else}}\` starting at L6:C2 to be at an indentation of 4, but was found at 2.",
               "rule": "block-indentation",
               "severity": 2,
               "source": "{{else if bar}}


### PR DESCRIPTION
# Reason
Fixes https://github.com/ember-template-lint/ember-template-lint/issues/3134. Related to https://github.com/ember-template-lint/ember-template-lint/pull/2838, where I used `columnOffset > 0` as check for whether a template is embedded or not, but this is not necessarily the case.