### PR TITLE
[js, ts] Fix columnOffset of embedded 'backtick' template from 'return'

### DIFF
--- a/lib/helpers/rule-test-harness.js
+++ b/lib/helpers/rule-test-harness.js
@@ -40,18 +40,19 @@ const ALLOWED_GENERATE_RULE_TEST_PROPERTIES = new Set([
   'testMethod',
 ]);
 
-const ALLOWED_TEST_CASE_PROPERTIES_GOOD = new Set(['config', 'meta', 'name', 'template']);
+const ALLOWED_TEST_CASE_PROPERTIES_GOOD = new Set(['config', 'focus', 'meta', 'name', 'template']);
 
 const ALLOWED_TEST_CASE_PROPERTIES_BAD = new Set([
   'config',
   'fixedTemplate', // Only in bad test cases.
+  'focus',
   'meta',
   'name',
   'result',
   'results',
+  'skipDisabledTests',
   'template',
   'verifyResults',
-  'skipDisabledTests',
 ]);
 
 const ALLOWED_TEST_CASE_PROPERTIES_ERROR = new Set([

--- a/lib/template-info.js
+++ b/lib/template-info.js
@@ -169,6 +169,15 @@ export function templateInfoForScript(source) {
         currentIndentation.pop();
       },
     },
+    ReturnStatement: {
+      enter(path) {
+        let indent = path.node.loc.start.column;
+        currentIndentation.push(indent);
+      },
+      exit() {
+        currentIndentation.pop();
+      },
+    },
     TaggedTemplateExpression(path) {
       if (path.node.tag.name !== 'hbs') {
         return;

--- a/test/acceptance/rule-test.js
+++ b/test/acceptance/rule-test.js
@@ -402,7 +402,7 @@ describe('rule public api', function () {
         good: [{ foo: true }],
       })
     ).toThrowErrorMatchingInlineSnapshot(
-      `[AssertionError: Unexpected property passed to good test case: foo. Expected one of: config, meta, name, template.]`
+      `[AssertionError: Unexpected property passed to good test case: foo. Expected one of: config, focus, meta, name, template.]`
     );
   });
 
@@ -412,7 +412,7 @@ describe('rule public api', function () {
         bad: [{ foo: true }],
       })
     ).toThrowErrorMatchingInlineSnapshot(
-      `[AssertionError: Unexpected property passed to bad test case: foo. Expected one of: config, fixedTemplate, meta, name, result, results, template, verifyResults, skipDisabledTests.]`
+      `[AssertionError: Unexpected property passed to bad test case: foo. Expected one of: config, fixedTemplate, focus, meta, name, result, results, skipDisabledTests, template, verifyResults.]`
     );
   });
 

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -252,6 +252,24 @@ generateRuleTests({
       template: [
         "import { hbs } from 'ember-cli-htmlbars';",
         '',
+        'hooks.beforeEach(function() {',
+        '  this.renderTemplate = () => {',
+        '    return render(hbs`',
+        '      <div class="parent">',
+        '        <div class="child"></div>',
+        '      </div>',
+        '    `);',
+        '  };',
+        '});',
+      ].join('\n'),
+      meta: {
+        filePath: 'layout.js',
+      },
+    },
+    {
+      template: [
+        "import { hbs } from 'ember-cli-htmlbars';",
+        '',
         "test('it renders', async (assert) => {",
         '  await render(hbs`<div class="parent">',
         '    <div class="child"></div>',

--- a/test/unit/temp-babel-backtick-extract-test.js
+++ b/test/unit/temp-babel-backtick-extract-test.js
@@ -10,6 +10,18 @@ const simpleTest = [
   '});',
 ].join('\n');
 
+const returnTest = [
+  'hooks.beforeEach(function() {',
+  '  this.renderTemplate = () => {',
+  '    return render(hbs`',
+  '      <div class="parent">',
+  '        <div class="child"></div>',
+  '      </div>',
+  '    `);',
+  '  };',
+  '});',
+].join('\n');
+
 const multiTemplate = [
   'export const Name = hbs`',
   '  {{@name}}',
@@ -39,6 +51,27 @@ describe('template-info', () => {
               <div class="child"></div>
             </div>
           ",
+          },
+        ]
+      `);
+    });
+
+    it('return', () => {
+      expect(templateInfoForScript(returnTest)).toMatchInlineSnapshot(`
+        [
+          {
+            "column": 22,
+            "columnOffset": 4,
+            "end": 163,
+            "isEmbedded": true,
+            "isStrictMode": false,
+            "line": 3,
+            "start": 84,
+            "template": "
+              <div class="parent">
+                <div class="child"></div>
+              </div>
+            ",
           },
         ]
       `);


### PR DESCRIPTION
# Reason
Fixes https://github.com/ember-template-lint/ember-template-lint/issues/3164. While I was figuring out how to run a single test, I ran into the problem that `focus: true` from https://github.com/ember-template-lint/ember-template-lint/pull/1169 was complaining that the key was not allowed, so I fixed that as well.