### PR TITLE
Support compound extensions ending in .hbs

### DIFF
--- a/lib/-private/file-path.js
+++ b/lib/-private/file-path.js
@@ -15,7 +15,7 @@ function isGlimmerScript(ext) {
 }
 
 function isHBS(ext) {
-  return ext === HBS;
+  return ext.endsWith(HBS);
 }
 
 function isHTML(ext) {

--- a/test/unit/-private/file-path-test.js
+++ b/test/unit/-private/file-path-test.js
@@ -1,0 +1,154 @@
+import { parseFilePath, canProcessFile, processFile } from '../../../lib/-private/file-path.js';
+import { vi } from 'vitest';
+
+describe('file-path', function () {
+  describe('parseFilePath', function () {
+    it('correctly parses .hbs file paths', function () {
+      const { base, dir, ext, name } = parseFilePath('src/components/button.hbs');
+      expect(base).toBe('button.hbs');
+      expect(dir).toBe('src/components');
+      expect(ext).toBe('.hbs');
+      expect(name).toBe('button');
+    });
+
+    it('correctly parses nested .hbs file paths', function () {
+      const { base, dir, ext, name } = parseFilePath(
+        'app/templates/components/nested/path/button.hbs'
+      );
+      expect(base).toBe('button.hbs');
+      expect(dir).toBe('app/templates/components/nested/path');
+      expect(ext).toBe('.hbs');
+      expect(name).toBe('button');
+    });
+
+    it('correctly parses compound .hbs file paths', function () {
+      const { base, dir, ext, name } = parseFilePath('src/components/button.test.hbs');
+      expect(base).toBe('button.test.hbs');
+      expect(dir).toBe('src/components');
+      expect(ext).toBe('.test.hbs');
+      expect(name).toBe('button');
+    });
+
+    it('correctly parses deeply nested compound .hbs file paths', function () {
+      const { base, dir, ext, name } = parseFilePath(
+        'app/templates/components/button.special.test.hbs'
+      );
+      expect(base).toBe('button.special.test.hbs');
+      expect(dir).toBe('app/templates/components');
+      expect(ext).toBe('.special.test.hbs');
+      expect(name).toBe('button');
+    });
+  });
+
+  describe('canProcessFile', function () {
+    it('returns false for empty file paths', function () {
+      expect(canProcessFile('')).toBe(false);
+      expect(canProcessFile(null)).toBe(false);
+      expect(canProcessFile(undefined)).toBe(false);
+    });
+
+    it('returns true for .hbs files', function () {
+      expect(canProcessFile('template.hbs')).toBe(true);
+      expect(canProcessFile('path/to/template.hbs')).toBe(true);
+      expect(canProcessFile('app/templates/components/button.hbs')).toBe(true);
+    });
+
+    it('returns true for compound .hbs files', function () {
+      expect(canProcessFile('template.test.hbs')).toBe(true);
+      expect(canProcessFile('path/to/template.special.hbs')).toBe(true);
+      expect(canProcessFile('app/templates/components/button.test.hbs')).toBe(true);
+      expect(canProcessFile('app/templates/components/button.special.test.hbs')).toBe(true);
+    });
+
+    it('returns true for other supported file types', function () {
+      // Glimmer script files
+      expect(canProcessFile('component.gjs')).toBe(true);
+      expect(canProcessFile('component.gts')).toBe(true);
+
+      // HTML files
+      expect(canProcessFile('template.html')).toBe(true);
+
+      // JavaScript and TypeScript files (soon deprecated)
+      expect(canProcessFile('script.js')).toBe(true);
+      expect(canProcessFile('script.ts')).toBe(true);
+
+      // TypeScript declaration files
+      expect(canProcessFile('types.d.ts')).toBe(true);
+      expect(canProcessFile('app.css.d.ts')).toBe(true);
+    });
+
+    it('returns false for unsupported file extensions', function () {
+      expect(canProcessFile('file.txt')).toBe(false);
+      expect(canProcessFile('file.css')).toBe(false);
+      expect(canProcessFile('file.json')).toBe(false);
+      expect(canProcessFile('file.md')).toBe(false);
+      expect(canProcessFile('file.xml')).toBe(false);
+    });
+  });
+
+  describe('processFile', function () {
+    it('processes .hbs files as templates', async function () {
+      const tasks = {
+        template: vi.fn().mockResolvedValue('template result'),
+        glimmerScript: vi.fn(),
+        script: vi.fn(),
+        default: vi.fn(),
+      };
+
+      const result = await processFile('template.hbs', tasks);
+      expect(result).toBe('template result');
+      expect(tasks.template).toHaveBeenCalled();
+      expect(tasks.glimmerScript).not.toHaveBeenCalled();
+      expect(tasks.script).not.toHaveBeenCalled();
+      expect(tasks.default).not.toHaveBeenCalled();
+    });
+
+    it('processes nested .hbs files as templates', async function () {
+      const tasks = {
+        template: vi.fn().mockResolvedValue('template result'),
+        glimmerScript: vi.fn(),
+        script: vi.fn(),
+        default: vi.fn(),
+      };
+
+      const result = await processFile('app/templates/components/button.hbs', tasks);
+      expect(result).toBe('template result');
+      expect(tasks.template).toHaveBeenCalled();
+      expect(tasks.glimmerScript).not.toHaveBeenCalled();
+      expect(tasks.script).not.toHaveBeenCalled();
+      expect(tasks.default).not.toHaveBeenCalled();
+    });
+
+    it('processes compound .hbs files as templates', async function () {
+      const tasks = {
+        template: vi.fn().mockResolvedValue('template result'),
+        glimmerScript: vi.fn(),
+        script: vi.fn(),
+        default: vi.fn(),
+      };
+
+      const result = await processFile('app/templates/components/button.test.hbs', tasks);
+      expect(result).toBe('template result');
+      expect(tasks.template).toHaveBeenCalled();
+      expect(tasks.glimmerScript).not.toHaveBeenCalled();
+      expect(tasks.script).not.toHaveBeenCalled();
+      expect(tasks.default).not.toHaveBeenCalled();
+    });
+
+    it('processes deeply nested compound .hbs files as templates', async function () {
+      const tasks = {
+        template: vi.fn().mockResolvedValue('template result'),
+        glimmerScript: vi.fn(),
+        script: vi.fn(),
+        default: vi.fn(),
+      };
+
+      const result = await processFile('app/templates/components/button.special.test.hbs', tasks);
+      expect(result).toBe('template result');
+      expect(tasks.template).toHaveBeenCalled();
+      expect(tasks.glimmerScript).not.toHaveBeenCalled();
+      expect(tasks.script).not.toHaveBeenCalled();
+      expect(tasks.default).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Issue
The linter currently only recognizes files with exactly `.hbs` extension, but fails to process files with compound extensions like `.component.hbs`. This affects users who need to use compound extensions for their Handlebars templates.
Resolves #3162 

## Current Behavior
When running `ember-template-lint --fix` on files with compound extensions (e.g., `*.component.hbs`), the linter fails to process them because the file extension detection is too strict.

## Expected Behavior
The linter should process any file that ends with `.hbs`, regardless of additional extensions before it (e.g., `.test.hbs`, `.component.hbs`, etc.).

## Technical Details
The issue is in `lib/-private/file-path.js` where the `isHBS` function performs an exact match:

```javascript
function isHBS(ext) {
  return ext === HBS;  // HBS is '.hbs'
}
```

This should be changed to:

```javascript
function isHBS(ext) {
  return ext.endsWith(HBS);
}
```

## Impact
This affects users who:
1. Use compound extensions for their Handlebars templates
2. Follow naming conventions that require additional extensions

## Environment
- ember-template-lint version: 7.0.2
- Node.js version: ^18.18.0 || >= 20.9.0