### PR TITLE
fix: support compound extensions when globbing

### DIFF
--- a/lib/-private/file-path.js
+++ b/lib/-private/file-path.js
@@ -6,7 +6,7 @@ const HBS = '.hbs';
 const HTML = '.html';
 export const SOON_DEPRECATED = ['.js', '.ts'];
 
-function isDTS(ext) {
+export function isDTS(ext) {
   return ext.endsWith(DTS);
 }
 
@@ -47,7 +47,7 @@ export function canProcessFile(filePath) {
  *
  * @return
  *
- * An object with `base`, `dir`, `ext`, and `name`.
+ * An object with `base`, `dir`, `ext`, `shortExt`, and `name`.
  *
  * @example
  *
@@ -55,14 +55,17 @@ export function canProcessFile(filePath) {
  * const filePath = 'src/components/navigation-menu.d.ts';
  * const { base, dir, ext, name } = parseFilePath(filePath);
  *
- * // base -> 'navigation-menu.d.ts'
- * // dir  -> 'src/components'
- * // ext  -> '.d.ts'
- * // name -> 'navigation-menu'
+ * // base     -> 'navigation-menu.d.ts'
+ * // dir      -> 'src/components'
+ * // ext      -> '.d.ts'
+ * // shortExt -> '.ts'
+ * // name     -> 'navigation-menu'
  * ```
  */
 export function parseFilePath(filePath) {
   let { base, dir, ext, name } = parse(filePath);
+
+  const shortExt = ext;
 
   // eslint-disable-next-line no-constant-condition
   while (true) {
@@ -76,7 +79,7 @@ export function parseFilePath(filePath) {
     name = fileName;
   }
 
-  return { base, dir, ext, name };
+  return { base, dir, ext, shortExt, name };
 }
 
 export async function processFile(filePath = '', tasks) {

--- a/lib/helpers/cli.js
+++ b/lib/helpers/cli.js
@@ -8,7 +8,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import yargs from 'yargs';
 
-import { parseFilePath, SOON_DEPRECATED } from '../-private/file-path.js';
+import { parseFilePath, SOON_DEPRECATED, isDTS } from '../-private/file-path.js';
 import camelize from './camelize.js';
 
 const STDIN = '/dev/stdin';
@@ -294,9 +294,9 @@ function executeGlobby(workingDir, pattern, ignore) {
     ignore[0] === false ? { cwd: workingDir } : { cwd: workingDir, gitignore: true, ignore };
 
   return globbySync(pattern, options).filter((filePath) => {
-    const { ext } = parseFilePath(filePath);
+    const { shortExt, ext } = parseFilePath(filePath);
 
-    return supportedExtensions.has(ext);
+    return supportedExtensions.has(shortExt) && !isDTS(ext);
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-template-lint",
-  "version": "7.0.5",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ember-template-lint",
-      "version": "7.0.5",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.26.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-template-lint",
-  "version": "6.1.0",
+  "version": "7.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ember-template-lint",
-      "version": "6.1.0",
+      "version": "7.0.5",
       "license": "MIT",
       "dependencies": {
         "@babel/generator": "^7.26.9",

--- a/test/acceptance/cli-test.js
+++ b/test/acceptance/cli-test.js
@@ -477,6 +477,32 @@ describe('ember-template-lint executable', function () {
       });
     });
 
+    describe('given wildcard path resolving to single file with compound extension', function () {
+      it('should print errors', async function () {
+        await project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        await project.write({
+          app: {
+            templates: {
+              'application.example.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+              components: {
+                'foo.hbs': '{{fooData}}',
+              },
+            },
+          },
+        });
+
+        let result = await runBin('app/templates/*');
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toBeTruthy();
+        expect(result.stderr).toBeFalsy();
+      });
+    });
+
     describe('given directory path', function () {
       it('should print errors', async function () {
         await project.setConfig({
@@ -503,6 +529,45 @@ describe('ember-template-lint executable', function () {
           	.hbs: 2
 
           app/templates/application.hbs
+            1:4  error  Non-translated string used  no-bare-strings
+            1:25  error  Non-translated string used  no-bare-strings
+
+          ✖ 2 problems (2 errors, 0 warnings)"
+        `);
+        expect(result.stderr).toBeFalsy();
+      });
+    });
+
+    describe('given directory path containing file with compound extension', function () {
+      it('should print errors', async function () {
+        await project.setConfig({
+          rules: {
+            'no-bare-strings': true,
+          },
+        });
+        await project.write({
+          app: {
+            templates: {
+              'application.example.hbs': '<h2>Here too!!</h2> <div>Bare strings are bad...</div>',
+              'index.ts': '// not ignored',
+              'index.d.ts': 'ignored',
+              components: {
+                'foo.hbs': '{{fooData}}',
+              },
+            },
+          },
+        });
+
+        let result = await runBin('app');
+
+        expect(result.exitCode).toEqual(1);
+        expect(result.stdout).toMatchInlineSnapshot(`
+          "Linting 3 Total Files with TemplateLint
+          	.example.hbs: 1
+          	.ts: 1
+          	.hbs: 1
+
+          app/templates/application.example.hbs
             1:4  error  Non-translated string used  no-bare-strings
             1:25  error  Non-translated string used  no-bare-strings
 

--- a/test/unit/-private/file-path-test.js
+++ b/test/unit/-private/file-path-test.js
@@ -1,4 +1,9 @@
-import { parseFilePath, canProcessFile, processFile, isDTS } from '../../../lib/-private/file-path.js';
+import {
+  parseFilePath,
+  canProcessFile,
+  processFile,
+  isDTS,
+} from '../../../lib/-private/file-path.js';
 import { vi } from 'vitest';
 
 describe('file-path', function () {
@@ -152,12 +157,12 @@ describe('file-path', function () {
     });
   });
 
-  describe('isDTS', function() {
-    it("matches extensions ending in .d.ts", () => {
-      expect(isDTS(".d.ts")).toBe(true);
-      expect(isDTS(".compound.d.ts")).toBe(true);
-      expect(isDTS(".ts")).toBe(false);
-      expect(isDTS(".d.js")).toBe(false);
+  describe('isDTS', function () {
+    it('matches extensions ending in .d.ts', () => {
+      expect(isDTS('.d.ts')).toBe(true);
+      expect(isDTS('.compound.d.ts')).toBe(true);
+      expect(isDTS('.ts')).toBe(false);
+      expect(isDTS('.d.js')).toBe(false);
     });
   });
 });

--- a/test/unit/-private/file-path-test.js
+++ b/test/unit/-private/file-path-test.js
@@ -1,4 +1,4 @@
-import { parseFilePath, canProcessFile, processFile } from '../../../lib/-private/file-path.js';
+import { parseFilePath, canProcessFile, processFile, isDTS } from '../../../lib/-private/file-path.js';
 import { vi } from 'vitest';
 
 describe('file-path', function () {
@@ -149,6 +149,15 @@ describe('file-path', function () {
       expect(tasks.glimmerScript).not.toHaveBeenCalled();
       expect(tasks.script).not.toHaveBeenCalled();
       expect(tasks.default).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('isDTS', function() {
+    it("matches extensions ending in .d.ts", () => {
+      expect(isDTS(".d.ts")).toBe(true);
+      expect(isDTS(".compound.d.ts")).toBe(true);
+      expect(isDTS(".ts")).toBe(false);
+      expect(isDTS(".d.js")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
Fixes #3166 

- add `shortExt` to `parseFilePath`
- use `shortExt` in `executeGlobby`
- export & add tests for `isDTS` 
- exclude `.d.ts` in `executeGlobby`
- add tests for templates with compound file extensions in `test/acceptance/cli-test.js`
  - these new tests fail when using `ext` as current behavior does in `executeGlobby`
- ~~`package-lock.json` updated via `npm install`; looks like version number only~~