### PR TITLE
fix #3171 False positive in TypeScript files

### DIFF
--- a/lib/-private/file-path.js
+++ b/lib/-private/file-path.js
@@ -83,18 +83,20 @@ export function parseFilePath(filePath) {
 }
 
 export async function processFile(filePath = '', tasks) {
-  const { ext } = parseFilePath(filePath);
+  const { ext, shortExt } = parseFilePath(filePath);
 
-  if (isGlimmerScript(ext)) {
-    return await tasks.glimmerScript();
-  }
+  for (let extension of [ext, shortExt]) {
+    if (isGlimmerScript(extension)) {
+      return await tasks.glimmerScript();
+    }
 
-  if (isHBS(ext) || isHTML(ext)) {
-    return await tasks.template();
-  }
+    if (isHBS(extension) || isHTML(extension)) {
+      return await tasks.template();
+    }
 
-  if (isScript(ext)) {
-    return await tasks.script();
+    if (isScript(extension)) {
+      return await tasks.script();
+    }
   }
 
   return await tasks.default();

--- a/test/unit/-private/file-path-test.js
+++ b/test/unit/-private/file-path-test.js
@@ -92,6 +92,21 @@ describe('file-path', function () {
   });
 
   describe('processFile', function () {
+    it('execute script task .ts file has complex extension', async function () {
+      const tasks = {
+        template: vi.fn(),
+        glimmerScript: vi.fn(),
+        script: vi.fn().mockResolvedValue('template result'),
+        default: vi.fn(),
+      };
+
+      const result = await processFile('image.helper.ts', tasks);
+      expect(result).toBe('template result');
+      expect(tasks.template).not.toHaveBeenCalled();
+      expect(tasks.glimmerScript).not.toHaveBeenCalled();
+      expect(tasks.script).toHaveBeenCalled();
+      expect(tasks.default).not.toHaveBeenCalled();
+    });
     it('processes .hbs files as templates', async function () {
       const tasks = {
         template: vi.fn().mockResolvedValue('template result'),


### PR DESCRIPTION
Resolves https://github.com/ember-template-lint/ember-template-lint/issues/3171

Adding fallback iteration with `short extension` before resolving default behaviour