### PR TITLE
fix mode for no-action-modifier with PathExpressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Each rule has emojis denoting:
 | [no-abstract-roles](./docs/rule/no-abstract-roles.md)                                                     | ✅  |     | ⌨️  |     |
 | [no-accesskey-attribute](./docs/rule/no-accesskey-attribute.md)                                           | ✅  |     | ⌨️  | 🔧  |
 | [no-action](./docs/rule/no-action.md)                                                                     | ✅  |     |     |     |
-| [no-action-modifiers](./docs/rule/no-action-modifiers.md)                                                 |     |     |     |     |
+| [no-action-modifiers](./docs/rule/no-action-modifiers.md)                                                 |     |     |     | 🔧  |
 | [no-action-on-submit-button](./docs/rule/no-action-on-submit-button.md)                                   | ✅  |     |     |     |
 | [no-args-paths](./docs/rule/no-args-paths.md)                                                             | ✅  |     |     |     |
 | [no-arguments-for-html-elements](./docs/rule/no-arguments-for-html-elements.md)                           | ✅  |     |     |     |

--- a/docs/rule/no-action-modifiers.md
+++ b/docs/rule/no-action-modifiers.md
@@ -1,5 +1,7 @@
 # no-action-modifiers
 
+🔧 The `--fix` option on the command line can automatically fix some of the problems reported by this rule.
+
 This rule forbids the use of `{{action}}` modifiers on elements.
 
 The recommended alternative is the `on` modifier. `on` is available in Ember 3.11+ and by [polyfill](https://github.com/buschtoens/ember-on-modifier) for earlier versions.

--- a/lib/rules/no-action-modifiers.js
+++ b/lib/rules/no-action-modifiers.js
@@ -1,5 +1,6 @@
 import createErrorMessage from '../helpers/create-error-message.js';
 import Rule from './_base.js';
+import { builders as b } from 'ember-template-recast';
 
 const ERROR_MESSAGE = 'Do not use the `action` modifier. Instead, use the `on` modifier.';
 
@@ -35,6 +36,11 @@ export default class NoActionModifiers extends Rule {
 
   visitor() {
     return {
+      /**
+       *
+       * @param {import('ember-template-recast').AST.ElementModifierStatement} node
+       * @returns
+       */
       ElementModifierStatement(node, { parentNode }) {
         let modifierName = node.path.original;
         if (modifierName !== 'action') {
@@ -45,11 +51,24 @@ export default class NoActionModifiers extends Rule {
           return;
         }
 
-        this.log({
-          message: ERROR_MESSAGE,
-          node,
-          source: this.sourceForNode(parentNode),
-        });
+        let [maybePath, ...args] = node.params;
+        let couldFix = maybePath && maybePath.type === 'PathExpression';
+
+        if (this.mode === 'fix') {
+          node.path.original = 'on';
+          if (args.length === 0) {
+            node.params.unshift(b.string('click'));
+          } else {
+            node.params = [b.string('click'), b.sexpr(b.path('fn'), [maybePath, ...args])];
+          }
+        } else {
+          this.log({
+            message: ERROR_MESSAGE,
+            node,
+            source: this.sourceForNode(parentNode),
+            isFixable: couldFix,
+          });
+        }
       },
     };
   }

--- a/test/unit/rules/no-action-modifiers-test.js
+++ b/test/unit/rules/no-action-modifiers-test.js
@@ -20,6 +20,14 @@ generateRuleTests({
 
   bad: [
     {
+      template: '<div {{action this.foo}}></div>',
+      fixedTemplate: '<div {{on "click" this.foo}}></div>',
+    },
+    {
+      template: '<div {{action this.foo bar baz}}></div>',
+      fixedTemplate: '<div {{on "click" (fn this.foo bar baz)}}></div>',
+    },
+    {
       template: '<button {{action "foo"}}></button>',
 
       verifyResults(results) {
@@ -30,6 +38,7 @@ generateRuleTests({
               "endColumn": 24,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": false,
               "line": 1,
               "message": "Do not use the \`action\` modifier. Instead, use the \`on\` modifier.",
               "rule": "no-action-modifiers",
@@ -51,6 +60,7 @@ generateRuleTests({
               "endColumn": 28,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": false,
               "line": 1,
               "message": "Do not use the \`action\` modifier. Instead, use the \`on\` modifier.",
               "rule": "no-action-modifiers",
@@ -73,6 +83,7 @@ generateRuleTests({
               "endColumn": 28,
               "endLine": 1,
               "filePath": "layout.hbs",
+              "isFixable": false,
               "line": 1,
               "message": "Do not use the \`action\` modifier. Instead, use the \`on\` modifier.",
               "rule": "no-action-modifiers",


### PR DESCRIPTION
Adding fix for no-action-modifier rule, to help with https://deprecations.emberjs.com/id/template-action/