### PR TITLE
fix: #3159 [no-nested-interactive]  false positive with content within {{#if}}/{{else}}

### DIFF
--- a/lib/rules/no-nested-interactive.js
+++ b/lib/rules/no-nested-interactive.js
@@ -20,8 +20,23 @@ import parseConfig from '../helpers/parse-interactive-element-config.js';
 import Rule from './_base.js';
 
 export default class NoNestedInteractive extends Rule {
+  constructor(options) {
+    super(options);
+    this.blocks = [
+      {
+        _seenInteractiveChild: false,
+      },
+    ];
+  }
   parseConfig(config) {
     return parseConfig(this.ruleName, config);
+  }
+
+  get _seenInteractiveChild() {
+    return this.blocks.some((block) => block._seenInteractiveChild);
+  }
+  set _seenInteractiveChild(value) {
+    this.blocks.at(-1)._seenInteractiveChild = value;
   }
 
   visitor() {
@@ -80,6 +95,16 @@ export default class NoNestedInteractive extends Rule {
     return {
       ElementNode: visitor,
       ComponentNode: visitor,
+      Block: {
+        enter() {
+          this.blocks.push({
+            _seenInteractiveChild: this._seenInteractiveChild,
+          });
+        },
+        exit() {
+          this.blocks.pop();
+        },
+      },
     };
   }
 

--- a/test/unit/rules/no-nested-interactive-test.js
+++ b/test/unit/rules/no-nested-interactive-test.js
@@ -27,6 +27,28 @@ generateRuleTests({
       </li>
     </ul>
     `,
+    `
+  <label> My input:
+    {{#if @select}}
+      <select></select>
+    {{else}}
+      <input type='text'>
+    {{/if}}
+  </label>
+    `,
+    `
+  <label> My input:
+    {{#if @select}}
+      {{#if @multiple}}
+        <select multiple></select>
+      {{else}}
+        <select></select>
+      {{/if}}
+    {{else}}
+      <input type='text'>
+    {{/if}}
+  </label>
+    `,
     {
       config: {
         ignoredTags: ['button'],


### PR DESCRIPTION
resolves https://github.com/ember-template-lint/ember-template-lint/issues/3159