### PR TITLE
fix #3092 fix missing characters on no-unnecessary-curly-parens fix

### DIFF
--- a/lib/rules/no-unnecessary-curly-parens.js
+++ b/lib/rules/no-unnecessary-curly-parens.js
@@ -1,23 +1,36 @@
+import Rule from './_base.js';
 import { builders as b } from 'ember-template-recast';
 
-import Rule from './_base.js';
-import replaceNode from '../helpers/replace-node.js';
-
 export default class NoUnnecessaryCurlyParens extends Rule {
+  isFixableMustache(node) {
+    return (
+      node.path.type === 'SubExpression' && (node.path.params.length || node.path.hash.pairs.length)
+    );
+  }
+  fixedMustacheNode(node) {
+    const params = node.path.params;
+    const hash = node.path.hash;
+    return b.mustache(node.path.path, params, hash);
+  }
   visitor() {
     return {
-      MustacheStatement(node, path) {
-        if (
-          node.path.type === 'SubExpression' &&
-          (node.path.params.length || node.path.hash.pairs.length)
-        ) {
+      ConcatStatement(node) {
+        if (this.mode === 'fix') {
+          node.parts = node.parts.map((part) => {
+            if (part.type === 'MustacheStatement' && this.isFixableMustache(part)) {
+              return this.fixedMustacheNode(part);
+            } else if (part.type === 'TextNode') {
+              return b.text(part.chars);
+            } else {
+              return part;
+            }
+          });
+        }
+      },
+      MustacheStatement(node) {
+        if (this.isFixableMustache(node)) {
           if (this.mode === 'fix') {
-            replaceNode(
-              node,
-              path.parentNode,
-              path.parentKey,
-              b.mustache(node.path.path, node.path.params, node.path.hash)
-            );
+            return this.fixedMustacheNode(node);
           } else {
             this.log({
               node,

--- a/test/unit/rules/no-unnecessary-curly-parens-test.js
+++ b/test/unit/rules/no-unnecessary-curly-parens-test.js
@@ -16,6 +16,18 @@ generateRuleTests({
 
   bad: [
     {
+      template: '<FooBar @x="{{index}}X{{(someHelper foo)}}" />',
+      fixedTemplate: '<FooBar @x="{{index}}X{{someHelper foo}}" />',
+    },
+    {
+      template: '<FooBar @x="{{index}}XY{{(someHelper foo)}}" />',
+      fixedTemplate: '<FooBar @x="{{index}}XY{{someHelper foo}}" />',
+    },
+    {
+      template: '<FooBar @x="{{index}}--{{(someHelper foo)}}" />',
+      fixedTemplate: '<FooBar @x="{{index}}--{{someHelper foo}}" />',
+    },
+    {
       template: '{{(concat "a" "b")}}',
       fixedTemplate: '{{concat "a" "b"}}',
 


### PR DESCRIPTION
resolves: https://github.com/ember-template-lint/ember-template-lint/issues/3092

It's actually error inside https://github.com/ember-template-lint/ember-template-recast/issues/999,
But I able to figure-out fix on our side