### PR TITLE
fix #3042 fix false-positive for no-block-params-for-html-elements

### DIFF
--- a/lib/rules/_base.js
+++ b/lib/rules/_base.js
@@ -48,7 +48,7 @@ export default class {
     this._reportUnusedDisableDirectives =
       typeof options.reportUnusedDisableDirectives === 'boolean'
         ? options.reportUnusedDisableDirectives
-        : (options.fileConfig?.reportUnusedDisableDirectives ?? false);
+        : options.fileConfig?.reportUnusedDisableDirectives ?? false;
 
     this.severity = options.defaultSeverity;
     this.results = [];

--- a/lib/rules/_base.js
+++ b/lib/rules/_base.js
@@ -48,7 +48,7 @@ export default class {
     this._reportUnusedDisableDirectives =
       typeof options.reportUnusedDisableDirectives === 'boolean'
         ? options.reportUnusedDisableDirectives
-        : options.fileConfig?.reportUnusedDisableDirectives ?? false;
+        : (options.fileConfig?.reportUnusedDisableDirectives ?? false);
 
     this.severity = options.defaultSeverity;
     this.results = [];

--- a/lib/rules/no-block-params-for-html-elements.js
+++ b/lib/rules/no-block-params-for-html-elements.js
@@ -8,7 +8,8 @@ export default class NoBlockParamsForHtmlElements extends Rule {
         if (
           node.blockParams.length !== 0 &&
           !isAngleBracketComponent(this.scope, node) &&
-          !node.tag.startsWith(':')
+          !node.tag.startsWith(':') &&
+          !node.tag.includes('.')
         ) {
           this.log({
             message: NoBlockParamsForHtmlElements.generateErrorMessage(node.tag),

--- a/test/unit/rules/no-block-params-for-html-elements-test.js
+++ b/test/unit/rules/no-block-params-for-html-elements-test.js
@@ -12,6 +12,7 @@ generateRuleTests({
     '<this.foo as |blah|></this.foo>',
     '{{#let (component \'foo\') as |bar|}} <bar @name="1" as |n|><n/></bar> {{/let}}',
     '<Something><:Item as |foo|></:Item></Something>',
+    '<Layouts.Navigation @tag="div" as |navs|><navs></navs></Layouts.Navigation>'
   ],
 
   bad: [

--- a/test/unit/rules/no-block-params-for-html-elements-test.js
+++ b/test/unit/rules/no-block-params-for-html-elements-test.js
@@ -12,7 +12,7 @@ generateRuleTests({
     '<this.foo as |blah|></this.foo>',
     '{{#let (component \'foo\') as |bar|}} <bar @name="1" as |n|><n/></bar> {{/let}}',
     '<Something><:Item as |foo|></:Item></Something>',
-    '<Layouts.Navigation @tag="div" as |navs|><navs></navs></Layouts.Navigation>'
+    '<Layouts.Navigation @tag="div" as |navs|><navs></navs></Layouts.Navigation>',
   ],
 
   bad: [


### PR DESCRIPTION
Resolves: https://github.com/ember-template-lint/ember-template-lint/issues/3042