### PR TITLE
fix #2969 allow no-invalid-link-text to be configured for custom link…

### DIFF
--- a/docs/rule/no-invalid-link-text.md
+++ b/docs/rule/no-invalid-link-text.md
@@ -51,6 +51,7 @@ This rule **allows** the following:
 * boolean -- `true` for enabled / `false` for disabled
 * object -- Containing the following values:
   * `allowEmptyLinks` - When `false`, empty links are not allowed. Defaults to `false`.
+  * `linkComponents` - Array of component names to check for invalid link text. For example,  `['ExternalLink', 'Link']`.
 
 ## References
 

--- a/lib/rules/no-invalid-link-text.js
+++ b/lib/rules/no-invalid-link-text.js
@@ -1,7 +1,7 @@
 import AstNodeInfo from '../helpers/ast-node-info.js';
 import Rule from './_base.js';
 
-const DEFAULT_CONFIG = { allowEmptyLinks: false };
+const DEFAULT_CONFIG = { allowEmptyLinks: false, linkComponents: [] };
 const DISALLOWED_LINK_TEXT = new Set([
   // WCAG F84-Provided Examples
   'click here',
@@ -82,10 +82,13 @@ export default class NoInvalidLinkText extends Rule {
 
     switch (configType) {
       case 'boolean': {
-        return config ? DEFAULT_CONFIG : false;
+        return config ? structuredClone(DEFAULT_CONFIG) : false;
       }
       case 'object': {
-        return { allowEmptyLinks: config.allowEmptyLinks };
+        return {
+          allowEmptyLinks: config.allowEmptyLinks,
+          linkComponents: config.linkComponents || [],
+        };
       }
       case 'undefined': {
         return false;
@@ -99,7 +102,11 @@ export default class NoInvalidLinkText extends Rule {
         // In strict mode, LinkTo is ignored even with invalid text
         // This is because we can't tell if the component is actually a built-in LinkTo
         // or just has the same name. It's better to risk false negatives than false positives.
-        if (node.tag === 'a' || (node.tag === 'LinkTo' && !this.isStrictMode)) {
+        if (
+          node.tag === 'a' ||
+          (node.tag === 'LinkTo' && !this.isStrictMode) ||
+          this.config.linkComponents.includes(node.tag)
+        ) {
           // Report if one or more child TextNode element(s) is on the disallowed list
           if (hasInvalidLinkText(node, this.config.allowEmptyLinks)) {
             this.log({

--- a/test/unit/rules/no-invalid-link-text-test.js
+++ b/test/unit/rules/no-invalid-link-text-test.js
@@ -321,5 +321,26 @@ generateRuleTests({
         `);
       },
     },
+    {
+      template: '<MyLink>click here</MyLink>',
+      config: { linkComponents: ['MyLink'] },
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 0,
+              "endColumn": 27,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "line": 1,
+              "message": "Links should have descriptive text",
+              "rule": "no-invalid-link-text",
+              "severity": 2,
+              "source": "<MyLink>click here</MyLink>",
+            },
+          ]
+        `);
+      },
+    },
   ],
 });


### PR DESCRIPTION
Resolves https://github.com/ember-template-lint/ember-template-lint/issues/2969