### PR TITLE
fix #2924 no-obscure-array-access fix is incorrect with modifier usage

### DIFF
--- a/lib/rules/no-obscure-array-access.js
+++ b/lib/rules/no-obscure-array-access.js
@@ -20,24 +20,43 @@ function getHelperParams(node) {
   const firstDigitIndex = originalParts.findIndex((part) => DIGIT_REGEXP.test(part));
 
   return [
-    builders.path({ head: originalParts.slice(0, firstDigitIndex).join('.') }, node.loc),
-    builders.literal('StringLiteral', originalParts.slice(firstDigitIndex).join('.'), node.loc),
+    builders.path({ head: originalParts.slice(0, firstDigitIndex).join('.') }),
+    builders.literal('StringLiteral', originalParts.slice(firstDigitIndex).join('.')),
   ];
 }
 
 export default class NoObscureArrayAccess extends Rule {
+  isFixablePath(node) {
+    return node.type === 'PathExpression' && node.original && PATH_REGEXP.test(node.original);
+  }
   visitor() {
     return {
+      MustacheStatement: {
+        exit(node) {
+          const shouldFixPath = this.isFixablePath(node.path);
+          const shouldFixParams = node.params.some((param) => this.isFixablePath(param));
+          if (shouldFixPath && this.mode === 'fix') {
+            return builders.mustache(
+              builders.path('get'),
+              [...getHelperParams(node.path), ...node.params],
+              node.hash
+            );
+          }
+          if (shouldFixParams && this.mode === 'fix') {
+            for (let i = 0; i < node.params.length; i++) {
+              if (this.isFixablePath(node.params[i])) {
+                node.params[i] = builders.sexpr('get', getHelperParams(node.params[i]));
+              }
+            }
+          }
+          return node;
+        },
+      },
       PathExpression(node, path) {
-        if (node.original && PATH_REGEXP.test(node.original)) {
+        if (this.isFixablePath(node)) {
           if (this.mode === 'fix') {
-            // for paths with a MustacheStatement parentNode replace the pathExpression with a get helper pathExpression
-            if (path.parentNode.type === 'MustacheStatement') {
-              path.parentNode[path.parentKey] = builders.path('get', node.loc);
-              path.parentNode.params = getHelperParams(node);
-            } else {
-              // replace the pathExpression with a get helper subExpression
-              node = builders.sexpr('get', getHelperParams(node));
+            if (path.parentNode.type !== 'MustacheStatement') {
+              return builders.sexpr('get', getHelperParams(node));
             }
           } else {
             this.log({
@@ -48,8 +67,6 @@ export default class NoObscureArrayAccess extends Rule {
             });
           }
         }
-
-        return node;
       },
     };
   }

--- a/test/unit/rules/no-obscure-array-access-test.js
+++ b/test/unit/rules/no-obscure-array-access-test.js
@@ -23,6 +23,28 @@ generateRuleTests({
 
   bad: [
     {
+      template: '<Foo @onClick={{fn this.func @foo.0.bar}} />',
+      fixedTemplate: '<Foo @onClick={{fn this.func (get @foo "0.bar")}} />',
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 29,
+              "endColumn": 39,
+              "endLine": 1,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 1,
+              "message": "Obscure expressions are prohibited. Please use Ember's get helper instead. e.g. {{get @list '0'}}",
+              "rule": "no-obscure-array-access",
+              "severity": 2,
+              "source": "@foo.0.bar",
+            },
+          ]
+        `);
+      },
+    },
+    {
       template: '{{foo bar=this.list.[0]}}',
       fixedTemplate: '{{foo bar=(get this.list "0")}}',
       verifyResults(results) {


### PR DESCRIPTION
Resolves: https://github.com/ember-template-lint/ember-template-lint/issues/2924
Overshades: https://github.com/ember-template-lint/ember-template-lint/pull/2923

Tldr seems issue with ember-template-recast, have to workaround it