### PR TITLE
Fix #2654 require-presentational-children fails for named blocks

### DIFF
--- a/lib/rules/require-presentational-children.js
+++ b/lib/rules/require-presentational-children.js
@@ -12,6 +12,9 @@ function createErrorMessage(ancestorElement, role, descendantElement) {
  */
 function getAllElementNodeDescendants(node) {
   return AstNodeInfo.childrenFor(node).flatMap((childNode) => {
+    if (childNode.type === 'ElementNode' && childNode.tag.startsWith(':')) {
+      return getAllElementNodeDescendants(childNode);
+    }
     const isNotPresentationRole =
       AstNodeInfo.attributeTextValue(AstNodeInfo.findAttribute(childNode, 'role')) !==
       'presentation';

--- a/test/unit/rules/require-presentational-children-test.js
+++ b/test/unit/rules/require-presentational-children-test.js
@@ -29,6 +29,11 @@ generateRuleTests({
       config: { additionalNonSemanticTags: ['custom-element'] },
       template: `<button><div>item1</div><custom-element>item2</custom-element></button>`,
     },
+    `
+      <MyButton role="tab">
+        <:default>Button text</:default>
+      </MyButton>
+    `,
   ],
 
   bad: [


### PR DESCRIPTION
Resolves: https://github.com/ember-template-lint/ember-template-lint/issues/2654