### PR TITLE
peformance: pool file processing

### DIFF
--- a/lib/-private/process-with-pool.js
+++ b/lib/-private/process-with-pool.js
@@ -1,0 +1,68 @@
+export async function processWithPool(items, concurrency, processor) {
+  const results = [];
+  const running = new Set();
+  let firstError = null;
+
+  async function runTask(item) {
+    const promise = processor(item);
+    running.add(promise);
+
+    try {
+      const result = await promise;
+      results.push(result);
+      return result;
+    } catch (error) {
+      // Store the first error to reject with later
+      if (!firstError) {
+        firstError = error;
+      }
+      // Re-throw to ensure promise is rejected
+      throw error;
+    } finally {
+      running.delete(promise);
+    }
+  }
+
+  async function spawnTasks() {
+    for (const item of items) {
+      // Don't start new tasks if an error has occurred
+      if (firstError) {
+        break;
+      }
+
+      if (running.size >= concurrency) {
+        try {
+          // Wait for at least one task to complete before spawning more
+          await Promise.race(running);
+        } catch {
+          // Error caught here, but handled in runTask
+          // Just continue to process remaining tasks
+        }
+      }
+
+      // Don't await here, just spawn the task
+      runTask(item).catch(() => {
+        // Errors are already handled in runTask
+        // This catch is just to prevent "unhandled rejection" warnings
+      });
+    }
+
+    try {
+      // Wait for all remaining tasks to complete
+      if (running.size > 0) {
+        await Promise.all(running);
+      }
+    } catch {
+      // Error caught here, but firstError is already stored in runTask
+    }
+  }
+
+  await spawnTasks();
+
+  // If an error occurred, reject with it
+  if (firstError) {
+    throw firstError;
+  }
+
+  return results;
+}

--- a/test/unit/-private/process-with-pool-test.js
+++ b/test/unit/-private/process-with-pool-test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { processWithPool } from '../../../lib/-private/process-with-pool.js';
+
+describe('processWithPool', () => {
+  it('processes all items', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const processor = vi.fn(async (item) => {
+      await new Promise((resolve) => setTimeout(resolve, 10)); // Simulate async work
+      return item * 2;
+    });
+
+    const results = await processWithPool(items, 2, processor);
+
+    expect(processor).toHaveBeenCalledTimes(5);
+    expect(results).toEqual([2, 4, 6, 8, 10]);
+  });
+
+  it('respects concurrency limit', async () => {
+    const items = [1, 2, 3, 4, 5];
+    let running = 0;
+    let maxRunning = 0;
+
+    async function processor(item) {
+      running++;
+      maxRunning = Math.max(maxRunning, running);
+
+      // Simulate async work
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      running--;
+      return item;
+    }
+
+    await processWithPool(items, 3, processor);
+
+    expect(maxRunning).toBeLessThanOrEqual(3);
+  });
+
+  it('handles empty array', async () => {
+    const processor = vi.fn(async (item) => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return item;
+    });
+
+    const results = await processWithPool([], 5, processor);
+
+    expect(processor).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it('handles errors properly', async () => {
+    const items = [1, 2, 3, 4, 5];
+
+    async function processor(item) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      if (item === 3) {
+        throw new Error('Test error');
+      }
+      return item;
+    }
+
+    await expect(processWithPool(items, 2, processor)).rejects.toThrow('Test error');
+  });
+
+  it('processes items in correct order by concurrency', async () => {
+    const items = [100, 50, 25, 10, 5]; // Times in ms each task takes
+    const processed = [];
+
+    async function processor(item) {
+      await new Promise((resolve) => setTimeout(resolve, item));
+      processed.push(item);
+      return item;
+    }
+
+    await processWithPool(items, 2, processor);
+
+    // With concurrency 2, the expected order would be:
+    // - 100ms and 50ms start immediately
+    // - 50ms finishes first, then 25ms starts
+    // - 25ms finishes, then 10ms starts
+    // - 10ms finishes, then 5ms starts
+    // - 100ms finishes
+    // - 5ms finishes
+    // So the processed order should be [50, 25, 10, 100, 5]
+    expect(processed).toEqual([50, 25, 10, 5, 100]);
+  });
+
+  it('handles large number of items efficiently', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => i);
+    async function processor(item) {
+      await new Promise((resolve) => setTimeout(resolve, 1)); // Simulate async work
+      return item;
+    }
+
+    const results = await processWithPool(items, 10, processor);
+
+    expect(results.length).toBe(100);
+    expect(results.sort((a, b) => a - b)).toEqual(items);
+  });
+});


### PR DESCRIPTION
trying to maximize CPU usage here
In current state of things we do async lint/verify file-by-file.
Problem with this approach is that `verify` step contain list of  async `io` operations and we basically waiting until promise is resolved.

To address this issue we creating a `linting` pool to process multiple files in same time (for now in one thread)

We should see improvement on projects with large amount of templates or on projects with slow IO (windows)

this is initial steps to https://github.com/ember-template-lint/ember-template-lint/pull/3188