### PR TITLE
fix #1728 support absolute paths in no-this-in-template-only-components

### DIFF
--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -24,6 +24,15 @@ function isTemplateOnlyComponent(hbsFilePath, validComponentExtensions) {
     return validComponentExtensions.some((ext) => fs.existsSync(pathWithoutExtension + ext));
   }
   const paths = path.normalize(hbsFilePath).split(path.sep);
+
+  while (paths.length > 0 && paths[0] !== 'app' && paths[0] !== 'addon') {
+    paths.shift();
+  }
+
+  if (paths.length === 0) {
+    // no app or addon directory found
+    return false;
+  }
   if (paths[0] === 'app' || paths[0] === 'addon') {
     if (paths[1] === 'templates') {
       if (paths[2] === 'components') {

--- a/test/unit/rules/no-this-in-template-only-components-test.js
+++ b/test/unit/rules/no-this-in-template-only-components-test.js
@@ -16,13 +16,21 @@ generateRuleTests({
         filePath: 'app/templates/route-template.hbs',
       },
     },
+    {
+      template: '{{my-component model=this.model}}',
+      meta: {
+        filePath: '/some-absolute/path/like/app/templates/route-template.hbs',
+      },
+    },
   ],
 
   bad: [
     {
       template: '{{my-component model=this.model}}',
       fixedTemplate: '{{my-component model=@model}}',
-
+      meta: {
+        filePath: 'addon/templates/components/foo-bar.hbs',
+      },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -30,7 +38,7 @@ generateRuleTests({
               "column": 21,
               "endColumn": 31,
               "endLine": 1,
-              "filePath": "layout.hbs",
+              "filePath": "addon/templates/components/foo-bar.hbs",
               "isFixable": true,
               "line": 1,
               "message": "Usage of 'this' in path 'this.model' is not allowed in a template-only component. Use '@model' if it is a named argument or create a component.js for this component.",
@@ -45,7 +53,9 @@ generateRuleTests({
     {
       template: '{{my-component action=(action this.myAction)}}',
       fixedTemplate: '{{my-component action=(action @myAction)}}',
-
+      meta: {
+        filePath: 'app/components/foo-bar.hbs',
+      },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -53,7 +63,7 @@ generateRuleTests({
               "column": 30,
               "endColumn": 43,
               "endLine": 1,
-              "filePath": "layout.hbs",
+              "filePath": "app/components/foo-bar.hbs",
               "isFixable": true,
               "line": 1,
               "message": "Usage of 'this' in path 'this.myAction' is not allowed in a template-only component. Use '@myAction' if it is a named argument or create a component.js for this component.",
@@ -68,7 +78,9 @@ generateRuleTests({
     {
       template: '<MyComponent @prop={{can "edit" this.model}} />',
       fixedTemplate: '<MyComponent @prop={{can "edit" @model}} />',
-
+      meta: {
+        filePath: 'app/templates/components/foo-bar.hbs',
+      },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -76,7 +88,7 @@ generateRuleTests({
               "column": 32,
               "endColumn": 42,
               "endLine": 1,
-              "filePath": "layout.hbs",
+              "filePath": "app/templates/components/foo-bar.hbs",
               "isFixable": true,
               "line": 1,
               "message": "Usage of 'this' in path 'this.model' is not allowed in a template-only component. Use '@model' if it is a named argument or create a component.js for this component.",
@@ -90,6 +102,9 @@ generateRuleTests({
     },
     {
       template: '{{input id=(concat this.elementId "-username")}}',
+      meta: {
+        filePath: 'app/components/foo/bar/baz.hbs',
+      },
       verifyResults(results) {
         expect(results).toMatchInlineSnapshot(`
           [
@@ -97,7 +112,7 @@ generateRuleTests({
               "column": 19,
               "endColumn": 33,
               "endLine": 1,
-              "filePath": "layout.hbs",
+              "filePath": "app/components/foo/bar/baz.hbs",
               "isFixable": false,
               "line": 1,
               "message": "Usage of 'this' in path 'this.elementId' is not allowed in a template-only component. Use '@elementId' if it is a named argument or create a component.js for this component.",


### PR DESCRIPTION
Resolves https://github.com/ember-template-lint/ember-template-lint/issues/1728