### PR TITLE
fix: Crash in block indentation auto-fixer

### DIFF
--- a/lib/rules/block-indentation.js
+++ b/lib/rules/block-indentation.js
@@ -376,9 +376,16 @@ export default class BlockIndentation extends Rule {
               start: { line: node.loc.start.line, column: node.loc.start.column },
             })}`;
         const lines = elementSource.split('\n');
+        let lineNumber = node.loc.end.line - (path ? 1 : node.loc.start.line);
+        // TODO: debug this behaviour
+        // this should not happen, but, it's happen
+        // seems rule works fine and related test too
+        if (lines[lineNumber] === undefined) {
+          return node;
+        }
         const fixedNode = this.fixLine(
           lines,
-          node.loc.end.line - (path ? 1 : node.loc.start.line),
+          lineNumber,
           correctedEndColumn,
           expectedEndColumn,
           path

--- a/test/unit/rules/block-indentation-test.js
+++ b/test/unit/rules/block-indentation-test.js
@@ -2132,6 +2132,10 @@ generateRuleTests({
       },
     },
     {
+      template: '  <div>\n  </div>\n  <div>\n  </div>\n',
+      fixedTemplate: '<div>\n</div>\n<div>\n</div>\n',
+    },
+    {
       // Messed up indentation with if/else in embedded template can be fixed
       template: [
         '<template>',


### PR DESCRIPTION
It's kinda fix (at least, template is fixed and rule not failed).

based on https://github.com/ember-template-lint/ember-template-lint/pull/2379