### PR TITLE
Removed remaining references to jest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ If you are opening an issue to request a new feature, please provide:
 - npm run new:rule
 
 # test rule
-- npm run test:jest rule-name
+- npm run test:node rule-name
 
 ```
 
@@ -63,8 +63,8 @@ For the linter, there are a few options:
 To test:
 
 1. To run tests and the linter at once, run `npm test` (or `npm run test`)
-2. To just run the tests, run `npm run test:jest`
-3. To just run a specific test (i.e., `require-valid-alt-text`), run `npm run test:jest require-valid-alt-text`
+2. To just run the tests, run `npm run test:node`
+3. To just run a specific test (i.e., `require-valid-alt-text`), run `npm run test:node require-valid-alt-text`
 
 ### Submitting a Pull Request(PR)
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -246,7 +246,7 @@ generateRuleTests({
 
 #### Snapshot tests
 
-Adding a [Vitest snapshot](https://vitest.dev/guide/snapshot.html) to `bad` test cases is recommended. You can update the snapshots by running `pnpm vitest -u`.
+Adding a [Vitest snapshot](https://vitest.dev/guide/snapshot.html) to `bad` test cases is recommended. You can update the snapshots by running `npm vitest -u`.
 
 ### Helper: `ASTHelpers`
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -191,7 +191,7 @@ generateRuleTests({
   // Failing test cases:
   bad: [
     {
-      // Jest snapshot test case (recommended):
+      // Vitest snapshot test case (recommended):
       template: '{{#if (not condition)}}<img>{{/if}}',
       fixedTemplate: '{{#unless condition}}<img>{{/unless}}',
 
@@ -246,7 +246,7 @@ generateRuleTests({
 
 #### Snapshot tests
 
-The [Jest Snapshot](https://jestjs.io/docs/snapshot-testing) version of `bad` test cases is recommended as it can be easily updated with `jest --updateSnapshot`.
+Adding a [Vitest snapshot](https://vitest.dev/guide/snapshot.html) to `bad` test cases is recommended. You can update the snapshots by running `pnpm vitest -u`.
 
 ### Helper: `ASTHelpers`
 


### PR DESCRIPTION
## Background

In #3100, we had replaced `jest` with `vitest`. Documentations for contributors still showed commands related to `jest`.
