### PR TITLE
fix: no-this-in-template-only-components should early exit in gjs/gts (skipping this lint)

### DIFF
--- a/lib/rules/no-this-in-template-only-components.js
+++ b/lib/rules/no-this-in-template-only-components.js
@@ -10,6 +10,8 @@ function message(original, fixed) {
   );
 }
 
+const glimmerScriptExtensions = ['.gjs', '.gts'];
+
 /**
  * Tests whether the template has a corresponding component class file
  * @param hbsFilePath - path to the template file
@@ -17,6 +19,13 @@ function message(original, fixed) {
  * @returns {boolean} true if a component class was found
  */
 function isTemplateOnlyComponent(hbsFilePath, validComponentExtensions) {
+  if (
+    glimmerScriptExtensions.some((ext) => {
+      return hbsFilePath.endsWith(ext);
+    })
+  ) {
+    return false;
+  }
   /**
    * Tests whether the component class exists as `component.js`, `component.ts`, etc.
    */

--- a/test/unit/rules/no-this-in-template-only-components-test.js
+++ b/test/unit/rules/no-this-in-template-only-components-test.js
@@ -17,6 +17,24 @@ generateRuleTests({
       },
     },
     {
+      template: '{{this.name}}',
+      meta: {
+        filePath: 'app/templates/route-template.gts',
+      },
+    },
+    {
+      template: '{{this.data}}',
+      meta: {
+        filePath: 'addon/templates/components/foo-bar.gjs',
+      },
+    },
+    {
+      template: '{{this.bar}}',
+      meta: {
+        filePath: 'addon/templates/components/foo-bar.gts',
+      },
+    },
+    {
       template: '{{my-component model=this.model}}',
       meta: {
         filePath: '/some-absolute/path/like/app/templates/route-template.hbs',

--- a/test/unit/rules/no-this-in-template-only-components-test.js
+++ b/test/unit/rules/no-this-in-template-only-components-test.js
@@ -17,19 +17,19 @@ generateRuleTests({
       },
     },
     {
-      template: '{{this.name}}',
+      template: '<template>{{this.name}}</template>',
       meta: {
         filePath: 'app/templates/route-template.gts',
       },
     },
     {
-      template: '{{this.data}}',
+      template: '<template>{{this.data}}</template>',
       meta: {
         filePath: 'addon/templates/components/foo-bar.gjs',
       },
     },
     {
-      template: '{{this.bar}}',
+      template: '<template>{{this.bar}}</template>',
       meta: {
         filePath: 'addon/templates/components/foo-bar.gts',
       },


### PR DESCRIPTION
Resolves: https://github.com/ember-template-lint/ember-template-lint/issues/3217