### PR TITLE
Ensured that ...attributes is listed last

### DIFF
--- a/docs/rule/sort-invocations.md
+++ b/docs/rule/sort-invocations.md
@@ -14,7 +14,7 @@ By sorting things that are order-independent, you can more easily refactor code.
 
 > [!TIP]
 >
-> The `--fix` option for this rule doesn't preserve formatting. You can use [`prettier-plugin-ember-hbs-tag`](https://github.com/ijlee2/prettier-plugin-ember-hbs-tag) and [`prettier-plugin-ember-template-tag`](https://github.com/ember-tooling/prettier-plugin-ember-template-tag) to format `*.hbs` and `*.{gjs,gts}`, respectively.
+> The `--fix` option for this rule doesn't preserve formatting. You can use `prettier`, [`prettier-plugin-ember-hbs-tag`](https://github.com/ijlee2/prettier-plugin-ember-hbs-tag), and [`prettier-plugin-ember-template-tag`](https://github.com/ember-tooling/prettier-plugin-ember-template-tag) to format templates in `*.hbs`, `hbs` tags, and `<template>` tags, respectively.
 
 ## Examples
 
@@ -53,7 +53,7 @@ When invoking a helper, list the named arguments in alphabetical order.
 {{t
   "my-component.description"
   installedOn=this.installationDate
-  packageName="@ember/source"
+  packageName="ember-source"
   packageVersion="6.0.0"
 }}
 ```

--- a/lib/rules/sort-invocations.js
+++ b/lib/rules/sort-invocations.js
@@ -40,6 +40,27 @@ function getModifierName(node) {
   return node.path.original;
 }
 
+function canSkipListSplattributesLast(node) {
+  const { attributes, modifiers } = node;
+
+  const splattributes = attributes.at(-1);
+  const lastModifier = modifiers.at(-1);
+
+  if (splattributes?.name !== '...attributes' || !lastModifier) {
+    return true;
+  }
+
+  // Check that ...attributes appears after the last modifier
+  const splattributesPosition = splattributes.loc.start;
+  const lastModifierPosition = lastModifier.loc.start;
+
+  if (splattributesPosition.line > lastModifierPosition.line) {
+    return true;
+  }
+
+  return splattributesPosition.column > lastModifierPosition.column;
+}
+
 function compareAttributes(a, b) {
   const positionA = getAttributePosition(a);
   const positionB = getAttributePosition(b);
@@ -147,43 +168,47 @@ function getUnsortedModifierIndex(modifiers) {
   });
 }
 
-function listSplattributesLast(node, lineNumber) {
-  const lastAttribute = node.attributes.at(-1);
-  const hasSplattributes = lastAttribute.name === '...attributes';
+function listSplattributesLast(node) {
+  let { attributes, modifiers } = node;
 
-  if (!hasSplattributes) {
-    return;
-  }
+  const splattributes = attributes.at(-1);
 
-  node.attributes.splice(
+  // Assign each modifier the location of its predecessor
+  let start = splattributes.loc.start;
+
+  modifiers = modifiers.map((modifier) => {
+    const { hash, loc, params, path } = modifier;
+
+    const newLocation = {
+      start,
+      end: {
+        column: start.column + (loc.end.column - loc.start.column),
+        line: start.line + (loc.end.line - loc.start.line) + 1,
+      },
+    };
+
+    start = newLocation.end;
+
+    return b.elementModifier(path, params, hash, newLocation);
+  });
+
+  // Assign ...attributes the original location of the last modifier
+  attributes.splice(
     -1,
     1,
     b.attr('...attributes', b.text(''), {
-      start: {
-        column: 0,
-        line: lineNumber + node.modifiers.length + 1,
-      },
+      start,
       end: {
-        column: '...attributes'.length,
-        line: lineNumber + node.modifiers.length + 1,
+        column: start.column + '...attributes'.length,
+        line: start.line,
       },
     })
   );
 
-  node.modifiers = node.modifiers.map((modifier) => {
-    const { hash, loc, params, path } = modifier;
-
-    return b.elementModifier(path, params, hash, {
-      start: {
-        column: loc.start.column,
-        line: loc.start.line - 1,
-      },
-      end: {
-        column: loc.end.column,
-        line: loc.end.line - 1,
-      },
-    });
-  });
+  return {
+    attributes,
+    modifiers,
+  };
 }
 
 function sortAttributes(attributes) {
@@ -259,14 +284,12 @@ export default class SortInvocations extends Rule {
 
       ElementNode(node) {
         const { attributes, modifiers } = node;
-        let hasBeenSorted = false;
 
         let index = getUnsortedAttributeIndex(attributes);
 
         if (index !== -1) {
           if (this.mode === 'fix') {
             node.attributes = sortAttributes(attributes);
-            hasBeenSorted = true;
           } else {
             this.log({
               isFixable: true,
@@ -281,7 +304,6 @@ export default class SortInvocations extends Rule {
         if (index !== -1) {
           if (this.mode === 'fix') {
             node.modifiers = sortModifiers(modifiers);
-            hasBeenSorted = true;
           } else {
             this.log({
               isFixable: true,
@@ -291,14 +313,20 @@ export default class SortInvocations extends Rule {
           }
         }
 
-        if (!hasBeenSorted) {
-          return;
+        if (!canSkipListSplattributesLast(node)) {
+          if (this.mode === 'fix') {
+            const { attributes, modifiers } = listSplattributesLast(node);
+
+            node.attributes = attributes;
+            node.modifiers = modifiers;
+          } else {
+            this.log({
+              isFixable: true,
+              message: `\`...attributes\` must appear after modifiers`,
+              node,
+            });
+          }
         }
-
-        // The originally last attribute's location has the highest line number
-        const lineNumber = attributes.at(-1).loc.start.line;
-
-        listSplattributesLast(node, lineNumber);
       },
 
       MustacheStatement(node) {

--- a/test/unit/rules/sort-invocations-test.js
+++ b/test/unit/rules/sort-invocations-test.js
@@ -567,7 +567,7 @@ generateRuleTests({
             this.styles
             "button"
             (unless this.enableSubmit "disabled")
-          }} data-cucumber-button="Submit form" data-test-button ...attributes {{autofocus}} {{on "click" @onSubmit}}
+          }} data-cucumber-button="Submit form" data-test-button {{autofocus}} {{on "click" @onSubmit}} ...attributes
         />
 
         <Ui::Button
@@ -575,7 +575,7 @@ generateRuleTests({
             this.styles
             "button"
             (unless this.enableSubmit "disabled")
-          }} data-cucumber-button="Submit form" data-test-button={{""}} ...attributes {{autofocus}} {{on "click" @onSubmit}}
+          }} data-cucumber-button="Submit form" data-test-button={{""}} {{autofocus}} {{on "click" @onSubmit}} ...attributes
         >
           Submit form
         </Ui::Button>
@@ -1018,7 +1018,7 @@ generateRuleTests({
             this.styles
             "button"
             (unless this.enableSubmit "disabled")
-          }} data-cucumber-button="Submit form" data-test-button ...attributes {{autofocus}} {{on "click" @onSubmit}} {{! @glint-expect-error: @onSubmit has incorrect type }} {{!-- @glint-expect-error: this.enableSubmit has incorrect type --}}
+          }} data-cucumber-button="Submit form" data-test-button {{autofocus}} {{on "click" @onSubmit}} ...attributes {{! @glint-expect-error: @onSubmit has incorrect type }} {{!-- @glint-expect-error: this.enableSubmit has incorrect type --}}
         />
       `,
       verifyResults(results) {
@@ -1327,7 +1327,7 @@ generateRuleTests({
       `,
       fixedTemplate: `
         <button
-          class={{local this.styles "button" "disabled"}} data-cucumber-button="Submit form" data-test-button disabled type="submit" ...attributes {{autofocus}} {{on "click" @onSubmit}}
+          class={{local this.styles "button" "disabled"}} data-cucumber-button="Submit form" data-test-button disabled type="submit" {{autofocus}} {{on "click" @onSubmit}} ...attributes
         >
           Submit form
         </button>
@@ -1741,6 +1741,152 @@ generateRuleTests({
                         >
                           {{t "components.ui.form.submit"}}
                         </button>",
+            },
+          ]
+        `);
+      },
+    },
+    {
+      template: `
+        <iframe
+          class="full-screen"
+          data-test-id="my-iframe"
+          id={{@id}}
+          src={{this.url}}
+          {{did-insert this.doSomething1}}
+          {{on "load" this.doSomething2}}
+          ...attributes
+        ></iframe>
+
+        <iframe
+          {{did-insert this.doSomething1}}
+          {{on "load" this.doSomething2}}
+        ></iframe>
+
+        <iframe
+          ...attributes
+          {{did-insert this.doSomething1}}
+          {{on "load" this.doSomething2}}
+        ></iframe>
+
+        <iframe
+          {{did-insert this.doSomething1}}
+          {{on "load" this.doSomething2}}
+          ...attributes
+        ></iframe>
+
+        <iframe
+          class="full-screen"
+          data-test-id="my-iframe"
+          id={{@id}}
+          src={{this.url}}
+        ></iframe>
+
+        <iframe
+          class="full-screen"
+          data-test-id="my-iframe"
+          id={{@id}}
+          src={{this.url}}
+          ...attributes
+        ></iframe>
+
+        <iframe
+          class="full-screen"
+          data-test-id="my-iframe"
+          id={{@id}}
+          src={{this.url}}
+          ...attributes
+          {{did-insert this.doSomething1}}
+          {{on "load" this.doSomething2}}
+        ></iframe>
+      `,
+      fixedTemplate: `
+        <iframe
+          class="full-screen"
+          data-test-id="my-iframe"
+          id={{@id}}
+          src={{this.url}}
+          {{did-insert this.doSomething1}}
+          {{on "load" this.doSomething2}}
+          ...attributes
+        ></iframe>
+
+        <iframe
+          {{did-insert this.doSomething1}}
+          {{on "load" this.doSomething2}}
+        ></iframe>
+
+        <iframe
+          {{did-insert this.doSomething1}} {{on "load" this.doSomething2}} ...attributes
+        ></iframe>
+
+        <iframe
+          {{did-insert this.doSomething1}}
+          {{on "load" this.doSomething2}}
+          ...attributes
+        ></iframe>
+
+        <iframe
+          class="full-screen"
+          data-test-id="my-iframe"
+          id={{@id}}
+          src={{this.url}}
+        ></iframe>
+
+        <iframe
+          class="full-screen"
+          data-test-id="my-iframe"
+          id={{@id}}
+          src={{this.url}}
+          ...attributes
+        ></iframe>
+
+        <iframe
+          class="full-screen"
+          data-test-id="my-iframe"
+          id={{@id}}
+          src={{this.url}}
+          {{did-insert this.doSomething1}} {{on "load" this.doSomething2}} ...attributes
+        ></iframe>
+      `,
+      verifyResults(results) {
+        expect(results).toMatchInlineSnapshot(`
+          [
+            {
+              "column": 8,
+              "endColumn": 18,
+              "endLine": 21,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 17,
+              "message": "\`...attributes\` must appear after modifiers",
+              "rule": "sort-invocations",
+              "severity": 2,
+              "source": "<iframe
+                    ...attributes
+                    {{did-insert this.doSomething1}}
+                    {{on "load" this.doSomething2}}
+                  ></iframe>",
+            },
+            {
+              "column": 8,
+              "endColumn": 18,
+              "endLine": 52,
+              "filePath": "layout.hbs",
+              "isFixable": true,
+              "line": 44,
+              "message": "\`...attributes\` must appear after modifiers",
+              "rule": "sort-invocations",
+              "severity": 2,
+              "source": "<iframe
+                    class="full-screen"
+                    data-test-id="my-iframe"
+                    id={{@id}}
+                    src={{this.url}}
+                    ...attributes
+                    {{did-insert this.doSomething1}}
+                    {{on "load" this.doSomething2}}
+                  ></iframe>",
             },
           ]
         `);


### PR DESCRIPTION
Downstreams [ember-codemod-sort-invocations#28](https://github.com/ijlee2/ember-codemod-sort-invocations/pull/28) and [#29](https://github.com/ijlee2/ember-codemod-sort-invocations/pull/29).

The check for when we can skip listing `...attributes` last missed a couple of cases.

```hbs
{{! Skipped when it shouldn't be, because attributes and modifiers are sorted correctly }}
<iframe
  ...attributes
  {{did-insert this.doSomething1}}
  {{on "load" this.doSomething2}}
></iframe>

{{! Skipped when it shouldn't be, because attributes and modifiers are sorted correctly }}
<iframe
  {{did-insert this.doSomething1}}
  ...attributes
  {{on "load" this.doSomething2}}
></iframe>

{{! Skipped correctly }}
<iframe
  {{did-insert this.doSomething1}}
  {{on "load" this.doSomething2}}
  ...attributes
></iframe>
```

In addition, the calculations for the new locations of `...attributes` and modifiers didn't work always.
